### PR TITLE
Medium 優先度 issue 群の修正 (#62, #63, #64, #65, #67)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,7 @@
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/helpdesk_hub"
 
 # Auth.js
-NEXTAUTH_SECRET="your-secret-key-here"
+# Generate with: openssl rand -base64 32
+# Must be at least 32 characters; the default placeholder is rejected in production.
+NEXTAUTH_SECRET=""
 NEXTAUTH_URL="http://localhost:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,8 @@ services:
       - "3000:3000"
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/helpdesk_hub
-      NEXTAUTH_SECRET: change-me-in-production
-      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET must be set in .env (copy from .env.example and generate a secure value)}
+      NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
     depends_on:
       db:
         condition: service_healthy

--- a/src/app/(app)/tickets/page.tsx
+++ b/src/app/(app)/tickets/page.tsx
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { isAgent as checkIsAgent } from '@/lib/role';
 import { STATUS_LABELS, STATUS_COLORS, PRIORITY_LABELS, PRIORITY_COLORS } from '@/lib/constants';
 import { TicketFilters } from '@/features/tickets/components/TicketFilters';
+import { clampPage, parsePageParam } from '@/lib/validations/pagination';
 import type { TicketStatus, Priority, Prisma } from '@/generated/prisma';
 
 const PAGE_SIZE = 20;
