### PR TITLE
Ticket / Notification に頻出クエリ用 DB インデックスを追加 (#58)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,13 +96,13 @@ model Category {
 // ─────────────────────────────────────────────
 
 model Ticket {
-  id          String       @id @default(cuid())
-  title       String
-  body        String
-  status      TicketStatus @default(New)
-  priority    Priority     @default(Medium)
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @updatedAt
+  id        String       @id @default(cuid())
+  title     String
+  body      String
+  status    TicketStatus @default(New)
+  priority  Priority     @default(Medium)
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
 
   // SLA
   firstResponseDueAt DateTime?
@@ -115,18 +115,24 @@ model Ticket {
   escalationReason String?
 
   // Foreign keys
-  creatorId    String
-  assigneeId   String?
-  categoryId   String?
+  creatorId  String
+  assigneeId String?
+  categoryId String?
 
   // Relations
-  creator       User           @relation("TicketCreator", fields: [creatorId], references: [id])
-  assignee      User?          @relation("TicketAssignee", fields: [assigneeId], references: [id])
-  category      Category?      @relation(fields: [categoryId], references: [id])
+  creator       User            @relation("TicketCreator", fields: [creatorId], references: [id])
+  assignee      User?           @relation("TicketAssignee", fields: [assigneeId], references: [id])
+  category      Category?       @relation(fields: [categoryId], references: [id])
   comments      TicketComment[]
   histories     TicketHistory[]
   faqCandidate  FaqCandidate?
   notifications Notification[]
+
+  @@index([creatorId])
+  @@index([assigneeId])
+  @@index([status])
+  @@index([categoryId])
+  @@index([createdAt(sort: Desc)])
 }
 
 // ─────────────────────────────────────────────
@@ -164,6 +170,9 @@ model Notification {
 
   user   User    @relation(fields: [userId], references: [id], onDelete: Cascade)
   ticket Ticket? @relation(fields: [ticketId], references: [id], onDelete: SetNull)
+
+  @@index([userId, read])
+  @@index([userId, createdAt(sort: Desc)])
 }
 
 // ─────────────────────────────────────────────
@@ -187,15 +196,15 @@ model TicketComment {
 // ─────────────────────────────────────────────
 
 model TicketHistory {
-  id         String       @id @default(cuid())
-  field      HistoryField
-  oldValue   String?
-  newValue   String?
-  createdAt  DateTime     @default(now())
+  id        String       @id @default(cuid())
+  field     HistoryField
+  oldValue  String?
+  newValue  String?
+  createdAt DateTime     @default(now())
 
-  ticketId   String
+  ticketId    String
   changedById String
 
-  ticket     Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade)
-  changedBy  User   @relation(fields: [changedById], references: [id])
+  ticket    Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  changedBy User   @relation(fields: [changedById], references: [id])
 }


### PR DESCRIPTION
## Summary

Issue #58 の対応。頻出クエリに対応する `@@index` を `Ticket` / `Notification` モデルへ追加。

### 追加したインデックス

- `Ticket`
  - `@@index([creatorId])` — requester 一覧の `where.creatorId`
  - `@@index([assigneeId])` — ダッシュボード `groupBy` / 担当者フィルタ
  - `@@index([status])` — ダッシュボードの status 別 `count` / 一覧フィルタ
  - `@@index([categoryId])` — 一覧のカテゴリフィルタ
  - `@@index([createdAt(sort: Desc)])` — 一覧の `orderBy: { createdAt: 'desc' }`
- `Notification`
  - `@@index([userId, read])` — `getUnreadNotificationCount` の最頻出クエリ
  - `@@index([userId, createdAt(sort: Desc)])` — 自分宛て一覧のソート

### マイグレーション

本リポジトリは `prisma/migrations/` を追跡していないため、スキーマ変更のみをコミット。デプロイ時は `npx prisma migrate deploy` もしくは `prisma db push` 経由でインデックスが作成される想定。必要に応じて `EXPLAIN` で index scan を確認してください。

## Test plan

- [x] `DATABASE_URL=... npx prisma validate` でスキーマ検証
- [x] `DATABASE_URL=... npx prisma generate` でクライアント再生成
- [x] `npm run typecheck`
- [x] `npm run test` (49 件 pass)
- [ ] Postgres 上で `EXPLAIN` し、対象クエリが index scan になることを確認

Closes #58

https://claude.ai/code/session_01R3zMc1no9zjDjWScs1ep6p