### PR TITLE
docs: 既存コードに初心者向けコメント追加 (1/3 コア・インフラ)

### DIFF
--- a/src/data/adapters/memory/category-repository.memory.ts
+++ b/src/data/adapters/memory/category-repository.memory.ts
@@ -1,16 +1,20 @@
+// カテゴリリポジトリの契約 (port) と、テスト用メモリストア型をインポート
 import type { CategoryRepository } from '@/data/ports/category-repository';
 import type { Store } from './store';
 
+// メモリストアを使ったカテゴリリポジトリを生成するファクトリ関数
 export function makeCategoryRepo(store: Store): CategoryRepository {
   return {
+    // 全カテゴリを名前昇順で取得
     async list() {
-      return [...store.categories.values()]
-        .map((c) => ({ id: c.id, name: c.name }))
-        .sort((a, b) => a.name.localeCompare(b.name));
+      return [...store.categories.values()] // Map から配列化
+        .map((c) => ({ id: c.id, name: c.name })) // 返却用に id/name だけ抽出
+        .sort((a, b) => a.name.localeCompare(b.name)); // 名前でロケール順に並び替え
     },
+    // ID 指定で 1 件取得 (存在しなければ null)
     async findById(id) {
-      const c = store.categories.get(id);
-      return c ? { id: c.id, name: c.name } : null;
+      const c = store.categories.get(id); // Map から取得
+      return c ? { id: c.id, name: c.name } : null; // 見つかれば要約を返す
     },
   };
 }

--- a/src/data/adapters/memory/faq-repository.memory.ts
+++ b/src/data/adapters/memory/faq-repository.memory.ts
@@ -1,21 +1,29 @@
+// FAQ リポジトリの契約 (port) と、ドメイン型/ストア関連をインポート
 import type { FaqListItem, FaqRepository } from '@/data/ports/faq-repository';
 import type { FaqCandidate } from '@/domain/types';
 import { nextId, type Store } from './store';
 
