### PR TITLE
Implement ticket status transition domain logic

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -1,0 +1,16 @@
+# 実装メモ
+
+## 2026-04-10
+
+`docs/requirements.md` の「5. ステータス遷移」をもとに、チケット状態遷移のドメインロジックを追加しました。
+
+- `src/domain/ticket-status.ts`
+  - `TicketStatus` の型定義
+  - 遷移ルール定義（`STATUS_TRANSITION_RULES`）
+  - 遷移可否判定（`canTransition`）
+  - 不正遷移エラー（`InvalidStatusTransitionError`）
+  - サーバ側バリデーション用の `assertValidTransition`
+- `tests/ticket-status.test.ts`
+  - 許可遷移 / 不正遷移 / 再オープン遷移のテストを追加
+
+> 備考: 依存関係のインストール制約により、この環境では test 実行は未完了。

--- a/docs/self-review.md
+++ b/docs/self-review.md
@@ -1,0 +1,25 @@
+# Self Review (2026-04-10)
+
+対象変更:
+- `src/domain/ticket-status.ts`
+- `tests/ticket-status.test.ts`
+- `docs/implementation-notes.md`
+
+## 観点と結果
+
+1. 要件整合性
+- `docs/requirements.md` のステータス遷移定義（New/Open/In Progress/Waiting for User/Escalated/Resolved/Closed）に一致することを確認。
+- `Resolved -> Open` の再オープン遷移を実装済み。
+
+2. 型安全性
+- `as const` + `TicketStatus` union により、遷移ルールのキー/値が型で拘束されることを確認。
+
+3. サーバ側バリデーション想定
+- `assertValidTransition` で不正遷移時に明示的エラーを投げられるため、API層から利用可能。
+
+4. テスト妥当性
+- 許可遷移、再オープン、不正遷移をカバー。
+- ただし、環境制約で依存取得できず実行未確認。
+
+## フォローアップ
+- ネットワーク制約のない環境で `npm install && npm test && npm run typecheck` を実行し、結果をPRに追記する。

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "helpdesk-hub",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/src/domain/ticket-status.ts
+++ b/src/domain/ticket-status.ts
@@ -1,0 +1,42 @@
+export const TICKET_STATUSES = [
+  'New',
+  'Open',
+  'Waiting for User',
+  'In Progress',
+  'Escalated',
+  'Resolved',
+  'Closed',
+] as const;
+
+export type TicketStatus = (typeof TICKET_STATUSES)[number];
+
+export const STATUS_TRANSITION_RULES: Readonly<Record<TicketStatus, readonly TicketStatus[]>> = {
+  New: ['Open'],
+  Open: ['In Progress'],
+  'Waiting for User': [],
+  'In Progress': ['Waiting for User', 'Escalated', 'Resolved'],
+  Escalated: [],
+  Resolved: ['Closed', 'Open'],
+  Closed: [],
+};
+
+export class InvalidStatusTransitionError extends Error {
+  constructor(from: TicketStatus, to: TicketStatus) {
+    super(`Invalid status transition: ${from} -> ${to}`);
+    this.name = 'InvalidStatusTransitionError';
+  }
+}
+
+export function getAvailableTransitions(from: TicketStatus): readonly TicketStatus[] {
+  return STATUS_TRANSITION_RULES[from];
+}
+
+export function canTransition(from: TicketStatus, to: TicketStatus): boolean {
+  return STATUS_TRANSITION_RULES[from].includes(to);
+}
+
+export function assertValidTransition(from: TicketStatus, to: TicketStatus): void {
+  if (!canTransition(from, to)) {
+    throw new InvalidStatusTransitionError(from, to);
+  }
+}

--- a/tests/ticket-status.test.ts
+++ b/tests/ticket-status.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertValidTransition,
+  canTransition,
+  getAvailableTransitions,
+  InvalidStatusTransitionError,
+  TICKET_STATUSES,
+} from '../src/domain/ticket-status';
+
+describe('ticket status transition rules', () => {
+  it('supports only defined statuses', () => {
+    expect(TICKET_STATUSES).toEqual([
+      'New',
+      'Open',
+      'Waiting for User',
+      'In Progress',
+      'Escalated',
+      'Resolved',
+      'Closed',
+    ]);
+  });
+
+  it('allows valid transitions from In Progress', () => {
+    expect(getAvailableTransitions('In Progress')).toEqual([
+      'Waiting for User',
+      'Escalated',
+      'Resolved',
+    ]);
+
+    expect(canTransition('In Progress', 'Resolved')).toBe(true);
+    expect(canTransition('In Progress', 'Escalated')).toBe(true);
+  });
+
+  it('allows reopening from Resolved to Open', () => {
+    expect(canTransition('Resolved', 'Open')).toBe(true);
+  });
+
+  it('rejects invalid transitions', () => {
+    expect(canTransition('Open', 'Resolved')).toBe(false);
+
+    expect(() => assertValidTransition('Open', 'Resolved')).toThrowError(
+      InvalidStatusTransitionError,
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
### Motivation
- Implement the canonical ticket status state machine from `docs/requirements.md` to ensure server-side enforcement of allowed transitions.
- Provide a type-safe domain primitive so front-end and API code can share a single source of truth for status values and rules.
- Add minimal TypeScript project scaffolding to support unit tests and future typechecking in the repository.

### Description
- Added `src/domain/ticket-status.ts` which defines `TICKET_STATUSES`, the `TicketStatus` union, `STATUS_TRANSITION_RULES`, `getAvailableTransitions`, `canTransition`, `assertValidTransition`, and `InvalidStatusTransitionError` for server-side validation.
- Added unit tests in `tests/ticket-status.test.ts` that cover the canonical status list, allowed transitions (including `Resolved -> Open` reopen), and rejection of invalid transitions via `assertValidTransition`.
- Added project files `package.json` and `tsconfig.json` to enable `typecheck` and `test` scripts, and documented the change in `docs/implementation-notes.md` and `docs/self-review.md`.

### Testing
- Added `vitest`-based unit tests under `tests/` but test execution was not completed because `npm install` failed with a registry `403 Forbidden` error in this environment. 
- No successful automated test or typecheck run occurred here due to dependency installation failure. 
- Follow-up validation to run in an unrestricted environment: `npm install` then `npm run typecheck` and `npm test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9214c470883228742d4c2e2a6f742)