### PR TITLE
fix: サイドバーの親メニューを配下ページでもアクティブ表示

### DIFF
--- a/docs/self-review.md
+++ b/docs/self-review.md
@@ -47,3 +47,25 @@
 
 ## フォローアップ
 - GitHub 側で対象リポジトリに移動後、`docs/github-issues.md` を元に順次 Issue 登録する。
+
+---
+
+# Self Review (2026-04-15, Sidebarアクティブ状態修正)
+
+対象変更:
+- `src/components/layout/Sidebar.tsx`
+
+## 観点と結果
+
+1. 再現性
+- 既存実装は `pathname === item.href` の完全一致判定のみで、`/tickets/xxx` や `/faq/xxx` など配下ページ閲覧時にサイドバーの親メニューがアクティブ表示されないことを確認。
+
+2. 影響範囲
+- ナビゲーション表示ロジックのみ変更し、リンク遷移先・表示権限制御（`agentOnly`）には影響しないことを確認。
+
+3. 実装妥当性
+- `pathname === href || pathname.startsWith(\`\${href}/\`)` により、同一パスと配下パスの両方をアクティブとして扱うよう修正。
+- `/` については誤判定を防ぐためのガードを追加。
+
+4. 品質確認
+- `npm run typecheck` / `npm run test` で既存テストが全件通過することを確認。

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -23,6 +23,10 @@ export function Sidebar({ role }: Props) {
   const [collapsed, setCollapsed] = useState(false);
 
   const visibleItems = navItems.filter((item) => !item.agentOnly || isAgent(role));
+  const isItemActive = (href: string) => {
+    if (href === '/') return pathname === '/';
+    return pathname === href || pathname.startsWith(`${href}/`);
+  };
 
   return (
     <aside
@@ -43,7 +47,7 @@ export function Sidebar({ role }: Props) {
       {!collapsed && (
         <nav className="flex-1 space-y-1 px-3 py-4">
           {visibleItems.map((item) => {
-            const isActive = pathname === item.href;
+            const isActive = isItemActive(item.href);
             return (
               <Link
                 key={item.href}


### PR DESCRIPTION
### Motivation
- サイドバーのアクティブ判定が `pathname === item.href` の完全一致のみだったため、`/tickets/123` や `/faq/abc` といった配下ページで親メニューがアクティブ表示されない問題を修正するため。

### Description
- `src/components/layout/Sidebar.tsx` に `isItemActive` ヘルパーを追加し、`pathname === href || pathname.startsWith(`${href}/`)` で同一パスと配下パスの両方をアクティブ扱いに変更した。 
- ルート (`'/'`) の誤判定を避けるガードを追加した。 
- 実装に影響が出ないよう既存の描画・権限制御ロジックは維持した。 
- `docs/self-review.md` に本変更の自己レビュー（2026-04-15）を追記した。

### Testing
- `npm run typecheck` を実行して型チェックは成功した。 
- `npm run test` を実行してユニットテストは全件成功した（17 passed）。 
- `npm run lint` は Next.js の `next lint` 廃止警告および環境依存の circular structure エラーにより失敗したため未完了である。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df6fe9b6f48322814d5cfb6273c517)