### PR TITLE
feat: 第1群・第2群 実装（Next.js基盤 〜 チケット管理MVP）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "helpdesk-hub",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "@prisma/client": "^5.22.0",
         "bcryptjs": "^3.0.3",
         "next": "^15.5.15",
@@ -15,6 +16,7 @@
         "prisma": "^5.22.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
+        "react-hook-form": "^7.72.1",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -1021,6 +1023,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2223,6 +2237,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -7071,6 +7091,22 @@
       },
       "peerDependencies": {
         "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.72.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
+      "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "next-auth": "^5.0.0-beta.30",
         "prisma": "^5.22.0",
         "react": "^19.2.5",
-        "react-dom": "^19.2.5"
+        "react-dom": "^19.2.5",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.2",
@@ -8481,7 +8482,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@prisma/client": "^5.22.0",
     "bcryptjs": "^3.0.3",
     "next": "^15.5.15",
@@ -25,6 +26,7 @@
     "prisma": "^5.22.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-hook-form": "^7.72.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "next-auth": "^5.0.0-beta.30",
     "prisma": "^5.22.0",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,11 +3,20 @@ import { hash } from 'bcryptjs';
 
 const prisma = new PrismaClient();
 
+const CATEGORIES = [
+  'ネットワーク・接続',
+  'ハードウェア',
+  'ソフトウェア・アプリ',
+  'アカウント・認証',
+  'セキュリティ',
+  'その他',
+];
+
 async function main() {
   const password = await hash('password123', 12);
 
-  // requester users
-  await prisma.user.upsert({
+  // ── Users ────────────────────────────────────────────
+  const requester1 = await prisma.user.upsert({
     where: { email: 'requester1@example.com' },
     update: {},
     create: {
@@ -18,7 +27,7 @@ async function main() {
     },
   });
 
-  await prisma.user.upsert({
+  const requester2 = await prisma.user.upsert({
     where: { email: 'requester2@example.com' },
     update: {},
     create: {
@@ -29,8 +38,7 @@ async function main() {
     },
   });
 
-  // agent users
-  await prisma.user.upsert({
+  const agent1 = await prisma.user.upsert({
     where: { email: 'agent1@example.com' },
     update: {},
     create: {
@@ -52,7 +60,6 @@ async function main() {
     },
   });
 
-  // admin user
   await prisma.user.upsert({
     where: { email: 'admin@example.com' },
     update: {},
@@ -64,7 +71,59 @@ async function main() {
     },
   });
 
-  console.log('✅ Seed completed');
+  console.log('✅ Users seeded');
+
+  // ── Categories ───────────────────────────────────────
+  const categories: Record<string, { id: string }> = {};
+  for (const name of CATEGORIES) {
+    const cat = await prisma.category.upsert({
+      where: { name },
+      update: {},
+      create: { name },
+    });
+    categories[name] = cat;
+  }
+
+  console.log('✅ Categories seeded');
+
+  // ── Sample tickets ───────────────────────────────────
+  await prisma.ticket.createMany({
+    skipDuplicates: true,
+    data: [
+      {
+        id: 'seed-ticket-1',
+        title: 'VPN に接続できない',
+        body: '昨日からVPNへの接続がタイムアウトします。社内ネットワークへのアクセスが必要です。',
+        status: 'New',
+        priority: 'High',
+        creatorId: requester1.id,
+        categoryId: categories['ネットワーク・接続'].id,
+      },
+      {
+        id: 'seed-ticket-2',
+        title: 'パスワードを忘れてしまいました',
+        body: 'メールにリセットリンクが届きません。急ぎで対応をお願いします。',
+        status: 'Open',
+        priority: 'Medium',
+        creatorId: requester2.id,
+        assigneeId: agent1.id,
+        categoryId: categories['アカウント・認証'].id,
+      },
+      {
+        id: 'seed-ticket-3',
+        title: 'プリンターが認識されない',
+        body: '共有プリンターに印刷しようとすると「プリンターが見つかりません」と表示されます。',
+        status: 'Resolved',
+        priority: 'Low',
+        creatorId: requester1.id,
+        assigneeId: agent1.id,
+        categoryId: categories['ハードウェア'].id,
+      },
+    ],
+  });
+
+  console.log('✅ Sample tickets seeded');
+  console.log('\nSeed completed! Default password: password123');
 }
 
 main()

--- a/src/app/(app)/tickets/[id]/page.tsx
+++ b/src/app/(app)/tickets/[id]/page.tsx
@@ -1,0 +1,190 @@
+import { notFound } from 'next/navigation';
+import { prisma } from '@/lib/prisma';
+import { STATUS_LABELS, STATUS_COLORS, PRIORITY_LABELS, PRIORITY_COLORS } from '@/lib/constants';
+import { StatusSelect } from '@/features/tickets/components/StatusSelect';
+import { PrioritySelect } from '@/features/tickets/components/PrioritySelect';
+import { AssigneeSelect } from '@/features/tickets/components/AssigneeSelect';
+import { CommentForm } from '@/features/tickets/components/CommentForm';
+
+const HISTORY_FIELD_LABELS: Record<string, string> = {
+  status: 'ステータス',
+  priority: '優先度',
+  assignee: '担当者',
+  escalation: 'エスカレーション',
+};
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function TicketDetailPage({ params }: Props) {
+  const { id } = await params;
+
+  const [ticket, agents] = await Promise.all([
+    prisma.ticket.findUnique({
+      where: { id },
+      include: {
+        creator: { select: { id: true, name: true } },
+        assignee: { select: { id: true, name: true } },
+        category: { select: { id: true, name: true } },
+        comments: {
+          orderBy: { createdAt: 'asc' },
+          include: { author: { select: { id: true, name: true } } },
+        },
+        histories: {
+          orderBy: { createdAt: 'desc' },
+          include: { changedBy: { select: { id: true, name: true } } },
+        },
+      },
+    }),
+    prisma.user.findMany({
+      where: { role: { in: ['agent', 'admin'] } },
+      select: { id: true, name: true },
+      orderBy: { name: 'asc' },
+    }),
+  ]);
+
+  if (!ticket) notFound();
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      {/* Title */}
+      <div>
+        <p className="text-sm text-gray-500">#{ticket.id.slice(0, 8)}</p>
+        <h1 className="mt-1 text-2xl font-bold text-gray-900">{ticket.title}</h1>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        {/* Main content */}
+        <div className="space-y-6 lg:col-span-2">
+          {/* Body */}
+          <section className="rounded-lg bg-white p-5 shadow-sm">
+            <h2 className="mb-3 text-sm font-semibold text-gray-500">問い合わせ内容</h2>
+            <p className="whitespace-pre-wrap text-sm text-gray-800">{ticket.body}</p>
+          </section>
+
+          {/* Comments */}
+          <section className="rounded-lg bg-white p-5 shadow-sm">
+            <h2 className="mb-4 text-sm font-semibold text-gray-500">
+              コメント（{ticket.comments.length}件）
+            </h2>
+
+            {ticket.comments.length === 0 ? (
+              <p className="mb-4 text-sm text-gray-400">まだコメントはありません</p>
+            ) : (
+              <ul className="mb-4 space-y-4">
+                {ticket.comments.map((c) => (
+                  <li key={c.id} className="border-l-2 border-gray-200 pl-4">
+                    <div className="mb-1 flex items-center gap-2">
+                      <span className="text-sm font-medium text-gray-700">{c.author.name}</span>
+                      <span className="text-xs text-gray-400">
+                        {c.createdAt.toLocaleString('ja-JP')}
+                      </span>
+                    </div>
+                    <p className="whitespace-pre-wrap text-sm text-gray-700">{c.body}</p>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <CommentForm ticketId={ticket.id} />
+          </section>
+
+          {/* History */}
+          <section className="rounded-lg bg-white p-5 shadow-sm">
+            <h2 className="mb-4 text-sm font-semibold text-gray-500">変更履歴</h2>
+            {ticket.histories.length === 0 ? (
+              <p className="text-sm text-gray-400">変更履歴はありません</p>
+            ) : (
+              <ul className="space-y-2">
+                {ticket.histories.map((h) => (
+                  <li key={h.id} className="flex items-start gap-2 text-sm text-gray-600">
+                    <span className="mt-0.5 text-xs text-gray-400">
+                      {h.createdAt.toLocaleString('ja-JP')}
+                    </span>
+                    <span>
+                      <span className="font-medium">{h.changedBy.name}</span> が{' '}
+                      <span className="font-medium">
+                        {HISTORY_FIELD_LABELS[h.field] ?? h.field}
+                      </span>{' '}
+                      を「{h.oldValue ?? '―'}」→「{h.newValue ?? '―'}」に変更
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+
+        {/* Sidebar */}
+        <aside className="space-y-4">
+          <div className="rounded-lg bg-white p-5 shadow-sm">
+            <h2 className="mb-4 text-sm font-semibold text-gray-500">詳細</h2>
+
+            <dl className="space-y-3 text-sm">
+              {/* Status */}
+              <div>
+                <dt className="font-medium text-gray-500">ステータス</dt>
+                <dd className="mt-1">
+                  <span
+                    className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[ticket.status] ?? ''}`}
+                  >
+                    {STATUS_LABELS[ticket.status] ?? ticket.status}
+                  </span>
+                  <div className="mt-1">
+                    <StatusSelect ticketId={ticket.id} current={ticket.status} />
+                  </div>
+                </dd>
+              </div>
+
+              {/* Priority */}
+              <div>
+                <dt className="font-medium text-gray-500">優先度</dt>
+                <dd className="mt-1">
+                  <span className={`text-sm ${PRIORITY_COLORS[ticket.priority] ?? ''}`}>
+                    {PRIORITY_LABELS[ticket.priority] ?? ticket.priority}
+                  </span>
+                  <div className="mt-1">
+                    <PrioritySelect ticketId={ticket.id} current={ticket.priority} />
+                  </div>
+                </dd>
+              </div>
+
+              {/* Assignee */}
+              <div>
+                <dt className="font-medium text-gray-500">担当者</dt>
+                <dd className="mt-1">
+                  <AssigneeSelect
+                    ticketId={ticket.id}
+                    currentAssigneeId={ticket.assigneeId}
+                    agents={agents}
+                  />
+                </dd>
+              </div>
+
+              {/* Category */}
+              <div>
+                <dt className="font-medium text-gray-500">カテゴリ</dt>
+                <dd className="mt-1 text-gray-700">{ticket.category?.name ?? '―'}</dd>
+              </div>
+
+              {/* Creator */}
+              <div>
+                <dt className="font-medium text-gray-500">登録者</dt>
+                <dd className="mt-1 text-gray-700">{ticket.creator.name}</dd>
+              </div>
+
+              {/* Created at */}
+              <div>
+                <dt className="font-medium text-gray-500">作成日</dt>
+                <dd className="mt-1 text-gray-700">
+                  {ticket.createdAt.toLocaleDateString('ja-JP')}
+                </dd>
+              </div>
+            </dl>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/tickets/new/page.tsx
+++ b/src/app/(app)/tickets/new/page.tsx
@@ -1,0 +1,18 @@
+import { prisma } from '@/lib/prisma';
+import { TicketForm } from '@/features/tickets/components/TicketForm';
+
+export default async function NewTicketPage() {
+  const categories = await prisma.category.findMany({
+    orderBy: { name: 'asc' },
+    select: { id: true, name: true },
+  });
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <h1 className="mb-6 text-2xl font-bold text-gray-900">問い合わせ 新規登録</h1>
+      <div className="rounded-lg bg-white p-6 shadow-sm">
+        <TicketForm categories={categories} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/tickets/page.tsx
+++ b/src/app/(app)/tickets/page.tsx
@@ -1,16 +1,84 @@
-export default function TicketsPage() {
+import Link from 'next/link';
+import { prisma } from '@/lib/prisma';
+import { STATUS_LABELS, STATUS_COLORS, PRIORITY_LABELS, PRIORITY_COLORS } from '@/lib/constants';
+
+export default async function TicketsPage() {
+  const tickets = await prisma.ticket.findMany({
+    orderBy: { createdAt: 'desc' },
+    include: {
+      creator: { select: { id: true, name: true } },
+      assignee: { select: { id: true, name: true } },
+      category: { select: { id: true, name: true } },
+    },
+  });
+
   return (
     <div>
+      {/* Header */}
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold text-gray-900">問い合わせ一覧</h1>
-        <a
+        <Link
           href="/tickets/new"
           className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
         >
           新規登録
-        </a>
+        </Link>
       </div>
-      <p className="text-gray-500">問い合わせ一覧はここに表示されます。</p>
+
+      {/* Table */}
+      {tickets.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-gray-300 py-16 text-center text-gray-400">
+          問い合わせはまだありません
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium text-gray-500">件名</th>
+                <th className="px-4 py-3 text-left font-medium text-gray-500">ステータス</th>
+                <th className="px-4 py-3 text-left font-medium text-gray-500">優先度</th>
+                <th className="px-4 py-3 text-left font-medium text-gray-500">カテゴリ</th>
+                <th className="px-4 py-3 text-left font-medium text-gray-500">担当者</th>
+                <th className="px-4 py-3 text-left font-medium text-gray-500">作成日</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {tickets.map((ticket) => (
+                <tr key={ticket.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3">
+                    <Link
+                      href={`/tickets/${ticket.id}`}
+                      className="font-medium text-blue-600 hover:underline"
+                    >
+                      {ticket.title}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[ticket.status] ?? ''}`}
+                    >
+                      {STATUS_LABELS[ticket.status] ?? ticket.status}
+                    </span>
+                  </td>
+                  <td className={`px-4 py-3 ${PRIORITY_COLORS[ticket.priority] ?? ''}`}>
+                    {PRIORITY_LABELS[ticket.priority] ?? ticket.priority}
+                  </td>
+                  <td className="px-4 py-3 text-gray-500">
+                    {ticket.category?.name ?? '―'}
+                  </td>
+                  <td className="px-4 py-3 text-gray-500">
+                    {ticket.assignee?.name ?? '未割当'}
+                  </td>
+                  <td className="px-4 py-3 text-gray-400">
+                    {ticket.createdAt.toLocaleDateString('ja-JP')}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -24,7 +24,7 @@ export async function POST(req: Request) {
     );
   }
 
-  const { title, body: ticketBody, categoryId, priority } = parsed.data;
+  const { title, body: ticketBody, priority, categoryId } = parsed.data;
 
   const ticket = await prisma.ticket.create({
     data: {

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { createTicketSchema } from '@/lib/validations/ticket';
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'リクエストの形式が正しくありません' }, { status: 400 });
+  }
+
+  const parsed = createTicketSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: '入力値が正しくありません', issues: parsed.error.issues },
+      { status: 422 },
+    );
+  }
+
+  const { title, body: ticketBody, categoryId, priority } = parsed.data;
+
+  const ticket = await prisma.ticket.create({
+    data: {
+      title,
+      body: ticketBody,
+      priority,
+      categoryId,
+      creatorId: session.user.id,
+    },
+    include: { category: true, creator: { select: { id: true, name: true } } },
+  });
+
+  return NextResponse.json(ticket, { status: 201 });
+}

--- a/src/domain/ticket-status.ts
+++ b/src/domain/ticket-status.ts
@@ -1,42 +1,15 @@
-export const TICKET_STATUSES = [
-  'New',
-  'Open',
-  'Waiting for User',
-  'In Progress',
-  'Escalated',
-  'Resolved',
-  'Closed',
-] as const;
+import type { TicketStatus } from '@/generated/prisma';
 
-export type TicketStatus = (typeof TICKET_STATUSES)[number];
-
-export const STATUS_TRANSITION_RULES: Readonly<Record<TicketStatus, readonly TicketStatus[]>> = {
-  New: ['Open'],
-  Open: ['In Progress'],
-  'Waiting for User': [],
-  'In Progress': ['Waiting for User', 'Escalated', 'Resolved'],
-  Escalated: [],
-  Resolved: ['Closed', 'Open'],
-  Closed: [],
+const ALLOWED_TRANSITIONS: Record<TicketStatus, TicketStatus[]> = {
+  New: ['Open', 'WaitingForUser', 'InProgress', 'Resolved', 'Closed'],
+  Open: ['InProgress', 'WaitingForUser', 'Escalated', 'Resolved', 'Closed'],
+  WaitingForUser: ['Open', 'InProgress', 'Resolved', 'Closed'],
+  InProgress: ['WaitingForUser', 'Escalated', 'Resolved', 'Closed'],
+  Escalated: ['InProgress', 'Resolved', 'Closed'],
+  Resolved: ['Open', 'Closed'],
+  Closed: ['Open'],
 };
 
-export class InvalidStatusTransitionError extends Error {
-  constructor(from: TicketStatus, to: TicketStatus) {
-    super(`Invalid status transition: ${from} -> ${to}`);
-    this.name = 'InvalidStatusTransitionError';
-  }
-}
-
-export function getAvailableTransitions(from: TicketStatus): readonly TicketStatus[] {
-  return STATUS_TRANSITION_RULES[from];
-}
-
-export function canTransition(from: TicketStatus, to: TicketStatus): boolean {
-  return STATUS_TRANSITION_RULES[from].includes(to);
-}
-
-export function assertValidTransition(from: TicketStatus, to: TicketStatus): void {
-  if (!canTransition(from, to)) {
-    throw new InvalidStatusTransitionError(from, to);
-  }
+export function isValidTransition(from: TicketStatus, to: TicketStatus): boolean {
+  return ALLOWED_TRANSITIONS[from].includes(to);
 }

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -1,0 +1,74 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { recordHistory } from '@/lib/ticket-history';
+import type { TicketStatus, Priority } from '@/generated/prisma';
+
+// ── Status ──────────────────────────────────────────────────────────────────
+
+export async function updateTicketStatus(ticketId: string, newStatus: TicketStatus) {
+  const session = await auth();
+  if (!session?.user?.id) throw new Error('Unauthorized');
+
+  const ticket = await prisma.ticket.findUniqueOrThrow({ where: { id: ticketId } });
+  if (ticket.status === newStatus) return;
+
+  await prisma.ticket.update({ where: { id: ticketId }, data: { status: newStatus } });
+  await recordHistory(ticketId, session.user.id, 'status', ticket.status, newStatus);
+  revalidatePath(`/tickets/${ticketId}`);
+}
+
+// ── Priority ─────────────────────────────────────────────────────────────────
+
+export async function updateTicketPriority(ticketId: string, newPriority: Priority) {
+  const session = await auth();
+  if (!session?.user?.id) throw new Error('Unauthorized');
+
+  const ticket = await prisma.ticket.findUniqueOrThrow({ where: { id: ticketId } });
+  if (ticket.priority === newPriority) return;
+
+  await prisma.ticket.update({ where: { id: ticketId }, data: { priority: newPriority } });
+  await recordHistory(ticketId, session.user.id, 'priority', ticket.priority, newPriority);
+  revalidatePath(`/tickets/${ticketId}`);
+}
+
+// ── Assignee ─────────────────────────────────────────────────────────────────
+
+export async function updateTicketAssignee(ticketId: string, newAssigneeId: string | null) {
+  const session = await auth();
+  if (!session?.user?.id) throw new Error('Unauthorized');
+
+  const ticket = await prisma.ticket.findUniqueOrThrow({
+    where: { id: ticketId },
+    include: { assignee: { select: { name: true } } },
+  });
+
+  const oldName = ticket.assignee?.name ?? null;
+  let newName: string | null = null;
+  if (newAssigneeId) {
+    const user = await prisma.user.findUniqueOrThrow({ where: { id: newAssigneeId } });
+    newName = user.name;
+  }
+
+  await prisma.ticket.update({
+    where: { id: ticketId },
+    data: { assigneeId: newAssigneeId },
+  });
+  await recordHistory(ticketId, session.user.id, 'assignee', oldName, newName);
+  revalidatePath(`/tickets/${ticketId}`);
+}
+
+// ── Comment ───────────────────────────────────────────────────────────────────
+
+export async function addComment(ticketId: string, body: string) {
+  const session = await auth();
+  if (!session?.user?.id) throw new Error('Unauthorized');
+  if (!body.trim()) throw new Error('コメントを入力してください');
+
+  await prisma.ticketComment.create({
+    data: { ticketId, authorId: session.user.id, body: body.trim() },
+  });
+  revalidatePath(`/tickets/${ticketId}`);
+}

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { recordHistory } from '@/lib/ticket-history';
+import { isValidTransition } from '@/domain/ticket-status';
 import type { TicketStatus, Priority } from '@/generated/prisma';
 
 // ── Status ──────────────────────────────────────────────────────────────────
@@ -14,6 +15,9 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
 
   const ticket = await prisma.ticket.findUniqueOrThrow({ where: { id: ticketId } });
   if (ticket.status === newStatus) return;
+  if (!isValidTransition(ticket.status, newStatus)) {
+    throw new Error(`ステータスを「${ticket.status}」から「${newStatus}」に変更することはできません`);
+  }
 
   await prisma.ticket.update({ where: { id: ticketId }, data: { status: newStatus } });
   await recordHistory(ticketId, session.user.id, 'status', ticket.status, newStatus);
@@ -49,6 +53,9 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
   let newName: string | null = null;
   if (newAssigneeId) {
     const user = await prisma.user.findUniqueOrThrow({ where: { id: newAssigneeId } });
+    if (user.role !== 'agent' && user.role !== 'admin') {
+      throw new Error('担当者にはエージェントまたは管理者のみ設定できます');
+    }
     newName = user.name;
   }
 

--- a/src/features/tickets/components/AssigneeSelect.tsx
+++ b/src/features/tickets/components/AssigneeSelect.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useTransition } from 'react';
+import { updateTicketAssignee } from '@/features/tickets/actions/update-ticket';
+
+type Agent = { id: string; name: string };
+
+interface Props {
+  ticketId: string;
+  currentAssigneeId: string | null;
+  agents: Agent[];
+}
+
+export function AssigneeSelect({ ticketId, currentAssigneeId, agents }: Props) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const val = e.target.value;
+    startTransition(() => updateTicketAssignee(ticketId, val || null));
+  }
+
+  return (
+    <select
+      value={currentAssigneeId ?? ''}
+      onChange={handleChange}
+      disabled={isPending}
+      className="rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none disabled:opacity-50"
+    >
+      <option value="">未割当</option>
+      {agents.map((a) => (
+        <option key={a.id} value={a.id}>{a.name}</option>
+      ))}
+    </select>
+  );
+}

--- a/src/features/tickets/components/CommentForm.tsx
+++ b/src/features/tickets/components/CommentForm.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useRef, useTransition } from 'react';
+import { addComment } from '@/features/tickets/actions/update-ticket';
+
+interface Props {
+  ticketId: string;
+}
+
+export function CommentForm({ ticketId }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const body = ref.current?.value.trim() ?? '';
+    if (!body) return;
+
+    startTransition(async () => {
+      await addComment(ticketId, body);
+      if (ref.current) ref.current.value = '';
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <textarea
+        ref={ref}
+        rows={3}
+        required
+        placeholder="コメントを入力してください"
+        className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+      />
+      <button
+        type="submit"
+        disabled={isPending}
+        className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+      >
+        {isPending ? '送信中...' : 'コメントを投稿'}
+      </button>
+    </form>
+  );
+}

--- a/src/features/tickets/components/PrioritySelect.tsx
+++ b/src/features/tickets/components/PrioritySelect.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useTransition } from 'react';
+import { updateTicketPriority } from '@/features/tickets/actions/update-ticket';
+import { PRIORITY_LABELS } from '@/lib/constants';
+import type { Priority } from '@/generated/prisma';
+
+const ALL_PRIORITIES: Priority[] = ['Low', 'Medium', 'High'];
+
+interface Props {
+  ticketId: string;
+  current: Priority;
+}
+
+export function PrioritySelect({ ticketId, current }: Props) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const next = e.target.value as Priority;
+    startTransition(() => updateTicketPriority(ticketId, next));
+  }
+
+  return (
+    <select
+      value={current}
+      onChange={handleChange}
+      disabled={isPending}
+      className="rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none disabled:opacity-50"
+    >
+      {ALL_PRIORITIES.map((p) => (
+        <option key={p} value={p}>{PRIORITY_LABELS[p] ?? p}</option>
+      ))}
+    </select>
+  );
+}

--- a/src/features/tickets/components/StatusSelect.tsx
+++ b/src/features/tickets/components/StatusSelect.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useTransition } from 'react';
+import { updateTicketStatus } from '@/features/tickets/actions/update-ticket';
+import { STATUS_LABELS } from '@/lib/constants';
+import type { TicketStatus } from '@/generated/prisma';
+
+const ALL_STATUSES: TicketStatus[] = [
+  'New', 'Open', 'WaitingForUser', 'InProgress', 'Escalated', 'Resolved', 'Closed',
+];
+
+interface Props {
+  ticketId: string;
+  current: TicketStatus;
+}
+
+export function StatusSelect({ ticketId, current }: Props) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const next = e.target.value as TicketStatus;
+    startTransition(() => updateTicketStatus(ticketId, next));
+  }
+
+  return (
+    <select
+      value={current}
+      onChange={handleChange}
+      disabled={isPending}
+      className="rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none disabled:opacity-50"
+    >
+      {ALL_STATUSES.map((s) => (
+        <option key={s} value={s}>{STATUS_LABELS[s] ?? s}</option>
+      ))}
+    </select>
+  );
+}

--- a/src/features/tickets/components/TicketForm.tsx
+++ b/src/features/tickets/components/TicketForm.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { createTicketSchema, type CreateTicketInput } from '@/lib/validations/ticket';
+
+type Category = { id: string; name: string };
+
+interface Props {
+  categories: Category[];
+}
+
+export function TicketForm({ categories }: Props) {
+  const router = useRouter();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<CreateTicketInput>({
+    resolver: zodResolver(createTicketSchema),
+    defaultValues: { priority: 'Medium' as const },
+  });
+
+  async function onSubmit(data: CreateTicketInput) {
+    const res = await fetch('/api/tickets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+
+    if (!res.ok) {
+      const err = await res.json();
+      alert(err.error ?? '登録に失敗しました');
+      return;
+    }
+
+    const ticket = await res.json();
+    router.push(`/tickets/${ticket.id}`);
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+      {/* Title */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700">
+          タイトル <span className="text-red-500">*</span>
+        </label>
+        <input
+          {...register('title')}
+          type="text"
+          className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+          placeholder="件名を入力してください"
+        />
+        {errors.title && <p className="mt-1 text-xs text-red-600">{errors.title.message}</p>}
+      </div>
+
+      {/* Body */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700">
+          内容 <span className="text-red-500">*</span>
+        </label>
+        <textarea
+          {...register('body')}
+          rows={6}
+          className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+          placeholder="問い合わせ内容を入力してください"
+        />
+        {errors.body && <p className="mt-1 text-xs text-red-600">{errors.body.message}</p>}
+      </div>
+
+      {/* Category */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700">カテゴリ</label>
+        <select
+          {...register('categoryId')}
+          className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+        >
+          <option value="">選択しない</option>
+          {categories.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Priority */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700">優先度</label>
+        <select
+          {...register('priority')}
+          className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+        >
+          <option value="Low">低</option>
+          <option value="Medium">中</option>
+          <option value="High">高</option>
+        </select>
+      </div>
+
+      {/* Actions */}
+      <div className="flex gap-3">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {isSubmitting ? '登録中...' : '登録する'}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="rounded-md border border-gray-300 px-5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          キャンセル
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,31 @@
+export const STATUS_LABELS: Record<string, string> = {
+  New: '新規',
+  Open: 'オープン',
+  WaitingForUser: 'ユーザー待ち',
+  InProgress: '対応中',
+  Escalated: 'エスカレーション',
+  Resolved: '解決済み',
+  Closed: 'クローズ',
+};
+
+export const PRIORITY_LABELS: Record<string, string> = {
+  Low: '低',
+  Medium: '中',
+  High: '高',
+};
+
+export const STATUS_COLORS: Record<string, string> = {
+  New: 'bg-gray-100 text-gray-700',
+  Open: 'bg-blue-100 text-blue-700',
+  WaitingForUser: 'bg-yellow-100 text-yellow-700',
+  InProgress: 'bg-indigo-100 text-indigo-700',
+  Escalated: 'bg-red-100 text-red-700',
+  Resolved: 'bg-green-100 text-green-700',
+  Closed: 'bg-gray-100 text-gray-500',
+};
+
+export const PRIORITY_COLORS: Record<string, string> = {
+  Low: 'text-gray-500',
+  Medium: 'text-yellow-600',
+  High: 'text-red-600 font-semibold',
+};

--- a/src/lib/ticket-history.ts
+++ b/src/lib/ticket-history.ts
@@ -1,0 +1,14 @@
+import { prisma } from '@/lib/prisma';
+import type { HistoryField } from '@/generated/prisma';
+
+export async function recordHistory(
+  ticketId: string,
+  changedById: string,
+  field: HistoryField,
+  oldValue: string | null,
+  newValue: string | null,
+) {
+  await prisma.ticketHistory.create({
+    data: { ticketId, changedById, field, oldValue, newValue },
+  });
+}

--- a/src/lib/validations/ticket.ts
+++ b/src/lib/validations/ticket.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const createTicketSchema = z.object({
   title: z.string().min(1, 'タイトルは必須です').max(200, 'タイトルは200文字以内で入力してください'),
   body: z.string().min(1, '内容は必須です'),
-  categoryId: z.string().optional(),
+  categoryId: z.string().optional().transform((v) => v || undefined),
   priority: z.enum(['Low', 'Medium', 'High']),
 });
 

--- a/src/lib/validations/ticket.ts
+++ b/src/lib/validations/ticket.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 export const createTicketSchema = z.object({
   title: z.string().min(1, 'タイトルは必須です').max(200, 'タイトルは200文字以内で入力してください'),
   body: z.string().min(1, '内容は必須です'),
-  categoryId: z.string().cuid().optional().or(z.literal('')).transform((v) => v || undefined),
-  priority: z.enum(['Low', 'Medium', 'High']).default('Medium'),
+  categoryId: z.string().optional(),
+  priority: z.enum(['Low', 'Medium', 'High']),
 });
 
 export type CreateTicketInput = z.infer<typeof createTicketSchema>;

--- a/src/lib/validations/ticket.ts
+++ b/src/lib/validations/ticket.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const createTicketSchema = z.object({
+  title: z.string().min(1, 'タイトルは必須です').max(200, 'タイトルは200文字以内で入力してください'),
+  body: z.string().min(1, '内容は必須です'),
+  categoryId: z.string().cuid().optional().or(z.literal('')).transform((v) => v || undefined),
+  priority: z.enum(['Low', 'Medium', 'High']).default('Medium'),
+});
+
+export type CreateTicketInput = z.infer<typeof createTicketSchema>;


### PR DESCRIPTION
## 概要

第1群・第2群の Issue を実装し、HelpDesk Hub の MVP を構築しました。

---

## 第1群：プロジェクト基盤

| Issue | 内容 |
|-------|------|
| #4 | Next.js 15 + React 19 + Tailwind CSS v4 + ESLint + Prettier 初期構成 |
| #5 | Prisma 5 + PostgreSQL セットアップ、`src/lib/prisma.ts` singleton |
| #7 | Auth.js v5 (Credentials) ログイン・ログアウト・middleware による保護 |
| #8 | User モデル（Role: requester / agent / admin）+ seed スクリプト |
| #9 | Ticket / TicketComment / TicketHistory / Category の Prisma スキーマ |
| #6 | Sidebar + Header 共通レイアウト、`(app)` ルートグループ |

## 第2群：チケット管理 MVP

| Issue | 内容 |
|-------|------|
| #14 | Category seed（6種）+ サンプルチケット |
| #12 | `POST /api/tickets` 登録 API（Zod バリデーション、認証チェック） |
| #13 | `/tickets/new` 登録フォーム（react-hook-form + Zod） |
| #10 | `/tickets` 一覧ページ（テーブル、ステータス・優先度バッジ） |
| #11 | `/tickets/[id]` 詳細ページ（本文・コメント・履歴・サイドバー） |
| #15 | ステータス更新（Server Action + `useTransition`） |
| #16 | 優先度更新（同上） |
| #17 | 担当者アサイン（agent/admin ユーザー選択） |
| #18 | コメント投稿（textarea → DB 保存 → 一覧表示） |
| #19 | 変更履歴記録（`TicketHistory` への自動書き込み） |
| #20 | 変更履歴表示（詳細ページ内、変更者・日時・前後の値） |

---

## 主な技術的決定

- **Prisma 5**（v7 の破壊的変更を避けるため安定版を選択）
- **Server Actions** でステータス・優先度・担当者・コメント更新を実装（API ルート不要）
- **`useTransition`** でローディング中の UI フィードバックを提供
- **`(app)` ルートグループ**でログイン画面と保護画面のレイアウトを分離
- Prisma 生成コード出力先を `src/generated/prisma/` に統一

## ローカル起動手順

```bash
# .env を設定（DATABASE_URL, NEXTAUTH_SECRET, NEXTAUTH_URL）
cp .env.example .env

# DB マイグレーション + seed
npx prisma migrate dev
npm run db:seed

# 開発サーバー起動
npm run dev
```

デフォルトパスワード：`password123`