### PR TITLE
バックログ issue #62 #63 #64 #65 #67 の解決

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,29 @@
 
 ## 主な機能
 
-| カテゴリ | 機能 |
-|---|---|
-| 認証 | ログイン/ログアウト、ロール別アクセス制御（requester / agent / admin） |
-| チケット | 登録・一覧・詳細・キーワード検索・多条件フィルタ・ページネーション |
-| ワークフロー | ステータス遷移管理、優先度・担当者アサイン、コメント、変更履歴 |
-| SLA | 解決期限設定・期限間近/超過バッジ表示 |
-| エスカレーション | 二次対応へのエスカレーション（理由・日時記録、履歴残存） |
-| ダッシュボード | ステータス別件数、SLA超過件数、担当者別ワークロード |
-| FAQ候補 | 解決済み問い合わせのFAQ変換（公開/却下管理） |
-| 通知 | アサイン・エスカレーション時の自動通知、未読バッジ |
+| カテゴリ         | 機能                                                                   |
+| ---------------- | ---------------------------------------------------------------------- |
+| 認証             | ログイン/ログアウト、ロール別アクセス制御（requester / agent / admin） |
+| チケット         | 登録・一覧・詳細・キーワード検索・多条件フィルタ・ページネーション     |
+| ワークフロー     | ステータス遷移管理、優先度・担当者アサイン、コメント、変更履歴         |
+| SLA              | 解決期限設定・期限間近/超過バッジ表示                                  |
+| エスカレーション | 二次対応へのエスカレーション（理由・日時記録、履歴残存）               |
+| ダッシュボード   | ステータス別件数、SLA超過件数、担当者別ワークロード                    |
+| FAQ候補          | 解決済み問い合わせのFAQ変換（公開/却下管理）                           |
+| 通知             | アサイン・エスカレーション時の自動通知、未読バッジ                     |
 
 ## 技術スタック
 
-| レイヤー | 技術 |
-|---|---|
-| フロントエンド | Next.js 15 (App Router), React 19, Tailwind CSS v4 |
-| 認証 | Auth.js v5 (next-auth@beta), Credentials プロバイダ |
-| ORM | Prisma 5 |
-| DB | PostgreSQL |
-| バリデーション | Zod |
-| フォーム | react-hook-form + @hookform/resolvers |
-| テスト | Vitest (unit), Playwright (E2E) |
-| インフラ | Docker / Docker Compose |
+| レイヤー       | 技術                                                |
+| -------------- | --------------------------------------------------- |
+| フロントエンド | Next.js 15 (App Router), React 19, Tailwind CSS v4  |
+| 認証           | Auth.js v5 (next-auth@beta), Credentials プロバイダ |
+| ORM            | Prisma 5                                            |
+| DB             | PostgreSQL                                          |
+| バリデーション | Zod                                                 |
+| フォーム       | react-hook-form + @hookform/resolvers               |
+| テスト         | Vitest (unit), Playwright (E2E)                     |
+| インフラ       | Docker / Docker Compose                             |
 
 ## セットアップ
 
@@ -34,12 +34,15 @@
 
 ```bash
 cp .env.example .env
+# `.env` の NEXTAUTH_SECRET を強い値に設定 (例: `openssl rand -base64 32`)
 docker compose up -d
 docker compose exec app npx prisma migrate deploy
 docker compose exec app npx prisma db seed
 ```
 
 アプリは http://localhost:3000 で起動します。
+
+> **注意:** `NEXTAUTH_SECRET` が未設定のまま `docker compose up` を実行すると compose 自体が起動に失敗します。本番デプロイでは必ず強いランダム値を設定してください。
 
 ### ローカル直接起動
 
@@ -63,11 +66,11 @@ npm run dev
 
 ## デフォルトユーザー（seed後）
 
-| メールアドレス | ロール | パスワード |
-|---|---|---|
+| メールアドレス         | ロール    | パスワード  |
+| ---------------------- | --------- | ----------- |
 | requester1@example.com | requester | password123 |
-| agent1@example.com | agent | password123 |
-| admin@example.com | admin | password123 |
+| agent1@example.com     | agent     | password123 |
+| admin@example.com      | admin     | password123 |
 
 ## コマンド一覧
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,9 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - '5432:5432'
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
       interval: 5s
       timeout: 5s
       retries: 5
@@ -20,11 +20,11 @@ services:
     build: .
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - '3000:3000'
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/helpdesk_hub
-      NEXTAUTH_SECRET: change-me-in-production
-      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?set NEXTAUTH_SECRET in .env — see .env.example}
+      NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
     depends_on:
       db:
         condition: service_healthy

