### PR TITLE
SSE 購読レジストリを NotificationBroadcaster ポートに抽象化 (#60)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,13 +32,13 @@ Next.js 15 App Router をベースとしたフルスタック構成。Server Com
 
 ## ディレクトリ構成の考え方
 
-| ディレクトリ | 役割 |
-|---|---|
-| `src/app/(app)/` | 認証済みページ群（Route Group） |
-| `src/domain/` | ビジネスロジック（ステータス遷移ルールなど）|
-| `src/features/` | 機能別モジュール（actions / components） |
-| `src/lib/` | 横断的ユーティリティ（prisma, auth, sla, notifications） |
-| `src/components/layout/` | 共通 UI（Sidebar, Header） |
+| ディレクトリ             | 役割                                                     |
+| ------------------------ | -------------------------------------------------------- |
+| `src/app/(app)/`         | 認証済みページ群（Route Group）                          |
+| `src/domain/`            | ビジネスロジック（ステータス遷移ルールなど）             |
+| `src/features/`          | 機能別モジュール（actions / components）                 |
+| `src/lib/`               | 横断的ユーティリティ（prisma, auth, sla, notifications） |
+| `src/components/layout/` | 共通 UI（Sidebar, Header）                               |
 
 ## 認証フロー
 
@@ -54,29 +54,37 @@ Server Actions (`'use server'`) を使用。クライアントから直接呼び
 
 ## RBAC
 
-| ロール | チケット閲覧 | チケット更新 | エスカレーション | FAQ管理 |
-|---|---|---|---|---|
-| requester | 自分のみ | 不可 | 不可 | 不可 |
-| agent | 全件 | 可 | 可 | 可 |
-| admin | 全件 | 可 | 可 | 可 |
+| ロール    | チケット閲覧 | チケット更新 | エスカレーション | FAQ管理 |
+| --------- | ------------ | ------------ | ---------------- | ------- |
+| requester | 自分のみ     | 不可         | 不可             | 不可    |
+| agent     | 全件         | 可           | 可               | 可      |
+| admin     | 全件         | 可           | 可               | 可      |
 
 ## リアルタイム通知（SSE）と水平スケール制約
 
 未読通知数のリアルタイム配信は Server-Sent Events を利用しています。
 
-- `GET /api/notifications/stream` がクライアントの EventSource を受け、購読を `src/lib/sse-subscribers.ts` の **プロセス内 Map** に登録します。
-- Server Action から `createNotification` / `markAllRead` 等が呼ばれると、同モジュールの `broadcast(userId, count)` でそのプロセスに繋がっている購読者にのみイベントが送られます。
+- `GET /api/notifications/stream` がクライアントの EventSource を受け、購読を `NotificationBroadcaster` ポートに登録します。
+- Server Action から `createNotification` / `markAllRead` 等が呼ばれると、同ポートの `broadcast(userId, count)` 経由でそのプロセスに繋がっている購読者にイベントが送られます。
+
+### ポート / アダプタ構成
+
+Issue [#60](https://github.com/izumacha/helpdesk-hub/issues/60) に基づき、SSE 配信経路は `src/data/ports/notification-broadcaster.ts` のポートに抽象化されています。
+
+- ポート: `NotificationBroadcaster` — `addSubscriber` / `removeSubscriber` / `broadcast` の 3 メソッド。
+- デフォルトアダプタ: `createInMemoryNotificationBroadcaster`（`src/data/adapters/memory/notification-broadcaster.memory.ts`）。プロセス内 `Map` で購読者を管理する従来の実装。
+- コンポジションルート: `src/data/index.ts` が `notificationBroadcaster` を公開します。
+- 後方互換の facade: `src/lib/sse-subscribers.ts` はポートに委譲する薄いラッパです。既存の呼び出し元（SSE route, Server Actions）はそのまま。
 
 ### 制約
 
-- **単一インスタンス前提**です。スタンドアロンの Docker / Node プロセスで動作する限り問題ありませんが、ロードバランサ背後で複数インスタンスを並べた瞬間、別インスタンスで発生した通知は購読中のユーザーに届きません（次回ページロードまで未読カウントがズレる）。
-- 該当 issue: [#60](https://github.com/izumacha/helpdesk-hub/issues/60)。
+- 既定アダプタは **単一インスタンス前提** です。スタンドアロンの Docker / Node プロセスで動作する限り問題ありませんが、ロードバランサ背後で複数インスタンスを並べた瞬間、別インスタンスで発生した通知は購読中のユーザーに届きません（次回ページロードまで未読カウントがズレる）。
 
 ### 水平スケール時の対応方針
 
-`src/lib/sse-subscribers.ts` のエクスポート (`addSubscriber` / `removeSubscriber` / `broadcast`) を維持したまま、Map ベースの実装を以下のいずれかに差し替えます。
+ポートの抽象化により、アダプタの差し替えだけで複数インスタンス対応に移行できます。SSE エンドポイント (`src/app/api/notifications/stream/route.ts`) と Server Action 側のコードは変更不要です。
 
-- Redis pub/sub: 各インスタンスがチャンネルを購読し、`broadcast` は publish のみ行う。
+- Redis pub/sub: 各インスタンスがチャンネルを購読し、`broadcast` は publish のみ行う。他インスタンスは subscribe したメッセージを受けて自プロセスのローカル controller に再配信。
 - PostgreSQL `LISTEN/NOTIFY`: 既存の DB を再利用できるが、メッセージサイズと接続数の上限に注意。
 
-SSE エンドポイント (`src/app/api/notifications/stream/route.ts`) は registry の差し替えに影響を受けない設計を維持してください。
+新しいアダプタを作る際は `NotificationBroadcaster` を実装し、`src/data/index.ts` の `notificationBroadcaster` 生成ロジックを環境変数（例: `NOTIFICATION_BROADCASTER=redis`）などで分岐させてください。

--- a/src/data/adapters/memory/notification-broadcaster.memory.ts
+++ b/src/data/adapters/memory/notification-broadcaster.memory.ts
@@ -1,0 +1,62 @@
+import type {
+  BroadcastController,
+  NotificationBroadcaster,
+} from '@/data/ports/notification-broadcaster';
+
+/**
+ * In-process Map implementation of `NotificationBroadcaster`.
+ *
+ * Safe for single-process deployments (standalone Docker) only. Each user maps
+ * to a Set of `ReadableStreamDefaultController` instances — one per open
+ * browser tab / EventSource connection.
+ *
+ * Horizontal scaling caveat: when running behind a load balancer with multiple
+ * app instances, a `broadcast` call produced on instance B will not reach a
+ * user whose EventSource is attached to instance A — the unread count will
+ * silently drift until the next cache revalidation. Swap this adapter for a
+ * Redis/Postgres-backed one to fix that.
+ */
+export function createInMemoryNotificationBroadcaster(): NotificationBroadcaster {
+  const subscribers = new Map<string, Set<BroadcastController>>();
+
+  const encodeCount = (count: number): Uint8Array =>
+    new TextEncoder().encode(`event: count\ndata: ${JSON.stringify({ count })}\n\n`);
+
+  return {
+    addSubscriber(userId, controller) {
+      let controllers = subscribers.get(userId);
+      if (!controllers) {
+        controllers = new Set();
+        subscribers.set(userId, controllers);
+      }
+      controllers.add(controller);
+    },
+
+    removeSubscriber(userId, controller) {
+      const controllers = subscribers.get(userId);
+      if (!controllers) return;
+      controllers.delete(controller);
+      if (controllers.size === 0) {
+        subscribers.delete(userId);
+      }
+    },
+
+    broadcast(userId, count) {
+      const controllers = subscribers.get(userId);
+      if (!controllers || controllers.size === 0) return;
+
+      const message = encodeCount(count);
+      for (const controller of controllers) {
+        try {
+          controller.enqueue(message);
+        } catch {
+          controllers.delete(controller);
+        }
+      }
+
+      if (controllers.size === 0) {
+        subscribers.delete(userId);
+      }
+    },
+  };
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -9,10 +9,23 @@
  */
 
 import { prisma } from '@/lib/prisma';
+import { createInMemoryNotificationBroadcaster } from './adapters/memory/notification-broadcaster.memory';
 import { buildPrismaRepos, buildPrismaUow } from './adapters/prisma';
+import type { NotificationBroadcaster } from './ports/notification-broadcaster';
 import type { Repos, UnitOfWork } from './ports/unit-of-work';
 
 export type { Repos, UnitOfWork } from './ports/unit-of-work';
+export type { NotificationBroadcaster } from './ports/notification-broadcaster';
 
 export const repos: Repos = buildPrismaRepos(prisma);
 export const uow: UnitOfWork = buildPrismaUow(prisma);
+
+/**
+ * Default notification broadcaster: single-process in-memory registry.
+ *
+ * Multi-instance deployments must replace this with a Redis / Postgres
+ * `LISTEN/NOTIFY` adapter (see `src/data/ports/notification-broadcaster.ts`
+ * and GitHub issue #60).
+ */
+export const notificationBroadcaster: NotificationBroadcaster =
+  createInMemoryNotificationBroadcaster();

--- a/src/data/ports/notification-broadcaster.ts
+++ b/src/data/ports/notification-broadcaster.ts
@@ -1,0 +1,18 @@
+/**
+ * Port: notification broadcaster.
+ *
+ * Abstracts the delivery of unread-count SSE events to connected clients.
+ * The SSE route handler and Server Actions depend on this port, not on any
+ * concrete registry implementation. Swap adapters (Redis pub/sub, Postgres
+ * `LISTEN/NOTIFY`, etc.) without touching the call sites.
+ *
+ * Tracking: see GitHub issue #60.
+ */
+
+export type BroadcastController = ReadableStreamDefaultController<Uint8Array>;
+
+export interface NotificationBroadcaster {
+  addSubscriber(userId: string, controller: BroadcastController): void;
+  removeSubscriber(userId: string, controller: BroadcastController): void;
+  broadcast(userId: string, count: number): void;
+}

--- a/src/lib/sse-subscribers.ts
+++ b/src/lib/sse-subscribers.ts
@@ -1,66 +1,26 @@
 /**
- * In-memory SSE subscriber registry.
+ * Thin facade over the `NotificationBroadcaster` port.
  *
- * Safe for single-process deployments (standalone Docker) ONLY.
- * Each user maps to a Set of ReadableStreamDefaultController instances —
- * one per open browser tab / EventSource connection.
- *
- * Horizontal scaling caveat: when running behind a load balancer with
- * multiple app instances, a notification produced on instance B will not
- * reach a user whose EventSource is attached to instance A — the unread
- * count will silently drift until the next page load (60 s cache TTL).
- *
- * To support multi-instance deployments, replace this Map-backed registry
- * with a Redis pub/sub or Postgres LISTEN/NOTIFY adapter. Keep the
- * exported function signatures (`addSubscriber` / `removeSubscriber` /
- * `broadcast`) stable so the SSE route handler does not change.
+ * Historic call sites (SSE route handler, Server Actions) keep importing
+ * `addSubscriber` / `removeSubscriber` / `broadcast` from this module. The
+ * actual registry lives in `@/data` and can be swapped to a Redis / Postgres
+ * `LISTEN/NOTIFY` adapter without touching these call sites.
  *
  * Tracking: see GitHub issue #60.
  */
 
-type Controller = ReadableStreamDefaultController<Uint8Array>;
+import { notificationBroadcaster } from '@/data';
 
-const subscribers = new Map<string, Set<Controller>>();
+export type Controller = ReadableStreamDefaultController<Uint8Array>;
 
 export function addSubscriber(userId: string, controller: Controller): void {
-  let controllers = subscribers.get(userId);
-  if (!controllers) {
-    controllers = new Set();
-    subscribers.set(userId, controllers);
-  }
-  controllers.add(controller);
+  notificationBroadcaster.addSubscriber(userId, controller);
 }
 
 export function removeSubscriber(userId: string, controller: Controller): void {
-  const controllers = subscribers.get(userId);
-  if (!controllers) return;
-  controllers.delete(controller);
-  if (controllers.size === 0) {
-    subscribers.delete(userId);
-  }
+  notificationBroadcaster.removeSubscriber(userId, controller);
 }
 
-/**
- * Send a "count" SSE event to every open stream for a given user.
- * Silently drops a controller if enqueue throws (client already disconnected).
- */
 export function broadcast(userId: string, count: number): void {
-  const controllers = subscribers.get(userId);
-  if (!controllers || controllers.size === 0) return;
-
-  const message = new TextEncoder().encode(
-    `event: count\ndata: ${JSON.stringify({ count })}\n\n`,
-  );
-
-  for (const controller of controllers) {
-    try {
-      controller.enqueue(message);
-    } catch {
-      controllers.delete(controller);
-    }
-  }
-
-  if (controllers.size === 0) {
-    subscribers.delete(userId);
-  }
+  notificationBroadcaster.broadcast(userId, count);
 }

--- a/tests/data/notification-broadcaster.memory.test.ts
+++ b/tests/data/notification-broadcaster.memory.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createInMemoryNotificationBroadcaster } from '@/data/adapters/memory/notification-broadcaster.memory';
+import type { BroadcastController } from '@/data/ports/notification-broadcaster';
+
+function fakeController(): BroadcastController & { enqueue: ReturnType<typeof vi.fn> } {
+  return {
+    enqueue: vi.fn(),
+    close: vi.fn(),
+    error: vi.fn(),
+    desiredSize: 1,
+  } as unknown as BroadcastController & { enqueue: ReturnType<typeof vi.fn> };
+}
+
+function decodeCount(chunk: unknown): number {
+  const text = new TextDecoder().decode(chunk as Uint8Array);
+  const match = text.match(/data: (\{.*?\})/);
+  if (!match) throw new Error(`no data payload in chunk: ${text}`);
+  return JSON.parse(match[1]).count as number;
+}
+
+describe('in-memory notification broadcaster', () => {
+  it('delivers broadcasts to every open controller for the target user', () => {
+    const broadcaster = createInMemoryNotificationBroadcaster();
+    const ctrlA1 = fakeController();
+    const ctrlA2 = fakeController();
+    const ctrlB = fakeController();
+
+    broadcaster.addSubscriber('user-a', ctrlA1);
+    broadcaster.addSubscriber('user-a', ctrlA2);
+    broadcaster.addSubscriber('user-b', ctrlB);
+
+    broadcaster.broadcast('user-a', 3);
+
+    expect(ctrlA1.enqueue).toHaveBeenCalledTimes(1);
+    expect(ctrlA2.enqueue).toHaveBeenCalledTimes(1);
+    expect(ctrlB.enqueue).not.toHaveBeenCalled();
+    expect(decodeCount(ctrlA1.enqueue.mock.calls[0][0])).toBe(3);
+  });
+
+  it('removes a controller on removeSubscriber', () => {
+    const broadcaster = createInMemoryNotificationBroadcaster();
+    const ctrl = fakeController();
+
+    broadcaster.addSubscriber('user-a', ctrl);
+    broadcaster.removeSubscriber('user-a', ctrl);
+    broadcaster.broadcast('user-a', 1);
+
+    expect(ctrl.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when broadcasting to an unknown user', () => {
+    const broadcaster = createInMemoryNotificationBroadcaster();
+    expect(() => broadcaster.broadcast('ghost', 5)).not.toThrow();
+  });
+
+  it('silently drops a controller whose enqueue throws', () => {
+    const broadcaster = createInMemoryNotificationBroadcaster();
+    const healthy = fakeController();
+    const broken = fakeController();
+    broken.enqueue.mockImplementation(() => {
+      throw new Error('stream closed');
+    });
+
+    broadcaster.addSubscriber('user-a', healthy);
+    broadcaster.addSubscriber('user-a', broken);
+
+    broadcaster.broadcast('user-a', 2);
+    expect(healthy.enqueue).toHaveBeenCalledTimes(1);
+
+    broken.enqueue.mockClear();
+    broadcaster.broadcast('user-a', 4);
+    expect(broken.enqueue).not.toHaveBeenCalled();
+    expect(healthy.enqueue).toHaveBeenCalledTimes(2);
+  });
+
+  it('isolates state between independent broadcaster instances', () => {
+    const a = createInMemoryNotificationBroadcaster();
+    const b = createInMemoryNotificationBroadcaster();
+    const ctrl = fakeController();
+
+    a.addSubscriber('user-a', ctrl);
+    b.broadcast('user-a', 9);
+
+    expect(ctrl.enqueue).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #60 のアーキテクチャ改善パート。SSE 購読レジストリを `src/data` の port/adapter パターンに揃え、将来 Redis pub/sub / Postgres `LISTEN/NOTIFY` への差し替えを **呼び出し元を変更せず** に行えるようにした。

- `src/data/ports/notification-broadcaster.ts` — `NotificationBroadcaster` ポート (`addSubscriber` / `removeSubscriber` / `broadcast`)
- `src/data/adapters/memory/notification-broadcaster.memory.ts` — 既定の in-memory アダプタ (従来の Map ベース実装をここに集約)
- `src/data/index.ts` — `notificationBroadcaster` をコンポジションルートから公開
- `src/lib/sse-subscribers.ts` — ポートへ委譲する薄いファサードに変更。SSE route / Server Action 等の既存呼び出し元は一切変更なし
- `tests/data/notification-broadcaster.memory.test.ts` — 配信 / 切断 / 独立性 / エラーハンドリング (5 ケース, 計 60 tests green)
- `docs/architecture.md` — ポート / アダプタ構成と差し替え手順を追記

### 本 PR の範囲外

Redis / Postgres 実アダプタの実装は別 PR。ポート抽象化によって、アダプタ追加時のパッチは `src/data/index.ts` のコンポジション差分と新しいアダプタファイルのみで済む想定。

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test` (60 passed — 新規 5 ケース含む)
- [ ] 手動で SSE ストリームが従来どおり動作することを dev server で確認 (reviewer 依頼)
