### PR TITLE
refactor: 第2回コードレビュー修正（定数集約・キャッシュ・バリデーション）

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -66,12 +66,12 @@ export default async function DashboardPage() {
   const nameMap = Object.fromEntries(assigneeNames.map((u) => [u.id, u.name]));
 
   const statCards = [
-    { label: '新規', status: 'New', count: newCount, color: STATUS_COLORS['New'] },
-    { label: 'オープン', status: 'Open', count: openCount, color: STATUS_COLORS['Open'] },
-    { label: 'ユーザー待ち', status: 'WaitingForUser', count: waitingCount, color: STATUS_COLORS['WaitingForUser'] },
-    { label: '対応中', status: 'InProgress', count: inProgressCount, color: STATUS_COLORS['InProgress'] },
-    { label: 'エスカレーション', status: 'Escalated', count: escalatedCount, color: STATUS_COLORS['Escalated'] },
-    { label: '解決済み', status: 'Resolved', count: resolvedCount, color: STATUS_COLORS['Resolved'] },
+    { status: 'New', count: newCount },
+    { status: 'Open', count: openCount },
+    { status: 'WaitingForUser', count: waitingCount },
+    { status: 'InProgress', count: inProgressCount },
+    { status: 'Escalated', count: escalatedCount },
+    { status: 'Resolved', count: resolvedCount },
   ];
 
   return (
@@ -89,9 +89,9 @@ export default async function DashboardPage() {
             >
               <p className="text-2xl font-bold text-gray-900">{card.count}</p>
               <span
-                className={`mt-1 inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${card.color}`}
+                className={`mt-1 inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[card.status]}`}
               >
-                {card.label}
+                {STATUS_LABELS[card.status]}
               </span>
             </Link>
           ))}