@@ -26,8 +27,7 @@ export default async function TicketsPage({ searchParams }: Props) {
   if (!session?.user?.id) return null;
 
   const isAgent = checkIsAgent(session.user.role);
-  const page = Math.max(1, parseInt(sp.page ?? '1', 10));
-  const skip = (page - 1) * PAGE_SIZE;
+  const requestedPage = parsePageParam(sp.page);
 
   // Build Prisma where clause
   const where: Prisma.TicketWhereInput = {};
@@ -56,7 +56,12 @@ export default async function TicketsPage({ searchParams }: Props) {
     where.assigneeId = sp.assigneeId === 'unassigned' ? null : sp.assigneeId;
   }
 
-  const [tickets, total, categories, agents] = await Promise.all([
+  const total = await prisma.ticket.count({ where });
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const page = clampPage(requestedPage, totalPages);
+  const skip = (page - 1) * PAGE_SIZE;
+
+  const [tickets, categories, agents] = await Promise.all([
     prisma.ticket.findMany({
       where,
       orderBy: { createdAt: 'desc' },
@@ -68,7 +73,6 @@ export default async function TicketsPage({ searchParams }: Props) {
         category: { select: { id: true, name: true } },
       },
     }),
-    prisma.ticket.count({ where }),
     prisma.category.findMany({ orderBy: { name: 'asc' } }),
     isAgent
       ? prisma.user.findMany({
@@ -78,8 +82,6 @@ export default async function TicketsPage({ searchParams }: Props) {
         })
       : Promise.resolve([]),
   ]);
-
-  const totalPages = Math.ceil(total / PAGE_SIZE);
 
   return (
     <div>
@@ -200,7 +202,15 @@ function Pagination({
 }
 
 function isValidStatus(s: string): s is TicketStatus {
-  return ['New', 'Open', 'WaitingForUser', 'InProgress', 'Escalated', 'Resolved', 'Closed'].includes(s);
+  return [
+    'New',
+    'Open',
+    'WaitingForUser',
+    'InProgress',
+    'Escalated',
+    'Resolved',
+    'Closed',
+  ].includes(s);
 }
 
 function isValidPriority(p: string): p is Priority {

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -26,6 +26,26 @@ export async function POST(req: Request) {
   }
 
   const { title, body: ticketBody, priority, categoryId } = parsed.data;
+
+  if (categoryId) {
+    const category = await repos.categories.findById(categoryId);
+    if (!category) {
+      return NextResponse.json(
+        {
+          error: '入力値が正しくありません',
+          issues: [
+            {
+              code: 'custom',
+              path: ['categoryId'],
+              message: '指定されたカテゴリが存在しません',
+            },
+          ],
+        },
+        { status: 422 },
+      );
+    }
+  }
+
   const now = new Date();
 
   const ticket = await repos.tickets.create({

--- a/src/data/adapters/memory/category-repository.memory.ts
+++ b/src/data/adapters/memory/category-repository.memory.ts
@@ -8,5 +8,9 @@ export function makeCategoryRepo(store: Store): CategoryRepository {
         .map((c) => ({ id: c.id, name: c.name }))
         .sort((a, b) => a.name.localeCompare(b.name));
     },
+    async findById(id) {
+      const row = store.categories.get(id);
+      return row ? { id: row.id, name: row.name } : null;
+    },
   };
 }

--- a/src/data/adapters/prisma/category-repository.prisma.ts
+++ b/src/data/adapters/prisma/category-repository.prisma.ts
@@ -10,5 +10,12 @@ export function makeCategoryRepo(db: PrismaLike): CategoryRepository {
       });
       return rows;
     },
+    async findById(id) {
+      const row = await db.category.findUnique({
+        where: { id },
+        select: { id: true, name: true },
+      });
+      return row;
+    },
   };
 }

--- a/src/data/ports/category-repository.ts
+++ b/src/data/ports/category-repository.ts
@@ -5,4 +5,5 @@ export interface CategorySummary {
 
 export interface CategoryRepository {
   list(): Promise<CategorySummary[]>;
+  findById(id: string): Promise<CategorySummary | null>;
 }

--- a/src/features/faq/actions/faq-actions.ts
+++ b/src/features/faq/actions/faq-actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { isAgent } from '@/lib/role';
+import { FAQ_ELIGIBLE_STATUSES } from '@/lib/constants';
 import { faqCandidateSchema } from '@/lib/validations/faq';
 
 export async function createFaqCandidate(ticketId: string, question: string, answer: string) {
@@ -20,7 +21,7 @@ export async function createFaqCandidate(ticketId: string, question: string, ans
 
   const ticket = await prisma.ticket.findUnique({ where: { id: ticketId } });
   if (!ticket) throw new Error('チケットが見つかりません');
-  if (ticket.status !== 'Resolved') {
+  if (!FAQ_ELIGIBLE_STATUSES.includes(ticket.status)) {
     throw new Error('解決済みチケットのみFAQ候補に変換できます');
   }
 

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -87,9 +87,14 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
   ]);
 
   if (!ticket) throw new Error('チケットが見つかりません');
-  if (newAssigneeId && !newUser) throw new Error('担当者ユーザーが見つかりません');
-  if (newUser && !isAgent(newUser.role)) {
-    throw new Error('担当者にはエージェントまたは管理者のみ設定できます');
+  if (newAssigneeId && (!newUser || !isAgent(newUser.role))) {
+    const reason: 'not-found' | 'not-agent' = newUser ? 'not-agent' : 'not-found';
+    console.warn('[updateTicketAssignee] assignee rejected', {
+      ticketId,
+      newAssigneeId,
+      reason,
+    });
+    throw new Error('指定された担当者を設定できません');
   }
 
   const oldName = ticket.assignee?.name ?? null;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,18 @@ import { compare } from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
 import type { Role } from '@/generated/prisma';
 
+const INSECURE_SECRETS = new Set(['change-me-in-production', 'your-secret-key-here', '']);
+const secret = process.env.NEXTAUTH_SECRET ?? '';
+if (INSECURE_SECRETS.has(secret) || secret.length < 32) {
+  const message =
+    '[auth] NEXTAUTH_SECRET is missing, default, or shorter than 32 characters. ' +
+    'Generate a secure value (e.g. `openssl rand -base64 32`) before deploying.';
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(message);
+  }
+  console.warn(message);
+}
+
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [
     Credentials({

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,7 @@
+import type { TicketStatus } from '@/generated/prisma';
+
+export const FAQ_ELIGIBLE_STATUSES: readonly TicketStatus[] = ['Resolved'];
+
 export const STATUS_LABELS: Record<string, string> = {
   New: '新規',
   Open: 'オープン',

--- a/src/lib/validations/pagination.ts
+++ b/src/lib/validations/pagination.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const pageParamSchema = z.coerce.number().int().min(1).catch(1);
+
+export function parsePageParam(raw: unknown): number {
+  return pageParamSchema.parse(raw);
+}
+
+export function clampPage(page: number, totalPages: number): number {
+  if (totalPages <= 0) return 1;
+  return Math.min(Math.max(page, 1), totalPages);
+}

--- a/tests/features/update-ticket.test.ts
+++ b/tests/features/update-ticket.test.ts
@@ -177,7 +177,7 @@ describe('updateTicketAssignee (provider-agnostic)', () => {
     const { updateTicketAssignee } = await import('@/features/tickets/actions/update-ticket');
 
     await expect(updateTicketAssignee(ticketId, 'u-req-1')).rejects.toThrow(
-      /エージェントまたは管理者のみ設定/,
+      /指定された担当者を設定できません/,
     );
     expect([...store.histories.values()]).toHaveLength(0);
     expect([...store.notifications.values()]).toHaveLength(0);


### PR DESCRIPTION
## Summary

現状 open な issue のうち最高優先度帯 (Medium) を対象に、複雑な #66 (レート制限) と仕様確認の必要な #68 / E2E 追加の #69 (Low) を除く 5 件を実装。

### 修正内容

- **#62** `createFaqCandidate` の `'Resolved'` 文字列比較を `FAQ_ELIGIBLE_STATUSES: readonly TicketStatus[]` に切り出し、`@/generated/prisma` の enum 型で保護。将来の Status 改名がコンパイル時に検知される。
- **#63** `POST /api/tickets` で `categoryId` 指定時に `repos.categories.findById` で存在検証。未存在なら 422 を Zod issue 形式で返却。`CategoryRepository` ポートに `findById` を追加し、Prisma / memory 両アダプタを更新。
- **#64** `src/lib/validations/pagination.ts` に `pageParamSchema` (`z.coerce.number().int().min(1).catch(1)`) と `clampPage` を追加。`tickets/page.tsx` では先に件数取得 → `totalPages` クランプで巨大 OFFSET を防止。`NaN` / 負数 / `page=abc` も安全にフォールバック。
- **#65** `updateTicketAssignee` の「ユーザー未存在」と「requester ロール」を同一メッセージ `指定された担当者を設定できません` に統一。詳細 (`reason: 'not-found' | 'not-agent'`) は `console.warn` でサーバーログのみに残す。既存テストも更新。
- **#67** `docker-compose.yml` の `NEXTAUTH_SECRET` を `${NEXTAUTH_SECRET:?...}` に変更し、未設定で compose 自体が起動失敗するように。`src/lib/auth.ts` でデフォルト値 / 32 文字未満を検知し、本番は起動拒否・開発は警告。`.env.example` に生成手順を記載。

### 未対応 / 別 PR 推奨

- **#66** レート制限: Redis / メモリベースのトークンバケット実装が必要で、単独の PR で扱うべき規模のため本 PR には含めず。
- **#68** `Closed → Open` の要件確認: `docs/requirements.md` での仕様合意後に別 issue として実装。
- **#69** E2E RBAC 境界ケースの追加: 別 PR 推奨。

## Test plan

- [x] `npm run typecheck` パス
- [x] `npm run test` — 60/60 パス (テストファイル 7)
- [ ] `npm run test:e2e` — 本環境では DB 未起動のため未実施
- [ ] Docker 起動確認 — NEXTAUTH_SECRET 未設定時の compose 起動エラーを手動確認
- [ ] `POST /api/tickets` で不正な `categoryId` → 422 応答を手動確認
- [ ] `/tickets?page=abc` / `?page=-1` / `?page=99999999` の挙動確認

https://claude.ai/code/session_012f9BkA1PxPgLj5auJoVyds