### PR TITLE
バックログ issue #66 #68 #69 に対応

### DIFF
--- a/e2e/rbac.spec.ts
+++ b/e2e/rbac.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect, Page } from '@playwright/test';
+
+// Issue #69: verify requester RBAC boundaries and middleware 401 behaviour.
+// Seed data assumed: see `prisma/seed.ts`.
+//   - requester1@example.com owns `seed-t-01` (New)
+//   - requester3@example.com owns `seed-t-04` (InProgress)
+const REQUESTER1 = 'requester1@example.com';
+const OWN_TICKET_ID = 'seed-t-01';
+const OTHERS_TICKET_ID = 'seed-t-04';
+
+async function login(page: Page, email: string) {
+  await page.goto('/login');
+  await page.getByLabel(/メールアドレス|Email/i).fill(email);
+  await page.getByLabel(/パスワード|Password/i).fill('password123');
+  await page.getByRole('button', { name: /ログイン/i }).click();
+  await page.waitForURL(/\/dashboard|\/tickets/);
+}
+
+test.describe('requester RBAC 境界', () => {
+  test('他リクエスタのチケット詳細を直接 URL で開くと not-found になる', async ({ page }) => {
+    await login(page, REQUESTER1);
+    const res = await page.goto(`/tickets/${OTHERS_TICKET_ID}`);
+    expect(res?.status()).toBe(404);
+  });
+
+  test('自分のチケット詳細ではステータス/優先度/担当/エスカレーション/FAQ 操作 UI が見えない', async ({
+    page,
+  }) => {
+    await login(page, REQUESTER1);
+    await page.goto(`/tickets/${OWN_TICKET_ID}`);
+    await expect(page.getByText('問い合わせ内容')).toBeVisible();
+
+    // Sidebar dropdowns are agent-only. Requesters see the value as plain text.
+    await expect(page.locator('main select')).toHaveCount(0);
+
+    // Escalation trigger / FAQ candidate controls are agent-only.
+    await expect(page.getByRole('button', { name: /エスカレーション/ })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /FAQ候補/ })).toHaveCount(0);
+
+    // Comment input is still available to the creator.
+    await expect(page.getByPlaceholder(/コメント/)).toBeVisible();
+  });
+});
+
+test.describe('middleware の API 401', () => {
+  test('未認証で POST /api/tickets すると 401 を返す', async ({ request }) => {
+    const res = await request.post('/api/tickets', {
+      data: { title: 'unauthenticated', body: 'no session' },
+    });
+    expect(res.status()).toBe(401);
+    const payload = await res.json().catch(() => null);
+    expect(payload?.error).toMatch(/認証/);
+  });
+
+  test('未認証で GET /api/notifications/stream すると 401 を返す', async ({ request }) => {
+    const res = await request.get('/api/notifications/stream');
+    expect(res.status()).toBe(401);
+  });
+});

--- a/src/domain/ticket-status.ts
+++ b/src/domain/ticket-status.ts
@@ -1,5 +1,9 @@
 import type { TicketStatus } from '@/generated/prisma';
 
