### PR TITLE
Refine ticket action auth, comment permissions, sidebar active matching, and middleware API passthrough

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -25,11 +25,6 @@ export function Sidebar({ role }: Props) {
   const visibleItems = navItems.filter((item) => !item.agentOnly || isAgent(role));
   const isItemActive = (href: string) => {
     if (href === '/') return pathname === '/';
-    return pathname === href || pathname.startsWith(`${href}/`);
-  };
-
-  const isItemActive = (href: string) => {
-    if (href === '/') return pathname === '/';
     if (pathname === href) return true;
     // nav item に完全一致するパスが存在する場合は prefix マッチを使わない
     // （例: /tickets/new 閲覧時に /tickets を誤ってアクティブにしない）

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -8,10 +8,22 @@ import { recordHistory } from '@/lib/ticket-history';
 import { createNotification } from '@/lib/notifications';
 import { isValidTransition } from '@/domain/ticket-status';
 import type { TicketStatus, Priority } from '@/generated/prisma';
+import type { Session } from 'next-auth';
+
+function assertAuthenticatedUser(session: Session | null): asserts session is Session {
+  if (!session?.user?.id) throw new Error('Unauthorized');
+}
+
+function assertAgentRole(session: Session | null): asserts session is Session {
+  assertAuthenticatedUser(session);
+  if (!isAgent(session.user.role)) {
+    throw new Error('この操作はエージェントまたは管理者のみ実行できます');
+  }
+}
 
 export async function updateTicketStatus(ticketId: string, newStatus: TicketStatus) {
   const session = await auth();
-  if (!session?.user?.id) throw new Error('Unauthorized');
+  assertAgentRole(session);
 
   const ticket = await prisma.ticket.findUniqueOrThrow({ where: { id: ticketId } });
   if (ticket.status === newStatus) return;
@@ -26,7 +38,7 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
 
 export async function updateTicketPriority(ticketId: string, newPriority: Priority) {
   const session = await auth();
-  if (!session?.user?.id) throw new Error('Unauthorized');
+  assertAgentRole(session);
 
   const ticket = await prisma.ticket.findUniqueOrThrow({ where: { id: ticketId } });
   if (ticket.priority === newPriority) return;
@@ -38,7 +50,7 @@ export async function updateTicketPriority(ticketId: string, newPriority: Priori
 
 export async function updateTicketAssignee(ticketId: string, newAssigneeId: string | null) {
   const session = await auth();
-  if (!session?.user?.id) throw new Error('Unauthorized');
+  assertAgentRole(session);
 
   const [ticket, newUser] = await Promise.all([
     prisma.ticket.findUniqueOrThrow({
@@ -77,10 +89,7 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
 
 export async function escalateTicket(ticketId: string, reason: string) {
   const session = await auth();
-  if (!session?.user?.id) throw new Error('Unauthorized');
-  if (!isAgent(session.user.role)) {
-    throw new Error('エスカレーション操作はエージェントまたは管理者のみ実行できます');
-  }
+  assertAgentRole(session);
 
   const [ticket, agents] = await Promise.all([
     prisma.ticket.findUniqueOrThrow({ where: { id: ticketId } }),
@@ -116,8 +125,18 @@ export async function escalateTicket(ticketId: string, reason: string) {
 
 export async function addComment(ticketId: string, body: string) {
   const session = await auth();
-  if (!session?.user?.id) throw new Error('Unauthorized');
+  assertAuthenticatedUser(session);
   if (!body.trim()) throw new Error('コメントを入力してください');
+
+  const ticket = await prisma.ticket.findUniqueOrThrow({
+    where: { id: ticketId },
+    select: { creatorId: true },
+  });
+
+  const canComment = isAgent(session.user.role) || ticket.creatorId === session.user.id;
+  if (!canComment) {
+    throw new Error('このチケットへのコメント権限がありません');
+  }
 
   await prisma.ticketComment.create({
     data: { ticketId, authorId: session.user.id, body: body.trim() },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,10 +5,17 @@ import { isAgent } from '@/lib/role';
 export default auth((req) => {
   const isLoggedIn = !!req.auth;
   const isAuthPage = req.nextUrl.pathname.startsWith('/login');
-  const isApiRoute = req.nextUrl.pathname.startsWith('/api/');
   const isApiAuth = req.nextUrl.pathname.startsWith('/api/auth');
+  const isApiRoute = req.nextUrl.pathname.startsWith('/api/');
 
-  if (isApiAuth || isApiRoute) return NextResponse.next();
+  if (isApiAuth) return NextResponse.next();
+
+  if (isApiRoute) {
+    if (!isLoggedIn) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+    return NextResponse.next();
+  }
 
   if (!isLoggedIn && !isAuthPage) {
     return NextResponse.redirect(new URL('/login', req.url));

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,9 +5,10 @@ import { isAgent } from '@/lib/role';
 export default auth((req) => {
   const isLoggedIn = !!req.auth;
   const isAuthPage = req.nextUrl.pathname.startsWith('/login');
+  const isApiRoute = req.nextUrl.pathname.startsWith('/api/');
   const isApiAuth = req.nextUrl.pathname.startsWith('/api/auth');
 
-  if (isApiAuth) return NextResponse.next();
+  if (isApiAuth || isApiRoute) return NextResponse.next();
 
   if (!isLoggedIn && !isAuthPage) {
     return NextResponse.redirect(new URL('/login', req.url));


### PR DESCRIPTION
### Motivation
- Centralize and strengthen authentication/authorization checks for ticket mutation actions to reduce duplication and improve error messages.
- Prevent incorrect sidebar item activation when a more specific route exactly matches the current path.
- Ensure API routes are not blocked by the page auth middleware.

### Description
- Added `assertAuthenticatedUser` and `assertAgentRole` helpers (typed with `Session`) and replaced repetitive inline auth checks in `src/features/tickets/actions/update-ticket.ts` for `updateTicketStatus`, `updateTicketPriority`, `updateTicketAssignee`, and `escalateTicket`.
- Tightened comment permissions in `addComment` by requiring authentication and allowing comments only from agents or the ticket creator, after fetching the ticket `creatorId`.
- Improved sidebar active detection in `src/components/layout/Sidebar.tsx` so prefix matching is disabled when there is an exact nav item that matches the current pathname, preventing parent item from being marked active for more specific routes (e.g. avoid marking `/tickets` active on `/tickets/new`).
- Updated `src/middleware.ts` to skip middleware for API routes by treating paths that start with `/api/` as passthroughs along with `/api/auth`.

### Testing
- Ran the test suite with `pnpm test` and all tests passed.
- Performed a TypeScript build check with `pnpm build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfaacfcbf883229ca7850ea5fa972b)