### PR TITLE
feat: 第4群 実装（ダッシュボード・FAQ候補・通知・シードデータ）

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,19 @@ enum HistoryField {
   escalation
 }
 
+enum FaqStatus {
+  Candidate
+  Published
+  Rejected
+}
+
+enum NotificationType {
+  assigned
+  escalated
+  commented
+  statusChanged
+}
+
 // ─────────────────────────────────────────────
 // User
 // ─────────────────────────────────────────────
@@ -62,6 +75,8 @@ model User {
   assignedTickets Ticket[]        @relation("TicketAssignee")
   comments        TicketComment[]
   histories       TicketHistory[]
+  faqCandidates   FaqCandidate[]
+  notifications   Notification[]
 }
 
 // ─────────────────────────────────────────────
@@ -105,11 +120,50 @@ model Ticket {
   categoryId   String?
 
   // Relations
-  creator    User          @relation("TicketCreator", fields: [creatorId], references: [id])
-  assignee   User?         @relation("TicketAssignee", fields: [assigneeId], references: [id])
-  category   Category?     @relation(fields: [categoryId], references: [id])
-  comments   TicketComment[]
-  histories  TicketHistory[]
+  creator       User           @relation("TicketCreator", fields: [creatorId], references: [id])
+  assignee      User?          @relation("TicketAssignee", fields: [assigneeId], references: [id])
+  category      Category?      @relation(fields: [categoryId], references: [id])
+  comments      TicketComment[]
+  histories     TicketHistory[]
+  faqCandidate  FaqCandidate?
+  notifications Notification[]
+}
+
+// ─────────────────────────────────────────────
+// FaqCandidate
+// ─────────────────────────────────────────────
+
+model FaqCandidate {
+  id        String    @id @default(cuid())
+  question  String
+  answer    String
+  status    FaqStatus @default(Candidate)
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  ticketId    String @unique
+  createdById String
+
+  ticket    Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  createdBy User   @relation(fields: [createdById], references: [id])
+}
+
+// ─────────────────────────────────────────────
+// Notification
+// ─────────────────────────────────────────────
+
+model Notification {
+  id        String           @id @default(cuid())
+  type      NotificationType
+  message   String
+  read      Boolean          @default(false)
+  createdAt DateTime         @default(now())
+
+  userId   String
+  ticketId String?
+
+  user   User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  ticket Ticket? @relation(fields: [ticketId], references: [id], onDelete: SetNull)
 }
 
 // ─────────────────────────────────────────────

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -19,118 +19,247 @@ async function main() {
   const requester1 = await prisma.user.upsert({
     where: { email: 'requester1@example.com' },
     update: {},
-    create: {
-      email: 'requester1@example.com',
-      name: '田中 花子',
-      passwordHash: password,
-      role: Role.requester,
-    },
+    create: { email: 'requester1@example.com', name: '田中 花子', passwordHash: password, role: Role.requester },
   });
-
   const requester2 = await prisma.user.upsert({
     where: { email: 'requester2@example.com' },
     update: {},
-    create: {
-      email: 'requester2@example.com',
-      name: '鈴木 一郎',
-      passwordHash: password,
-      role: Role.requester,
-    },
+    create: { email: 'requester2@example.com', name: '鈴木 一郎', passwordHash: password, role: Role.requester },
   });
-
+  const requester3 = await prisma.user.upsert({
+    where: { email: 'requester3@example.com' },
+    update: {},
+    create: { email: 'requester3@example.com', name: '伊藤 直子', passwordHash: password, role: Role.requester },
+  });
   const agent1 = await prisma.user.upsert({
     where: { email: 'agent1@example.com' },
     update: {},
-    create: {
-      email: 'agent1@example.com',
-      name: '佐藤 健太',
-      passwordHash: password,
-      role: Role.agent,
-    },
+    create: { email: 'agent1@example.com', name: '佐藤 健太', passwordHash: password, role: Role.agent },
   });
-
-  await prisma.user.upsert({
+  const agent2 = await prisma.user.upsert({
     where: { email: 'agent2@example.com' },
     update: {},
-    create: {
-      email: 'agent2@example.com',
-      name: '山田 美咲',
-      passwordHash: password,
-      role: Role.agent,
-    },
+    create: { email: 'agent2@example.com', name: '山田 美咲', passwordHash: password, role: Role.agent },
   });
-
-  await prisma.user.upsert({
+  const agent3 = await prisma.user.upsert({
+    where: { email: 'agent3@example.com' },
+    update: {},
+    create: { email: 'agent3@example.com', name: '中村 大輔', passwordHash: password, role: Role.agent },
+  });
+  const admin = await prisma.user.upsert({
     where: { email: 'admin@example.com' },
     update: {},
-    create: {
-      email: 'admin@example.com',
-      name: '管理者',
-      passwordHash: password,
-      role: Role.admin,
-    },
+    create: { email: 'admin@example.com', name: '管理者', passwordHash: password, role: Role.admin },
   });
 
   console.log('✅ Users seeded');
 
   // ── Categories ───────────────────────────────────────
-  const categories: Record<string, { id: string }> = {};
+  const cats: Record<string, { id: string }> = {};
   for (const name of CATEGORIES) {
-    const cat = await prisma.category.upsert({
-      where: { name },
-      update: {},
-      create: { name },
-    });
-    categories[name] = cat;
+    cats[name] = await prisma.category.upsert({ where: { name }, update: {}, create: { name } });
   }
-
   console.log('✅ Categories seeded');
 
-  // ── Sample tickets ───────────────────────────────────
-  await prisma.ticket.createMany({
-    skipDuplicates: true,
-    data: [
-      {
-        id: 'seed-ticket-1',
-        title: 'VPN に接続できない',
-        body: '昨日からVPNへの接続がタイムアウトします。社内ネットワークへのアクセスが必要です。',
-        status: 'New',
-        priority: 'High',
-        creatorId: requester1.id,
-        categoryId: categories['ネットワーク・接続'].id,
-      },
-      {
-        id: 'seed-ticket-2',
-        title: 'パスワードを忘れてしまいました',
-        body: 'メールにリセットリンクが届きません。急ぎで対応をお願いします。',
-        status: 'Open',
-        priority: 'Medium',
-        creatorId: requester2.id,
-        assigneeId: agent1.id,
-        categoryId: categories['アカウント・認証'].id,
-      },
-      {
-        id: 'seed-ticket-3',
-        title: 'プリンターが認識されない',
-        body: '共有プリンターに印刷しようとすると「プリンターが見つかりません」と表示されます。',
-        status: 'Resolved',
-        priority: 'Low',
-        creatorId: requester1.id,
-        assigneeId: agent1.id,
-        categoryId: categories['ハードウェア'].id,
-      },
-    ],
-  });
+  const now = new Date();
+  const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const threeDaysAgo = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000);
+  const twoDaysLater = new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000);
+  const tenHoursLater = new Date(now.getTime() + 10 * 60 * 60 * 1000);
 
-  console.log('✅ Sample tickets seeded');
-  console.log('\nSeed completed! Default password: password123');
+  // ── Tickets ──────────────────────────────────────────
+  const ticketDefs = [
+    {
+      id: 'seed-t-01',
+      title: 'VPN に接続できない',
+      body: '昨日からVPNへの接続がタイムアウトします。社内ネットワークへのアクセスが必要です。',
+      status: 'New' as const,
+      priority: 'High' as const,
+      creatorId: requester1.id,
+      categoryId: cats['ネットワーク・接続'].id,
+    },
+    {
+      id: 'seed-t-02',
+      title: 'パスワードを忘れてしまいました',
+      body: 'メールにリセットリンクが届きません。急ぎで対応をお願いします。',
+      status: 'Open' as const,
+      priority: 'Medium' as const,
+      creatorId: requester2.id,
+      assigneeId: agent1.id,
+      categoryId: cats['アカウント・認証'].id,
+    },
+    {
+      id: 'seed-t-03',
+      title: 'プリンターが認識されない',
+      body: '共有プリンターに印刷しようとすると「プリンターが見つかりません」と表示されます。',
+      status: 'Resolved' as const,
+      priority: 'Low' as const,
+      creatorId: requester1.id,
+      assigneeId: agent1.id,
+      categoryId: cats['ハードウェア'].id,
+      resolvedAt: yesterday,
+    },
+    {
+      id: 'seed-t-04',
+      title: 'Slack の通知が来ない',
+      body: 'PCを再起動してから Slack のプッシュ通知が届かなくなりました。',
+      status: 'InProgress' as const,
+      priority: 'Medium' as const,
+      creatorId: requester3.id,
+      assigneeId: agent2.id,
+      categoryId: cats['ソフトウェア・アプリ'].id,
+      resolutionDueAt: twoDaysLater,
+    },
+    {
+      id: 'seed-t-05',
+      title: '不審なメールが届いた',
+      body: '添付ファイル付きの不審なメールが届きました。開いてしまいましたが問題ないでしょうか？',
+      status: 'Escalated' as const,
+      priority: 'High' as const,
+      creatorId: requester2.id,
+      assigneeId: agent3.id,
+      categoryId: cats['セキュリティ'].id,
+      escalatedAt: yesterday,
+      escalationReason: 'セキュリティインシデントの可能性があるため二次対応へ',
+      resolutionDueAt: yesterday,
+    },
+    {
+      id: 'seed-t-06',
+      title: 'ファイルサーバーにアクセスできない',
+      body: '今朝から社内ファイルサーバーへの接続が拒否されます。',
+      status: 'WaitingForUser' as const,
+      priority: 'High' as const,
+      creatorId: requester1.id,
+      assigneeId: agent1.id,
+      categoryId: cats['ネットワーク・接続'].id,
+      resolutionDueAt: tenHoursLater,
+    },
+    {
+      id: 'seed-t-07',
+      title: 'Excel が起動しない',
+      body: 'Windows Update 後から Excel が起動しません。エラーコード 0x80004005 が表示されます。',
+      status: 'New' as const,
+      priority: 'Medium' as const,
+      creatorId: requester3.id,
+      categoryId: cats['ソフトウェア・アプリ'].id,
+    },
+    {
+      id: 'seed-t-08',
+      title: 'ノートPCのバッテリーが急速に減る',
+      body: '先週から充電が 2 時間しか持たなくなりました。',
+      status: 'Resolved' as const,
+      priority: 'Low' as const,
+      creatorId: requester2.id,
+      assigneeId: agent2.id,
+      categoryId: cats['ハードウェア'].id,
+      resolvedAt: threeDaysAgo,
+    },
+    {
+      id: 'seed-t-09',
+      title: '二要素認証が設定できない',
+      body: '認証アプリのQRコードをスキャンしてもコードが生成されません。',
+      status: 'Open' as const,
+      priority: 'Medium' as const,
+      creatorId: requester1.id,
+      assigneeId: agent3.id,
+      categoryId: cats['アカウント・認証'].id,
+      resolutionDueAt: twoDaysLater,
+    },
+    {
+      id: 'seed-t-10',
+      title: 'リモートデスクトップが接続できない',
+      body: 'VPN 経由でリモートデスクトップ接続しようとすると認証エラーになります。',
+      status: 'Closed' as const,
+      priority: 'Medium' as const,
+      creatorId: requester3.id,
+      assigneeId: agent1.id,
+      categoryId: cats['ネットワーク・接続'].id,
+      resolvedAt: threeDaysAgo,
+    },
+  ];
+
+  for (const def of ticketDefs) {
+    await prisma.ticket.upsert({
+      where: { id: def.id },
+      update: {},
+      create: def,
+    });
+  }
+
+  console.log('✅ Tickets seeded');
+
+  // ── Comments ─────────────────────────────────────────
+  const commentDefs = [
+    { ticketId: 'seed-t-02', authorId: agent1.id, body: '確認します。メールアドレスを教えてください。' },
+    { ticketId: 'seed-t-02', authorId: requester2.id, body: 'suzuki@example.com です。よろしくお願いします。' },
+    { ticketId: 'seed-t-03', authorId: agent1.id, body: 'ドライバを再インストールしたところ認識されました。' },
+    { ticketId: 'seed-t-05', authorId: agent3.id, body: '添付ファイルをスキャンしました。マルウェアは検出されませんでしたが念のためパスワードの変更を推奨します。' },
+    { ticketId: 'seed-t-06', authorId: agent1.id, body: 'アクセス権限の設定を確認します。マシン名を教えてください。' },
+    { ticketId: 'seed-t-06', authorId: requester1.id, body: 'PC-TANAKA-001 です。' },
+  ];
+
+  for (const c of commentDefs) {
+    const exists = await prisma.ticketComment.findFirst({
+      where: { ticketId: c.ticketId, authorId: c.authorId, body: c.body },
+    });
+    if (!exists) await prisma.ticketComment.create({ data: c });
+  }
+
+  console.log('✅ Comments seeded');
+
+  // ── Histories ─────────────────────────────────────────
+  const historyDefs = [
+    { ticketId: 'seed-t-02', changedById: admin.id, field: 'assignee' as const, oldValue: null, newValue: agent1.name },
+    { ticketId: 'seed-t-03', changedById: agent1.id, field: 'status' as const, oldValue: 'Open', newValue: 'Resolved' },
+    { ticketId: 'seed-t-05', changedById: agent3.id, field: 'escalation' as const, oldValue: 'InProgress', newValue: 'Escalated' },
+    { ticketId: 'seed-t-09', changedById: admin.id, field: 'assignee' as const, oldValue: null, newValue: agent3.name },
+  ];
+
+  for (const h of historyDefs) {
+    const exists = await prisma.ticketHistory.findFirst({
+      where: { ticketId: h.ticketId, changedById: h.changedById, field: h.field },
+    });
+    if (!exists) await prisma.ticketHistory.create({ data: h });
+  }
+
+  console.log('✅ Histories seeded');
+
+  // ── FAQ Candidate ────────────────────────────────────
+  const faqExists = await prisma.faqCandidate.findFirst({ where: { ticketId: 'seed-t-03' } });
+  if (!faqExists) {
+    await prisma.faqCandidate.create({
+      data: {
+        ticketId: 'seed-t-03',
+        createdById: agent1.id,
+        question: '共有プリンターで「プリンターが見つかりません」と表示される',
+        answer: 'プリンタードライバを削除し、最新のドライバを再インストールすることで解決します。[コントロールパネル] → [デバイスとプリンター] → 対象プリンターを右クリックして削除後、再度追加してください。',
+        status: 'Published',
+      },
+    });
+  }
+
+  const faqExists2 = await prisma.faqCandidate.findFirst({ where: { ticketId: 'seed-t-08' } });
+  if (!faqExists2) {
+    await prisma.faqCandidate.create({
+      data: {
+        ticketId: 'seed-t-08',
+        createdById: agent2.id,
+        question: 'ノートPCのバッテリーの持ちが急に悪くなった',
+        answer: 'バッテリーのキャリブレーションを実施してください。完全放電後に満充電することで正確な残量表示が回復します。改善しない場合はバッテリー交換が必要です。',
+        status: 'Candidate',
+      },
+    });
+  }
+
+  console.log('✅ FAQ candidates seeded');
+  console.log('\nSeed completed!\nDefault password: password123');
+  console.log('Users:', [
+    'requester1@example.com', 'requester2@example.com', 'requester3@example.com',
+    'agent1@example.com', 'agent2@example.com', 'agent3@example.com',
+    'admin@example.com',
+  ].join(', '));
 }
 
 main()
-  .catch((e) => {
-    console.error(e);
-    process.exit(1);
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-  });
+  .catch((e) => { console.error(e); process.exit(1); })
+  .finally(async () => { await prisma.$disconnect(); });

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,8 +1,155 @@
-export default function DashboardPage() {
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { STATUS_LABELS, STATUS_COLORS } from '@/lib/constants';
+
+export default async function DashboardPage() {
+  const session = await auth();
+  if (!session?.user?.id) return null;
+
+  const isAgent = session.user.role === 'agent' || session.user.role === 'admin';
+
+  // Base filter for RBAC
+  const baseWhere = isAgent ? {} : { creatorId: session.user.id };
+
+  const now = new Date();
+
+  const [
+    newCount,
+    openCount,
+    inProgressCount,
+    escalatedCount,
+    resolvedCount,
+    waitingCount,
+    slaOverdueCount,
+    workload,
+  ] = await Promise.all([
+    prisma.ticket.count({ where: { ...baseWhere, status: 'New' } }),
+    prisma.ticket.count({ where: { ...baseWhere, status: 'Open' } }),
+    prisma.ticket.count({ where: { ...baseWhere, status: 'InProgress' } }),
+    prisma.ticket.count({ where: { ...baseWhere, status: 'Escalated' } }),
+    prisma.ticket.count({ where: { ...baseWhere, status: 'Resolved' } }),
+    prisma.ticket.count({ where: { ...baseWhere, status: 'WaitingForUser' } }),
+    isAgent
+      ? prisma.ticket.count({
+          where: {
+            resolutionDueAt: { lt: now },
+            resolvedAt: null,
+            status: { notIn: ['Resolved', 'Closed'] },
+          },
+        })
+      : Promise.resolve(0),
+    isAgent
+      ? prisma.ticket.groupBy({
+          by: ['assigneeId'],
+          where: { status: { notIn: ['Resolved', 'Closed'] } },
+          _count: { id: true },
+          orderBy: { _count: { id: 'desc' } },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  // Resolve assignee names for workload
+  const assigneeIds = (workload as { assigneeId: string | null; _count: { id: number } }[])
+    .filter((w) => w.assigneeId !== null)
+    .map((w) => w.assigneeId as string);
+
+  const assigneeNames =
+    assigneeIds.length > 0
+      ? await prisma.user.findMany({
+          where: { id: { in: assigneeIds } },
+          select: { id: true, name: true },
+        })
+      : [];
+
+  const nameMap = Object.fromEntries(assigneeNames.map((u) => [u.id, u.name]));
+
+  const statCards = [
+    { label: '新規', status: 'New', count: newCount, color: STATUS_COLORS['New'] },
+    { label: 'オープン', status: 'Open', count: openCount, color: STATUS_COLORS['Open'] },
+    { label: 'ユーザー待ち', status: 'WaitingForUser', count: waitingCount, color: STATUS_COLORS['WaitingForUser'] },
+    { label: '対応中', status: 'InProgress', count: inProgressCount, color: STATUS_COLORS['InProgress'] },
+    { label: 'エスカレーション', status: 'Escalated', count: escalatedCount, color: STATUS_COLORS['Escalated'] },
+    { label: '解決済み', status: 'Resolved', count: resolvedCount, color: STATUS_COLORS['Resolved'] },
+  ];
+
   return (
-    <div>
-      <h1 className="mb-6 text-2xl font-bold text-gray-900">ダッシュボード</h1>
-      <p className="text-gray-500">ダッシュボードの内容はここに表示されます。</p>
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold text-gray-900">ダッシュボード</h1>
+
+      {/* Stats */}
+      <section>
+        <h2 className="mb-4 text-sm font-semibold text-gray-500">ステータス別件数</h2>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+          {statCards.map((card) => (
+            <Link
+              key={card.status}
+              href={`/tickets?status=${card.status}`}
+              className="rounded-lg bg-white p-4 shadow-sm transition hover:shadow-md"
+            >
+              <p className="text-2xl font-bold text-gray-900">{card.count}</p>
+              <span
+                className={`mt-1 inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${card.color}`}
+              >
+                {card.label}
+              </span>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* SLA overdue (agent/admin only) */}
+      {isAgent && (
+        <section>
+          <h2 className="mb-4 text-sm font-semibold text-gray-500">SLA 超過</h2>
+          <div className="w-40 rounded-lg bg-white p-4 shadow-sm">
+            <p className="text-2xl font-bold text-red-600">{slaOverdueCount}</p>
+            <p className="mt-1 text-xs text-gray-500">SLA 期限超過件数</p>
+          </div>
+        </section>
+      )}
+
+      {/* Workload by assignee (agent/admin only) */}
+      {isAgent && (workload as { assigneeId: string | null; _count: { id: number } }[]).length > 0 && (
+        <section>
+          <h2 className="mb-4 text-sm font-semibold text-gray-500">担当者別 未完了件数</h2>
+          <div className="overflow-hidden rounded-lg bg-white shadow-sm">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left font-medium text-gray-500">担当者</th>
+                  <th className="px-4 py-3 text-right font-medium text-gray-500">件数</th>
+                  <th className="px-4 py-3 text-right font-medium text-gray-500"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {(workload as { assigneeId: string | null; _count: { id: number } }[]).map((row) => {
+                  const name = row.assigneeId ? (nameMap[row.assigneeId] ?? '不明') : '未割当';
+                  const query = row.assigneeId
+                    ? `assigneeId=${row.assigneeId}`
+                    : 'assigneeId=unassigned';
+                  return (
+                    <tr key={row.assigneeId ?? 'unassigned'} className="hover:bg-gray-50">
+                      <td className="px-4 py-3 text-gray-700">{name}</td>
+                      <td className="px-4 py-3 text-right font-semibold text-gray-900">
+                        {row._count.id}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <Link
+                          href={`/tickets?${query}`}
+                          className="text-xs text-blue-600 hover:underline"
+                        >
+                          一覧を見る
+                        </Link>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/src/app/(app)/faq/page.tsx
+++ b/src/app/(app)/faq/page.tsx
@@ -1,0 +1,98 @@
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { notFound } from 'next/navigation';
+import { updateFaqStatus } from '@/features/faq/actions/faq-actions';
+
+const STATUS_LABELS: Record<string, string> = {
+  Candidate: '候補',
+  Published: '公開済み',
+  Rejected: '却下',
+};
+const STATUS_COLORS: Record<string, string> = {
+  Candidate: 'bg-yellow-100 text-yellow-700',
+  Published: 'bg-green-100 text-green-700',
+  Rejected: 'bg-gray-100 text-gray-500',
+};
+
+export default async function FaqPage() {
+  const session = await auth();
+  if (!session?.user?.id) return null;
+  if (session.user.role !== 'agent' && session.user.role !== 'admin') notFound();
+
+  const faqs = await prisma.faqCandidate.findMany({
+    orderBy: { createdAt: 'desc' },
+    include: {
+      ticket: { select: { id: true, title: true } },
+      createdBy: { select: { name: true } },
+    },
+  });
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">FAQ候補一覧</h1>
+
+      {faqs.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-gray-300 py-16 text-center text-gray-400">
+          FAQ候補はまだありません
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {faqs.map((faq) => (
+            <div key={faq.id} className="rounded-lg bg-white p-5 shadow-sm">
+              <div className="mb-2 flex items-center justify-between">
+                <span
+                  className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[faq.status] ?? ''}`}
+                >
+                  {STATUS_LABELS[faq.status] ?? faq.status}
+                </span>
+                <span className="text-xs text-gray-400">
+                  登録者: {faq.createdBy.name} / 元チケット:{' '}
+                  <a
+                    href={`/tickets/${faq.ticket.id}`}
+                    className="text-blue-600 hover:underline"
+                  >
+                    {faq.ticket.title}
+                  </a>
+                </span>
+              </div>
+
+              <h3 className="mb-1 font-semibold text-gray-800">Q. {faq.question}</h3>
+              <p className="whitespace-pre-wrap text-sm text-gray-600">A. {faq.answer}</p>
+
+              {faq.status === 'Candidate' && (
+                <div className="mt-3 flex gap-2">
+                  <form
+                    action={async () => {
+                      'use server';
+                      await updateFaqStatus(faq.id, 'Published');
+                    }}
+                  >
+                    <button
+                      type="submit"
+                      className="rounded-md bg-green-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-700"
+                    >
+                      公開する
+                    </button>
+                  </form>
+                  <form
+                    action={async () => {
+                      'use server';
+                      await updateFaqStatus(faq.id, 'Rejected');
+                    }}
+                  >
+                    <button
+                      type="submit"
+                      className="rounded-md border border-gray-300 px-3 py-1.5 text-xs text-gray-600 hover:bg-gray-50"
+                    >
+                      却下
+                    </button>
+                  </form>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -1,0 +1,75 @@
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { markAllRead } from '@/features/notifications/actions/notification-actions';
+
+const TYPE_LABELS: Record<string, string> = {
+  assigned: '担当割当',
+  escalated: 'エスカレーション',
+  commented: 'コメント',
+  statusChanged: 'ステータス変更',
+};
+
+export default async function NotificationsPage() {
+  const session = await auth();
+  if (!session?.user?.id) return null;
+
+  const notifications = await prisma.notification.findMany({
+    where: { userId: session.user.id },
+    orderBy: { createdAt: 'desc' },
+    take: 50,
+    include: { ticket: { select: { id: true, title: true } } },
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">通知</h1>
+        {notifications.some((n) => !n.read) && (
+          <form action={markAllRead}>
+            <button
+              type="submit"
+              className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
+            >
+              すべて既読にする
+            </button>
+          </form>
+        )}
+      </div>
+
+      {notifications.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-gray-300 py-16 text-center text-gray-400">
+          通知はありません
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {notifications.map((n) => (
+            <li
+              key={n.id}
+              className={`rounded-lg bg-white p-4 shadow-sm ${!n.read ? 'border-l-4 border-blue-500' : ''}`}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <span className="mr-2 inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+                    {TYPE_LABELS[n.type] ?? n.type}
+                  </span>
+                  <span className="text-sm text-gray-800">{n.message}</span>
+                  {n.ticket && (
+                    <a
+                      href={`/tickets/${n.ticket.id}`}
+                      className="ml-2 text-xs text-blue-600 hover:underline"
+                    >
+                      チケットを見る
+                    </a>
+                  )}
+                </div>
+                <span className="shrink-0 text-xs text-gray-400">
+                  {n.createdAt.toLocaleString('ja-JP')}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/tickets/[id]/page.tsx
+++ b/src/app/(app)/tickets/[id]/page.tsx
@@ -9,6 +9,7 @@ import { CommentForm } from '@/features/tickets/components/CommentForm';
 import { EscalationForm } from '@/features/tickets/components/EscalationForm';
 import { getSlaState, SLA_LABELS, SLA_COLORS } from '@/lib/sla';
 import { getAllowedTransitions } from '@/domain/ticket-status';
+import { FaqCandidateForm } from '@/features/faq/components/FaqCandidateForm';
 
 const HISTORY_FIELD_LABELS: Record<string, string> = {
   status: 'ステータス',
@@ -43,6 +44,7 @@ export default async function TicketDetailPage({ params }: Props) {
           orderBy: { createdAt: 'desc' },
           include: { changedBy: { select: { id: true, name: true } } },
         },
+        faqCandidate: { select: { id: true } },
       },
     }),
     isAgent
@@ -61,6 +63,7 @@ export default async function TicketDetailPage({ params }: Props) {
 
   const slaState = getSlaState(ticket.resolutionDueAt, ticket.resolvedAt);
   const canEscalate = isAgent && getAllowedTransitions(ticket.status).includes('Escalated');
+  const canAddFaq = isAgent && ticket.status === 'Resolved' && !ticket.faqCandidate;
 
   return (
     <div className="mx-auto max-w-4xl space-y-6">
@@ -245,6 +248,22 @@ export default async function TicketDetailPage({ params }: Props) {
                   <dd className="mt-1">
                     <EscalationForm ticketId={ticket.id} />
                   </dd>
+                </div>
+              )}
+
+              {/* FAQ candidate */}
+              {canAddFaq && (
+                <div>
+                  <dt className="font-medium text-gray-500">FAQ候補</dt>
+                  <dd className="mt-1">
+                    <FaqCandidateForm ticketId={ticket.id} ticketTitle={ticket.title} />
+                  </dd>
+                </div>
+              )}
+              {ticket.faqCandidate && (
+                <div>
+                  <dt className="font-medium text-gray-500">FAQ候補</dt>
+                  <dd className="mt-1 text-xs text-green-600">登録済み</dd>
                 </div>
               )}
             </dl>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,15 @@
+import Link from 'next/link';
 import { auth, signOut } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
 
 export async function Header() {
   const session = await auth();
+
+  const unreadCount = session?.user?.id
+    ? await prisma.notification.count({
+        where: { userId: session.user.id, read: false },
+      })
+    : 0;
 
   return (
     <header className="flex h-14 items-center justify-between border-b border-gray-200 bg-white px-6">
@@ -9,6 +17,14 @@ export async function Header() {
       <div className="flex items-center gap-4">
         {session?.user && (
           <>
+            <Link href="/notifications" className="relative text-sm text-gray-700 hover:text-gray-900">
+              通知
+              {unreadCount > 0 && (
+                <span className="absolute -right-2 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white">
+                  {unreadCount > 9 ? '9+' : unreadCount}
+                </span>
+              )}
+            </Link>
             <span className="text-sm text-gray-700">
               {session.user.name}（{session.user.role}）
             </span>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -7,6 +7,8 @@ const navItems = [
   { href: '/dashboard', label: 'ダッシュボード' },
   { href: '/tickets', label: '問い合わせ一覧' },
   { href: '/tickets/new', label: '新規登録' },
+  { href: '/faq', label: 'FAQ候補' },
+  { href: '/notifications', label: '通知' },
 ];
 
 export function Sidebar() {

--- a/src/features/faq/actions/faq-actions.ts
+++ b/src/features/faq/actions/faq-actions.ts
@@ -1,0 +1,41 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export async function createFaqCandidate(ticketId: string, question: string, answer: string) {
+  const session = await auth();
+  if (!session?.user?.id) throw new Error('Unauthorized');
+  if (session.user.role !== 'agent' && session.user.role !== 'admin') {
+    throw new Error('エージェントまたは管理者のみ実行できます');
+  }
+
+  const ticket = await prisma.ticket.findUniqueOrThrow({ where: { id: ticketId } });
+  if (ticket.status !== 'Resolved') {
+    throw new Error('解決済みチケットのみFAQ候補に変換できます');
+  }
+
+  await prisma.faqCandidate.create({
+    data: {
+      ticketId,
+      createdById: session.user.id,
+      question: question.trim(),
+      answer: answer.trim(),
+    },
+  });
+
+  revalidatePath(`/tickets/${ticketId}`);
+  revalidatePath('/faq');
+}
+
+export async function updateFaqStatus(faqId: string, status: 'Published' | 'Rejected') {
+  const session = await auth();
+  if (!session?.user?.id) throw new Error('Unauthorized');
+  if (session.user.role !== 'agent' && session.user.role !== 'admin') {
+    throw new Error('エージェントまたは管理者のみ実行できます');
+  }
+
+  await prisma.faqCandidate.update({ where: { id: faqId }, data: { status } });
+  revalidatePath('/faq');
+}

--- a/src/features/faq/components/FaqCandidateForm.tsx
+++ b/src/features/faq/components/FaqCandidateForm.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useRef, useTransition, useState } from 'react';
+import { createFaqCandidate } from '@/features/faq/actions/faq-actions';
+
+interface Props {
+  ticketId: string;
+  ticketTitle: string;
+}
+
+export function FaqCandidateForm({ ticketId, ticketTitle }: Props) {
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const questionRef = useRef<HTMLTextAreaElement>(null);
+  const answerRef = useRef<HTMLTextAreaElement>(null);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const q = questionRef.current?.value.trim() ?? '';
+    const a = answerRef.current?.value.trim() ?? '';
+    if (!q || !a) return;
+
+    startTransition(async () => {
+      await createFaqCandidate(ticketId, q, a);
+      setOpen(false);
+    });
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="mt-2 rounded-md border border-blue-500 px-3 py-1.5 text-xs font-medium text-blue-600 hover:bg-blue-50"
+      >
+        FAQ候補に登録
+      </button>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-2 space-y-2">
+      <div>
+        <label className="block text-xs font-medium text-gray-600">質問</label>
+        <textarea
+          ref={questionRef}
+          rows={2}
+          required
+          defaultValue={ticketTitle}
+          className="block w-full rounded-md border border-gray-300 px-2 py-1.5 text-xs focus:border-blue-500 focus:outline-none"
+        />
+      </div>
+      <div>
+        <label className="block text-xs font-medium text-gray-600">回答</label>
+        <textarea
+          ref={answerRef}
+          rows={3}
+          required
+          placeholder="解決方法を入力してください"
+          className="block w-full rounded-md border border-gray-300 px-2 py-1.5 text-xs focus:border-blue-500 focus:outline-none"
+        />
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {isPending ? '登録中...' : '登録'}
+        </button>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="rounded-md border border-gray-300 px-3 py-1.5 text-xs text-gray-600 hover:bg-gray-50"
+        >
+          キャンセル
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/notifications/actions/notification-actions.ts
+++ b/src/features/notifications/actions/notification-actions.ts
@@ -1,0 +1,16 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export async function markAllRead() {
+  const session = await auth();
+  if (!session?.user?.id) throw new Error('Unauthorized');
+
+  await prisma.notification.updateMany({
+    where: { userId: session.user.id, read: false },
+    data: { read: true },
+  });
+  revalidatePath('/notifications');
+}

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { recordHistory } from '@/lib/ticket-history';
+import { createNotification } from '@/lib/notifications';
 import { isValidTransition } from '@/domain/ticket-status';
 import type { TicketStatus, Priority } from '@/generated/prisma';
 
@@ -64,6 +65,17 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
     data: { assigneeId: newAssigneeId },
   });
   await recordHistory(ticketId, session.user.id, 'assignee', oldName, newName);
+
+  // Notify the newly assigned agent
+  if (newAssigneeId) {
+    await createNotification(
+      newAssigneeId,
+      'assigned',
+      `チケット「${ticket.title}」の担当者に割り当てられました`,
+      ticketId,
+    );
+  }
+
   revalidatePath(`/tickets/${ticketId}`);
 }
 
@@ -87,6 +99,23 @@ export async function escalateTicket(ticketId: string, reason: string) {
     data: { status: 'Escalated', escalatedAt: now, escalationReason: reason.trim() },
   });
   await recordHistory(ticketId, session.user.id, 'escalation', ticket.status, 'Escalated');
+
+  // Notify all agents and admins
+  const agents = await prisma.user.findMany({
+    where: { role: { in: ['agent', 'admin'] } },
+    select: { id: true },
+  });
+  await Promise.all(
+    agents.map((a) =>
+      createNotification(
+        a.id,
+        'escalated',
+        `チケット「${ticket.title}」がエスカレーションされました`,
+        ticketId,
+      ),
+    ),
+  );
+
   revalidatePath(`/tickets/${ticketId}`);
 }
 

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,13 @@
+import { prisma } from '@/lib/prisma';
+import type { NotificationType } from '@/generated/prisma';
+
+export async function createNotification(
+  userId: string,
+  type: NotificationType,
+  message: string,
+  ticketId?: string,
+) {
+  await prisma.notification.create({
+    data: { userId, type, message, ticketId },
+  });
+}


### PR DESCRIPTION
## Summary

- **#29** ダッシュボード（`/dashboard`）— ステータス別件数カード（各カードから絞り込み一覧へリンク）
- **#30** 担当者別ワークロード可視化 — 未完了チケット件数を担当者ごとに集計・表示（未割当含む）
- **#31** FAQ候補機能 — `FaqCandidate` モデル、解決済みチケット詳細から登録、`/faq` ページで公開/却下管理
- **#32** 通知機能 — `Notification` モデル、アサイン時・エスカレーション時に自動作成、ヘッダーに未読バッジ、`/notifications` ページ
- **#33** デモ用シードデータ — requester×3・agent×3・admin×1、10チケット（各ステータス・SLA超過・エスカレーション含む）、コメント・履歴・FAQ候補付き

## Changed Files

| ファイル | 変更内容 |
|---|---|
| `prisma/schema.prisma` | `FaqCandidate` / `Notification` モデル + enum 追加 |
| `prisma/seed.ts` | リッチなデモデータに刷新 |
| `src/app/(app)/dashboard/page.tsx` | ダッシュボードページ（新規） |
| `src/app/(app)/faq/page.tsx` | FAQ候補一覧ページ（新規） |
| `src/app/(app)/notifications/page.tsx` | 通知一覧ページ（新規） |
| `src/features/faq/actions/faq-actions.ts` | FAQ Server Actions（新規） |
| `src/features/faq/components/FaqCandidateForm.tsx` | FAQ候補登録フォーム（新規） |
| `src/features/notifications/actions/notification-actions.ts` | 通知既読 Server Action（新規） |
| `src/lib/notifications.ts` | 通知作成ユーティリティ（新規） |
| `src/features/tickets/actions/update-ticket.ts` | アサイン・エスカレーション時の通知トリガー追加 |
| `src/app/(app)/tickets/[id]/page.tsx` | FAQ候補ボタン追加 |
| `src/components/layout/Header.tsx` | 未読通知バッジ追加 |
| `src/components/layout/Sidebar.tsx` | FAQ・通知ナビリンク追加 |

## Test plan

- [ ] `/dashboard` でステータス別件数カードが表示され、クリックで絞り込み一覧に遷移できることを確認
- [ ] ダッシュボードに担当者別未完了件数テーブルが表示されることを確認（agent ログイン時のみ）
- [ ] 解決済みチケット詳細で「FAQ候補に登録」ボタンが表示されることを確認（agent のみ）
- [ ] FAQ候補を登録後、`/faq` ページに表示されることを確認
- [ ] FAQ候補を「公開する」すると Published になることを確認
- [ ] アサイン変更後、担当者に通知が作成されることを確認
- [ ] エスカレーション後、全 agent/admin に通知が作成されることを確認
- [ ] ヘッダーに未読件数バッジが表示されることを確認
- [ ] `/notifications` で「すべて既読にする」後にバッジが消えることを確認
- [ ] `npx prisma db seed` 実行後に各画面のデータが確認できることを確認

https://claude.ai/code/session_01WMeRa1gJvD428GngPhEtpd