--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -1,13 +1,7 @@
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { markAllRead } from '@/features/notifications/actions/notification-actions';
-
-const TYPE_LABELS: Record<string, string> = {
-  assigned: '担当割当',
-  escalated: 'エスカレーション',
-  commented: 'コメント',
-  statusChanged: 'ステータス変更',
-};
+import { NOTIFICATION_TYPE_LABELS } from '@/lib/constants';
 
 export default async function NotificationsPage() {
   const session = await auth();
@@ -50,7 +44,7 @@ export default async function NotificationsPage() {
               <div className="flex items-start justify-between gap-2">
                 <div>
                   <span className="mr-2 inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
-                    {TYPE_LABELS[n.type] ?? n.type}
+                    {NOTIFICATION_TYPE_LABELS[n.type] ?? n.type}
                   </span>
                   <span className="text-sm text-gray-800">{n.message}</span>
                   {n.ticket && (

--- a/src/app/(app)/tickets/[id]/page.tsx
+++ b/src/app/(app)/tickets/[id]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { isAgent as checkIsAgent } from '@/lib/role';
-import { STATUS_LABELS, STATUS_COLORS, PRIORITY_LABELS, PRIORITY_COLORS } from '@/lib/constants';
+import { STATUS_LABELS, STATUS_COLORS, PRIORITY_LABELS, PRIORITY_COLORS, HISTORY_FIELD_LABELS } from '@/lib/constants';
 import { StatusSelect } from '@/features/tickets/components/StatusSelect';
 import { PrioritySelect } from '@/features/tickets/components/PrioritySelect';
 import { AssigneeSelect } from '@/features/tickets/components/AssigneeSelect';
@@ -11,13 +11,6 @@ import { EscalationForm } from '@/features/tickets/components/EscalationForm';
 import { getSlaState, SLA_LABELS, SLA_COLORS } from '@/lib/sla';
 import { getAllowedTransitions } from '@/domain/ticket-status';
 import { FaqCandidateForm } from '@/features/faq/components/FaqCandidateForm';
-
-const HISTORY_FIELD_LABELS: Record<string, string> = {
-  status: 'ステータス',
-  priority: '優先度',
-  assignee: '担当者',
-  escalation: 'エスカレーション',
-};
 
 interface Props {
   params: Promise<{ id: string }>;

--- a/src/features/faq/actions/faq-actions.ts
+++ b/src/features/faq/actions/faq-actions.ts
@@ -37,6 +37,11 @@ export async function updateFaqStatus(faqId: string, status: 'Published' | 'Reje
     throw new Error('エージェントまたは管理者のみ実行できます');
   }
 
+  const faq = await prisma.faqCandidate.findUniqueOrThrow({ where: { id: faqId } });
+  if (faq.status !== 'Candidate') {
+    throw new Error('候補ステータスのFAQのみ公開・却下できます');
+  }
+
   await prisma.faqCandidate.update({ where: { id: faqId }, data: { status } });
   revalidatePath('/faq');
 }

--- a/src/features/notifications/actions/notification-actions.ts
+++ b/src/features/notifications/actions/notification-actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 
@@ -13,4 +13,5 @@ export async function markAllRead() {
     data: { read: true },
   });
   revalidatePath('/notifications');
+  revalidateTag(`notification-count-${session.user.id}`);
 }

--- a/src/features/tickets/components/TicketForm.tsx
+++ b/src/features/tickets/components/TicketForm.tsx
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
 import { createTicketSchema, type CreateTicketFormValues } from '@/lib/validations/ticket';
+import { PRIORITY_LABELS } from '@/lib/constants';
 
 type Category = { id: string; name: string };
 
@@ -92,9 +93,9 @@ export function TicketForm({ categories }: Props) {
           {...register('priority')}
           className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
         >
-          <option value="Low">低</option>
-          <option value="Medium">中</option>
-          <option value="High">高</option>
+          {Object.entries(PRIORITY_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>{label}</option>
+          ))}
         </select>
       </div>
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -41,3 +41,17 @@ export const FAQ_STATUS_COLORS: Record<string, string> = {
   Published: 'bg-green-100 text-green-700',
   Rejected: 'bg-gray-100 text-gray-500',
 };
+
+export const HISTORY_FIELD_LABELS: Record<string, string> = {
+  status: 'ステータス',
+  priority: '優先度',
+  assignee: '担当者',
+  escalation: 'エスカレーション',
+};
+
+export const NOTIFICATION_TYPE_LABELS: Record<string, string> = {
+  assigned: '担当割当',
+  escalated: 'エスカレーション',
+  commented: 'コメント',
+  statusChanged: 'ステータス変更',
+};

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,3 +1,4 @@
+import { unstable_cache, revalidateTag } from 'next/cache';
 import { prisma } from '@/lib/prisma';
 import type { NotificationType } from '@/generated/prisma';
 
@@ -10,8 +11,13 @@ export async function createNotification(
   await prisma.notification.create({
     data: { userId, type, message, ticketId },
   });
+  revalidateTag(`notification-count-${userId}`);
 }
 
-export async function getUnreadNotificationCount(userId: string): Promise<number> {
-  return prisma.notification.count({ where: { userId, read: false } });
+export function getUnreadNotificationCount(userId: string): Promise<number> {
+  return unstable_cache(
+    (id: string) => prisma.notification.count({ where: { userId: id, read: false } }),
+    ['notification-count'],
+    { tags: [`notification-count-${userId}`], revalidate: 60 },
+  )(userId);
 }


### PR DESCRIPTION
## Summary

- `HISTORY_FIELD_LABELS` / `NOTIFICATION_TYPE_LABELS` を `src/lib/constants.ts` に集約 — `tickets/[id]/page.tsx` と `notifications/page.tsx` のローカル定義を削除
- `dashboard/page.tsx` の statCards ラベルを `STATUS_LABELS`/`STATUS_COLORS` から参照するよう統一
- `TicketForm.tsx` の優先度オプションを `PRIORITY_LABELS` から動的生成
- `getUnreadNotificationCount` に `unstable_cache`（TTL 60秒、ユーザー別タグ）を追加し通知バッジのDB負荷を削減
- `createNotification` と `markAllRead` で `revalidateTag` を呼び出し、バッジが即時更新されるように
- `updateFaqStatus` に現在ステータス検証を追加（`Candidate` 以外からの公開・却下を拒否）

## Test plan

- [ ] `npm run test` — 17 tests passing
- [ ] `npm run typecheck` — no errors
- [ ] ダッシュボードのステータスカードのラベルが正しく表示されること
- [ ] 通知バッジが新着通知後に即時更新されること
- [ ] 公開済みFAQを再度公開しようとするとエラーになること

https://claude.ai/code/session_01WMeRa1gJvD428GngPhEtpd