--- a/src/app/(app)/tickets/page.tsx
+++ b/src/app/(app)/tickets/page.tsx
@@ -8,6 +8,14 @@ import { TicketFilters } from '@/features/tickets/components/TicketFilters';
 import type { TicketStatus, Priority, Prisma } from '@/generated/prisma';
 
 const PAGE_SIZE = 20;
+const MAX_PAGE = 10_000;
+
+function parsePageParam(raw: string | undefined): number {
+  if (!raw) return 1;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) return 1;
+  return Math.min(n, MAX_PAGE);
+}
 
 interface Props {
   searchParams: Promise<{
@@ -26,8 +34,8 @@ export default async function TicketsPage({ searchParams }: Props) {
   if (!session?.user?.id) return null;
 
   const isAgent = checkIsAgent(session.user.role);
-  const page = Math.max(1, parseInt(sp.page ?? '1', 10));
-  const skip = (page - 1) * PAGE_SIZE;
+  const requestedPage = parsePageParam(sp.page);
+  const skip = (requestedPage - 1) * PAGE_SIZE;
 
   // Build Prisma where clause
   const where: Prisma.TicketWhereInput = {};
@@ -80,6 +88,7 @@ export default async function TicketsPage({ searchParams }: Props) {
   ]);
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
+  const page = Math.min(requestedPage, Math.max(totalPages, 1));
 
   return (
     <div>
@@ -200,7 +209,15 @@ function Pagination({
 }
 
 function isValidStatus(s: string): s is TicketStatus {
-  return ['New', 'Open', 'WaitingForUser', 'InProgress', 'Escalated', 'Resolved', 'Closed'].includes(s);
+  return [
+    'New',
+    'Open',
+    'WaitingForUser',
+    'InProgress',
+    'Escalated',
+    'Resolved',
+    'Closed',
+  ].includes(s);
 }
 
 function isValidPriority(p: string): p is Priority {

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -26,8 +26,27 @@ export async function POST(req: Request) {
   }
 
   const { title, body: ticketBody, priority, categoryId } = parsed.data;
-  const now = new Date();
 
+  if (categoryId) {
+    const category = await repos.categories.findById(categoryId);
+    if (!category) {
+      return NextResponse.json(
+        {
+          error: '入力値が正しくありません',
+          issues: [
+            {
+              code: 'custom',
+              path: ['categoryId'],
+              message: '指定されたカテゴリが存在しません',
+            },
+          ],
+        },
+        { status: 422 },
+      );
+    }
+  }
+
+  const now = new Date();
   const ticket = await repos.tickets.create({
     title,
     body: ticketBody,

--- a/src/data/adapters/memory/category-repository.memory.ts
+++ b/src/data/adapters/memory/category-repository.memory.ts
@@ -8,5 +8,9 @@ export function makeCategoryRepo(store: Store): CategoryRepository {
         .map((c) => ({ id: c.id, name: c.name }))
         .sort((a, b) => a.name.localeCompare(b.name));
     },
+    async findById(id) {
+      const c = store.categories.get(id);
+      return c ? { id: c.id, name: c.name } : null;
+    },
   };
 }

--- a/src/data/adapters/prisma/category-repository.prisma.ts
+++ b/src/data/adapters/prisma/category-repository.prisma.ts
@@ -10,5 +10,11 @@ export function makeCategoryRepo(db: PrismaLike): CategoryRepository {
       });
       return rows;
     },
+    async findById(id) {
+      return db.category.findUnique({
+        where: { id },
+        select: { id: true, name: true },
+      });
+    },
   };
 }

--- a/src/data/ports/category-repository.ts
+++ b/src/data/ports/category-repository.ts
@@ -5,4 +5,5 @@ export interface CategorySummary {
 
 export interface CategoryRepository {
   list(): Promise<CategorySummary[]>;
+  findById(id: string): Promise<CategorySummary | null>;
 }

--- a/src/features/faq/actions/faq-actions.ts
+++ b/src/features/faq/actions/faq-actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { isAgent } from '@/lib/role';
+import { FAQ_ELIGIBLE_STATUSES } from '@/lib/constants';
 import { faqCandidateSchema } from '@/lib/validations/faq';
 
 export async function createFaqCandidate(ticketId: string, question: string, answer: string) {
@@ -20,7 +21,7 @@ export async function createFaqCandidate(ticketId: string, question: string, ans
 
   const ticket = await prisma.ticket.findUnique({ where: { id: ticketId } });
   if (!ticket) throw new Error('チケットが見つかりません');
-  if (ticket.status !== 'Resolved') {
+  if (!FAQ_ELIGIBLE_STATUSES.includes(ticket.status)) {
     throw new Error('解決済みチケットのみFAQ候補に変換できます');
   }
 

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -87,9 +87,12 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
   ]);
 
   if (!ticket) throw new Error('チケットが見つかりません');
-  if (newAssigneeId && !newUser) throw new Error('担当者ユーザーが見つかりません');
-  if (newUser && !isAgent(newUser.role)) {
-    throw new Error('担当者にはエージェントまたは管理者のみ設定できます');
+  if (newAssigneeId) {
+    const reason = !newUser ? 'not-found' : !isAgent(newUser.role) ? 'not-agent' : null;
+    if (reason) {
+      console.warn('[updateTicketAssignee] rejected', { ticketId, newAssigneeId, reason });
+      throw new Error('指定された担当者を設定できません');
+    }
   }
 
   const oldName = ticket.assignee?.name ?? null;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,24 @@ import { compare } from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
 import type { Role } from '@/generated/prisma';
 
+const WEAK_NEXTAUTH_SECRETS = new Set([
+  'change-me-in-production',
+  'your-secret-key-here',
+  'secret',
+  '',
+]);
+
+const secret = process.env.NEXTAUTH_SECRET;
+if (!secret) {
+  console.warn(
+    '[auth] NEXTAUTH_SECRET is not set — sessions will not be verifiable across restarts.',
+  );
+} else if (WEAK_NEXTAUTH_SECRETS.has(secret)) {
+  console.warn(
+    '[auth] NEXTAUTH_SECRET is set to a known placeholder value. Generate a strong secret (e.g. `openssl rand -base64 32`) before deploying.',
+  );
+}
+
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [
     Credentials({

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,7 @@
+import type { TicketStatus } from '@/generated/prisma';
+
+export const FAQ_ELIGIBLE_STATUSES: readonly TicketStatus[] = ['Resolved'];
+
 export const STATUS_LABELS: Record<string, string> = {
   New: '新規',
   Open: 'オープン',

--- a/tests/features/update-ticket.test.ts
+++ b/tests/features/update-ticket.test.ts
@@ -177,7 +177,18 @@ describe('updateTicketAssignee (provider-agnostic)', () => {
     const { updateTicketAssignee } = await import('@/features/tickets/actions/update-ticket');
 
     await expect(updateTicketAssignee(ticketId, 'u-req-1')).rejects.toThrow(
-      /エージェントまたは管理者のみ設定/,
+      /指定された担当者を設定できません/,
+    );
+    expect([...store.histories.values()]).toHaveLength(0);
+    expect([...store.notifications.values()]).toHaveLength(0);
+  });
+
+  it('refuses to assign a non-existent user with the same message', async () => {
+    const { ticketId } = await seed();
+    const { updateTicketAssignee } = await import('@/features/tickets/actions/update-ticket');
+
+    await expect(updateTicketAssignee(ticketId, 'u-missing')).rejects.toThrow(
+      /指定された担当者を設定できません/,
     );
     expect([...store.histories.values()]).toHaveLength(0);
     expect([...store.notifications.values()]).toHaveLength(0);


### PR DESCRIPTION
## Summary

バックログから以下 5 件の issue をまとめて解決。design 要件確認が必要な #68 / 大きめの仕様変更となる #66・#69 は今回対象外。

- **#62** `createFaqCandidate` の `ticket.status !== 'Resolved'` 文字列比較を、`@/generated/prisma` の `TicketStatus` 型で型付けした `FAQ_ELIGIBLE_STATUSES` 定数に置換。enum 改名時に `tsc` が検知できるように。
- **#63** `POST /api/tickets` で `categoryId` の存在を確認し、未存在なら 422 `{ issues: [...] }` を返す。`CategoryRepository` に `findById` を追加（prisma / memory 両アダプタ）。
- **#64** `/tickets?page=` を整数 + `[1, 10000]` にバリデーション。`NaN` / 負数 / 巨大値を弾き、表示ページは `Math.min(requestedPage, max(totalPages, 1))` で clip。
- **#65** `updateTicketAssignee` の「ユーザー不在」と「requester ロール」のエラーを同一文言（`指定された担当者を設定できません`）に統合、詳細はサーバーログに `reason` 付きで記録。
- **#67** `docker-compose.yml` の `NEXTAUTH_SECRET` を `${NEXTAUTH_SECRET:?...}` に変更、未設定なら compose 自体が起動しない。`src/lib/auth.ts` に既知の弱い / プレースホルダ値を検知した場合の起動時 warn を追加。README に注意書きを追記。

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (61 passed, including 2 new cases for unified assignee error message)
- [ ] `docker compose up` で `NEXTAUTH_SECRET` 未設定時に compose が起動失敗することを手動確認
- [ ] POST /api/tickets に存在しない categoryId を送って 422 が返ることを手動確認
- [ ] `/tickets?page=abc` `/tickets?page=-1` `/tickets?page=99999999` で 1 ページ目 or 最終ページに丸められることを確認

https://claude.ai/code/session_0126cAmjjKe83vXecV8V9Yyz