+// Source of truth for ticket status transitions. Mirrors `docs/requirements.md` §5
+// including `Closed → Open`（再オープン）which is an explicit product requirement,
+// not an oversight. Changing this table requires updating the requirements doc
+// and `tests/ticket-status.test.ts` together.
 const ALLOWED_TRANSITIONS: Record<TicketStatus, TicketStatus[]> = {
   New: ['Open', 'WaitingForUser', 'InProgress', 'Resolved', 'Closed'],
   Open: ['InProgress', 'WaitingForUser', 'Escalated', 'Resolved', 'Closed'],

--- a/src/features/faq/actions/faq-actions.ts
+++ b/src/features/faq/actions/faq-actions.ts
@@ -5,6 +5,7 @@ import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { isAgent } from '@/lib/role';
 import { FAQ_ELIGIBLE_STATUSES } from '@/lib/constants';
+import { enforceRateLimit } from '@/lib/rate-limit';
 import { faqCandidateSchema } from '@/lib/validations/faq';
 
 export async function createFaqCandidate(ticketId: string, question: string, answer: string) {
@@ -13,6 +14,7 @@ export async function createFaqCandidate(ticketId: string, question: string, ans
   if (!isAgent(session.user.role)) {
     throw new Error('エージェントまたは管理者のみ実行できます');
   }
+  enforceRateLimit(`faq-create:${session.user.id}`, { limit: 10, windowMs: 60_000 });
 
   const parsed = faqCandidateSchema.safeParse({ question, answer });
   if (!parsed.success) {
@@ -44,6 +46,7 @@ export async function updateFaqStatus(faqId: string, status: 'Published' | 'Reje
   if (!isAgent(session.user.role)) {
     throw new Error('エージェントまたは管理者のみ実行できます');
   }
+  enforceRateLimit(`faq-update:${session.user.id}`, { limit: 20, windowMs: 60_000 });
 
   const faq = await prisma.faqCandidate.findUnique({ where: { id: faqId } });
   if (!faq) throw new Error('FAQ候補が見つかりません');

--- a/src/features/notifications/actions/notification-actions.ts
+++ b/src/features/notifications/actions/notification-actions.ts
@@ -3,11 +3,16 @@
 import { revalidatePath, revalidateTag } from 'next/cache';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { enforceRateLimit } from '@/lib/rate-limit';
 import { broadcast } from '@/lib/sse-subscribers';
 
 export async function markAllRead() {
   const session = await auth();
   if (!session?.user?.id) throw new Error('Unauthorized');
+  enforceRateLimit(`notifications-mark-read:${session.user.id}`, {
+    limit: 10,
+    windowMs: 60_000,
+  });
 
   await prisma.notification.updateMany({
     where: { userId: session.user.id, read: false },

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -7,6 +7,7 @@ import { broadcastUnreadCount, broadcastUnreadCountToMany } from '@/features/not
 import { isAgent } from '@/lib/role';
 import { isValidTransition } from '@/domain/ticket-status';
 import type { Priority, TicketStatus } from '@/domain/types';
+import { enforceRateLimit } from '@/lib/rate-limit';
 import { commentBodySchema, escalationReasonSchema } from '@/lib/validations/ticket';
 import type { Session } from 'next-auth';
 
@@ -24,6 +25,7 @@ function assertAgentRole(session: Session | null): asserts session is Session {
 export async function updateTicketStatus(ticketId: string, newStatus: TicketStatus) {
   const session = await auth();
   assertAgentRole(session);
+  enforceRateLimit(`ticket-status:${session.user.id}:${ticketId}`, { limit: 10, windowMs: 10_000 });
 
   await uow.run(async (r) => {
     const ticket = await r.tickets.findById(ticketId);
@@ -58,6 +60,10 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
 export async function updateTicketPriority(ticketId: string, newPriority: Priority) {
   const session = await auth();
   assertAgentRole(session);
+  enforceRateLimit(`ticket-priority:${session.user.id}:${ticketId}`, {
+    limit: 10,
+    windowMs: 10_000,
+  });
 
   await uow.run(async (r) => {
     const ticket = await r.tickets.findById(ticketId);
@@ -80,6 +86,10 @@ export async function updateTicketPriority(ticketId: string, newPriority: Priori
 export async function updateTicketAssignee(ticketId: string, newAssigneeId: string | null) {
   const session = await auth();
   assertAgentRole(session);
+  enforceRateLimit(`ticket-assignee:${session.user.id}:${ticketId}`, {
+    limit: 10,
+    windowMs: 10_000,
+  });
 
   const [ticket, newUser] = await Promise.all([
     repos.tickets.findByIdWithRefs(ticketId),
@@ -124,6 +134,9 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
 export async function escalateTicket(ticketId: string, reason: string) {
   const session = await auth();
   assertAgentRole(session);
+  // Escalation fans out notifications to every agent, so we apply a tighter
+  // cap than per-ticket status/priority edits.
+  enforceRateLimit(`ticket-escalate:${session.user.id}`, { limit: 5, windowMs: 60_000 });
 
   const parsedReason = escalationReasonSchema.safeParse(reason);
   if (!parsedReason.success) {
@@ -172,6 +185,7 @@ export async function escalateTicket(ticketId: string, reason: string) {
 export async function addComment(ticketId: string, body: string) {
   const session = await auth();
   assertAuthenticatedUser(session);
+  enforceRateLimit(`ticket-comment:${session.user.id}`, { limit: 20, windowMs: 60_000 });
 
   const parsedBody = commentBodySchema.safeParse(body);
   if (!parsedBody.success) {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,57 @@
+/**
+ * In-process sliding-window rate limiter for Server Actions.
+ *
+ * Applied to mutation actions (`update-ticket`, `faq-actions`, …) so a single
+ * user cannot spam status changes / escalations and flood every agent's
+ * notification stream (see issue #66).
+ *
+ * Constraints:
+ * - Keyed by `userId:scope`; one user's quota does not affect another's.
+ * - Sliding window measured against `Date.now()` — rejections throw an
+ *   `Error` whose Japanese message surfaces to the user via the Server
+ *   Action error channel.
+ * - The registry is an in-process `Map`; it shares the same "single
+ *   Next.js instance" assumption as `sse-subscribers.ts`. Horizontal
+ *   scaling requires replacing this with Redis / a shared store.
+ */
+
+export type RateLimitOptions = {
+  /** Max allowed hits within the window. */
+  limit: number;
+  /** Window size in milliseconds. */
+  windowMs: number;
+};
+
+const buckets = new Map<string, number[]>();
+
+function prune(timestamps: number[], cutoff: number): number[] {
+  // Bucket entries are push-appended chronologically, so the first index
+  // where `ts >= cutoff` bounds the live window.
+  let i = 0;
+  while (i < timestamps.length && timestamps[i] < cutoff) i += 1;
+  return i === 0 ? timestamps : timestamps.slice(i);
+}
+
+export function enforceRateLimit(
+  key: string,
+  { limit, windowMs }: RateLimitOptions,
+  now: number = Date.now(),
+): void {
+  const cutoff = now - windowMs;
+  const existing = buckets.get(key) ?? [];
+  const live = prune(existing, cutoff);
+
+  if (live.length >= limit) {
+    const retryAfterMs = Math.max(0, live[0] + windowMs - now);
+    const retryAfterSec = Math.ceil(retryAfterMs / 1000);
+    throw new Error(`操作の頻度が高すぎます。${retryAfterSec}秒ほど待ってから再度お試しください。`);
+  }
+
+  live.push(now);
+  buckets.set(key, live);
+}
+
+/** Testing helper: clear all buckets between test cases. */
+export function __resetRateLimits(): void {
+  buckets.clear();
+}

--- a/tests/features/update-ticket.test.ts
+++ b/tests/features/update-ticket.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMemoryContext, type Store } from '@/data/adapters/memory';
 import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
+import { __resetRateLimits } from '@/lib/rate-limit';
 
 // Holders populated per-test before importing the Action under test.
 let store: Store;
@@ -68,6 +69,7 @@ beforeEach(() => {
   sessionUserId = 'u-agt-1';
   sessionRole = 'agent';
   vi.resetModules();
+  __resetRateLimits();
 });
 
 describe('updateTicketStatus (provider-agnostic)', () => {

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { __resetRateLimits, enforceRateLimit } from '../src/lib/rate-limit';
+
+describe('enforceRateLimit', () => {
+  beforeEach(() => {
+    __resetRateLimits();
+  });
+
+  it('allows calls up to the limit within the window', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < 3; i += 1) {
+      expect(() => enforceRateLimit('k', { limit: 3, windowMs: 10_000 }, now + i)).not.toThrow();
+    }
+  });
+
+  it('rejects the next call beyond the limit with a Japanese message', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < 3; i += 1) {
+      enforceRateLimit('k', { limit: 3, windowMs: 10_000 }, now + i);
+    }
+    expect(() => enforceRateLimit('k', { limit: 3, windowMs: 10_000 }, now + 4)).toThrow(
+      /操作の頻度/,
+    );
+  });
+
+  it('allows calls again once the oldest entry ages out of the window', () => {
+    const t0 = 1_000_000;
+    for (let i = 0; i < 3; i += 1) {
+      enforceRateLimit('k', { limit: 3, windowMs: 10_000 }, t0 + i);
+    }
+    // Jump just past the window relative to the first hit.
+    expect(() => enforceRateLimit('k', { limit: 3, windowMs: 10_000 }, t0 + 10_001)).not.toThrow();
+  });
+
+  it('tracks keys independently', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < 3; i += 1) {
+      enforceRateLimit('user-a', { limit: 3, windowMs: 10_000 }, now + i);
+    }
+    // Different key still has full budget.
+    expect(() => enforceRateLimit('user-b', { limit: 3, windowMs: 10_000 }, now)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

残っていたバックログ issue #66 / #68 / #69 をまとめて対応。

### #66 — Server Actions のレート制限
- `src/lib/rate-limit.ts` に in-process sliding-window リミッタを新設。外部依存なしで `userId:scope` 単位のバケットを保持する。ユニットテストは `tests/rate-limit.test.ts`。
- 適用先: `updateTicketStatus` / `updateTicketPriority` / `updateTicketAssignee` / `escalateTicket` / `addComment` / `createFaqCandidate` / `updateFaqStatus` / `markAllRead`。
- エスカレーションは `listAgentIds` 全員への通知 + `broadcastUnreadCountToMany` が走るため 5 回/分の厳しめ上限。通常操作は 10〜20 回/10〜60 秒で運用レンジを狭くしすぎないレベル。
- 閾値超過時は日本語メッセージを `throw` し、既存の Server Action エラーチャネル経由で UI に表示。
- 既存 `tests/features/update-ticket.test.ts` は `beforeEach` で `__resetRateLimits()` を呼び、ケース間にバケットが漏れないようにした。
- CLAUDE.md に明記されている単一インスタンス制約 (SSE と同様) を踏襲。水平スケール時は Redis 等の外部ストアへ差し替え前提、とコメントで明示。

### #68 — `Closed → Open` の仕様確認
- `docs/requirements.md` §5 に「Closed → Open（再オープン）」が明記されているため現状維持。
- 安易に削除されないよう、`src/domain/ticket-status.ts` のテーブル上に要件ドキュメントへのリンクコメントを追加。挙動変更なし。

### #69 — requester RBAC の E2E
- `e2e/rbac.spec.ts` を新設し、以下をカバー:
  - 他リクエスタのチケット詳細を直接 URL で叩くと 404
  - 自チケット詳細で agent 専用 UI (status/priority/assignee select, エスカレーション / FAQ 候補ボタン) が非表示
  - 未認証で `POST /api/tickets` → 401 JSON
  - 未認証で `GET /api/notifications/stream` → 401
- seed の `requester1@example.com` / `seed-t-01` / `seed-t-04` を前提。CLAUDE.md のルールに合わせて日本語正規表現セレクタで記述。

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (65 tests pass, 新規 4 件含む)
- [ ] `npm run test:e2e` — ローカルで dev サーバー + seed 済み DB が必要なため CI / 手動検証で実施

https://claude.ai/code/session_01UrTfiesQbqSmUaGjpGyxfd