### PR TITLE
feat: UX改善6件（ナビ表示制御・エラー表示・検索ボタン・折りたたみサイドバー・ロール別リダイレクト）

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -94,13 +94,13 @@
 
 ### 許可遷移
 
-- New → Open
-- Open → In Progress
-- In Progress → Waiting for User
-- In Progress → Escalated
-- In Progress → Resolved
-- Resolved → Closed
-- Resolved → Open（再オープン）
+- New → Open, Waiting for User, In Progress, Resolved, Closed
+- Open → In Progress, Waiting for User, Escalated, Resolved, Closed
+- Waiting for User → Open, In Progress, Resolved, Closed
+- In Progress → Waiting for User, Escalated, Resolved, Closed
+- Escalated → In Progress, Resolved, Closed
+- Resolved → Open（再オープン）, Closed
+- Closed → Open（再オープン）
 
 ## 6. 非機能要件
 

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -4,7 +4,7 @@ import { Sidebar } from '@/components/layout/Sidebar';
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const session = await auth();
-  const role = session?.user?.role ?? 'requester';
+  const role = session?.user?.role ?? ('requester' as const);
 
   return (
     <div className="flex h-screen overflow-hidden bg-gray-50">

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,10 +1,14 @@
+import { auth } from '@/lib/auth';
 import { Header } from '@/components/layout/Header';
 import { Sidebar } from '@/components/layout/Sidebar';
 
-export default function AppLayout({ children }: { children: React.ReactNode }) {
+export default async function AppLayout({ children }: { children: React.ReactNode }) {
+  const session = await auth();
+  const role = session?.user?.role ?? 'requester';
+
   return (
     <div className="flex h-screen overflow-hidden bg-gray-50">
-      <Sidebar />
+      <Sidebar role={role} />
       <div className="flex flex-1 flex-col overflow-hidden">
         <Header />
         <main className="flex-1 overflow-y-auto p-6">{children}</main>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { signIn } from 'next-auth/react';
+import { signIn, getSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { isAgent } from '@/lib/role';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -29,7 +30,8 @@ export default function LoginPage() {
     if (result?.error) {
       setError('メールアドレスまたはパスワードが正しくありません');
     } else {
-      router.push('/tickets');
+      const session = await getSession();
+      router.push(isAgent(session?.user?.role) ? '/dashboard' : '/tickets');
     }
   }
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,42 +1,64 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { isAgent } from '@/lib/role';
+
+interface Props {
+  role: string;
+}
 
 const navItems = [
   { href: '/dashboard', label: 'ダッシュボード' },
   { href: '/tickets', label: '問い合わせ一覧' },
   { href: '/tickets/new', label: '新規登録' },
-  { href: '/faq', label: 'FAQ候補' },
+  { href: '/faq', label: 'FAQ候補', agentOnly: true },
   { href: '/notifications', label: '通知' },
 ];
 
-export function Sidebar() {
+export function Sidebar({ role }: Props) {
   const pathname = usePathname();
+  const [collapsed, setCollapsed] = useState(false);
+
+  const visibleItems = navItems.filter((item) => !item.agentOnly || isAgent(role));
 
   return (
-    <aside className="flex w-56 flex-col border-r border-gray-200 bg-white">
-      <div className="border-b border-gray-200 px-6 py-4">
-        <span className="text-lg font-semibold text-gray-900">HelpDesk Hub</span>
+    <aside
+      className={`flex flex-col border-r border-gray-200 bg-white transition-all duration-200 ${collapsed ? 'w-10' : 'w-56'}`}
+    >
+      <div className="flex items-center justify-between border-b border-gray-200 px-3 py-4">
+        {!collapsed && (
+          <span className="text-lg font-semibold text-gray-900">HelpDesk Hub</span>
+        )}
+        <button
+          onClick={() => setCollapsed(!collapsed)}
+          className="ml-auto rounded p-0.5 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+          aria-label={collapsed ? 'サイドバーを展開' : 'サイドバーを折りたたむ'}
+        >
+          {collapsed ? '›' : '‹'}
+        </button>
       </div>
-      <nav className="flex-1 space-y-1 px-3 py-4">
-        {navItems.map((item) => {
-          const isActive = pathname === item.href;
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={`block rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-                isActive
-                  ? 'bg-blue-50 text-blue-700'
-                  : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900'
-              }`}
-            >
-              {item.label}
-            </Link>
-          );
-        })}
-      </nav>
+      {!collapsed && (
+        <nav className="flex-1 space-y-1 px-3 py-4">
+          {visibleItems.map((item) => {
+            const isActive = pathname === item.href;
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`block rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                  isActive
+                    ? 'bg-blue-50 text-blue-700'
+                    : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900'
+                }`}
+              >
+                {item.label}
+              </Link>
+            );
+          })}
+        </nav>
+      )}
     </aside>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -4,9 +4,10 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { isAgent } from '@/lib/role';
+import type { Role } from '@/generated/prisma';
 
 interface Props {
-  role: string;
+  role: Role;
 }
 
 const navItems = [

--- a/src/features/tickets/components/TicketFilters.tsx
+++ b/src/features/tickets/components/TicketFilters.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
-import { useTransition, useCallback } from 'react';
+import { useTransition, useCallback, useRef } from 'react';
 import { STATUS_LABELS, PRIORITY_LABELS } from '@/lib/constants';
 import type { TicketStatus, Priority } from '@/generated/prisma';
 
@@ -24,6 +24,7 @@ export function TicketFilters({ categories, agents, isAgent }: Props) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
+  const keywordRef = useRef<HTMLInputElement>(null);
 
   const update = useCallback(
     (key: string, value: string) => {
@@ -47,15 +48,22 @@ export function TicketFilters({ categories, agents, isAgent }: Props) {
     <div className={`flex flex-wrap items-center gap-2 ${isPending ? 'opacity-50' : ''}`}>
       {/* Keyword */}
       <input
+        ref={keywordRef}
         type="search"
         placeholder="キーワード検索"
+        key={searchParams.get('q') ?? ''}
         defaultValue={searchParams.get('q') ?? ''}
         onKeyDown={(e) => {
           if (e.key === 'Enter') update('q', (e.target as HTMLInputElement).value.trim());
         }}
-        onBlur={(e) => update('q', e.target.value.trim())}
         className="rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none"
       />
+      <button
+        onClick={() => update('q', keywordRef.current?.value.trim() ?? '')}
+        className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
+      >
+        検索
+      </button>
       {/* Status */}
       <select
         value={searchParams.get('status') ?? ''}

--- a/src/features/tickets/components/TicketForm.tsx
+++ b/src/features/tickets/components/TicketForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
@@ -14,6 +15,7 @@ interface Props {
 
 export function TicketForm({ categories }: Props) {
   const router = useRouter();
+  const [serverError, setServerError] = useState<string | null>(null);
   const {
     register,
     handleSubmit,
@@ -24,6 +26,7 @@ export function TicketForm({ categories }: Props) {
   });
 
   async function onSubmit(data: CreateTicketFormValues) {
+    setServerError(null);
     const res = await fetch('/api/tickets', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -32,7 +35,7 @@ export function TicketForm({ categories }: Props) {
 
     if (!res.ok) {
       const err = await res.json();
-      alert(err.error ?? '登録に失敗しました');
+      setServerError(err.error ?? '登録に失敗しました');
       return;
     }
 
@@ -98,6 +101,8 @@ export function TicketForm({ categories }: Props) {
           ))}
         </select>
       </div>
+
+      {serverError && <p className="text-sm text-red-600">{serverError}</p>}
 
       {/* Actions */}
       <div className="flex gap-3">

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,7 @@ import NextAuth from 'next-auth';
 import Credentials from 'next-auth/providers/credentials';
 import { compare } from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
+import type { Role } from '@/generated/prisma';
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [
@@ -36,14 +37,14 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     async jwt({ token, user }) {
       if (user) {
         token.id = user.id;
-        token.role = (user as { role: string }).role;
+        token.role = (user as { role: Role }).role;
       }
       return token;
     },
     async session({ session, token }) {
       if (token) {
         session.user.id = token.id as string;
-        session.user.role = token.role as string;
+        session.user.role = token.role as Role;
       }
       return session;
     },

--- a/src/lib/role.ts
+++ b/src/lib/role.ts
@@ -1,3 +1,5 @@
-export function isAgent(role: string | null | undefined): boolean {
+import type { Role } from '@/generated/prisma';
+
+export function isAgent(role: Role | string | null | undefined): boolean {
   return role === 'agent' || role === 'admin';
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import { auth } from '@/lib/auth';
 import { NextResponse } from 'next/server';
+import { isAgent } from '@/lib/role';
 
 export default auth((req) => {
   const isLoggedIn = !!req.auth;
@@ -13,7 +14,8 @@ export default auth((req) => {
   }
 
   if (isLoggedIn && isAuthPage) {
-    return NextResponse.redirect(new URL('/tickets', req.url));
+    const role = req.auth?.user?.role;
+    return NextResponse.redirect(new URL(isAgent(role) ? '/dashboard' : '/tickets', req.url));
   }
 
   return NextResponse.next();

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,10 +1,11 @@
-import { DefaultSession } from 'next-auth';
+import type { DefaultSession } from 'next-auth';
+import type { Role } from '@/generated/prisma';
 
 declare module 'next-auth' {
   interface Session {
     user: {
       id: string;
-      role: string;
+      role: Role;
     } & DefaultSession['user'];
   }
 }


### PR DESCRIPTION
## Summary

- **ロール別ナビゲーション表示制御**: FAQ候補メニューを `agent`/`admin` のみに表示。`requester` がアクセスして `notFound()` になる「押せるのに使えない」体験を解消
- **折りたたみサイドバー**: `‹`/`›` ボタンでサイドバーを `w-56` ⇔ `w-10` に切り替え。狭い画面でもコンテンツ領域を確保
- **起票失敗時のインラインエラー**: `alert()` をフォーム内インライン表示に変更。どの操作が失敗したか文脈で分かるように
- **キーワード検索ボタン追加**: Enter/blur 依存から明示的な「検索」ボタンへ。操作確信を向上
- **ログイン後のロール別リダイレクト**: `agent`/`admin` → `/dashboard`、`requester` → `/tickets`（`login/page.tsx` + `middleware.ts` 両方を修正）
- **ステータス遷移ドキュメント統一**: `docs/requirements.md` の遷移表を `ticket-status.ts` の実装と一致させる

## Test plan

- [ ] `npm run typecheck` — エラーなし ✅
- [ ] `npm run test` — 17件パス ✅
- [ ] `requester` でログイン → サイドバーに FAQ候補なし・`/tickets` にリダイレクト
- [ ] `agent` でログイン → FAQ候補あり・`/dashboard` にリダイレクト
- [ ] チケット新規作成でサーバーエラー発生時 → alert ではなくフォーム下部にインライン表示
- [ ] キーワード入力後「検索」ボタンクリック → URL更新・blur 時は反応しない
- [ ] サイドバーの `‹` ボタンクリック → 折りたたまれてコンテンツ領域が広がる

https://claude.ai/code/session_01WMeRa1gJvD428GngPhEtpd