### PR TITLE
feat: リアルタイム通知バッジ（Server-Sent Events）

### DIFF
--- a/src/app/api/notifications/stream/route.ts
+++ b/src/app/api/notifications/stream/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { getUnreadNotificationCount } from '@/lib/notifications';
+import { addSubscriber, removeSubscriber } from '@/lib/sse-subscribers';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const KEEPALIVE_INTERVAL_MS = 30_000;
+
+const encoder = new TextEncoder();
+
+function sseComment(text: string): Uint8Array {
+  return encoder.encode(`: ${text}\n\n`);
+}
+
+function sseEvent(eventName: string, data: unknown): Uint8Array {
+  return encoder.encode(`event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+export async function GET(): Promise<Response> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
+  const userId = session.user.id;
+
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  let keepaliveTimer: ReturnType<typeof setInterval> | undefined;
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(ctrl) {
+      controller = ctrl;
+      addSubscriber(userId, controller);
+
+      try {
+        const initialCount = await getUnreadNotificationCount(userId);
+        controller.enqueue(sseEvent('count', { count: initialCount }));
+      } catch {
+        // Non-fatal — client will receive future broadcast events.
+      }
+
+      keepaliveTimer = setInterval(() => {
+        try {
+          controller.enqueue(sseComment('ping'));
+        } catch {
+          clearInterval(keepaliveTimer);
+        }
+      }, KEEPALIVE_INTERVAL_MS);
+    },
+
+    cancel() {
+      clearInterval(keepaliveTimer);
+      removeSubscriber(userId, controller);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  });
+}

--- a/src/components/layout/NotificationBell.tsx
+++ b/src/components/layout/NotificationBell.tsx
@@ -1,16 +1,7 @@
-import Link from 'next/link';
 import { getUnreadNotificationCount } from '@/lib/notifications';
+import { NotificationBellClient } from './NotificationBellClient';
 
 export async function NotificationBell({ userId }: { userId: string }) {
-  const count = await getUnreadNotificationCount(userId);
-  return (
-    <Link href="/notifications" className="relative text-sm text-gray-700 hover:text-gray-900">
-      通知
-      {count > 0 && (
-        <span className="absolute -right-2 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white">
-          {count > 9 ? '9+' : count}
-        </span>
-      )}
-    </Link>
-  );
+  const initialCount = await getUnreadNotificationCount(userId);
+  return <NotificationBellClient initialCount={initialCount} userId={userId} />;
 }

--- a/src/components/layout/NotificationBellClient.tsx
+++ b/src/components/layout/NotificationBellClient.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface Props {
+  initialCount: number;
+  userId: string;
+}
+
+export function NotificationBellClient({ initialCount, userId }: Props) {
+  const [count, setCount] = useState<number>(initialCount);
+
+  useEffect(() => {
+    const es = new EventSource('/api/notifications/stream');
+
+    es.addEventListener('count', (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data) as { count: number };
+        setCount(data.count);
+      } catch {
+        // Malformed data — ignore.
+      }
+    });
+
+    // Suppress unhandled-error console noise; EventSource auto-reconnects.
+    es.addEventListener('error', () => {});
+
+    return () => {
+      es.close();
+    };
+  }, [userId]);
+
+  return (
+    <Link href="/notifications" className="relative text-sm text-gray-700 hover:text-gray-900">
+      通知
+      {count > 0 && (
+        <span className="absolute -right-2 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white">
+          {count > 9 ? '9+' : count}
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/src/features/notifications/actions/notification-actions.ts
+++ b/src/features/notifications/actions/notification-actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath, revalidateTag } from 'next/cache';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { broadcast } from '@/lib/sse-subscribers';
 
 export async function markAllRead() {
   const session = await auth();
@@ -12,6 +13,8 @@ export async function markAllRead() {
     where: { userId: session.user.id, read: false },
     data: { read: true },
   });
+
   revalidatePath('/notifications');
   revalidateTag(`notification-count-${session.user.id}`);
+  broadcast(session.user.id, 0);
 }

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,5 +1,6 @@
 import { unstable_cache, revalidateTag } from 'next/cache';
 import { prisma } from '@/lib/prisma';
+import { broadcast } from '@/lib/sse-subscribers';
 import type { NotificationType } from '@/generated/prisma';
 
 export async function createNotification(
@@ -11,7 +12,12 @@ export async function createNotification(
   await prisma.notification.create({
     data: { userId, type, message, ticketId },
   });
+
   revalidateTag(`notification-count-${userId}`);
+
+  // Query live count directly (not via cache — revalidateTag just invalidated it).
+  const newCount = await prisma.notification.count({ where: { userId, read: false } });
+  broadcast(userId, newCount);
 }
 
 export function getUnreadNotificationCount(userId: string): Promise<number> {

--- a/src/lib/sse-subscribers.ts
+++ b/src/lib/sse-subscribers.ts
@@ -1,0 +1,54 @@
+/**
+ * In-memory SSE subscriber registry.
+ *
+ * Safe for single-process deployments (standalone Docker).
+ * Each user maps to a Set of ReadableStreamDefaultController instances —
+ * one per open browser tab / EventSource connection.
+ */
+
+type Controller = ReadableStreamDefaultController<Uint8Array>;
+
+const subscribers = new Map<string, Set<Controller>>();
+
+export function addSubscriber(userId: string, controller: Controller): void {
+  let controllers = subscribers.get(userId);
+  if (!controllers) {
+    controllers = new Set();
+    subscribers.set(userId, controllers);
+  }
+  controllers.add(controller);
+}
+
+export function removeSubscriber(userId: string, controller: Controller): void {
+  const controllers = subscribers.get(userId);
+  if (!controllers) return;
+  controllers.delete(controller);
+  if (controllers.size === 0) {
+    subscribers.delete(userId);
+  }
+}
+
+/**
+ * Send a "count" SSE event to every open stream for a given user.
+ * Silently drops a controller if enqueue throws (client already disconnected).
+ */
+export function broadcast(userId: string, count: number): void {
+  const controllers = subscribers.get(userId);
+  if (!controllers || controllers.size === 0) return;
+
+  const message = new TextEncoder().encode(
+    `event: count\ndata: ${JSON.stringify({ count })}\n\n`,
+  );
+
+  for (const controller of controllers) {
+    try {
+      controller.enqueue(message);
+    } catch {
+      controllers.delete(controller);
+    }
+  }
+
+  if (controllers.size === 0) {
+    subscribers.delete(userId);
+  }
+}


### PR DESCRIPTION
## Summary

- `src/lib/sse-subscribers.ts` を新設 — モジュールレベルの購読者 `Map<userId, Set<Controller>>` + `addSubscriber` / `removeSubscriber` / `broadcast`
- `src/app/api/notifications/stream/route.ts` を新設 — SSE Route Handler（認証・初期カウント即時送信・30秒 keepalive ping・切断時クリーンアップ）
- `src/components/layout/NotificationBellClient.tsx` を新設 — `EventSource` 接続クライアントコンポーネント（`initialCount` で SSR 値を引き継ぎフラッシュなし）
- `src/components/layout/NotificationBell.tsx` を変更 — async Server Component のまま `initialCount` を取得して `NotificationBellClient` に渡す（Suspense 互換維持）
- `src/lib/notifications.ts` を変更 — `createNotification` 後に `broadcast()` 呼び出し
- `src/features/notifications/actions/notification-actions.ts` を変更 — `markAllRead` 後に `broadcast(userId, 0)` 呼び出し

サードパーティ不要・単一Dockerプロセスのインメモリ管理で実現。

## Test plan

- [ ] `npm run test` — 17 tests passing
- [ ] `npm run typecheck` — no errors
- [ ] ブラウザ2タブ開く: タブAでチケット担当者割り当て → タブBのバッジが即時更新されること
- [ ] 「すべて既読にする」クリック → バッジが即時消えること
- [ ] ネットワークタブで `/api/notifications/stream` が `text/event-stream` として開き続けること
- [ ] 30秒後に `: ping` keepalive コメントが届くこと

https://claude.ai/code/session_01WMeRa1gJvD428GngPhEtpd