+// メモリストアを使った FAQ リポジトリを生成する関数
 export function makeFaqRepo(store: Store): FaqRepository {
   return {
+    // ID で 1 件取得 (見つからなければ null)
     async findById(id) {
-      const row = store.faq.get(id);
-      return row ? { ...row } : null;
+      const row = store.faq.get(id); // Map から取得
+      return row ? { ...row } : null; // 破壊防止のため複製して返す
     },
 
+    // 全 FAQ 候補を新しい順で一覧化 (関連チケット/作成者名を結合)
     async list() {
+      // Map を配列化し、作成日時の降順で並べる
       const rows = [...store.faq.values()].sort((a, b) => +b.createdAt - +a.createdAt);
+      // 関連チケットと作成者を引き当てて結合
       return rows.map<FaqListItem>((f) => {
-        const ticket = store.tickets.get(f.ticketId);
-        const createdBy = store.users.get(f.createdById);
+        const ticket = store.tickets.get(f.ticketId); // 元チケット
+        const createdBy = store.users.get(f.createdById); // 作成者
+        // 整合性チェック: ないはずのデータが欠けていれば例外
         if (!ticket) throw new Error(`memory adapter: ticket ${f.ticketId} missing`);
         if (!createdBy) throw new Error(`memory adapter: user ${f.createdById} missing`);
+        // FAQ 候補に関連情報を結合して返す
         return {
           ...f,
           ticket: { id: ticket.id, title: ticket.title },
@@ -24,10 +32,13 @@ export function makeFaqRepo(store: Store): FaqRepository {
       });
     },
 
+    // 新規 FAQ 候補を作成してストアに登録
     async create(input) {
+      // 現在時刻を createdAt/updatedAt に使用
       const now = new Date();
+      // 新しい FAQ 候補行を組み立て (状態は Candidate 固定で開始)
       const row: FaqCandidate = {
-        id: nextId(store, 'faq'),
+        id: nextId(store, 'faq'), // 'faq_...' 形式の一意 ID
         ticketId: input.ticketId,
         createdById: input.createdById,
         question: input.question,
@@ -36,13 +47,17 @@ export function makeFaqRepo(store: Store): FaqRepository {
         createdAt: now,
         updatedAt: now,
       };
+      // ストアに登録
       store.faq.set(row.id, row);
+      // 作成結果を返す
       return row;
     },
 
+    // FAQ 候補の状態を更新 (候補/公開/却下)
     async updateStatus(id, status) {
-      const row = store.faq.get(id);
-      if (!row) throw new Error(`faq candidate not found: ${id}`);
+      const row = store.faq.get(id); // 更新対象を取得
+      if (!row) throw new Error(`faq candidate not found: ${id}`); // 無ければエラー
+      // 状態と更新日時を書き換えて保存
       store.faq.set(id, { ...row, status, updatedAt: new Date() });
     },
   };

--- a/src/data/adapters/memory/index.ts
+++ b/src/data/adapters/memory/index.ts
@@ -1,4 +1,6 @@
+// リポジトリ束 (Repos) と UnitOfWork の型をインポート
 import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
+// 各エンティティ用のメモリリポジトリ生成関数を取り込む
 import { makeCategoryRepo } from './category-repository.memory';
 import { makeFaqRepo } from './faq-repository.memory';
 import { makeNotificationRepo } from './notification-repository.memory';
@@ -8,10 +10,13 @@ import { makeTicketHistoryRepo } from './ticket-history-repository.memory';
 import { makeTicketRepo } from './ticket-repository.memory';
 import { makeUserRepo } from './user-repository.memory';
 
+// Store 型と空ストアファクトリを外部にも再公開 (テストで使用)
 export type { Store } from './store';
 export { createEmptyStore } from './store';
 
+// 指定ストアを使った全リポジトリ一式 (Repos) を組み立てて返す関数
 export function buildMemoryRepos(store: Store): Repos {
+  // 各ポートに対応するメモリ実装を組み立てる
   return {
     tickets: makeTicketRepo(store),
     users: makeUserRepo(store),
@@ -27,14 +32,18 @@ export function buildMemoryRepos(store: Store): Repos {
  * Minimal transaction implementation: snapshot store, run callback, restore on throw.
  * Matches the Prisma adapter's all-or-nothing semantics — good enough for unit tests.
  */
+// メモリ版 UnitOfWork。スナップショットを取り、例外時に巻き戻す擬似トランザクション
 export function buildMemoryUow(store: Store): UnitOfWork {
   return {
     async run(fn) {
-      const snapshot = cloneStore(store);
+      const snapshot = cloneStore(store); // トランザクション開始時点のスナップショット
       try {
+        // 実際の処理を同じストア上で実行
         return await fn(buildMemoryRepos(store));
       } catch (error) {
+        // 失敗したらストアをスナップショットに戻す (ロールバック相当)
         overwriteStore(store, snapshot);
+        // エラーは呼び出し元に再 throw
         throw error;
       }
     },
@@ -44,8 +53,10 @@ export function buildMemoryUow(store: Store): UnitOfWork {
 /**
  * Convenience for tests: create a fresh store + matching repos + uow bound to it.
  */
+// テスト用に「新規ストア + リポジトリ一式 + UoW」をまとめて生成するヘルパー
 export function createMemoryContext(): { store: Store; repos: Repos; uow: UnitOfWork } {
-  const store = createEmptyStore();
+  const store = createEmptyStore(); // 空ストアを作成
+  // 同一ストアに紐づく repos と uow を組み立てて返す
   return {
     store,
     repos: buildMemoryRepos(store),

--- a/src/data/adapters/memory/notification-broadcaster.memory.ts
+++ b/src/data/adapters/memory/notification-broadcaster.memory.ts
@@ -1,3 +1,4 @@
+// 通知ブロードキャスタのポート型とコントローラー型をインポート
 import type {
   BroadcastController,
   NotificationBroadcaster,
@@ -16,36 +17,47 @@ import type {
  * silently drift until the next cache revalidation. Swap this adapter for a
  * Redis/Postgres-backed one to fix that.
  */
+// プロセス内 Map を使った NotificationBroadcaster 実装を生成する関数
 export function createInMemoryNotificationBroadcaster(): NotificationBroadcaster {
+  // ユーザー ID → そのユーザーの全 SSE 接続 (Set) のマップ
   const subscribers = new Map<string, Set<BroadcastController>>();
 
+  // SSE メッセージ文字列をバイト列にエンコードするヘルパー (event: count 形式)
   const encodeCount = (count: number): Uint8Array =>
     new TextEncoder().encode(`event: count\ndata: ${JSON.stringify({ count })}\n\n`);
 
   return {
+    // 新しい購読 (SSE 接続) を登録
     addSubscriber(userId, controller) {
+      // 既存の Set を取得 (まだ無ければ新規作成)
       let controllers = subscribers.get(userId);
       if (!controllers) {
         controllers = new Set();
         subscribers.set(userId, controllers);
       }
+      // コントローラーを Set に追加
       controllers.add(controller);
     },
 
+    // 購読 (SSE 接続) を解除
     removeSubscriber(userId, controller) {
-      const controllers = subscribers.get(userId);
-      if (!controllers) return;
-      controllers.delete(controller);
+      const controllers = subscribers.get(userId); // 該当ユーザーの Set を取得
+      if (!controllers) return; // 未登録なら何もしない
+      controllers.delete(controller); // 対象の接続を削除
+      // Set が空になったらユーザーキーごとマップから削除
       if (controllers.size === 0) {
         subscribers.delete(userId);
       }
     },
 
+    // 指定ユーザーの全接続に未読件数を送信
     broadcast(userId, count) {
-      const controllers = subscribers.get(userId);
-      if (!controllers || controllers.size === 0) return;
+      const controllers = subscribers.get(userId); // 該当ユーザーの接続集合
+      if (!controllers || controllers.size === 0) return; // 接続なしなら終了
 
+      // 送信メッセージを事前エンコード (全接続で使い回す)
       const message = encodeCount(count);
+      // 各接続に送る。書き込みに失敗した接続は Set から除外する
       for (const controller of controllers) {
         try {
           controller.enqueue(message);
@@ -54,6 +66,7 @@ export function createInMemoryNotificationBroadcaster(): NotificationBroadcaster
         }
       }
 
+      // 全接続が切れていた場合はユーザーキーごとマップから削除
       if (controllers.size === 0) {
         subscribers.delete(userId);
       }

--- a/src/data/adapters/memory/notification-repository.memory.ts
+++ b/src/data/adapters/memory/notification-repository.memory.ts
@@ -1,3 +1,4 @@
+// 通知リポジトリの契約 (port) とドメイン型、ストア関連をインポート
 import type {
   NotificationListItem,
   NotificationRepository,
@@ -5,37 +6,47 @@ import type {
 import type { Notification } from '@/domain/types';
 import { nextId, type Store } from './store';
 
+// メモリストアを使った通知リポジトリを生成する関数
 export function makeNotificationRepo(store: Store): NotificationRepository {
   return {
+    // 通知を 1 件作成してストアに登録
     async create(input) {
+      // 新しい通知行を組み立てる (read は false で開始)
       const notification: Notification = {
-        id: nextId(store, 'ntf'),
+        id: nextId(store, 'ntf'), // 'ntf_...' 形式の一意 ID
         userId: input.userId,
-        ticketId: input.ticketId ?? null,
+        ticketId: input.ticketId ?? null, // 未指定は null
         type: input.type,
         message: input.message,
         read: false,
         createdAt: new Date(),
       };
+      // ストアに登録
       store.notifications.set(notification.id, notification);
+      // 作成結果を返す
       return notification;
     },
 
+    // 指定ユーザーの未読件数をカウント
     async countUnread(userId) {
-      let n = 0;
+      let n = 0; // カウンタ
+      // 全通知を走査し、対象ユーザー & 未読のものを数える
       for (const n0 of store.notifications.values()) {
         if (n0.userId === userId && !n0.read) n += 1;
       }
+      // 件数を返す
       return n;
     },
 
+    // 指定ユーザーの通知を新しい順に limit 件取得 (関連チケット付き)
     async list(userId, { limit }) {
-      const rows = [...store.notifications.values()]
-        .filter((n) => n.userId === userId)
-        .sort((a, b) => +b.createdAt - +a.createdAt)
-        .slice(0, limit);
+      const rows = [...store.notifications.values()] // 全通知を配列化
+        .filter((n) => n.userId === userId) // 対象ユーザーのみ
+        .sort((a, b) => +b.createdAt - +a.createdAt) // 新しい順にソート
+        .slice(0, limit); // 先頭 limit 件に切る
+      // 各通知に関連チケットの要約を結合して返す
       return rows.map<NotificationListItem>((n) => {
-        const ticket = n.ticketId ? (store.tickets.get(n.ticketId) ?? null) : null;
+        const ticket = n.ticketId ? (store.tickets.get(n.ticketId) ?? null) : null; // 関連チケット取得
         return {
           ...n,
           ticket: ticket ? { id: ticket.id, title: ticket.title } : null,
@@ -43,8 +54,11 @@ export function makeNotificationRepo(store: Store): NotificationRepository {
       });
     },
 
+    // 指定ユーザーの未読通知を全て既読に更新
     async markAllRead(userId) {
+      // Map の全エントリを走査
       for (const [id, n] of store.notifications) {
+        // 対象ユーザーかつ未読のものだけ read: true にして書き換え
         if (n.userId === userId && !n.read) {
           store.notifications.set(id, { ...n, read: true });
         }

--- a/src/data/adapters/memory/store.ts
+++ b/src/data/adapters/memory/store.ts
@@ -1,3 +1,4 @@
+// ドメイン型をインポート (メモリストア内に保持するデータ型)
 import type {
   FaqCandidate,
   Notification,
@@ -7,10 +8,11 @@ import type {
   User,
 } from '@/domain/types';
 
+// メモリ内で保持するカテゴリ行 (id/name/作成日時)
 export interface CategoryRow {
-  id: string;
-  name: string;
-  createdAt: Date;
+  id: string; // カテゴリ ID
+  name: string; // カテゴリ名
+  createdAt: Date; // 作成日時
 }
 
 /**
@@ -19,18 +21,21 @@ export interface CategoryRow {
  * The `idSeq` counter is per-store so different test contexts never share state
  * and produce stable id sequences in isolation.
  */
+// テスト用メモリストアの型。エンティティごとに Map を持つ
 export interface Store {
-  users: Map<string, User>;
-  categories: Map<string, CategoryRow>;
-  tickets: Map<string, Ticket>;
-  comments: Map<string, TicketComment>;
-  histories: Map<string, TicketHistory>;
-  faq: Map<string, FaqCandidate>;
-  notifications: Map<string, Notification>;
-  idSeq: { value: number };
+  users: Map<string, User>; // ユーザー
+  categories: Map<string, CategoryRow>; // カテゴリ
+  tickets: Map<string, Ticket>; // チケット
+  comments: Map<string, TicketComment>; // コメント
+  histories: Map<string, TicketHistory>; // 履歴
+  faq: Map<string, FaqCandidate>; // FAQ 候補
+  notifications: Map<string, Notification>; // 通知
+  idSeq: { value: number }; // 連番生成用のカウンタ (オブジェクトに包んで参照共有)
 }
 
+// 空のストアを作って返すファクトリ関数
 export function createEmptyStore(): Store {
+  // 全エンティティを空の Map とし、連番を 0 から開始
   return {
     users: new Map(),
     categories: new Map(),
@@ -43,7 +48,9 @@ export function createEmptyStore(): Store {
   };
 }
 
+// ストアを浅くコピーする関数 (トランザクション擬似実装のスナップショット用)
 export function cloneStore(src: Store): Store {
+  // 各 Map を複製し、連番カウンタの値もコピー
   return {
     users: new Map(src.users),
     categories: new Map(src.categories),
@@ -56,7 +63,9 @@ export function cloneStore(src: Store): Store {
   };
 }
 
+// dst の中身を src で上書きする関数 (ロールバック用)
 export function overwriteStore(dst: Store, src: Store): void {
+  // 各エンティティを src のコピーで置き換える
   dst.users = new Map(src.users);
   dst.categories = new Map(src.categories);
   dst.tickets = new Map(src.tickets);
@@ -64,6 +73,7 @@ export function overwriteStore(dst: Store, src: Store): void {
   dst.histories = new Map(src.histories);
   dst.faq = new Map(src.faq);
   dst.notifications = new Map(src.notifications);
+  // 連番も元に戻す
   dst.idSeq.value = src.idSeq.value;
 }
 
@@ -71,7 +81,10 @@ export function overwriteStore(dst: Store, src: Store): void {
  * Per-store id generator. Not a real cuid — the contract test only requires
  * that ids are unique within a store.
  */
+// ストア単位の ID 生成関数 (テスト内で一意であれば十分)
 export function nextId(store: Store, prefix: string): string {
+  // カウンタをインクリメント
   store.idSeq.value += 1;
+  // prefix + 36 進カウンタ + ランダム文字列 で ID を構築して返す
   return `${prefix}_${store.idSeq.value.toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
 }

--- a/src/data/adapters/memory/ticket-comment-repository.memory.ts
+++ b/src/data/adapters/memory/ticket-comment-repository.memory.ts
@@ -1,18 +1,24 @@
+// コメントリポジトリの契約 (port) と、メモリストア/ID 生成ヘルパーをインポート
 import type { TicketCommentRepository } from '@/data/ports/ticket-comment-repository';
 import type { TicketComment } from '@/domain/types';
 import { nextId, type Store } from './store';
 
+// メモリストアを使ったコメントリポジトリを生成する関数
 export function makeTicketCommentRepo(store: Store): TicketCommentRepository {
   return {
+    // コメントを 1 件作成してストアに登録する
     async create(input) {
+      // 作成用オブジェクトを組み立てる (ID と作成日時をここで決定)
       const row: TicketComment = {
-        id: nextId(store, 'cmt'),
-        ticketId: input.ticketId,
-        authorId: input.authorId,
-        body: input.body,
-        createdAt: new Date(),
+        id: nextId(store, 'cmt'), // 'cmt_...' 形式の一意 ID
+        ticketId: input.ticketId, // 対象チケット
+        authorId: input.authorId, // 書き込みユーザー
+        body: input.body, // コメント本文
+        createdAt: new Date(), // 現在時刻
       };
+      // ストアに登録
       store.comments.set(row.id, row);
+      // 作成結果を呼び出し元に返す
       return row;
     },
   };

--- a/src/data/adapters/memory/ticket-history-repository.memory.ts
+++ b/src/data/adapters/memory/ticket-history-repository.memory.ts
@@ -1,19 +1,24 @@
+// 履歴リポジトリの契約 (port) と、メモリストア/ID 生成ヘルパーをインポート
 import type { TicketHistoryRepository } from '@/data/ports/ticket-history-repository';
 import type { TicketHistory } from '@/domain/types';
 import { nextId, type Store } from './store';
 
+// メモリストアを使った履歴リポジトリを生成する関数
 export function makeTicketHistoryRepo(store: Store): TicketHistoryRepository {
   return {
+    // 履歴を 1 件記録する
     async record(input) {
+      // 新しい履歴行を組み立てる
       const row: TicketHistory = {
-        id: nextId(store, 'hst'),
-        ticketId: input.ticketId,
-        changedById: input.changedById,
-        field: input.field,
-        oldValue: input.oldValue,
-        newValue: input.newValue,
-        createdAt: new Date(),
+        id: nextId(store, 'hst'), // 'hst_...' 形式の一意 ID
+        ticketId: input.ticketId, // 対象チケット
+        changedById: input.changedById, // 変更者
+        field: input.field, // 変更対象フィールド
+        oldValue: input.oldValue, // 変更前の値
+        newValue: input.newValue, // 変更後の値
+        createdAt: new Date(), // 変更日時
       };
+      // ストアに登録 (返り値はなし)
       store.histories.set(row.id, row);
     },
   };

--- a/src/data/adapters/memory/ticket-repository.memory.ts
+++ b/src/data/adapters/memory/ticket-repository.memory.ts
@@ -1,3 +1,4 @@
+// ドメイン型 (チケット関連) をインポート
 import type {
   Ticket,
   TicketComment,
@@ -5,26 +6,33 @@ import type {
   TicketWithRefs,
   UserSummary,
 } from '@/domain/types';
+// チケットリポジトリ契約と関連型をインポート
 import type {
   AssigneeWorkloadRow,
   TicketDetail,
   TicketListFilter,
   TicketRepository,
 } from '@/data/ports/ticket-repository';
+// メモリストアと ID 生成ヘルパーをインポート
 import { nextId, type Store } from './store';
 
+// ID からユーザー概要を作るヘルパー (見つからなければ null)
 function userSummary(store: Store, id: string | null): UserSummary | null {
-  if (!id) return null;
-  const u = store.users.get(id);
-  return u ? { id: u.id, name: u.name } : null;
+  if (!id) return null; // null なら何もしない
+  const u = store.users.get(id); // Map から取得
+  return u ? { id: u.id, name: u.name } : null; // 見つかれば要約に変換
 }
 
+// チケットに起票者/担当者/カテゴリを結合して TicketWithRefs を作る関数
 function attachRefs(ticket: Ticket, store: Store): TicketWithRefs {
-  const creator = userSummary(store, ticket.creatorId);
+  const creator = userSummary(store, ticket.creatorId); // 起票者を取得
+  // 起票者は必須。欠損していれば整合性エラーとして throw
   if (!creator) {
     throw new Error(`memory adapter: creator ${ticket.creatorId} missing for ticket ${ticket.id}`);
   }
+  // カテゴリ ID があれば引き当て (無ければ null)
   const category = ticket.categoryId ? (store.categories.get(ticket.categoryId) ?? null) : null;
+  // 全フィールドをそのまま引き継ぎつつ、関連情報を上書きで付加する
   return {
     ...ticket,
     creator,
@@ -33,65 +41,84 @@ function attachRefs(ticket: Ticket, store: Store): TicketWithRefs {
   };
 }
 
+// 指定フィルタ条件に一致するかを判定するヘルパー
 function matchesFilter(t: Ticket, filter: TicketListFilter): boolean {
+  // 起票者フィルター: 指定があり一致しなければ除外
   if (filter.creatorId !== undefined && t.creatorId !== filter.creatorId) return false;
+  // 状態フィルター
   if (filter.status !== undefined && t.status !== filter.status) return false;
+  // 優先度フィルター
   if (filter.priority !== undefined && t.priority !== filter.priority) return false;
+  // カテゴリフィルター
   if (filter.categoryId !== undefined && t.categoryId !== filter.categoryId) return false;
+  // 担当者フィルター (undefined は無指定、'unassigned' は未アサインを意味する)
   if (filter.assigneeId !== undefined) {
     const target = filter.assigneeId === 'unassigned' ? null : filter.assigneeId;
     if (t.assigneeId !== target) return false;
   }
+  // テキスト検索フィルター (title または body の部分一致)
   if (filter.text) {
+    // 大文字小文字を無視する場合は両方小文字化する
     const needle = filter.text.caseInsensitive
       ? filter.text.contains.toLowerCase()
       : filter.text.contains;
+    // 判定関数 (文字列 s に needle が含まれるか)
     const match = (s: string) => {
       const haystack = filter.text!.caseInsensitive ? s.toLowerCase() : s;
       return haystack.includes(needle);
     };
+    // title にも body にも無ければ除外
     if (!match(t.title) && !match(t.body)) return false;
   }
+  // 全条件を満たした
   return true;
 }
 
+// メモリストアを使ったチケットリポジトリを生成する関数
 export function makeTicketRepo(store: Store): TicketRepository {
   return {
+    // ID で最小フィールドのチケットを 1 件取得 (複製して返す)
     async findById(id) {
       const t = store.tickets.get(id);
       return t ? { ...t } : null;
     },
 
+    // ID で起票者/担当者/カテゴリを結合したチケットを取得
     async findByIdWithRefs(id) {
       const t = store.tickets.get(id);
       return t ? attachRefs(t, store) : null;
     },
 
+    // 詳細ページ用に、コメント/履歴/FAQ 候補を含むチケットを取得
     async findByIdWithDetail(id) {
-      const t = store.tickets.get(id);
-      if (!t) return null;
-      const withRefs = attachRefs(t, store);
+      const t = store.tickets.get(id); // 本体取得
+      if (!t) return null; // 無ければ null
+      const withRefs = attachRefs(t, store); // 関連情報を結合
 
+      // 対象チケットのコメントを古い順に整形
       const comments = [...store.comments.values()]
-        .filter((c) => c.ticketId === id)
-        .sort((a, b) => +a.createdAt - +b.createdAt)
+        .filter((c) => c.ticketId === id) // 対象チケットのみ
+        .sort((a, b) => +a.createdAt - +b.createdAt) // 時系列 (古い→新しい)
         .map((c: TicketComment) => {
-          const author = userSummary(store, c.authorId);
+          const author = userSummary(store, c.authorId); // 書き込み者
           if (!author) throw new Error(`memory adapter: author ${c.authorId} missing`);
           return { ...c, author };
         });
 
+      // 対象チケットの履歴を新しい順に整形
       const histories = [...store.histories.values()]
         .filter((h) => h.ticketId === id)
         .sort((a, b) => +b.createdAt - +a.createdAt)
         .map((h: TicketHistory) => {
-          const changedBy = userSummary(store, h.changedById);
+          const changedBy = userSummary(store, h.changedById); // 変更者
           if (!changedBy) throw new Error(`memory adapter: changedBy ${h.changedById} missing`);
           return { ...h, changedBy };
         });
 
+      // 紐づく FAQ 候補を 1 件だけ検索 (なければ null)
       const faqRow = [...store.faq.values()].find((f) => f.ticketId === id) ?? null;
 
+      // 詳細オブジェクトを組み立てて返す
       const detail: TicketDetail = {
         ...withRefs,
         comments,
@@ -101,67 +128,91 @@ export function makeTicketRepo(store: Store): TicketRepository {
       return detail;
     },
 
+    // 一覧取得 (フィルタ/ソート/ページング)
     async list({ filter, page, sort }) {
+      // フィルター適用
       let rows = [...store.tickets.values()].filter((t) => matchesFilter(t, filter));
+      // ソート方向を決定 (既定は降順)
       const direction = sort?.direction ?? 'desc';
+      // createdAt で並び替え
       rows.sort((a, b) =>
         direction === 'asc' ? +a.createdAt - +b.createdAt : +b.createdAt - +a.createdAt,
       );
+      // ページング適用
       rows = rows.slice(page.skip, page.skip + page.take);
+      // 各行に関連情報を結合して返す
       return rows.map((t) => attachRefs(t, store));
     },
 
+    // 条件に一致する件数をカウント
     async count(filter) {
-      let n = 0;
+      let n = 0; // カウンタ
+      // 全チケットを走査し、条件一致を加算
       for (const t of store.tickets.values()) {
         if (matchesFilter(t, filter)) n += 1;
       }
+      // 件数を返す
       return n;
     },
 
+    // 特定状態のチケット件数を取得 (起票者フィルタ付き)
     async countByStatus({ creatorId, status }) {
-      let n = 0;
+      let n = 0; // カウンタ
+      // 全チケットを走査
       for (const t of store.tickets.values()) {
-        if (t.status !== status) continue;
-        if (creatorId !== undefined && t.creatorId !== creatorId) continue;
-        n += 1;
+        if (t.status !== status) continue; // 状態が違えばスキップ
+        if (creatorId !== undefined && t.creatorId !== creatorId) continue; // 起票者指定を反映
+        n += 1; // カウントアップ
       }
+      // 件数を返す
       return n;
     },
 
+    // SLA 期限超過 (未解決) 件数をカウント
     async countSlaOverdue(now) {
-      let n = 0;
+      let n = 0; // カウンタ
+      // 全チケットを走査
       for (const t of store.tickets.values()) {
-        if (!t.resolutionDueAt) continue;
-        if (t.resolutionDueAt >= now) continue;
-        if (t.resolvedAt !== null) continue;
-        if (t.status === 'Resolved' || t.status === 'Closed') continue;
-        n += 1;
+        if (!t.resolutionDueAt) continue; // 期限未設定はスキップ
+        if (t.resolutionDueAt >= now) continue; // 期限未到来はスキップ
+        if (t.resolvedAt !== null) continue; // 解決済みはスキップ
+        if (t.status === 'Resolved' || t.status === 'Closed') continue; // 終息状態もスキップ
+        n += 1; // 超過として加算
       }
+      // 件数を返す
       return n;
     },
 
+    // 担当者別の保持チケット件数を取得 (指定状態は除外)
     async workloadByAssignee({ excludeStatuses }) {
+      // 担当者 ID ごとの件数カウント用 Map
       const counts = new Map<string | null, number>();
+      // 全チケットを走査
       for (const t of store.tickets.values()) {
-        if (excludeStatuses.includes(t.status)) continue;
+        if (excludeStatuses.includes(t.status)) continue; // 除外状態ならスキップ
+        // 現在の件数に 1 を加算してセット
         counts.set(t.assigneeId, (counts.get(t.assigneeId) ?? 0) + 1);
       }
+      // Map を配列形式 (AssigneeWorkloadRow) に変換
       const rows: AssigneeWorkloadRow[] = [...counts.entries()].map(([assigneeId, count]) => ({
         assigneeId,
         count,
       }));
+      // 件数の多い順に並び替え
       rows.sort((a, b) => b.count - a.count);
+      // 結果を返す
       return rows;
     },
 
+    // 新規チケットを作成 (初期状態は 'New')
     async create(input) {
-      const now = new Date();
+      const now = new Date(); // 作成時刻
+      // 新規チケット行を組み立て
       const ticket: Ticket = {
-        id: nextId(store, 'tkt'),
+        id: nextId(store, 'tkt'), // 'tkt_...' 形式の一意 ID
         title: input.title,
         body: input.body,
-        status: 'New',
+        status: 'New', // 新規状態でスタート
         priority: input.priority,
         createdAt: now,
         updatedAt: now,
@@ -172,31 +223,38 @@ export function makeTicketRepo(store: Store): TicketRepository {
         escalatedAt: null,
         escalationReason: null,
         creatorId: input.creatorId,
-        assigneeId: null,
+        assigneeId: null, // 初期は未アサイン
         categoryId: input.categoryId,
       };
+      // ストアに登録
       store.tickets.set(ticket.id, ticket);
+      // 関連情報を付けて返却
       return attachRefs(ticket, store);
     },
 
+    // 状態を更新 (併せて解決日時もセットする)
     async updateStatus(id, status, resolvedAt) {
-      const t = store.tickets.get(id);
-      if (!t) throw new Error(`ticket not found: ${id}`);
+      const t = store.tickets.get(id); // 対象取得
+      if (!t) throw new Error(`ticket not found: ${id}`); // 無ければエラー
+      // 新しい状態/解決日時/更新時刻で置き換え
       store.tickets.set(id, { ...t, status, resolvedAt, updatedAt: new Date() });
     },
 
+    // 優先度を更新
     async updatePriority(id, priority) {
       const t = store.tickets.get(id);
       if (!t) throw new Error(`ticket not found: ${id}`);
       store.tickets.set(id, { ...t, priority, updatedAt: new Date() });
     },
 
+    // 担当者を更新 (null で未アサインに戻す)
     async updateAssignee(id, assigneeId) {
       const t = store.tickets.get(id);
       if (!t) throw new Error(`ticket not found: ${id}`);
       store.tickets.set(id, { ...t, assigneeId, updatedAt: new Date() });
     },
 
+    // エスカレーション扱いに更新 (状態 + 理由 + 実行時刻)
     async markEscalated(id, args) {
       const t = store.tickets.get(id);
       if (!t) throw new Error(`ticket not found: ${id}`);

--- a/src/data/adapters/memory/user-repository.memory.ts
+++ b/src/data/adapters/memory/user-repository.memory.ts
@@ -1,46 +1,67 @@
+// ユーザーリポジトリの契約 (port) と、ドメイン型/ストア型をインポート
 import type { UserRepository } from '@/data/ports/user-repository';
 import type { UserSummary } from '@/domain/types';
 import type { Store } from './store';
 
+// メモリストアを使ったユーザーリポジトリを生成する関数
 export function makeUserRepo(store: Store): UserRepository {
   return {
+    // ID で 1 件取得 (見つからなければ null)
     async findById(id) {
-      const u = store.users.get(id);
-      return u ? { ...u } : null;
+      const u = store.users.get(id); // Map から取得
+      return u ? { ...u } : null; // 破壊防止のためスプレッドで複製して返す
     },
 
+    // メールアドレスで 1 件取得 (線形検索)
     async findByEmail(email) {
+      // 全ユーザーを走査
       for (const u of store.users.values()) {
+        // メール一致で即返す (複製して返却)
         if (u.email === email) return { ...u };
       }
+      // 見つからなければ null
       return null;
     },
 
+    // agent または admin を名前順で一覧取得
     async listAgents() {
+      // 結果を入れる配列を準備
       const agents: UserSummary[] = [];
+      // 全ユーザーを走査し、エージェント系だけ抽出
       for (const u of store.users.values()) {
         if (u.role === 'agent' || u.role === 'admin') {
           agents.push({ id: u.id, name: u.name });
         }
       }
+      // 名前でロケール順に並び替え
       agents.sort((a, b) => a.name.localeCompare(b.name));
+      // 結果を返す
       return agents;
     },
 
+    // agent または admin の ID だけを一覧取得 (通知一斉送信などに使用)
     async listAgentIds() {
+      // 結果 ID 配列
       const ids: string[] = [];
+      // 全ユーザーを走査し、対象の ID を追加
       for (const u of store.users.values()) {
         if (u.role === 'agent' || u.role === 'admin') ids.push(u.id);
       }
+      // 結果を返す
       return ids;
     },
 
+    // 指定 ID 群に含まれるユーザーの概要をまとめて返す
     async findSummariesByIds(ids) {
+      // 検索効率化のため ID を Set にする
       const set = new Set(ids);
+      // 結果配列
       const out: UserSummary[] = [];
+      // 全ユーザーを走査し、Set に含まれる ID だけ抽出
       for (const u of store.users.values()) {
         if (set.has(u.id)) out.push({ id: u.id, name: u.name });
       }
+      // 結果を返す
       return out;
     },
   };

--- a/src/data/adapters/prisma/category-repository.prisma.ts
+++ b/src/data/adapters/prisma/category-repository.prisma.ts
@@ -1,16 +1,23 @@
+// カテゴリリポジトリの契約 (port) と、Prisma クライアント共通型をインポート
 import type { CategoryRepository } from '@/data/ports/category-repository';
 import type { PrismaLike } from './types';
 
+// Prisma クライアントを使ったカテゴリリポジトリを生成する関数
 export function makeCategoryRepo(db: PrismaLike): CategoryRepository {
   return {
+    // 全カテゴリを名前昇順で取得
     async list() {
+      // Prisma の findMany で全件取得 (select で列を限定)
       const rows = await db.category.findMany({
-        orderBy: { name: 'asc' },
-        select: { id: true, name: true },
+        orderBy: { name: 'asc' }, // 名前昇順
+        select: { id: true, name: true }, // id と name だけ取得
       });
+      // 結果をそのまま返す (port 契約と同じ形)
       return rows;
     },
+    // ID 指定で 1 件取得 (見つからなければ null)
     async findById(id) {
+      // findUnique で主キー検索
       return db.category.findUnique({
         where: { id },
         select: { id: true, name: true },

--- a/src/data/adapters/prisma/faq-repository.prisma.ts
+++ b/src/data/adapters/prisma/faq-repository.prisma.ts
@@ -1,29 +1,37 @@
+// FAQ リポジトリの契約 (port)、マッパー、Prisma 共通型をインポート
 import type { FaqListItem, FaqRepository } from '@/data/ports/faq-repository';
 import { toFaq } from './mappers';
 import type { PrismaLike } from './types';
 
+// Prisma クライアントを使った FAQ リポジトリを生成する関数
 export function makeFaqRepo(db: PrismaLike): FaqRepository {
   return {
+    // ID で 1 件取得してドメイン型に変換
     async findById(id) {
       const row = await db.faqCandidate.findUnique({ where: { id } });
       return row ? toFaq(row) : null;
     },
 
+    // 一覧取得 (新しい順、関連チケットと作成者を同梱)
     async list() {
       const rows = await db.faqCandidate.findMany({
-        orderBy: { createdAt: 'desc' },
+        orderBy: { createdAt: 'desc' }, // 新しい順
         include: {
+          // 関連チケットの最小情報を JOIN
           ticket: { select: { id: true, title: true } },
+          // 作成者の名前だけを JOIN
           createdBy: { select: { name: true } },
         },
       });
+      // 各行を FaqListItem 形式に整形
       return rows.map<FaqListItem>((f) => ({
-        ...toFaq(f),
+        ...toFaq(f), // 本体はドメイン型に変換
         ticket: { id: f.ticket.id, title: f.ticket.title },
         createdBy: { name: f.createdBy.name },
       }));
     },
 
+    // 新規 FAQ 候補を作成 (ステータスは DB 側デフォルトで Candidate)
     async create(input) {
       const row = await db.faqCandidate.create({
         data: {
@@ -33,9 +41,11 @@ export function makeFaqRepo(db: PrismaLike): FaqRepository {
           answer: input.answer,
         },
       });
+      // 作成結果をドメイン型に変換して返す
       return toFaq(row);
     },
 
+    // 状態 (Candidate/Published/Rejected) を更新
     async updateStatus(id, status) {
       await db.faqCandidate.update({ where: { id }, data: { status } });
     },

--- a/src/data/adapters/prisma/index.ts
+++ b/src/data/adapters/prisma/index.ts
@@ -1,5 +1,7 @@
+// Prisma クライアント型と、リポジトリ束/UnitOfWork の契約型をインポート
 import type { PrismaClient } from '@/generated/prisma';
 import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
+// 各エンティティ用の Prisma リポジトリ生成関数を取り込む
 import { makeCategoryRepo } from './category-repository.prisma';
 import { makeFaqRepo } from './faq-repository.prisma';
 import { makeNotificationRepo } from './notification-repository.prisma';
@@ -7,11 +9,15 @@ import { makeTicketCommentRepo } from './ticket-comment-repository.prisma';
 import { makeTicketHistoryRepo } from './ticket-history-repository.prisma';
 import { makeTicketRepo } from './ticket-repository.prisma';
 import { makeUserRepo } from './user-repository.prisma';
+// Prisma クライアント/トランザクション共通型
 import type { PrismaLike } from './types';
 
+// 共通型を外部にも再公開 (別のモジュールから使うため)
 export type { PrismaLike } from './types';
 
+// 指定 Prisma クライアント (または tx) で動く全リポジトリを組み立てて返す関数
 export function buildPrismaRepos(db: PrismaLike): Repos {
+  // 各ポートに対応する Prisma 実装を組み立てる
   return {
     tickets: makeTicketRepo(db),
     users: makeUserRepo(db),
@@ -23,9 +29,12 @@ export function buildPrismaRepos(db: PrismaLike): Repos {
   };
 }
 
+// Prisma の $transaction を用いた UnitOfWork 実装を生成する関数
 export function buildPrismaUow(client: PrismaClient): UnitOfWork {
   return {
+    // run に渡した関数をトランザクション内で実行する
     async run(fn) {
+      // Prisma のトランザクションを開始し、tx クライアント用の Repos を渡して実行
       return client.$transaction(async (tx) => fn(buildPrismaRepos(tx)));
     },
   };

--- a/src/data/adapters/prisma/mappers.ts
+++ b/src/data/adapters/prisma/mappers.ts
@@ -1,4 +1,6 @@
+// Prisma が生成する型を参照するためにインポート
 import type { Prisma } from '@/generated/prisma';
+// ドメイン型 (アダプタが返すべき型) をインポート
 import type {
   Notification,
   FaqCandidate,
@@ -10,8 +12,11 @@ import type {
   UserSummary,
 } from '@/domain/types';
 
+// Prisma から取り出した User テーブルの型エイリアス (include なし)
 type UserRow = Prisma.UserGetPayload<Record<string, never>>;
+// Ticket テーブルの型エイリアス
 type TicketRow = Prisma.TicketGetPayload<Record<string, never>>;
+// 関連 (creator / assignee / category) を include した Ticket の型エイリアス
 type TicketRowWithRefs = Prisma.TicketGetPayload<{
   include: {
     creator: { select: { id: true; name: true } };
@@ -19,12 +24,18 @@ type TicketRowWithRefs = Prisma.TicketGetPayload<{
     category: { select: { id: true; name: true } };
   };
 }>;
+// Notification テーブルの型エイリアス
 type NotificationRow = Prisma.NotificationGetPayload<Record<string, never>>;
+// TicketComment テーブルの型エイリアス
 type CommentRow = Prisma.TicketCommentGetPayload<Record<string, never>>;
+// TicketHistory テーブルの型エイリアス
 type HistoryRow = Prisma.TicketHistoryGetPayload<Record<string, never>>;
+// FaqCandidate テーブルの型エイリアス
 type FaqRow = Prisma.FaqCandidateGetPayload<Record<string, never>>;
 
+// Prisma の User 行をドメイン型 User に変換する関数
 export function toUser(row: UserRow): User {
+  // 必要なフィールドだけを抜き出して返す (余計なフィールドは付与しない)
   return {
     id: row.id,
     email: row.email,
@@ -36,11 +47,15 @@ export function toUser(row: UserRow): User {
   };
 }
 
+// 一覧表示等に使う最小情報 (id/name) を持つ UserSummary に変換する関数
 export function toUserSummary(row: Pick<UserRow, 'id' | 'name'>): UserSummary {
+  // id と name だけのオブジェクトを返す
   return { id: row.id, name: row.name };
 }
 
+// Prisma の Ticket 行をドメイン型 Ticket に変換する関数
 export function toTicket(row: TicketRow): Ticket {
+  // 必要なフィールドをそのまま詰め替えて返す
   return {
     id: row.id,
     title: row.title,
@@ -61,15 +76,18 @@ export function toTicket(row: TicketRow): Ticket {
   };
 }
 
+// 関連情報付きチケット行を TicketWithRefs に変換する関数
 export function toTicketWithRefs(row: TicketRowWithRefs): TicketWithRefs {
+  // 本体を toTicket で変換しつつ、creator/assignee/category を詰め替える
   return {
     ...toTicket(row),
-    creator: toUserSummary(row.creator),
-    assignee: row.assignee ? toUserSummary(row.assignee) : null,
-    category: row.category ? { id: row.category.id, name: row.category.name } : null,
+    creator: toUserSummary(row.creator), // 起票者
+    assignee: row.assignee ? toUserSummary(row.assignee) : null, // 担当者 (未アサインなら null)
+    category: row.category ? { id: row.category.id, name: row.category.name } : null, // カテゴリ
   };
 }
 
+// Prisma の Notification 行をドメイン型 Notification に変換する関数
 export function toNotification(row: NotificationRow): Notification {
   return {
     id: row.id,
@@ -82,6 +100,7 @@ export function toNotification(row: NotificationRow): Notification {
   };
 }
 
+// Prisma の TicketComment 行をドメイン型 TicketComment に変換する関数
 export function toComment(row: CommentRow): TicketComment {
   return {
     id: row.id,
@@ -92,6 +111,7 @@ export function toComment(row: CommentRow): TicketComment {
   };
 }
 
+// Prisma の TicketHistory 行をドメイン型 TicketHistory に変換する関数
 export function toHistory(row: HistoryRow): TicketHistory {
   return {
     id: row.id,
@@ -104,6 +124,7 @@ export function toHistory(row: HistoryRow): TicketHistory {
   };
 }
 
+// Prisma の FaqCandidate 行をドメイン型 FaqCandidate に変換する関数
 export function toFaq(row: FaqRow): FaqCandidate {
   return {
     id: row.id,

--- a/src/data/adapters/prisma/notification-repository.prisma.ts
+++ b/src/data/adapters/prisma/notification-repository.prisma.ts
@@ -1,3 +1,4 @@
+// 通知リポジトリの契約 (port)、マッパー、Prisma 共通型をインポート
 import type {
   NotificationListItem,
   NotificationRepository,
@@ -5,37 +6,44 @@ import type {
 import { toNotification } from './mappers';
 import type { PrismaLike } from './types';
 
+// Prisma クライアントを使った通知リポジトリを生成する関数
 export function makeNotificationRepo(db: PrismaLike): NotificationRepository {
   return {
+    // 通知を 1 件作成してドメイン型に変換して返す
     async create(input) {
       const row = await db.notification.create({
         data: {
-          userId: input.userId,
-          type: input.type,
-          message: input.message,
-          ticketId: input.ticketId ?? null,
+          userId: input.userId, // 受信者
+          type: input.type, // 種別
+          message: input.message, // 表示文言
+          ticketId: input.ticketId ?? null, // 関連チケット (未指定なら null)
         },
       });
+      // Prisma 行 → ドメイン型 Notification に変換
       return toNotification(row);
     },
 
+    // 未読件数を取得 (DB 側で count)
     async countUnread(userId) {
       return db.notification.count({ where: { userId, read: false } });
     },
 
+    // 指定ユーザーの通知を新しい順に limit 件取得 (関連チケット付き)
     async list(userId, { limit }) {
       const rows = await db.notification.findMany({
         where: { userId },
-        orderBy: { createdAt: 'desc' },
-        take: limit,
-        include: { ticket: { select: { id: true, title: true } } },
+        orderBy: { createdAt: 'desc' }, // 新しい順
+        take: limit, // 件数上限
+        include: { ticket: { select: { id: true, title: true } } }, // 関連チケットを JOIN
       });
+      // NotificationListItem 形式に整形して返す
       return rows.map<NotificationListItem>((n) => ({
         ...toNotification(n),
         ticket: n.ticket ? { id: n.ticket.id, title: n.ticket.title } : null,
       }));
     },
 
+    // 指定ユーザーの未読を一括で既読に更新
     async markAllRead(userId) {
       await db.notification.updateMany({ where: { userId, read: false }, data: { read: true } });
     },

--- a/src/data/adapters/prisma/ticket-comment-repository.prisma.ts
+++ b/src/data/adapters/prisma/ticket-comment-repository.prisma.ts
@@ -1,17 +1,21 @@
+// コメントリポジトリの契約 (port)、マッパー、Prisma 共通型をインポート
 import type { TicketCommentRepository } from '@/data/ports/ticket-comment-repository';
 import { toComment } from './mappers';
 import type { PrismaLike } from './types';
 
+// Prisma クライアントを使ったコメントリポジトリを生成する関数
 export function makeTicketCommentRepo(db: PrismaLike): TicketCommentRepository {
   return {
+    // コメントを 1 件作成して、ドメイン型で返す
     async create(input) {
       const row = await db.ticketComment.create({
         data: {
-          ticketId: input.ticketId,
-          authorId: input.authorId,
-          body: input.body,
+          ticketId: input.ticketId, // 対象チケット
+          authorId: input.authorId, // 書き込みユーザー
+          body: input.body, // コメント本文
         },
       });
+      // Prisma 行をドメイン型 TicketComment に変換して返す
       return toComment(row);
     },
   };

--- a/src/data/adapters/prisma/ticket-history-repository.prisma.ts
+++ b/src/data/adapters/prisma/ticket-history-repository.prisma.ts
@@ -1,16 +1,20 @@
+// 履歴リポジトリの契約 (port) と Prisma 共通型をインポート
 import type { TicketHistoryRepository } from '@/data/ports/ticket-history-repository';
 import type { PrismaLike } from './types';
 
+// Prisma クライアントを使った履歴リポジトリを生成する関数
 export function makeTicketHistoryRepo(db: PrismaLike): TicketHistoryRepository {
   return {
+    // 履歴を 1 件記録する (戻り値なし)
     async record(input) {
+      // TicketHistory テーブルに 1 行挿入
       await db.ticketHistory.create({
         data: {
-          ticketId: input.ticketId,
-          changedById: input.changedById,
-          field: input.field,
-          oldValue: input.oldValue,
-          newValue: input.newValue,
+          ticketId: input.ticketId, // 対象チケット
+          changedById: input.changedById, // 変更者
+          field: input.field, // 変更項目
+          oldValue: input.oldValue, // 変更前
+          newValue: input.newValue, // 変更後
         },
       });
     },

--- a/src/data/adapters/prisma/ticket-repository.prisma.ts
+++ b/src/data/adapters/prisma/ticket-repository.prisma.ts
@@ -1,66 +1,87 @@
+// Prisma の where 条件型を参照するためにインポート
 import type { Prisma } from '@/generated/prisma';
+// チケットリポジトリ契約と関連型をインポート
 import type {
   AssigneeWorkloadRow,
   TicketListFilter,
   TicketRepository,
 } from '@/data/ports/ticket-repository';
+// Prisma 行 → ドメイン型のマッパー関数群
 import { toTicket, toTicketWithRefs, toUserSummary, toComment, toHistory } from './mappers';
+// Prisma クライアント共通型
 import type { PrismaLike } from './types';
 
+// ドメインのフィルター条件を Prisma の WhereInput に変換するヘルパー
 function buildWhere(f: TicketListFilter): Prisma.TicketWhereInput {
+  // 初期値は空 (条件なし)
   const where: Prisma.TicketWhereInput = {};
+  // 各フィルタが指定されていれば条件を積み上げる
   if (f.creatorId !== undefined) where.creatorId = f.creatorId;
   if (f.status !== undefined) where.status = f.status;
   if (f.priority !== undefined) where.priority = f.priority;
   if (f.categoryId !== undefined) where.categoryId = f.categoryId;
+  // 担当者条件: 'unassigned' は null に読み替え
   if (f.assigneeId !== undefined) {
     where.assigneeId = f.assigneeId === 'unassigned' ? null : f.assigneeId;
   }
+  // テキスト検索: title または body に contains を OR 条件で適用
   if (f.text) {
+    // 大文字小文字を無視する場合は Prisma の 'insensitive' モードを指定
     const mode = f.text.caseInsensitive ? ('insensitive' as const) : undefined;
     where.OR = [
       { title: { contains: f.text.contains, mode } },
       { body: { contains: f.text.contains, mode } },
     ];
   }
+  // 完成した where 条件を返す
   return where;
 }
 
+// チケット取得時に毎回使う関連 include の共通定義 (DRY 化)
 const REFS_INCLUDE = {
   creator: { select: { id: true, name: true } },
   assignee: { select: { id: true, name: true } },
   category: { select: { id: true, name: true } },
 } as const;
 
+// Prisma クライアントを使ったチケットリポジトリを生成する関数
 export function makeTicketRepo(db: PrismaLike): TicketRepository {
   return {
+    // 最小フィールドのチケットを 1 件取得 (ドメイン型変換)
     async findById(id) {
       const row = await db.ticket.findUnique({ where: { id } });
       return row ? toTicket(row) : null;
     },
 
+    // 関連情報付きで 1 件取得 (一覧/詳細以外のユースケース)
     async findByIdWithRefs(id) {
       const row = await db.ticket.findUnique({ where: { id }, include: REFS_INCLUDE });
       return row ? toTicketWithRefs(row) : null;
     },
 
+    // 詳細ページ用: 関連 + コメント + 履歴 + FAQ 候補を一括取得
     async findByIdWithDetail(id) {
       const row = await db.ticket.findUnique({
         where: { id },
         include: {
-          ...REFS_INCLUDE,
+          ...REFS_INCLUDE, // 起票者/担当者/カテゴリ
+          // コメントは古い順に、投稿者名を JOIN
           comments: {
             orderBy: { createdAt: 'asc' },
             include: { author: { select: { id: true, name: true } } },
           },
+          // 履歴は新しい順に、変更者名を JOIN
           histories: {
             orderBy: { createdAt: 'desc' },
             include: { changedBy: { select: { id: true, name: true } } },
           },
+          // 紐づく FAQ 候補 (存在すれば ID のみ)
           faqCandidate: { select: { id: true } },
         },
       });
+      // チケットが存在しなければ null を返す
       if (!row) return null;
+      // 取得結果を TicketDetail 形式に整形
       return {
         ...toTicketWithRefs(row),
         comments: row.comments.map((c) => ({
@@ -75,53 +96,63 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
       };
     },
 
+    // 一覧取得 (フィルタ/ソート/ページング)
     async list({ filter, page, sort }) {
       const rows = await db.ticket.findMany({
-        where: buildWhere(filter),
-        orderBy: { createdAt: sort?.direction ?? 'desc' },
-        skip: page.skip,
-        take: page.take,
-        include: REFS_INCLUDE,
+        where: buildWhere(filter), // ドメイン条件を Prisma 条件に変換
+        orderBy: { createdAt: sort?.direction ?? 'desc' }, // 既定は降順
+        skip: page.skip, // オフセット
+        take: page.take, // ページサイズ
+        include: REFS_INCLUDE, // 関連情報を同梱
       });
+      // 取得行を TicketWithRefs に変換
       return rows.map(toTicketWithRefs);
     },
 
+    // 件数取得 (ページング用)
     async count(filter) {
       return db.ticket.count({ where: buildWhere(filter) });
     },
 
+    // 状態別の件数 (起票者フィルタを任意適用)
     async countByStatus({ creatorId, status }) {
       return db.ticket.count({
         where: {
           status,
+          // creatorId が指定されていれば where に追加、なければ何も足さない
           ...(creatorId !== undefined ? { creatorId } : {}),
         },
       });
     },
 
+    // SLA 期限超過 (未解決) の件数
     async countSlaOverdue(now) {
       return db.ticket.count({
         where: {
-          resolutionDueAt: { lt: now },
-          resolvedAt: null,
-          status: { notIn: ['Resolved', 'Closed'] },
+          resolutionDueAt: { lt: now }, // 期限が現在より前
+          resolvedAt: null, // 未解決
+          status: { notIn: ['Resolved', 'Closed'] }, // 終息状態を除外
         },
       });
     },
 
+    // 担当者別の保持件数 (指定状態は除外)
     async workloadByAssignee({ excludeStatuses }) {
+      // Prisma の groupBy で assigneeId ごとに件数を集計
       const grouped = await db.ticket.groupBy({
         by: ['assigneeId'],
         where: { status: { notIn: excludeStatuses } },
         _count: { id: true },
-        orderBy: { _count: { id: 'desc' } },
+        orderBy: { _count: { id: 'desc' } }, // 件数の多い順
       });
+      // AssigneeWorkloadRow 形式に整形して返す
       return grouped.map<AssigneeWorkloadRow>((g) => ({
         assigneeId: g.assigneeId,
         count: g._count.id,
       }));
     },
 
+    // 新規チケットを作成 (関連情報付きで返す)
     async create(input) {
       const row = await db.ticket.create({
         data: {
@@ -133,23 +164,28 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
           firstResponseDueAt: input.firstResponseDueAt ?? null,
           resolutionDueAt: input.resolutionDueAt ?? null,
         },
-        include: REFS_INCLUDE,
+        include: REFS_INCLUDE, // 作成直後に関連情報も取得
       });
+      // TicketWithRefs に変換して返す
       return toTicketWithRefs(row);
     },
 
+    // 状態と解決日時を更新
     async updateStatus(id, status, resolvedAt) {
       await db.ticket.update({ where: { id }, data: { status, resolvedAt } });
     },
 
+    // 優先度を更新
     async updatePriority(id, priority) {
       await db.ticket.update({ where: { id }, data: { priority } });
     },
 
+    // 担当者を更新 (null で未アサインに戻す)
     async updateAssignee(id, assigneeId) {
       await db.ticket.update({ where: { id }, data: { assigneeId } });
     },
 
+    // エスカレーション扱いに更新 (状態 + 理由 + 実行時刻)
     async markEscalated(id, args) {
       await db.ticket.update({
         where: { id },

--- a/src/data/adapters/prisma/types.ts
+++ b/src/data/adapters/prisma/types.ts
@@ -1,3 +1,6 @@
+// Prisma クライアント本体と、トランザクション内で使う Prisma クライアント型をインポート
 import type { Prisma, PrismaClient } from '@/generated/prisma';
 
+// 通常クライアントでもトランザクション中のクライアントでも受け取れる共通型
+// (リポジトリ実装が両方のコンテキストで使えるようにするための型エイリアス)
 export type PrismaLike = PrismaClient | Prisma.TransactionClient;

--- a/src/data/adapters/prisma/user-repository.prisma.ts
+++ b/src/data/adapters/prisma/user-repository.prisma.ts
@@ -1,42 +1,53 @@
+// ユーザーリポジトリの契約 (port)、マッパー関数、Prisma 共通型をインポート
 import type { UserRepository } from '@/data/ports/user-repository';
 import { toUser, toUserSummary } from './mappers';
 import type { PrismaLike } from './types';
 
+// Prisma クライアントを使ったユーザーリポジトリを生成する関数
 export function makeUserRepo(db: PrismaLike): UserRepository {
   return {
+    // ID で 1 件取得し、ドメイン型 User に変換して返す
     async findById(id) {
-      const row = await db.user.findUnique({ where: { id } });
-      return row ? toUser(row) : null;
+      const row = await db.user.findUnique({ where: { id } }); // 主キー検索
+      return row ? toUser(row) : null; // 見つかれば変換、無ければ null
     },
 
+    // メールアドレスで 1 件取得 (ログインで使用)
     async findByEmail(email) {
-      const row = await db.user.findUnique({ where: { email } });
+      const row = await db.user.findUnique({ where: { email } }); // メール一致検索
       return row ? toUser(row) : null;
     },
 
+    // agent または admin の一覧を名前順で取得 (UserSummary に変換)
     async listAgents() {
       const rows = await db.user.findMany({
-        where: { role: { in: ['agent', 'admin'] } },
-        select: { id: true, name: true },
-        orderBy: { name: 'asc' },
+        where: { role: { in: ['agent', 'admin'] } }, // agent か admin のみ
+        select: { id: true, name: true }, // 必要列のみ
+        orderBy: { name: 'asc' }, // 名前昇順
       });
+      // 各行を UserSummary に変換
       return rows.map(toUserSummary);
     },
 
+    // agent または admin の ID だけを取得 (通知一斉送信などに使用)
     async listAgentIds() {
       const rows = await db.user.findMany({
         where: { role: { in: ['agent', 'admin'] } },
-        select: { id: true },
+        select: { id: true }, // id だけ
       });
+      // id の配列に変換して返す
       return rows.map((r) => r.id);
     },
 
+    // 指定 ID 配列に一致するユーザーの概要を一括取得
     async findSummariesByIds(ids) {
+      // 空配列で findMany を呼ぶと無駄なので早期 return
       if (ids.length === 0) return [];
       const rows = await db.user.findMany({
-        where: { id: { in: ids } },
+        where: { id: { in: ids } }, // IN 検索
         select: { id: true, name: true },
       });
+      // UserSummary 形式に変換して返す
       return rows.map(toUserSummary);
     },
   };

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -8,16 +8,23 @@
  * this file. The public `repos` / `uow` surface stays identical.
  */
 
+// Prisma クライアントのシングルトンを取り込む
 import { prisma } from '@/lib/prisma';
+// メモリ版の通知ブロードキャスタ実装
 import { createInMemoryNotificationBroadcaster } from './adapters/memory/notification-broadcaster.memory';
+// Prisma 版のリポジトリ束と UnitOfWork 生成関数
 import { buildPrismaRepos, buildPrismaUow } from './adapters/prisma';
+// ポート型 (外部アプリコードへの公開契約)
 import type { NotificationBroadcaster } from './ports/notification-broadcaster';
 import type { Repos, UnitOfWork } from './ports/unit-of-work';
 
+// 外部アプリコードで使う型だけを再公開する (データ層の公開 API)
 export type { Repos, UnitOfWork } from './ports/unit-of-work';
 export type { NotificationBroadcaster } from './ports/notification-broadcaster';
 
+// アプリ全体で共有する Prisma 版のリポジトリ束
 export const repos: Repos = buildPrismaRepos(prisma);
+// アプリ全体で共有する Prisma 版の UnitOfWork (トランザクション境界)
 export const uow: UnitOfWork = buildPrismaUow(prisma);
 
 /**
@@ -27,5 +34,7 @@ export const uow: UnitOfWork = buildPrismaUow(prisma);
  * `LISTEN/NOTIFY` adapter (see `src/data/ports/notification-broadcaster.ts`
  * and GitHub issue #60).
  */
+// 既定の通知ブロードキャスタ (プロセス内 Map 実装)
+// 複数インスタンス展開時は外部ストア版に差し替えること
 export const notificationBroadcaster: NotificationBroadcaster =
   createInMemoryNotificationBroadcaster();

--- a/src/data/ports/category-repository.ts
+++ b/src/data/ports/category-repository.ts
@@ -1,9 +1,11 @@
+// カテゴリの一覧表示などに使う軽量なカテゴリ情報
 export interface CategorySummary {
-  id: string;
-  name: string;
+  id: string; // カテゴリ ID
+  name: string; // カテゴリ名
 }
 
+// カテゴリ取得用リポジトリの契約 (port)
 export interface CategoryRepository {
-  list(): Promise<CategorySummary[]>;
-  findById(id: string): Promise<CategorySummary | null>;
+  list(): Promise<CategorySummary[]>; // 全カテゴリを取得する
+  findById(id: string): Promise<CategorySummary | null>; // ID 指定で 1 件取得 (無ければ null)
 }

--- a/src/data/ports/faq-repository.ts
+++ b/src/data/ports/faq-repository.ts
@@ -1,20 +1,24 @@
+// ドメイン型 (FAQ 候補/FAQ 状態) をインポート
 import type { FaqCandidate, FaqStatus } from '@/domain/types';
 
+// FAQ 候補を新規作成するときの入力値
 export interface CreateFaqInput {
-  ticketId: string;
-  createdById: string;
-  question: string;
-  answer: string;
+  ticketId: string; // 元となったチケット ID
+  createdById: string; // 候補化したユーザー ID
+  question: string; // 質問文
+  answer: string; // 回答文
 }
 
+// 一覧表示用の FAQ アイテム (関連チケットと作成者名を同梱)
 export interface FaqListItem extends FaqCandidate {
-  ticket: { id: string; title: string };
-  createdBy: { name: string };
+  ticket: { id: string; title: string }; // 元チケットの要約
+  createdBy: { name: string }; // 作成者の氏名
 }
 
+// FAQ リポジトリの契約 (port)
 export interface FaqRepository {
-  findById(id: string): Promise<FaqCandidate | null>;
-  list(): Promise<FaqListItem[]>;
-  create(input: CreateFaqInput): Promise<FaqCandidate>;
-  updateStatus(id: string, status: FaqStatus): Promise<void>;
+  findById(id: string): Promise<FaqCandidate | null>; // ID で 1 件取得
+  list(): Promise<FaqListItem[]>; // 一覧取得
+  create(input: CreateFaqInput): Promise<FaqCandidate>; // 候補を作成
+  updateStatus(id: string, status: FaqStatus): Promise<void>; // 公開/却下などの状態更新
 }

--- a/src/data/ports/filters.ts
+++ b/src/data/ports/filters.ts
@@ -5,18 +5,21 @@
  * (e.g. Prisma `WhereInput`, Drizzle/Kysely builders, raw SQL).
  */
 
+// 文字列部分一致フィルター (LIKE 検索相当)
 export interface TextFilter {
-  contains: string;
+  contains: string; // 部分一致させたい文字列
   /** If true, match is case-insensitive (adapter-specific implementation). */
-  caseInsensitive?: boolean;
+  caseInsensitive?: boolean; // 大文字小文字を無視するか (各アダプタで実装)
 }
 
+// ページング指定 (skip 件飛ばして take 件取得)
 export interface Page {
-  skip: number;
-  take: number;
+  skip: number; // スキップ件数 (オフセット)
+  take: number; // 取得件数 (ページサイズ)
 }
 
+// 並び替え指定 (指定フィールドを昇順/降順で)
 export interface Sort<Field extends string> {
-  field: Field;
-  direction: 'asc' | 'desc';
+  field: Field; // 並び替え対象のフィールド名
+  direction: 'asc' | 'desc'; // 昇順 or 降順
 }

--- a/src/data/ports/notification-broadcaster.ts
+++ b/src/data/ports/notification-broadcaster.ts
@@ -9,10 +9,13 @@
  * Tracking: see GitHub issue #60.
  */
 
+// SSE 接続 1 本分を表すコントローラー型 (Web 標準 ReadableStream のコントローラー)
 export type BroadcastController = ReadableStreamDefaultController<Uint8Array>;
 
+// 通知ブロードキャスタの契約 (port)
+// 実装は in-memory Map だったり、将来的には Redis pub/sub だったりする
 export interface NotificationBroadcaster {
-  addSubscriber(userId: string, controller: BroadcastController): void;
-  removeSubscriber(userId: string, controller: BroadcastController): void;
-  broadcast(userId: string, count: number): void;
+  addSubscriber(userId: string, controller: BroadcastController): void; // ユーザーの SSE 接続を登録
+  removeSubscriber(userId: string, controller: BroadcastController): void; // 接続を解除
+  broadcast(userId: string, count: number): void; // 指定ユーザーの全接続に未読件数を送信
 }

--- a/src/data/ports/notification-repository.ts
+++ b/src/data/ports/notification-repository.ts
@@ -1,19 +1,23 @@
+// ドメイン型 (通知本体/種別) をインポート
 import type { Notification, NotificationType } from '@/domain/types';
 
+// 通知を作成するときに渡す入力値
 export interface CreateNotificationInput {
-  userId: string;
-  type: NotificationType;
-  message: string;
-  ticketId?: string | null;
+  userId: string; // 受信者 ID
+  type: NotificationType; // 通知の種類
+  message: string; // 表示文言
+  ticketId?: string | null; // 関連チケット ID (任意)
 }
 
+// 一覧表示用の通知アイテム (関連チケットの一部情報を同梱)
 export interface NotificationListItem extends Notification {
-  ticket: { id: string; title: string } | null;
+  ticket: { id: string; title: string } | null; // 関連チケットの要約 (なければ null)
 }
 
+// 通知ストアの契約 (port)
 export interface NotificationRepository {
-  create(input: CreateNotificationInput): Promise<Notification>;
-  countUnread(userId: string): Promise<number>;
-  list(userId: string, opts: { limit: number }): Promise<NotificationListItem[]>;
-  markAllRead(userId: string): Promise<void>;
+  create(input: CreateNotificationInput): Promise<Notification>; // 通知を 1 件作成
+  countUnread(userId: string): Promise<number>; // 未読件数を取得
+  list(userId: string, opts: { limit: number }): Promise<NotificationListItem[]>; // 一覧取得
+  markAllRead(userId: string): Promise<void>; // 全通知を既読にする
 }

--- a/src/data/ports/ticket-comment-repository.ts
+++ b/src/data/ports/ticket-comment-repository.ts
@@ -1,11 +1,14 @@
+// ドメイン型 (コメント) をインポート
 import type { TicketComment } from '@/domain/types';
 
+// コメント作成時に渡す入力値
 export interface CreateCommentInput {
-  ticketId: string;
-  authorId: string;
-  body: string;
+  ticketId: string; // 対象チケット ID
+  authorId: string; // 書き込みユーザー ID
+  body: string; // コメント本文
 }
 
+// コメント書き込み用リポジトリの契約 (port)
 export interface TicketCommentRepository {
-  create(input: CreateCommentInput): Promise<TicketComment>;
+  create(input: CreateCommentInput): Promise<TicketComment>; // 1 件作成し、作成結果を返す
 }

--- a/src/data/ports/ticket-history-repository.ts
+++ b/src/data/ports/ticket-history-repository.ts
@@ -1,13 +1,16 @@
+// 履歴項目の種類 (status/priority/assignee/escalation) を示す型をインポート
 import type { HistoryField } from '@/domain/types';
 
+// 履歴 1 件を記録する際に渡す入力値
 export interface RecordHistoryInput {
-  ticketId: string;
-  changedById: string;
-  field: HistoryField;
-  oldValue: string | null;
-  newValue: string | null;
+  ticketId: string; // どのチケットの履歴か
+  changedById: string; // 変更を行ったユーザー ID
+  field: HistoryField; // 変更項目の種類
+  oldValue: string | null; // 変更前の値 (null 可)
+  newValue: string | null; // 変更後の値 (null 可)
 }
 
+// チケット履歴書き込み用リポジトリの契約 (port)
 export interface TicketHistoryRepository {
-  record(input: RecordHistoryInput): Promise<void>;
+  record(input: RecordHistoryInput): Promise<void>; // 履歴を 1 件追加する
 }

--- a/src/data/ports/ticket-repository.ts
+++ b/src/data/ports/ticket-repository.ts
@@ -1,3 +1,4 @@
+// ドメイン型 (チケット関連) とフィルター関連の基本型をインポート
 import type {
   Priority,
   Ticket,
@@ -9,66 +10,73 @@ import type {
 } from '@/domain/types';
 import type { Page, Sort, TextFilter } from './filters';
 
+// チケット一覧の絞り込み条件
 export interface TicketListFilter {
-  creatorId?: string;
+  creatorId?: string; // 起票者で絞る (依頼者ロールはこれを必ず付与)
   /** Searches title OR body. */
-  text?: TextFilter;
-  status?: TicketStatus;
-  priority?: Priority;
-  categoryId?: string;
+  text?: TextFilter; // タイトルまたは本文の部分一致
+  status?: TicketStatus; // 状態で絞る
+  priority?: Priority; // 優先度で絞る
+  categoryId?: string; // カテゴリで絞る
   /**
    * `undefined` = no filter, `null` or `'unassigned'` = only unassigned,
    * otherwise = exact match on assigneeId.
    */
-  assigneeId?: string | null | 'unassigned';
+  assigneeId?: string | null | 'unassigned'; // 担当者条件 (未アサイン指定も可能)
 }
 
+// チケット詳細画面用の型 (コメント/履歴/FAQ 候補を同梱)
 export interface TicketDetail extends TicketWithRefs {
-  comments: Array<TicketComment & { author: UserSummary }>;
-  histories: Array<TicketHistory & { changedBy: UserSummary }>;
-  faqCandidate: { id: string } | null;
+  comments: Array<TicketComment & { author: UserSummary }>; // コメント + 書き込み者
+  histories: Array<TicketHistory & { changedBy: UserSummary }>; // 履歴 + 変更者
+  faqCandidate: { id: string } | null; // 紐づく FAQ 候補 (なければ null)
 }
 
+// 担当者別の保持チケット件数を表す行 (ダッシュボード用)
 export interface AssigneeWorkloadRow {
-  assigneeId: string | null;
-  count: number;
+  assigneeId: string | null; // 担当者 ID (未アサイン集計は null)
+  count: number; // 件数
 }
 
+// チケット新規作成用の入力値
 export interface CreateTicketInput {
-  title: string;
-  body: string;
-  priority: Priority;
-  categoryId: string | null;
-  creatorId: string;
-  firstResponseDueAt?: Date | null;
-  resolutionDueAt?: Date | null;
+  title: string; // 件名
+  body: string; // 本文
+  priority: Priority; // 優先度
+  categoryId: string | null; // カテゴリ (無指定は null)
+  creatorId: string; // 起票者 ID
+  firstResponseDueAt?: Date | null; // 初回応答期限 (SLA)
+  resolutionDueAt?: Date | null; // 解決期限 (SLA)
 }
 
+// エスカレーション適用時の入力値
 export interface MarkEscalatedInput {
-  reason: string;
-  at: Date;
+  reason: string; // エスカレーション理由
+  at: Date; // エスカレーション実行日時
 }
 
+// チケットリポジトリの契約 (port)
 export interface TicketRepository {
-  findById(id: string): Promise<Ticket | null>;
-  findByIdWithRefs(id: string): Promise<TicketWithRefs | null>;
-  findByIdWithDetail(id: string): Promise<TicketDetail | null>;
+  findById(id: string): Promise<Ticket | null>; // ID で 1 件取得 (最小フィールド)
+  findByIdWithRefs(id: string): Promise<TicketWithRefs | null>; // 関連ユーザー/カテゴリ付きで 1 件取得
+  findByIdWithDetail(id: string): Promise<TicketDetail | null>; // 詳細ページ用に 1 件取得
 
+  // 一覧取得 (絞り込み + ページング + ソート)
   list(args: {
     filter: TicketListFilter;
     page: Page;
     sort?: Sort<'createdAt'>;
   }): Promise<TicketWithRefs[]>;
 
-  count(filter: TicketListFilter): Promise<number>;
+  count(filter: TicketListFilter): Promise<number>; // 件数取得 (ページング用)
 
-  countByStatus(args: { creatorId?: string; status: TicketStatus }): Promise<number>;
-  countSlaOverdue(now: Date): Promise<number>;
-  workloadByAssignee(args: { excludeStatuses: TicketStatus[] }): Promise<AssigneeWorkloadRow[]>;
+  countByStatus(args: { creatorId?: string; status: TicketStatus }): Promise<number>; // 状態別件数
+  countSlaOverdue(now: Date): Promise<number>; // SLA 超過件数 (ダッシュボード用)
+  workloadByAssignee(args: { excludeStatuses: TicketStatus[] }): Promise<AssigneeWorkloadRow[]>; // 担当者別件数
 
-  create(input: CreateTicketInput): Promise<TicketWithRefs>;
-  updateStatus(id: string, status: TicketStatus, resolvedAt: Date | null): Promise<void>;
-  updatePriority(id: string, priority: Priority): Promise<void>;
-  updateAssignee(id: string, assigneeId: string | null): Promise<void>;
-  markEscalated(id: string, args: MarkEscalatedInput): Promise<void>;
+  create(input: CreateTicketInput): Promise<TicketWithRefs>; // 新規作成
+  updateStatus(id: string, status: TicketStatus, resolvedAt: Date | null): Promise<void>; // 状態更新
+  updatePriority(id: string, priority: Priority): Promise<void>; // 優先度更新
+  updateAssignee(id: string, assigneeId: string | null): Promise<void>; // 担当者更新
+  markEscalated(id: string, args: MarkEscalatedInput): Promise<void>; // エスカレーション状態にする
 }

--- a/src/data/ports/unit-of-work.ts
+++ b/src/data/ports/unit-of-work.ts
@@ -1,3 +1,4 @@
+// 各リポジトリの契約 (port) を束ねて 1 セットとして扱うための型定義
 import type { CategoryRepository } from './category-repository';
 import type { FaqRepository } from './faq-repository';
 import type { NotificationRepository } from './notification-repository';
@@ -6,16 +7,19 @@ import type { TicketHistoryRepository } from './ticket-history-repository';
 import type { TicketRepository } from './ticket-repository';
 import type { UserRepository } from './user-repository';
 
+// アプリ全体で使うリポジトリ群 (全ポートをまとめた集合)
 export interface Repos {
-  tickets: TicketRepository;
-  users: UserRepository;
-  notifications: NotificationRepository;
-  faq: FaqRepository;
-  history: TicketHistoryRepository;
-  comments: TicketCommentRepository;
-  categories: CategoryRepository;
+  tickets: TicketRepository; // チケット操作
+  users: UserRepository; // ユーザー操作
+  notifications: NotificationRepository; // 通知操作
+  faq: FaqRepository; // FAQ 操作
+  history: TicketHistoryRepository; // 履歴操作
+  comments: TicketCommentRepository; // コメント操作
+  categories: CategoryRepository; // カテゴリ操作
 }
 
+// トランザクション境界を表す契約 (Unit of Work パターン)
+// run に渡した関数内ではトランザクション対応の Repos が使える
 export interface UnitOfWork {
   run<T>(fn: (txRepos: Repos) => Promise<T>): Promise<T>;
 }

--- a/src/data/ports/user-repository.ts
+++ b/src/data/ports/user-repository.ts
@@ -1,10 +1,12 @@
+// ドメイン層のユーザー型をインポート
 import type { User, UserSummary } from '@/domain/types';
 
+// ユーザー取得系リポジトリの契約 (port)
 export interface UserRepository {
-  findById(id: string): Promise<User | null>;
-  findByEmail(email: string): Promise<User | null>;
+  findById(id: string): Promise<User | null>; // ID 指定で 1 件取得
+  findByEmail(email: string): Promise<User | null>; // メール指定で 1 件取得 (ログインで利用)
   /** Agents and admins. */
-  listAgents(): Promise<UserSummary[]>;
-  listAgentIds(): Promise<string[]>;
-  findSummariesByIds(ids: string[]): Promise<UserSummary[]>;
+  listAgents(): Promise<UserSummary[]>; // agent と admin の一覧 (アサイン候補)
+  listAgentIds(): Promise<string[]>; // agent と admin の ID だけの一覧 (通知用)
+  findSummariesByIds(ids: string[]): Promise<UserSummary[]>; // ID 配列から概要をまとめて取得
 }

--- a/src/domain/ticket-status.ts
+++ b/src/domain/ticket-status.ts
@@ -1,23 +1,29 @@
+// チケット状態 (TicketStatus) の型を Prisma (DB 操作ライブラリ) が生成した定義から読み込む
 import type { TicketStatus } from '@/generated/prisma';
 
 // Source of truth for ticket status transitions. Mirrors `docs/requirements.md` §5
 // including `Closed → Open`（再オープン）which is an explicit product requirement,
 // not an oversight. Changing this table requires updating the requirements doc
 // and `tests/ticket-status.test.ts` together.
+// 以下は「どの状態からどの状態へ変えてよいか」を表す表 (遷移許可リスト)
 const ALLOWED_TRANSITIONS: Record<TicketStatus, TicketStatus[]> = {
-  New: ['Open', 'WaitingForUser', 'InProgress', 'Resolved', 'Closed'],
-  Open: ['InProgress', 'WaitingForUser', 'Escalated', 'Resolved', 'Closed'],
-  WaitingForUser: ['Open', 'InProgress', 'Resolved', 'Closed'],
-  InProgress: ['WaitingForUser', 'Escalated', 'Resolved', 'Closed'],
-  Escalated: ['InProgress', 'Resolved', 'Closed'],
-  Resolved: ['Open', 'Closed'],
-  Closed: ['Open'],
+  New: ['Open', 'WaitingForUser', 'InProgress', 'Resolved', 'Closed'], // 新規作成直後からはほぼ全状態へ進める
+  Open: ['InProgress', 'WaitingForUser', 'Escalated', 'Resolved', 'Closed'], // 受付済みから作業中・上位対応など
+  WaitingForUser: ['Open', 'InProgress', 'Resolved', 'Closed'], // 依頼者回答待ちから再開・解決など
+  InProgress: ['WaitingForUser', 'Escalated', 'Resolved', 'Closed'], // 作業中から保留・エスカレーション・解決
+  Escalated: ['InProgress', 'Resolved', 'Closed'], // エスカレーション後は作業再開か解決/完了のみ
+  Resolved: ['Open', 'Closed'], // 解決済みは再オープンまたは完了へ
+  Closed: ['Open'], // 完了からでも再オープン可 (要件定義で明示)
 };
 
+// 現在状態 from から次状態 to に遷移してよいかを true/false で返す関数
 export function isValidTransition(from: TicketStatus, to: TicketStatus): boolean {
+  // 許可表を参照し、to が含まれていれば遷移可能
   return ALLOWED_TRANSITIONS[from].includes(to);
 }
 
+// 現在状態 from から遷移できる次状態の一覧を配列で返す関数 (UI のプルダウン生成用)
 export function getAllowedTransitions(from: TicketStatus): TicketStatus[] {
+  // 許可表からそのまま返す (配列を共有するので呼び出し側で変更しないこと)
   return ALLOWED_TRANSITIONS[from];
 }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -6,8 +6,10 @@
  * Adapter code maps its native row shapes into these types.
  */
 
+// ユーザーの権限区分 (依頼者 / 担当者 / 管理者)
 export type Role = 'requester' | 'agent' | 'admin';
 
+// チケットの状態 (新規/受付中/依頼者待ち/作業中/エスカレーション/解決/完了)
 export type TicketStatus =
   | 'New'
   | 'Open'
@@ -17,89 +19,101 @@ export type TicketStatus =
   | 'Resolved'
   | 'Closed';
 
+// 優先度 (低/中/高)
 export type Priority = 'Low' | 'Medium' | 'High';
 
+// 履歴に記録する項目の種類 (状態/優先度/担当者/エスカレーション)
 export type HistoryField = 'status' | 'priority' | 'assignee' | 'escalation';
 
+// FAQ 候補の公開状態 (候補/公開中/却下)
 export type FaqStatus = 'Candidate' | 'Published' | 'Rejected';
 
+// ユーザー向け通知の種類 (担当割当/エスカレーション/コメント/状態変更)
 export type NotificationType = 'assigned' | 'escalated' | 'commented' | 'statusChanged';
 
+// 一覧表示などで最低限必要なユーザー情報だけを持つ軽量型
 export interface UserSummary {
-  id: string;
-  name: string;
+  id: string; // ユーザー ID
+  name: string; // 画面に表示する氏名
 }
 
+// ユーザー本体。認証情報と基本属性を保持する
 export interface User {
-  id: string;
-  email: string;
-  name: string;
-  passwordHash: string;
-  role: Role;
-  createdAt: Date;
-  updatedAt: Date;
+  id: string; // ユーザー ID (主キー)
+  email: string; // ログイン用メールアドレス (一意)
+  name: string; // 氏名
+  passwordHash: string; // bcrypt でハッシュ化済みパスワード (平文は保存しない)
+  role: Role; // 権限区分
+  createdAt: Date; // 登録日時
+  updatedAt: Date; // 最終更新日時
 }
 
+// チケット本体。問い合わせ 1 件に対応する中心データ
 export interface Ticket {
-  id: string;
-  title: string;
-  body: string;
-  status: TicketStatus;
-  priority: Priority;
-  createdAt: Date;
-  updatedAt: Date;
-  firstResponseDueAt: Date | null;
-  resolutionDueAt: Date | null;
-  firstRespondedAt: Date | null;
-  resolvedAt: Date | null;
-  escalatedAt: Date | null;
-  escalationReason: string | null;
-  creatorId: string;
-  assigneeId: string | null;
-  categoryId: string | null;
+  id: string; // チケット ID (主キー)
+  title: string; // 件名
+  body: string; // 本文 (問い合わせ内容)
+  status: TicketStatus; // 現在の状態
+  priority: Priority; // 優先度
+  createdAt: Date; // 起票日時
+  updatedAt: Date; // 最終更新日時
+  firstResponseDueAt: Date | null; // 初回応答期限 (SLA)。未設定なら null
+  resolutionDueAt: Date | null; // 解決期限 (SLA)。未設定なら null
+  firstRespondedAt: Date | null; // 初回応答した日時。未応答なら null
+  resolvedAt: Date | null; // 解決した日時。未解決なら null
+  escalatedAt: Date | null; // エスカレーションした日時。していなければ null
+  escalationReason: string | null; // エスカレーション理由のテキスト
+  creatorId: string; // 起票者ユーザー ID
+  assigneeId: string | null; // 担当者ユーザー ID (未アサインなら null)
+  categoryId: string | null; // カテゴリ ID (未分類なら null)
 }
 
+// チケット本体に関連ユーザー/カテゴリを埋め込んだ拡張版 (画面表示用)
 export interface TicketWithRefs extends Ticket {
-  creator: UserSummary;
-  assignee: UserSummary | null;
-  category: { id: string; name: string } | null;
+  creator: UserSummary; // 起票者の概要
+  assignee: UserSummary | null; // 担当者の概要 (未アサインなら null)
+  category: { id: string; name: string } | null; // カテゴリ概要 (未分類なら null)
 }
 
+// チケットに付いたコメント 1 件分
 export interface TicketComment {
-  id: string;
-  ticketId: string;
-  authorId: string;
-  body: string;
-  createdAt: Date;
+  id: string; // コメント ID
+  ticketId: string; // どのチケットに属すか
+  authorId: string; // 書き込んだユーザー ID
+  body: string; // コメント本文
+  createdAt: Date; // 投稿日時
 }
 
+// チケットの変更履歴 1 件分
 export interface TicketHistory {
-  id: string;
-  ticketId: string;
-  changedById: string;
-  field: HistoryField;
-  oldValue: string | null;
-  newValue: string | null;
-  createdAt: Date;
+  id: string; // 履歴 ID
+  ticketId: string; // どのチケットの履歴か
+  changedById: string; // 変更を行ったユーザー ID
+  field: HistoryField; // どの項目が変更されたか
+  oldValue: string | null; // 変更前の値 (初期登録時は null)
+  newValue: string | null; // 変更後の値
+  createdAt: Date; // 変更日時
 }
 
+// 解決済みチケットから派生した FAQ 候補 1 件分
 export interface FaqCandidate {
-  id: string;
-  ticketId: string;
-  createdById: string;
-  question: string;
-  answer: string;
-  status: FaqStatus;
-  createdAt: Date;
-  updatedAt: Date;
+  id: string; // FAQ 候補 ID
+  ticketId: string; // 元となったチケット ID
+  createdById: string; // 候補化したユーザー ID
+  question: string; // 公開用の質問文
+  answer: string; // 公開用の回答文
+  status: FaqStatus; // 候補/公開/却下のいずれか
+  createdAt: Date; // 候補化した日時
+  updatedAt: Date; // 最終更新日時
 }
 
+// ユーザー向け通知 1 件分
 export interface Notification {
-  id: string;
-  userId: string;
-  ticketId: string | null;
-  type: NotificationType;
-  message: string;
-  read: boolean;
-  createdAt: Date;
+  id: string; // 通知 ID
+  userId: string; // 通知の受信者
+  ticketId: string | null; // 関連チケット ID (ない場合は null)
+  type: NotificationType; // 通知の種類
+  message: string; // 表示する文言
+  read: boolean; // 既読かどうか (true=既読, false=未読)
+  createdAt: Date; // 通知の生成日時
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,9 +1,15 @@
+// next-auth (認証ライブラリ) の本体関数
 import NextAuth from 'next-auth';
+// 認証方式としてメール+パスワードを扱う Credentials プロバイダ
 import Credentials from 'next-auth/providers/credentials';
+// bcryptjs のパスワード照合関数 (ハッシュと平文を安全に比較)
 import { compare } from 'bcryptjs';
+// Prisma クライアント (ユーザー取得に使用)
 import { prisma } from '@/lib/prisma';
+// ロール (権限) 型
 import type { Role } from '@/generated/prisma';
 
+// 本番環境で使ってはいけない「弱い/既定値」のシークレット一覧
 const WEAK_NEXTAUTH_SECRETS = new Set([
   'change-me-in-production',
   'your-secret-key-here',
@@ -11,62 +17,83 @@ const WEAK_NEXTAUTH_SECRETS = new Set([
   '',
 ]);
 
+// 環境変数から NextAuth のシークレットを取得
 const secret = process.env.NEXTAUTH_SECRET;
+// シークレットが未設定なら警告 (サーバー再起動でセッションが失効する危険)
 if (!secret) {
   console.warn(
     '[auth] NEXTAUTH_SECRET is not set — sessions will not be verifiable across restarts.',
   );
+  // シークレットが既知の弱い値なら、本番投入前に強固な値に差し替えるよう警告
 } else if (WEAK_NEXTAUTH_SECRETS.has(secret)) {
   console.warn(
     '[auth] NEXTAUTH_SECRET is set to a known placeholder value. Generate a strong secret (e.g. `openssl rand -base64 32`) before deploying.',
   );
 }
 
+// NextAuth の初期化。後で使う handlers / auth / signIn / signOut を取り出す
 export const { handlers, auth, signIn, signOut } = NextAuth({
+  // 有効化する認証プロバイダの配列
   providers: [
     Credentials({
-      name: 'Credentials',
+      name: 'Credentials', // プロバイダ表示名
+      // 入力フィールド定義 (ラベル・入力タイプ)
       credentials: {
         email: { label: 'Email', type: 'email' },
         password: { label: 'Password', type: 'password' },
       },
+      // 実際の認証ロジック。成功ならユーザーオブジェクト、失敗なら null を返す
       async authorize(credentials) {
+        // 入力不足ならすぐ失敗
         if (!credentials?.email || !credentials?.password) return null;
 
+        // email で User テーブルを検索
         const user = await prisma.user.findUnique({
           where: { email: credentials.email as string },
         });
 
+        // ユーザー未存在、またはパスワード未設定なら失敗
         if (!user || !user.passwordHash) return null;
 
+        // 入力パスワードを DB のハッシュと比較 (bcrypt)
         const isValid = await compare(credentials.password as string, user.passwordHash);
+        // 一致しなければ失敗
         if (!isValid) return null;
 
+        // 認証成功: セッションに乗せるユーザー情報を返す
         return {
-          id: user.id,
-          email: user.email,
-          name: user.name,
-          role: user.role,
+          id: user.id, // ユーザー ID
+          email: user.email, // メール
+          name: user.name, // 氏名
+          role: user.role, // 権限
         };
       },
     }),
   ],
+  // JWT / セッションに独自情報を乗せるためのコールバック群
   callbacks: {
+    // JWT 発行時に呼ばれる。初回ログイン時だけ user が渡ってくる
     async jwt({ token, user }) {
+      // user があれば ID と role を JWT ペイロードに記録
       if (user) {
         token.id = user.id;
         token.role = (user as { role: Role }).role;
       }
+      // 更新したトークンを返す
       return token;
     },
+    // セッション取得時に呼ばれる。JWT の値をセッションに転記する
     async session({ session, token }) {
+      // JWT があれば session.user に id と role を載せる
       if (token) {
         session.user.id = token.id as string;
         session.user.role = token.role as Role;
       }
+      // 完成したセッションを返す
       return session;
     },
   },
+  // カスタムログインページのパス
   pages: {
     signIn: '/login',
   },

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,7 +1,10 @@
+// チケット状態型をインポート
 import type { TicketStatus } from '@/generated/prisma';
 
+// FAQ 候補化を許可するチケット状態一覧 (解決済みのみ候補化可能)
 export const FAQ_ELIGIBLE_STATUSES: readonly TicketStatus[] = ['Resolved'];
 
+// チケット状態の英語キーに対応する日本語表示ラベル
 export const STATUS_LABELS: Record<string, string> = {
   New: '新規',
   Open: 'オープン',
@@ -12,40 +15,46 @@ export const STATUS_LABELS: Record<string, string> = {
   Closed: 'クローズ',
 };
 
+// 優先度キーに対応する日本語表示ラベル
 export const PRIORITY_LABELS: Record<string, string> = {
   Low: '低',
   Medium: '中',
   High: '高',
 };
 
+// 状態ごとのバッジ配色 (Tailwind CSS クラス)
 export const STATUS_COLORS: Record<string, string> = {
-  New: 'bg-gray-100 text-gray-700',
-  Open: 'bg-blue-100 text-blue-700',
-  WaitingForUser: 'bg-yellow-100 text-yellow-700',
-  InProgress: 'bg-indigo-100 text-indigo-700',
-  Escalated: 'bg-red-100 text-red-700',
-  Resolved: 'bg-green-100 text-green-700',
-  Closed: 'bg-gray-100 text-gray-500',
+  New: 'bg-gray-100 text-gray-700', // 新規: 灰色系
+  Open: 'bg-blue-100 text-blue-700', // オープン: 青系
+  WaitingForUser: 'bg-yellow-100 text-yellow-700', // ユーザー待ち: 黄系
+  InProgress: 'bg-indigo-100 text-indigo-700', // 対応中: 藍系
+  Escalated: 'bg-red-100 text-red-700', // エスカレーション: 赤系
+  Resolved: 'bg-green-100 text-green-700', // 解決済み: 緑系
+  Closed: 'bg-gray-100 text-gray-500', // クローズ: 薄い灰色
 };
 
+// 優先度ごとの文字色クラス (Tailwind CSS)
 export const PRIORITY_COLORS: Record<string, string> = {
-  Low: 'text-gray-500',
-  Medium: 'text-yellow-600',
-  High: 'text-red-600 font-semibold',
+  Low: 'text-gray-500', // 低: グレー
+  Medium: 'text-yellow-600', // 中: 黄色
+  High: 'text-red-600 font-semibold', // 高: 赤 + 太字
 };
 
+// FAQ 状態キーに対応する日本語表示ラベル
 export const FAQ_STATUS_LABELS: Record<string, string> = {
   Candidate: '候補',
   Published: '公開済み',
   Rejected: '却下',
 };
 
+// FAQ 状態ごとのバッジ配色 (Tailwind CSS クラス)
 export const FAQ_STATUS_COLORS: Record<string, string> = {
-  Candidate: 'bg-yellow-100 text-yellow-700',
-  Published: 'bg-green-100 text-green-700',
-  Rejected: 'bg-gray-100 text-gray-500',
+  Candidate: 'bg-yellow-100 text-yellow-700', // 候補: 黄系
+  Published: 'bg-green-100 text-green-700', // 公開済み: 緑系
+  Rejected: 'bg-gray-100 text-gray-500', // 却下: 灰色系
 };
 
+// 履歴項目の英語キーに対応する日本語表示ラベル
 export const HISTORY_FIELD_LABELS: Record<string, string> = {
   status: 'ステータス',
   priority: '優先度',
@@ -53,6 +62,7 @@ export const HISTORY_FIELD_LABELS: Record<string, string> = {
   escalation: 'エスカレーション',
 };
 
+// 通知種別の英語キーに対応する日本語表示ラベル
 export const NOTIFICATION_TYPE_LABELS: Record<string, string> = {
   assigned: '担当割当',
   escalated: 'エスカレーション',

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,29 +1,40 @@
+// Next.js のキャッシュ機構 (unstable_cache) とキャッシュ無効化関数 (revalidateTag) を読み込む
 import { unstable_cache, revalidateTag } from 'next/cache';
+// Prisma クライアント (DB 操作) を読み込む
 import { prisma } from '@/lib/prisma';
+// SSE で未読件数をリアルタイム配信するためのブロードキャスト関数を読み込む
 import { broadcast } from '@/lib/sse-subscribers';
+// 通知の種類 (担当割当/エスカレーション/コメント/状態変更) を表す型を読み込む
 import type { NotificationType } from '@/generated/prisma';
 
+// 通知を 1 件作成し、未読件数キャッシュの無効化 + SSE 配信まで行う関数
 export async function createNotification(
-  userId: string,
-  type: NotificationType,
-  message: string,
-  ticketId?: string,
+  userId: string, // 通知を受け取るユーザー ID
+  type: NotificationType, // 通知の種類
+  message: string, // 画面に表示する文言
+  ticketId?: string, // 関連チケット ID (無ければ省略可)
 ) {
+  // 1. Notification テーブルに行を追加
   await prisma.notification.create({
     data: { userId, type, message, ticketId },
   });
 
+  // 2. 未読件数の Next.js キャッシュを無効化 (次回取得時に再計算させる)
   revalidateTag(`notification-count-${userId}`);
 
   // Query live count directly (not via cache — revalidateTag just invalidated it).
+  // 3. 最新の未読件数を直接 DB から取得する (キャッシュを経由しない)
   const newCount = await prisma.notification.count({ where: { userId, read: false } });
+  // 4. SSE 経由で当該ユーザーへ未読件数をプッシュ配信する
   broadcast(userId, newCount);
 }
 
+// 指定ユーザーの未読通知件数を取得する関数 (60 秒キャッシュ)
 export function getUnreadNotificationCount(userId: string): Promise<number> {
+  // unstable_cache で「同じタグなら 60 秒は使い回す」キャッシュ関数を生成し即呼び出す
   return unstable_cache(
-    (id: string) => prisma.notification.count({ where: { userId: id, read: false } }),
-    ['notification-count'],
-    { tags: [`notification-count-${userId}`], revalidate: 60 },
+    (id: string) => prisma.notification.count({ where: { userId: id, read: false } }), // 実際の DB カウント
+    ['notification-count'], // キャッシュキーのプレフィックス
+    { tags: [`notification-count-${userId}`], revalidate: 60 }, // 無効化用タグと再検証間隔 (秒)
   )(userId);
 }

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,13 +1,18 @@
+// 生成された Prisma クライアント (DB 操作の窓口) をインポート
 import { PrismaClient } from '@/generated/prisma';
 
+// 開発時のホットリロードで PrismaClient が大量生成されないよう、グローバル変数を借りてキャッシュする
 const globalForPrisma = globalThis as unknown as {
-  prisma: PrismaClient | undefined;
+  prisma: PrismaClient | undefined; // グローバルに保持する Prisma インスタンス (未定義の可能性あり)
 };
 
+// 既に生成済みのインスタンスがあればそれを再利用し、無ければ新しく作成する
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
+    // 開発環境では error と warn を表示、本番では error のみに絞る
     log: process.env.NODE_ENV === 'development' ? ['error', 'warn'] : ['error'],
   });
 
+// 本番以外 (dev/test) では作成した prisma をグローバルにキャッシュして再利用可能にする
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -15,43 +15,61 @@
  *   scaling requires replacing this with Redis / a shared store.
  */
 
+// レートリミット (流量制限) の設定を表す型
 export type RateLimitOptions = {
   /** Max allowed hits within the window. */
-  limit: number;
+  limit: number; // 窓内で許容される最大回数
   /** Window size in milliseconds. */
-  windowMs: number;
+  windowMs: number; // 判定に使う時間窓の長さ (ミリ秒)
 };
 
+// キー (userId:scope) ごとの実行タイムスタンプ一覧を持つバケット
 const buckets = new Map<string, number[]>();
 
+// cutoff より古いタイムスタンプを配列から捨てて、生き残りだけ返すヘルパー関数
 function prune(timestamps: number[], cutoff: number): number[] {
   // Bucket entries are push-appended chronologically, so the first index
   // where `ts >= cutoff` bounds the live window.
+  // 配列は時系列順なので、先頭から cutoff 未満を数えるだけで境界がわかる
   let i = 0;
+  // cutoff より古い要素の数を数える
   while (i < timestamps.length && timestamps[i] < cutoff) i += 1;
+  // 何も古くなければそのまま、古いものがあればその分を切り落として返す
   return i === 0 ? timestamps : timestamps.slice(i);
 }
 
+// 指定キーに対してレート制限を適用し、超過していれば日本語メッセージでエラーを投げる関数
 export function enforceRateLimit(
-  key: string,
-  { limit, windowMs }: RateLimitOptions,
-  now: number = Date.now(),
+  key: string, // "userId:scope" 形式のキー (ユーザーと操作種別を識別)
+  { limit, windowMs }: RateLimitOptions, // 制限値
+  now: number = Date.now(), // 現在時刻 (テスト時に差し替えできるよう引数化)
 ): void {
+  // 窓の開始時刻を計算 (この時刻より古い記録は無視)
   const cutoff = now - windowMs;
+  // 既存の履歴を取得 (なければ空配列)
   const existing = buckets.get(key) ?? [];
+  // 窓内に残る履歴だけに絞り込む
   const live = prune(existing, cutoff);
 
+  // 既に上限に達していた場合はエラーを投げる
   if (live.length >= limit) {
+    // 最古の記録が窓から抜けるまでの待ち時間 (ミリ秒) を算出
     const retryAfterMs = Math.max(0, live[0] + windowMs - now);
+    // 切り上げて秒単位に変換 (ユーザーに見せる用)
     const retryAfterSec = Math.ceil(retryAfterMs / 1000);
+    // 日本語メッセージ付きでエラーを投げ、Server Action 経由で画面に表示させる
     throw new Error(`操作の頻度が高すぎます。${retryAfterSec}秒ほど待ってから再度お試しください。`);
   }
 
+  // 今回の実行時刻を履歴の末尾に追加
   live.push(now);
+  // バケットを更新して保存
   buckets.set(key, live);
 }
 
 /** Testing helper: clear all buckets between test cases. */
+// テスト間で状態を初期化するためのヘルパー関数 (本番コードからは呼ばない)
 export function __resetRateLimits(): void {
+  // 全バケットを空にする
   buckets.clear();
 }

--- a/src/lib/role.ts
+++ b/src/lib/role.ts
@@ -1,5 +1,9 @@
+// Prisma が生成したロール (権限) 型をインポート
 import type { Role } from '@/generated/prisma';
 
+// 渡されたロールが「担当者権限を持っている」と判定できるかを返す関数
+// agent または admin ならエージェント扱い (admin 限定チェックではないことに注意)
 export function isAgent(role: Role | string | null | undefined): boolean {
+  // 'agent' か 'admin' のいずれかに一致すれば true を返す
   return role === 'agent' || role === 'admin';
 }

--- a/src/lib/sla.ts
+++ b/src/lib/sla.ts
@@ -1,44 +1,61 @@
+// 優先度を表すドメイン型 (Low/Medium/High) をインポート
 import type { Priority } from '@/domain/types';
 
+// SLA (サービス提供期限) の現在状態を表す文字列型
+// 'ok' = 余裕あり / 'warning' = 期限間近 / 'overdue' = 超過 / 'none' = 未設定
 export type SlaState = 'ok' | 'warning' | 'overdue' | 'none';
 
 /**
  * Hours allowed to resolve a ticket, by priority. Placeholder business policy —
  * replace with a config/DB-backed source once requirements are finalized.
  */
+// 優先度ごとの「解決までに許される時間 (時間単位)」
 export const SLA_RESOLUTION_HOURS_BY_PRIORITY: Record<Priority, number> = {
-  High: 24,
-  Medium: 72,
-  Low: 168,
+  High: 24, // 優先度高: 24 時間 (1 日)
+  Medium: 72, // 優先度中: 72 時間 (3 日)
+  Low: 168, // 優先度低: 168 時間 (7 日)
 };
 
+// 起票時刻 from から優先度に応じた解決期限を計算して返す関数
 export function calculateResolutionDueAt(priority: Priority, from: Date): Date {
+  // 表から対応する時間数を取得
   const hours = SLA_RESOLUTION_HOURS_BY_PRIORITY[priority];
+  // from の時刻 (ミリ秒) に hours 時間分のミリ秒を加えた新しい Date を返す
   return new Date(from.getTime() + hours * 60 * 60 * 1000);
 }
 
+// 期限日時と解決日時から現在の SLA 状態を判定する関数
 export function getSlaState(resolutionDueAt: Date | null, resolvedAt: Date | null): SlaState {
+  // 期限が未設定なら 'none' (対象外)
   if (!resolutionDueAt) return 'none';
+  // 既に解決済みなら 'ok' (問題なく終わった扱い)
   if (resolvedAt) return 'ok';
 
+  // 現在時刻を取得
   const now = new Date();
+  // 期限までの残りミリ秒を計算
   const msLeft = resolutionDueAt.getTime() - now.getTime();
 
+  // 残り時間がマイナスなら超過
   if (msLeft < 0) return 'overdue';
-  if (msLeft < 24 * 60 * 60 * 1000) return 'warning'; // within 24 h
+  // 残り 24 時間未満なら警告 (within 24 h)
+  if (msLeft < 24 * 60 * 60 * 1000) return 'warning';
+  // それ以外は余裕あり
   return 'ok';
 }
 
+// SLA 状態ごとに画面に表示するラベル文言
 export const SLA_LABELS: Record<SlaState, string> = {
-  ok: '',
+  ok: '', // 問題なしなら非表示
   warning: '期限間近',
   overdue: '期限超過',
-  none: '',
+  none: '', // 対象外も非表示
 };
 
+// SLA 状態ごとに適用する Tailwind カラークラス (バッジの色)
 export const SLA_COLORS: Record<SlaState, string> = {
   ok: '',
-  warning: 'bg-yellow-100 text-yellow-700',
-  overdue: 'bg-red-100 text-red-700',
+  warning: 'bg-yellow-100 text-yellow-700', // 黄色系
+  overdue: 'bg-red-100 text-red-700', // 赤系
   none: '',
 };

--- a/src/lib/sse-subscribers.ts
+++ b/src/lib/sse-subscribers.ts
@@ -9,18 +9,26 @@
  * Tracking: see GitHub issue #60.
  */
 
+// 通知配信の実体 (NotificationBroadcaster) をデータ層から読み込む
 import { notificationBroadcaster } from '@/data';
 
+// SSE (Server-Sent Events) で使うレスポンスコントローラーの型エイリアス
 export type Controller = ReadableStreamDefaultController<Uint8Array>;
 
+// 指定ユーザーの購読 (SSE 接続) を登録する関数
 export function addSubscriber(userId: string, controller: Controller): void {
+  // 下位実装 (notificationBroadcaster) に処理を委譲
   notificationBroadcaster.addSubscriber(userId, controller);
 }
 
+// 指定ユーザーの購読を解除する関数 (接続切断時などに呼ぶ)
 export function removeSubscriber(userId: string, controller: Controller): void {
+  // 下位実装に処理を委譲
   notificationBroadcaster.removeSubscriber(userId, controller);
 }
 
+// 指定ユーザーの全 SSE 接続に未読件数 (count) を送信する関数
 export function broadcast(userId: string, count: number): void {
+  // 下位実装に処理を委譲
   notificationBroadcaster.broadcast(userId, count);
 }

--- a/src/lib/ticket-history.ts
+++ b/src/lib/ticket-history.ts
@@ -1,13 +1,18 @@
+// Prisma クライアントのシングルトンを読み込む (DB 書き込みに使用)
 import { prisma } from '@/lib/prisma';
+// 履歴の「どの項目が変わったか」を示す型をインポート
 import type { HistoryField } from '@/generated/prisma';
 
+// チケットの変更履歴を 1 件 DB に追加する共通関数
+// 呼び出し側は status/priority/assignee/escalation のいずれかが変わったときに呼ぶ
 export async function recordHistory(
-  ticketId: string,
-  changedById: string,
-  field: HistoryField,
-  oldValue: string | null,
-  newValue: string | null,
+  ticketId: string, // どのチケットの履歴か
+  changedById: string, // 変更を行ったユーザーの ID
+  field: HistoryField, // 変更された項目の種類
+  oldValue: string | null, // 変更前の値 (初回は null もあり得る)
+  newValue: string | null, // 変更後の値
 ) {
+  // TicketHistory テーブルに 1 行挿入する (await で完了を待つ)
   await prisma.ticketHistory.create({
     data: { ticketId, changedById, field, oldValue, newValue },
   });

--- a/src/lib/validations/faq.ts
+++ b/src/lib/validations/faq.ts
@@ -1,11 +1,15 @@
+// Zod (スキーマ検証ライブラリ) をインポート
 import { z } from 'zod';
 
+// FAQ 候補フォームの入力検証スキーマ (質問と回答)
 export const faqCandidateSchema = z.object({
+  // 質問文: 前後空白を削り、1〜2000 文字に収まること
   question: z
     .string()
     .trim()
     .min(1, '質問を入力してください')
     .max(2_000, '質問は2000文字以内で入力してください'),
+  // 回答文: 前後空白を削り、1〜2000 文字に収まること
   answer: z
     .string()
     .trim()

--- a/src/lib/validations/ticket.ts
+++ b/src/lib/validations/ticket.ts
@@ -1,27 +1,37 @@
+// Zod (スキーマ検証ライブラリ) をインポート
 import { z } from 'zod';
 
+// チケット新規作成フォームの入力検証スキーマ
 export const createTicketSchema = z.object({
+  // タイトル: 1〜200 文字の文字列
   title: z
     .string()
-    .min(1, 'タイトルは必須です')
-    .max(200, 'タイトルは200文字以内で入力してください'),
+    .min(1, 'タイトルは必須です') // 空文字を許さない
+    .max(200, 'タイトルは200文字以内で入力してください'), // 上限制約
+  // 本文: 1〜10000 文字
   body: z.string().min(1, '内容は必須です').max(10_000, '内容は10000文字以内で入力してください'),
+  // カテゴリ ID: 任意。空文字なら undefined に変換 (未選択扱い)
   categoryId: z
     .string()
     .optional()
     .transform((v) => v || undefined),
+  // 優先度は Low/Medium/High のいずれか
   priority: z.enum(['Low', 'Medium', 'High']),
 });
 
+// スキーマから TypeScript 型を生成 (変換後の型)
 export type CreateTicketInput = z.infer<typeof createTicketSchema>;
+// フォーム入力時の生の型 (transform 前) を生成
 export type CreateTicketFormValues = z.input<typeof createTicketSchema>;
 
+// コメント本文の検証スキーマ (前後空白トリム、1〜5000 文字)
 export const commentBodySchema = z
   .string()
-  .trim()
+  .trim() // 前後の空白を削除
   .min(1, 'コメントを入力してください')
   .max(5_000, 'コメントは5000文字以内で入力してください');
 
+// エスカレーション理由の検証スキーマ (前後空白トリム、1〜1000 文字)
 export const escalationReasonSchema = z
   .string()
   .trim()

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,11 +1,15 @@
+// next-auth (認証ライブラリ) の既定セッション型をインポート
 import type { DefaultSession } from 'next-auth';
+// Prisma が生成したロール (権限) 型をインポート
 import type { Role } from '@/generated/prisma';
 
+// next-auth モジュールの型定義を拡張するブロック (モジュール拡張)
 declare module 'next-auth' {
+  // Session 型を拡張し、独自フィールドを追加する
   interface Session {
     user: {
-      id: string;
-      role: Role;
-    } & DefaultSession['user'];
+      id: string; // ユーザー ID を session.user.id で参照できるようにする
+      role: Role; // 権限 (requester/agent/admin) を session.user.role で参照できるようにする
+    } & DefaultSession['user']; // 既定の user フィールド (name/email/image) も維持
   }
 }


### PR DESCRIPTION
## Summary
- CLAUDE.md で追加したルール「1 行ごとに初心者でも意味がわかる日本語コメント」を既存コードに反映する 3 分割 PR の **1 本目 (コア・インフラ層)**。
- 対象: `src/domain/`, `src/types/`, `src/lib/` (validations 含む), `src/data/` (ports + memory/prisma adapters + composition root)。
- **ロジック変更は一切なし**。行単位の日本語解説コメントのみを追加。
- 全 45 ファイル / 781 行追加・320 行削除 (実質は既存 JSDoc を説明と統合した結果)。

## 分割方針 (詳細は `/root/.claude/plans/indexed-scribbling-aho.md` 参照)
- PR 1 (本 PR): コア & インフラ
- PR 2: `src/features/*/actions`, `src/app/api`
- PR 3: UI (`src/app/(app)`, `src/components`, `src/features/*/components`) + `tests/`, `e2e/`

## Test plan
- [x] `npm run db:generate`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 65/65 passed
- [x] 変更ファイルのみで `prettier --check`

https://claude.ai/code/session_01N1AvwVy6GMqssXL1JyT3ZL