### PR TITLE
docs: CLAUDE.mdに「1行ごとに初心者向けコメント」ルールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,3 +104,4 @@ Zod schemas live in `src/lib/validations/` (currently `ticket.ts`). Use `safePar
 - Import Prisma enums/types via `@/generated/prisma`, never `@prisma/client`.
 - Server Actions throw `Error(...)` with Japanese messages for user-facing failures; callers surface them to the user.
 - `docs/` holds design artifacts (`requirements.md`, `architecture.md`, `er-diagram.md`, `screen-flow.md`) — consult before changing status flow, permissions, or the ER model.
+- **1行ごとに初心者でも意味がわかるコメントアウトを書く**: コード 1 行ごとに、プログラミング初心者でも処理内容が理解できる日本語コメントを付ける。変数宣言・条件分岐・関数呼び出し・ループ・return など、すべての実行行に対して「何をしているか」を説明するコメントを必ず添える（型定義の単純な再エクスポートなど明らかに自明な行は除く）。コメントは行の直前または行末に記述し、専門用語を使うときは平易な言い換えを併記する。


### PR DESCRIPTION
## Summary
- `CLAUDE.md` の "Conventions to respect" に、コード 1 行ごとに初心者でも意味がわかる日本語コメントを付けるルールを追加
- 変数宣言・条件分岐・関数呼び出し・ループ・return など、すべての実行行に「何をしているか」を説明するコメントを必ず添える方針を明文化

## Test plan
- [ ] CLAUDE.md のレンダリングを GitHub 上で確認
- [ ] 以降のコード変更でこのルールが適用されることを確認

https://claude.ai/code/session_01N1AvwVy6GMqssXL1JyT3ZL