### PR TITLE
addComment 実行時に commented 通知を発行 (fix #59)

### DIFF
--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -179,15 +179,51 @@ export async function addComment(ticketId: string, body: string) {
   const ticket = await repos.tickets.findById(ticketId);
   if (!ticket) throw new Error('チケットが見つかりません');
 
-  const canComment = isAgent(session.user.role) || ticket.creatorId === session.user.id;
+  const authorId = session.user.id;
+  const authorIsAgent = isAgent(session.user.role);
+  const canComment = authorIsAgent || ticket.creatorId === authorId;
   if (!canComment) {
     throw new Error('このチケットへのコメント権限がありません');
   }
 
-  await repos.comments.create({
-    ticketId,
-    authorId: session.user.id,
-    body: trimmedBody,
+  const recipientIds = await resolveCommentRecipients(ticket, authorId, authorIsAgent);
+  const message = `チケット「${ticket.title}」に新しいコメントが追加されました`;
+
+  await uow.run(async (r) => {
+    await r.comments.create({
+      ticketId,
+      authorId,
+      body: trimmedBody,
+    });
+    await Promise.all(
+      recipientIds.map((id) =>
+        r.notifications.create({
+          userId: id,
+          type: 'commented',
+          message,
+          ticketId,
+        }),
+      ),
+    );
   });
+
+  if (recipientIds.length > 0) await broadcastUnreadCountToMany(recipientIds);
   revalidatePath(`/tickets/${ticketId}`);
+}
+
+async function resolveCommentRecipients(
+  ticket: { creatorId: string; assigneeId: string | null },
+  authorId: string,
+  authorIsAgent: boolean,
+): Promise<string[]> {
+  const candidates: string[] = [];
+  if (authorIsAgent) {
+    candidates.push(ticket.creatorId);
+    if (ticket.assigneeId) candidates.push(ticket.assigneeId);
+  } else if (ticket.assigneeId) {
+    candidates.push(ticket.assigneeId);
+  } else {
+    candidates.push(...(await repos.users.listAgentIds()));
+  }
+  return Array.from(new Set(candidates)).filter((id) => id !== authorId);
 }

--- a/tests/features/update-ticket.test.ts
+++ b/tests/features/update-ticket.test.ts
@@ -184,6 +184,104 @@ describe('updateTicketAssignee (provider-agnostic)', () => {
   });
 });
 
+describe('addComment (provider-agnostic)', () => {
+  it('notifies the assignee when a requester comments on an assigned ticket', async () => {
+    const { ticketId } = await seed();
+    await repos.tickets.updateAssignee(ticketId, 'u-agt-2');
+    sessionUserId = 'u-req-1';
+    sessionRole = 'requester';
+    const { addComment } = await import('@/features/tickets/actions/update-ticket');
+
+    await addComment(ticketId, '追加情報です');
+
+    const comments = [...store.comments.values()].filter((c) => c.ticketId === ticketId);
+    expect(comments).toHaveLength(1);
+    expect(comments[0].authorId).toBe('u-req-1');
+
+    const notifications = [...store.notifications.values()];
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].userId).toBe('u-agt-2');
+    expect(notifications[0].type).toBe('commented');
+    expect(notifications[0].ticketId).toBe(ticketId);
+  });
+
+  it('notifies every agent when a requester comments on an unassigned ticket', async () => {
+    const { ticketId } = await seed();
+    sessionUserId = 'u-req-1';
+    sessionRole = 'requester';
+    const { addComment } = await import('@/features/tickets/actions/update-ticket');
+
+    await addComment(ticketId, 'どうなってますか');
+
+    const notifications = [...store.notifications.values()];
+    expect(new Set(notifications.map((n) => n.userId))).toEqual(new Set(['u-agt-1', 'u-agt-2']));
+    for (const n of notifications) {
+      expect(n.type).toBe('commented');
+      expect(n.ticketId).toBe(ticketId);
+    }
+  });
+
+  it('notifies the ticket creator when an agent comments', async () => {
+    const { ticketId } = await seed();
+    const { addComment } = await import('@/features/tickets/actions/update-ticket');
+
+    await addComment(ticketId, '確認しました');
+
+    const notifications = [...store.notifications.values()];
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].userId).toBe('u-req-1');
+    expect(notifications[0].type).toBe('commented');
+  });
+
+  it('notifies both creator and assignee when a different agent comments', async () => {
+    const { ticketId } = await seed();
+    await repos.tickets.updateAssignee(ticketId, 'u-agt-2');
+    const { addComment } = await import('@/features/tickets/actions/update-ticket');
+
+    await addComment(ticketId, '対応を引き継ぎます');
+
+    const notifications = [...store.notifications.values()];
+    expect(new Set(notifications.map((n) => n.userId))).toEqual(new Set(['u-req-1', 'u-agt-2']));
+    for (const n of notifications) {
+      expect(n.type).toBe('commented');
+    }
+  });
+
+  it('does not notify the commenter themselves', async () => {
+    const { ticketId } = await seed();
+    await repos.tickets.updateAssignee(ticketId, 'u-agt-1');
+    // assignee and commenter are both u-agt-1
+    const { addComment } = await import('@/features/tickets/actions/update-ticket');
+
+    await addComment(ticketId, '自分のコメント');
+
+    const notifications = [...store.notifications.values()];
+    expect(notifications.map((n) => n.userId)).toEqual(['u-req-1']);
+  });
+
+  it('refuses to comment from a requester who is not the creator', async () => {
+    const { ticketId } = await seed();
+    sessionUserId = 'u-req-2';
+    sessionRole = 'requester';
+    // seed a second requester
+    const now = new Date();
+    store.users.set('u-req-2', {
+      id: 'u-req-2',
+      email: 'u-req-2@example.com',
+      name: '田中',
+      passwordHash: 'x',
+      role: 'requester',
+      createdAt: now,
+      updatedAt: now,
+    });
+    const { addComment } = await import('@/features/tickets/actions/update-ticket');
+
+    await expect(addComment(ticketId, 'よそからのコメント')).rejects.toThrow(/コメント権限/);
+    expect([...store.comments.values()]).toHaveLength(0);
+    expect([...store.notifications.values()]).toHaveLength(0);
+  });
+});
+
 describe('escalateTicket (provider-agnostic)', () => {
   it('marks escalated, records history, and notifies every agent', async () => {
     const { ticketId } = await seed();


### PR DESCRIPTION
## 概要

`addComment` が `NotificationType.commented` を一度も発行しておらず、チケットのコメントがリアルタイム通知に現れない問題（#59）を修正しました。

## 変更内容

`src/features/tickets/actions/update-ticket.ts::addComment`:

- コメント投稿者が **requester** → 担当エージェント（未アサイン時は全エージェント）へ `commented` 通知
- コメント投稿者が **agent / admin** → チケット creator と（いれば）assignee へ `commented` 通知
- 自分自身（投稿者）には通知しない
- コメント作成と通知作成を `uow.run` のトランザクションに統一し、既存の `updateTicketAssignee` / `escalateTicket` と同じ形に合わせた
- 通知発行後に `broadcastUnreadCountToMany(recipientIds)` で SSE 経由のバッジ更新をトリガ

## テスト

`tests/features/update-ticket.test.ts` に `addComment` の provider-agnostic テストを追加（全 5 ケース）:

- requester が assigned ticket にコメント → assignee のみ通知
- requester が unassigned ticket にコメント → 全エージェント通知
- agent がコメント → creator に通知
- agent（assignee 以外）がコメント → creator + assignee に通知
- 自分自身（assignee 兼 commenter）には通知されない
- 非 creator の requester からのコメントは権限エラー

## 確認

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test` ✅ (55 tests pass)

Closes #59