### PR TITLE
優先度Highのissue対応: FAQアクションの例外露出修正 と SSE単一インスタンス制約の明文化

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,3 +59,24 @@ Server Actions (`'use server'`) を使用。クライアントから直接呼び
 | requester | 自分のみ | 不可 | 不可 | 不可 |
 | agent | 全件 | 可 | 可 | 可 |
 | admin | 全件 | 可 | 可 | 可 |
+
+## リアルタイム通知（SSE）と水平スケール制約
+
+未読通知数のリアルタイム配信は Server-Sent Events を利用しています。
+
+- `GET /api/notifications/stream` がクライアントの EventSource を受け、購読を `src/lib/sse-subscribers.ts` の **プロセス内 Map** に登録します。
+- Server Action から `createNotification` / `markAllRead` 等が呼ばれると、同モジュールの `broadcast(userId, count)` でそのプロセスに繋がっている購読者にのみイベントが送られます。
+
+### 制約
+
+- **単一インスタンス前提**です。スタンドアロンの Docker / Node プロセスで動作する限り問題ありませんが、ロードバランサ背後で複数インスタンスを並べた瞬間、別インスタンスで発生した通知は購読中のユーザーに届きません（次回ページロードまで未読カウントがズレる）。
+- 該当 issue: [#60](https://github.com/izumacha/helpdesk-hub/issues/60)。
+
+### 水平スケール時の対応方針
+
+`src/lib/sse-subscribers.ts` のエクスポート (`addSubscriber` / `removeSubscriber` / `broadcast`) を維持したまま、Map ベースの実装を以下のいずれかに差し替えます。
+
+- Redis pub/sub: 各インスタンスがチャンネルを購読し、`broadcast` は publish のみ行う。
+- PostgreSQL `LISTEN/NOTIFY`: 既存の DB を再利用できるが、メッセージサイズと接続数の上限に注意。
+
+SSE エンドポイント (`src/app/api/notifications/stream/route.ts`) は registry の差し替えに影響を受けない設計を維持してください。

--- a/src/features/faq/actions/faq-actions.ts
+++ b/src/features/faq/actions/faq-actions.ts
@@ -18,7 +18,8 @@ export async function createFaqCandidate(ticketId: string, question: string, ans
     throw new Error(parsed.error.issues[0]?.message ?? 'FAQ候補の入力値が不正です');
   }
 
-  const ticket = await prisma.ticket.findUniqueOrThrow({ where: { id: ticketId } });
+  const ticket = await prisma.ticket.findUnique({ where: { id: ticketId } });
+  if (!ticket) throw new Error('チケットが見つかりません');
   if (ticket.status !== 'Resolved') {
     throw new Error('解決済みチケットのみFAQ候補に変換できます');
   }
@@ -43,7 +44,8 @@ export async function updateFaqStatus(faqId: string, status: 'Published' | 'Reje
     throw new Error('エージェントまたは管理者のみ実行できます');
   }
 
-  const faq = await prisma.faqCandidate.findUniqueOrThrow({ where: { id: faqId } });
+  const faq = await prisma.faqCandidate.findUnique({ where: { id: faqId } });
+  if (!faq) throw new Error('FAQ候補が見つかりません');
   if (faq.status !== 'Candidate') {
     throw new Error('候補ステータスのFAQのみ公開・却下できます');
   }

--- a/src/lib/sse-subscribers.ts
+++ b/src/lib/sse-subscribers.ts
@@ -1,9 +1,21 @@
 /**
  * In-memory SSE subscriber registry.
  *
- * Safe for single-process deployments (standalone Docker).
+ * Safe for single-process deployments (standalone Docker) ONLY.
  * Each user maps to a Set of ReadableStreamDefaultController instances —
  * one per open browser tab / EventSource connection.
+ *
+ * Horizontal scaling caveat: when running behind a load balancer with
+ * multiple app instances, a notification produced on instance B will not
+ * reach a user whose EventSource is attached to instance A — the unread
+ * count will silently drift until the next page load (60 s cache TTL).
+ *
+ * To support multi-instance deployments, replace this Map-backed registry
+ * with a Redis pub/sub or Postgres LISTEN/NOTIFY adapter. Keep the
+ * exported function signatures (`addSubscriber` / `removeSubscriber` /
+ * `broadcast`) stable so the SSE route handler does not change.
+ *
+ * Tracking: see GitHub issue #60.
  */
 
 type Controller = ReadableStreamDefaultController<Uint8Array>;


### PR DESCRIPTION
## Summary

優先度 High の 2 件 (#60, #61) に対応しました。

### #61 — FAQ アクションの `findUniqueOrThrow` が Prisma 例外をそのままユーザーに露出させる

`src/features/faq/actions/faq-actions.ts` の `createFaqCandidate` / `updateFaqStatus` で `findUniqueOrThrow` を使っており、レコード未存在時に Prisma の `NotFoundError` が UI に生メッセージで表示される可能性があった。

- `prisma.ticket.findUniqueOrThrow` → `findUnique` + `throw new Error('チケットが見つかりません')`
- `prisma.faqCandidate.findUniqueOrThrow` → `findUnique` + `throw new Error('FAQ候補が見つかりません')`

CLAUDE.md の "Server Actions throw `Error(...)` with Japanese messages for user-facing failures" 方針に揃え、既存の `update-ticket.ts:28-29` のパターンに合わせています。

### #60 — SSE 購読レジストリがプロセス内 Map（水平スケール時に通知欠落）

実装の差し替え（Redis pub/sub / Postgres LISTEN/NOTIFY）は出さず、まず制約を明文化:

- `src/lib/sse-subscribers.ts` のヘッダ JSDoc を強化し、単一プロセス前提と水平スケール時の差し替え方針 (`addSubscriber` / `removeSubscriber` / `broadcast` を維持したまま replaceable) を記述。issue #60 へのトラッキングリンクも明示。
- `docs/architecture.md` に「リアルタイム通知（SSE）と水平スケール制約」セクションを追加し、制約と将来の対応方針をドキュメント化。

中長期の実装差し替えは別 PR として対応する想定です。

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 55 tests passed (Vitest)
- [ ] `npm run lint` — `next lint` の deprecation に伴い `Converting circular structure to JSON` で失敗するが、これは本 PR の変更前から発生する既存の問題（lint 設定移行の別 issue 化推奨）
- [ ] FAQ 候補化 / 公開・却下を実際に存在しない ID で叩いて、日本語エラーが UI に表示されることを手動確認（要 dev server）

https://claude.ai/code/session_01Miukqv8cg51CiPV4x6AUMr