### PR TITLE
GitHub Actions CI ワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
   e2e:
     name: Playwright E2E
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     services:
       postgres:
         image: postgres:16-alpine
@@ -115,13 +118,60 @@ jobs:
           exit 1
 
       - name: Run Playwright tests
-        run: npx playwright test --reporter=list,html
+        id: pw
+        run: npx playwright test --reporter=list,html 2>&1 | tee playwright.log
 
-      - name: Dump app log on failure
+      - name: Dump logs on failure
         if: failure()
         run: |
           echo "=== app.log ==="
-          cat app.log || true
+          cat app.log 2>/dev/null || echo "(no app.log)"
+          echo "=== playwright.log (tail) ==="
+          tail -200 playwright.log 2>/dev/null || echo "(no playwright.log)"
+
+      - name: Post failure logs as PR comment
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const read = (p, n) => {
+              try {
+                const data = fs.readFileSync(p, 'utf8').split('\n');
+                return data.slice(-n).join('\n');
+              } catch {
+                return '(missing)';
+              }
+            };
+            const pw = read('playwright.log', 200);
+            const app = read('app.log', 120);
+            const body = [
+              '### Playwright E2E failure diagnostics',
+              '',
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              '',
+              '<details><summary>playwright.log (tail)</summary>',
+              '',
+              '```',
+              pw,
+              '```',
+              '',
+              '</details>',
+              '',
+              '<details><summary>app.log (tail)</summary>',
+              '',
+              '```',
+              app,
+              '```',
+              '',
+              '</details>',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,23 +91,37 @@ jobs:
         run: npm run build
 
       - name: Start app
-        run: nohup npm run start > app.log 2>&1 &
+        run: |
+          nohup npm run start > app.log 2>&1 &
+          echo $! > app.pid
+          echo "Started app with PID $(cat app.pid)"
 
       - name: Wait for app
         run: |
           for i in {1..60}; do
             if curl -sSf http://localhost:3000/login > /dev/null; then
-              echo "App is ready"
+              echo "App is ready after ${i}s"
               exit 0
+            fi
+            if ! kill -0 "$(cat app.pid)" 2>/dev/null; then
+              echo "App process died before becoming ready"
+              cat app.log
+              exit 1
             fi
             sleep 1
           done
-          echo "App failed to start"
+          echo "App failed to respond within 60s"
           cat app.log
           exit 1
 
       - name: Run Playwright tests
         run: npm run test:e2e
+
+      - name: Dump app log on failure
+        if: failure()
+        run: |
+          echo "=== app.log ==="
+          cat app.log || true
 
       - name: Upload Playwright report
         if: always()
@@ -116,3 +130,12 @@ jobs:
           name: playwright-report
           path: playwright-report
           retention-days: 7
+
+      - name: Upload app log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-log
+          path: app.log
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/helpdesk_hub
       NEXTAUTH_SECRET: ci-test-secret
       NEXTAUTH_URL: http://localhost:3000
+      AUTH_TRUST_HOST: 'true'
       BASE_URL: http://localhost:3000
       CI: 'true'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,117 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20'
+
+jobs:
+  lint-typecheck-test:
+    name: Lint / Typecheck / Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npm run db:generate
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Unit tests
+        run: npm run test
+
+  e2e:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: helpdesk_hub
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/helpdesk_hub
+      NEXTAUTH_SECRET: ci-test-secret
+      NEXTAUTH_URL: http://localhost:3000
+      BASE_URL: http://localhost:3000
+      CI: 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npm run db:generate
+
+      - name: Sync database schema
+        run: npx prisma db push --skip-generate
+
+      - name: Seed database
+        run: npm run db:seed
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build Next.js
+        run: npm run build
+
+      - name: Start app
+        run: nohup npm run start > app.log 2>&1 &
+
+      - name: Wait for app
+        run: |
+          for i in {1..60}; do
+            if curl -sSf http://localhost:3000/login > /dev/null; then
+              echo "App is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "App failed to start"
+          cat app.log
+          exit 1
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           exit 1
 
       - name: Run Playwright tests
-        run: npm run test:e2e
+        run: npx playwright test --reporter=list,html
 
       - name: Dump app log on failure
         if: failure()

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,18 @@
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-import { FlatCompat } from '@eslint/eslintrc';
+import nextCoreWebVitals from 'eslint-config-next/core-web-vitals';
+import nextTypescript from 'eslint-config-next/typescript';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
-
-const eslintConfig = [
-  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+const config = [
+  {
+    ignores: [
+      '.next/**',
+      'node_modules/**',
+      'src/generated/**',
+      'playwright-report/**',
+      'test-results/**',
+    ],
+  },
+  ...nextCoreWebVitals,
+  ...nextTypescript,
 ];
 
-export default eslintConfig;
+export default config;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "lint": "next lint",
+    "lint": "eslint .",
     "format": "prettier --write .",
     "test": "vitest run",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` を追加。`push` / `pull_request` (対象 `main`) でトリガー、同一 ref の実行はキャンセル。
- **lint-typecheck-test** ジョブ: `npm ci` → `prisma generate` → `lint` → `typecheck` → `vitest`。
- **e2e** ジョブ: `postgres:16-alpine` サービスを起動し、`prisma db push` でスキーマを同期 → `db:seed` → `next build` → バックグラウンドで `npm start` → `/login` を待機 → Playwright 実行。失敗時も `playwright-report` を artifact としてアップロード。
- migrations ディレクトリが未コミットのため `migrate deploy` ではなく `db push` を採用。
- E2E は seed ユーザー (`agent1@example.com` など) に依存するため seed を必ず流す。

## Test plan
- [ ] PR 作成時に CI ワークフローが走り、lint/typecheck/unit が green になる
- [ ] E2E ジョブで Postgres サービスが起動し、`prisma db push` と seed が成功する
- [ ] Next.js サーバーが起動して Playwright テストが通る
- [ ] 失敗ケースで `playwright-report` artifact が取得できる

https://claude.ai/code/session_01LDjfkFDZ48ThygRpU2CjBw