### PR TITLE
docs: 既存コードに初心者向けコメント追加 (2/3 アクション・API)

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,5 @@
+// next-auth の設定から生成されたリクエストハンドラ (GET/POST) を取り込む
 import { handlers } from '@/lib/auth';
 
+// /api/auth/[...nextauth] の GET/POST を next-auth のハンドラにそのまま委譲する
 export const { GET, POST } = handlers;

--- a/src/app/api/notifications/stream/route.ts
+++ b/src/app/api/notifications/stream/route.ts
@@ -1,65 +1,97 @@
+// JSON レスポンスを返すヘルパー
 import { NextResponse } from 'next/server';
+// 現在のセッション取得
 import { auth } from '@/lib/auth';
+// 未読件数を (キャッシュ付きで) 取得する関数
 import { getUnreadNotificationCount } from '@/lib/notifications';
+// SSE 購読者をプロセス内 Map に登録/解除する関数
 import { addSubscriber, removeSubscriber } from '@/lib/sse-subscribers';
 
+// このルートは常に動的実行 (キャッシュ無効)
 export const dynamic = 'force-dynamic';
+// Edge ではなく Node.js ランタイムで動かす (長時間接続のため)
 export const runtime = 'nodejs';
 
+// keep-alive ping を送る間隔 (30 秒)
 const KEEPALIVE_INTERVAL_MS = 30_000;
 
+// 文字列を SSE 用の UTF-8 バイト列に変換するエンコーダ
 const encoder = new TextEncoder();
 
+// SSE のコメント行 (":" で始まり通信維持に使う) を作る
 function sseComment(text: string): Uint8Array {
   return encoder.encode(`: ${text}\n\n`);
 }
 
+// SSE の「event + data」行を作る (クライアントで addEventListener 可能)
 function sseEvent(eventName: string, data: unknown): Uint8Array {
   return encoder.encode(`event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`);
 }
 
+// GET /api/notifications/stream : 未読件数更新を受け取る SSE エンドポイント
 export async function GET(): Promise<Response> {
+  // セッション取得
   const session = await auth();
+  // 未ログインなら 401 を返す (クライアントには JSON エラー)
   if (!session?.user?.id) {
     return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
   }
+  // 購読者 ID として使うログイン中ユーザーの ID
   const userId = session.user.id;
 
+  // ストリーム制御用のコントローラを外側スコープで保持
   let controller!: ReadableStreamDefaultController<Uint8Array>;
+  // keep-alive 用 setInterval の参照 (cancel 時にクリア)
   let keepaliveTimer: ReturnType<typeof setInterval> | undefined;
 
+  // SSE 本体となる ReadableStream を構築
   const stream = new ReadableStream<Uint8Array>({
+    // ストリーム開始時に購読登録と初期送信を行う
     async start(ctrl) {
+      // 外側で使えるようにコントローラを退避
       controller = ctrl;
+      // このユーザー向けの購読者 Map にコントローラを登録
       addSubscriber(userId, controller);
 
       try {
+        // 最初に現在の未読件数を取得し
         const initialCount = await getUnreadNotificationCount(userId);
+        // count イベントとして即時送信 (UI の初期表示用)
         controller.enqueue(sseEvent('count', { count: initialCount }));
       } catch {
-        // Non-fatal — client will receive future broadcast events.
+        // 致命的ではないので握りつぶす (以後のブロードキャストは届く)
       }
 
+      // 30 秒ごとにコメント行を送って接続を切らせないようにする
       keepaliveTimer = setInterval(() => {
         try {
           controller.enqueue(sseComment('ping'));
         } catch {
+          // 送信失敗 (既に切断) ならタイマー停止
           clearInterval(keepaliveTimer);
         }
       }, KEEPALIVE_INTERVAL_MS);
     },
 
+    // クライアント切断時のクリーンアップ
     cancel() {
+      // keep-alive タイマーを停止
       clearInterval(keepaliveTimer);
+      // 購読者 Map から外す
       removeSubscriber(userId, controller);
     },
   });
 
+  // SSE 用のヘッダを付けてストリームを返す
   return new Response(stream, {
     headers: {
+      // SSE のコンテンツタイプ
       'Content-Type': 'text/event-stream',
+      // 途中キャッシュを防ぐ
       'Cache-Control': 'no-cache, no-transform',
+      // 長時間接続を維持
       Connection: 'keep-alive',
+      // Nginx などのプロキシでバッファリングを無効化
       'X-Accel-Buffering': 'no',
     },
   });

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -1,23 +1,36 @@
+// JSON レスポンスを返すヘルパー
 import { NextResponse } from 'next/server';
+// セッション取得
 import { auth } from '@/lib/auth';
+// リポジトリ束 (tickets/categories などを持つ)
 import { repos } from '@/data';
+// 優先度から解決期限を計算する SLA ヘルパー
 import { calculateResolutionDueAt } from '@/lib/sla';
+// 新規チケット入力の Zod スキーマ
 import { createTicketSchema } from '@/lib/validations/ticket';
 
+// POST /api/tickets : 新規チケットを作成する HTTP エンドポイント
 export async function POST(req: Request) {
+  // セッション取得
   const session = await auth();
+  // 未ログインなら 401 を返す
   if (!session?.user?.id) {
     return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
   }
 
+  // リクエストボディ格納用
   let body: unknown;
   try {
+    // JSON としてパース
     body = await req.json();
   } catch {
+    // 不正な JSON は 400 で弾く
     return NextResponse.json({ error: 'リクエストの形式が正しくありません' }, { status: 400 });
   }
 
+  // Zod で入力値を検証
   const parsed = createTicketSchema.safeParse(body);
+  // 検証失敗時は 422 + issues でフォーム側にエラーを返す
   if (!parsed.success) {
     return NextResponse.json(
       { error: '入力値が正しくありません', issues: parsed.error.issues },
@@ -25,10 +38,14 @@ export async function POST(req: Request) {
     );
   }
 
+  // 検証済みの値を分解 (body は変数名衝突を避けてリネーム)
   const { title, body: ticketBody, priority, categoryId } = parsed.data;
 
+  // カテゴリ指定がある場合は存在確認
   if (categoryId) {
+    // カテゴリを取得
     const category = await repos.categories.findById(categoryId);
+    // 存在しなければ 422 (Zod 風の issues を返す)
     if (!category) {
       return NextResponse.json(
         {
@@ -46,15 +63,20 @@ export async function POST(req: Request) {
     }
   }
 
+  // 作成時刻 (SLA 期限の計算基準)
   const now = new Date();
+  // リポジトリ経由でチケットを作成
   const ticket = await repos.tickets.create({
     title,
     body: ticketBody,
     priority,
     categoryId: categoryId ?? null,
+    // 作成者は現在のログインユーザー
     creatorId: session.user.id,
+    // 優先度に応じた解決期限を計算
     resolutionDueAt: calculateResolutionDueAt(priority, now),
   });
 
+  // 作成された行を 201 で返す
   return NextResponse.json(ticket, { status: 201 });
 }

--- a/src/features/auth/actions.ts
+++ b/src/features/auth/actions.ts
@@ -1,7 +1,10 @@
 'use server';
 
+// ログアウト処理を行う next-auth のヘルパー関数をインポート
 import { signOut } from '@/lib/auth';
 
+// ログアウトを実行するサーバーアクション (ログアウト後は /login にリダイレクト)
 export async function logout() {
+  // next-auth にサインアウトを依頼し、完了後にログインページへ遷移させる
   await signOut({ redirectTo: '/login' });
 }

--- a/src/features/faq/actions/faq-actions.ts
+++ b/src/features/faq/actions/faq-actions.ts
@@ -1,59 +1,89 @@
 'use server';
 
+// ページキャッシュを無効化するための Next.js 関数
 import { revalidatePath } from 'next/cache';
+// 現在ログイン中のセッションを取得する next-auth ヘルパー
 import { auth } from '@/lib/auth';
+// DB 操作 (Prisma クライアント)
 import { prisma } from '@/lib/prisma';
+// 「エージェント権限を持つか」を判定するヘルパー
 import { isAgent } from '@/lib/role';
+// FAQ 候補化を許可する状態 (Resolved のみ) の一覧
 import { FAQ_ELIGIBLE_STATUSES } from '@/lib/constants';
+// レート制限 (連打防止) の共通関数
 import { enforceRateLimit } from '@/lib/rate-limit';
+// FAQ 候補入力の Zod スキーマ (質問/回答の検証)
 import { faqCandidateSchema } from '@/lib/validations/faq';
 
+// チケットを元に FAQ 候補を新規作成するサーバーアクション
 export async function createFaqCandidate(ticketId: string, question: string, answer: string) {
+  // ログインセッションを取得
   const session = await auth();
+  // 未ログインなら即エラー (認可前チェック)
   if (!session?.user?.id) throw new Error('Unauthorized');
+  // エージェント/管理者でなければ操作禁止
   if (!isAgent(session.user.role)) {
     throw new Error('エージェントまたは管理者のみ実行できます');
   }
+  // ユーザー単位で 60 秒あたり最大 10 件までに制限 (連打防止)
   enforceRateLimit(`faq-create:${session.user.id}`, { limit: 10, windowMs: 60_000 });
 
+  // 入力値 (質問/回答) を Zod で検証
   const parsed = faqCandidateSchema.safeParse({ question, answer });
+  // 検証失敗ならメッセージを日本語エラーとして投げる
   if (!parsed.success) {
     throw new Error(parsed.error.issues[0]?.message ?? 'FAQ候補の入力値が不正です');
   }
 
+  // 対象チケットを取得
   const ticket = await prisma.ticket.findUnique({ where: { id: ticketId } });
+  // 無ければエラー
   if (!ticket) throw new Error('チケットが見つかりません');
+  // 解決済み以外は FAQ 化不可
   if (!FAQ_ELIGIBLE_STATUSES.includes(ticket.status)) {
     throw new Error('解決済みチケットのみFAQ候補に変換できます');
   }
 
+  // FAQ 候補を DB に新規作成 (初期ステータスは schema 側の既定値 Candidate)
   await prisma.faqCandidate.create({
     data: {
       ticketId,
-      createdById: session.user.id,
-      question: parsed.data.question,
-      answer: parsed.data.answer,
+      createdById: session.user.id, // 作成者
+      question: parsed.data.question, // 検証済みの質問文
+      answer: parsed.data.answer, // 検証済みの回答文
     },
   });
 
+  // チケット詳細ページのキャッシュを無効化して再描画させる
   revalidatePath(`/tickets/${ticketId}`);
+  // FAQ 一覧ページのキャッシュも無効化
   revalidatePath('/faq');
 }
 
+// FAQ 候補の状態を公開/却下に切り替えるサーバーアクション
 export async function updateFaqStatus(faqId: string, status: 'Published' | 'Rejected') {
+  // セッション取得
   const session = await auth();
+  // 未ログインなら拒否
   if (!session?.user?.id) throw new Error('Unauthorized');
+  // エージェント/管理者以外は拒否
   if (!isAgent(session.user.role)) {
     throw new Error('エージェントまたは管理者のみ実行できます');
   }
+  // 60 秒あたり 20 回までに制限
   enforceRateLimit(`faq-update:${session.user.id}`, { limit: 20, windowMs: 60_000 });
 
+  // 対象 FAQ 候補を取得
   const faq = await prisma.faqCandidate.findUnique({ where: { id: faqId } });
+  // 見つからなければエラー
   if (!faq) throw new Error('FAQ候補が見つかりません');
+  // 既に公開/却下済みのものは対象外
   if (faq.status !== 'Candidate') {
     throw new Error('候補ステータスのFAQのみ公開・却下できます');
   }
 
+  // 状態を更新
   await prisma.faqCandidate.update({ where: { id: faqId }, data: { status } });
+  // FAQ 一覧のキャッシュを無効化
   revalidatePath('/faq');
 }

--- a/src/features/notifications/actions/notification-actions.ts
+++ b/src/features/notifications/actions/notification-actions.ts
@@ -1,25 +1,38 @@
 'use server';
 
+// Next.js のキャッシュ無効化 API (ページ単位とタグ単位)
 import { revalidatePath, revalidateTag } from 'next/cache';
+// 現在のセッション取得
 import { auth } from '@/lib/auth';
+// DB 操作クライアント
 import { prisma } from '@/lib/prisma';
+// レート制限 (連打防止)
 import { enforceRateLimit } from '@/lib/rate-limit';
+// SSE で未読件数を即時ブロードキャストする関数
 import { broadcast } from '@/lib/sse-subscribers';
 
+// ログイン中ユーザーの未読通知を一括で既読にするサーバーアクション
 export async function markAllRead() {
+  // セッション取得
   const session = await auth();
+  // 未ログインなら拒否
   if (!session?.user?.id) throw new Error('Unauthorized');
+  // 60 秒あたり最大 10 回までに制限
   enforceRateLimit(`notifications-mark-read:${session.user.id}`, {
     limit: 10,
     windowMs: 60_000,
   });
 
+  // 本人の未読通知を全て既読に更新
   await prisma.notification.updateMany({
     where: { userId: session.user.id, read: false },
     data: { read: true },
   });
 
+  // 通知一覧ページのキャッシュを無効化
   revalidatePath('/notifications');
+  // 未読件数キャッシュ (unstable_cache) を無効化
   revalidateTag(`notification-count-${session.user.id}`);
+  // 即時反映のため、未読 0 を SSE で配信
   broadcast(session.user.id, 0);
 }

--- a/src/features/notifications/notify.ts
+++ b/src/features/notifications/notify.ts
@@ -9,17 +9,27 @@
  * - Broadcast it over SSE.
  */
 
+// Next.js のキャッシュタグ無効化 API
 import { revalidateTag } from 'next/cache';
+// リポジトリ束 (未読件数取得に使用)
 import { repos } from '@/data';
+// SSE の送信関数
 import { broadcast } from '@/lib/sse-subscribers';
 
+// 指定ユーザー 1 人に対して未読件数を再計算して配信する
 export async function broadcastUnreadCount(userId: string): Promise<void> {
+  // キャッシュされた未読件数を無効化 (次の取得で再計算させる)
   revalidateTag(`notification-count-${userId}`);
+  // 最新件数を直接 DB から数える
   const count = await repos.notifications.countUnread(userId);
+  // 取得した件数を SSE で即時配信
   broadcast(userId, count);
 }
 
+// 複数ユーザー向けにまとめて未読件数を再配信するヘルパー
 export async function broadcastUnreadCountToMany(userIds: Iterable<string>): Promise<void> {
+  // 重複 ID を除去した配列に変換 (同じユーザーに 2 度配信しないため)
   const unique = Array.from(new Set(userIds));
+  // 並列に全ユーザーへ配信
   await Promise.all(unique.map(broadcastUnreadCount));
 }

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -1,42 +1,67 @@
 'use server';
 
+// ページキャッシュを無効化する Next.js の関数
 import { revalidatePath } from 'next/cache';
+// 現在のセッション (ログイン中ユーザー) を取得
 import { auth } from '@/lib/auth';
+// リポジトリ束 (repos) と 1 トランザクション実行用 (uow)
 import { repos, uow } from '@/data';
+// 未読件数を SSE で即時配信するヘルパー (単数/複数宛)
 import { broadcastUnreadCount, broadcastUnreadCountToMany } from '@/features/notifications/notify';
+// エージェント権限判定 (agent または admin のとき true)
 import { isAgent } from '@/lib/role';
+// ステータス遷移が許可されているか判定するドメイン関数
 import { isValidTransition } from '@/domain/ticket-status';
+// 型のみインポート (優先度/ステータス)
 import type { Priority, TicketStatus } from '@/domain/types';
+// レート制限 (連打防止) の共通ヘルパー
 import { enforceRateLimit } from '@/lib/rate-limit';
+// Zod スキーマ (コメント本文/エスカレーション理由の検証用)
 import { commentBodySchema, escalationReasonSchema } from '@/lib/validations/ticket';
+// next-auth のセッション型
 import type { Session } from 'next-auth';
 
+// セッションがログイン済みであることを保証するアサーション関数
 function assertAuthenticatedUser(session: Session | null): asserts session is Session {
+  // ユーザー ID が無ければ未ログインとみなしてエラー
   if (!session?.user?.id) throw new Error('Unauthorized');
 }
 
+// セッションがエージェント/管理者権限を持つことを保証するアサーション関数
 function assertAgentRole(session: Session | null): asserts session is Session {
+  // まずログイン済みかをチェック
   assertAuthenticatedUser(session);
+  // エージェント/管理者でなければ拒否
   if (!isAgent(session.user.role)) {
     throw new Error('この操作はエージェントまたは管理者のみ実行できます');
   }
 }
 
+// チケットのステータスを変更するサーバーアクション
 export async function updateTicketStatus(ticketId: string, newStatus: TicketStatus) {
+  // セッション取得
   const session = await auth();
+  // エージェント以上の権限を要求
   assertAgentRole(session);
+  // 10 秒あたり 10 回までに制限 (チケット単位)
   enforceRateLimit(`ticket-status:${session.user.id}:${ticketId}`, { limit: 10, windowMs: 10_000 });
 
+  // 1 トランザクションでチケット更新と履歴記録を実行
   await uow.run(async (r) => {
+    // 対象チケットを取得
     const ticket = await r.tickets.findById(ticketId);
+    // 見つからなければエラー
     if (!ticket) throw new Error('チケットが見つかりません');
+    // 変更前後が同じなら何もしない (冪等)
     if (ticket.status === newStatus) return;
+    // 遷移表で許可されていない変更は拒否
     if (!isValidTransition(ticket.status, newStatus)) {
       throw new Error(
         `ステータスを「${ticket.status}」から「${newStatus}」に変更することはできません`,
       );
     }
 
+    // Resolved に遷移したら解決日時を現在時刻に、Resolved から離れる場合はクリア、それ以外は据え置き
     const resolvedAt =
       newStatus === 'Resolved'
         ? new Date()
@@ -44,7 +69,9 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
           ? null
           : ticket.resolvedAt;
 
+    // ステータスと解決日時を更新
     await r.tickets.updateStatus(ticketId, newStatus, resolvedAt);
+    // 変更履歴を残す (誰が/どの項目を/旧値→新値)
     await r.history.record({
       ticketId,
       changedById: session.user.id,
@@ -54,23 +81,34 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
     });
   });
 
+  // チケット詳細ページのキャッシュを無効化して再描画
   revalidatePath(`/tickets/${ticketId}`);
 }
 
+// チケットの優先度を変更するサーバーアクション
 export async function updateTicketPriority(ticketId: string, newPriority: Priority) {
+  // セッション取得
   const session = await auth();
+  // エージェント以上のみ実行可
   assertAgentRole(session);
+  // 10 秒あたり 10 回までに制限
   enforceRateLimit(`ticket-priority:${session.user.id}:${ticketId}`, {
     limit: 10,
     windowMs: 10_000,
   });
 
+  // 1 トランザクションで更新と履歴記録
   await uow.run(async (r) => {
+    // チケットを取得
     const ticket = await r.tickets.findById(ticketId);
+    // 無ければエラー
     if (!ticket) throw new Error('チケットが見つかりません');
+    // 変更無しならスキップ
     if (ticket.priority === newPriority) return;
 
+    // 優先度を更新
     await r.tickets.updatePriority(ticketId, newPriority);
+    // 履歴を記録
     await r.history.record({
       ticketId,
       changedById: session.user.id,
@@ -80,36 +118,50 @@ export async function updateTicketPriority(ticketId: string, newPriority: Priori
     });
   });
 
+  // 詳細ページのキャッシュ無効化
   revalidatePath(`/tickets/${ticketId}`);
 }
 
+// チケットの担当者を割当/解除するサーバーアクション
 export async function updateTicketAssignee(ticketId: string, newAssigneeId: string | null) {
+  // セッション取得
   const session = await auth();
+  // エージェント以上のみ実行可
   assertAgentRole(session);
+  // 10 秒あたり 10 回までに制限
   enforceRateLimit(`ticket-assignee:${session.user.id}:${ticketId}`, {
     limit: 10,
     windowMs: 10_000,
   });
 
+  // チケット (既存担当者含む) と新担当者候補を並列で取得
   const [ticket, newUser] = await Promise.all([
     repos.tickets.findByIdWithRefs(ticketId),
     newAssigneeId ? repos.users.findById(newAssigneeId) : Promise.resolve(null),
   ]);
 
+  // チケットが無ければエラー
   if (!ticket) throw new Error('チケットが見つかりません');
+  // 担当者を付ける場合は相手の存在とロールを確認
   if (newAssigneeId) {
+    // ユーザー未存在 or エージェント/管理者でない場合は拒否理由を特定
     const reason = !newUser ? 'not-found' : !isAgent(newUser.role) ? 'not-agent' : null;
     if (reason) {
+      // 診断用ログ (不正割当の調査向け)
       console.warn('[updateTicketAssignee] rejected', { ticketId, newAssigneeId, reason });
       throw new Error('指定された担当者を設定できません');
     }
   }
 
+  // 履歴に残す旧/新の担当者名 (未割当は null)
   const oldName = ticket.assignee?.name ?? null;
   const newName = newUser?.name ?? null;
 
+  // 担当者更新・履歴記録・通知作成を 1 トランザクションで実行
   await uow.run(async (r) => {
+    // 担当者を差し替え (解除は null)
     await r.tickets.updateAssignee(ticketId, newAssigneeId);
+    // 変更履歴を残す
     await r.history.record({
       ticketId,
       changedById: session.user.id,
@@ -117,6 +169,7 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
       oldValue: oldName,
       newValue: newName,
     });
+    // 新担当者が居る場合のみ通知を生成
     if (newAssigneeId) {
       await r.notifications.create({
         userId: newAssigneeId,
@@ -127,38 +180,54 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
     }
   });
 
+  // 新担当者に未読件数を SSE で即時配信
   if (newAssigneeId) await broadcastUnreadCount(newAssigneeId);
+  // 詳細ページのキャッシュを無効化
   revalidatePath(`/tickets/${ticketId}`);
 }
 
+// チケットをエスカレーション (上位対応へ引き上げ) するサーバーアクション
 export async function escalateTicket(ticketId: string, reason: string) {
+  // セッション取得
   const session = await auth();
+  // エージェント以上のみ実行可
   assertAgentRole(session);
-  // Escalation fans out notifications to every agent, so we apply a tighter
-  // cap than per-ticket status/priority edits.
+  // エスカレーションは全エージェントに通知が飛ぶため、通常操作より厳しく制限
+  // (60 秒あたり 5 回まで)
   enforceRateLimit(`ticket-escalate:${session.user.id}`, { limit: 5, windowMs: 60_000 });
 
+  // 理由文を Zod で検証 (長さや必須チェック)
   const parsedReason = escalationReasonSchema.safeParse(reason);
+  // 検証失敗ならエラーを日本語で投げる
   if (!parsedReason.success) {
     throw new Error(parsedReason.error.issues[0]?.message ?? 'エスカレーション理由が不正です');
   }
+  // 検証済み (trim 等済み) の理由を取り出す
   const trimmedReason = parsedReason.data;
 
+  // チケット本体と通知対象の全エージェント ID 一覧を並列取得
   const [ticket, agentIds] = await Promise.all([
     repos.tickets.findById(ticketId),
     repos.users.listAgentIds(),
   ]);
 
+  // チケットが無ければエラー
   if (!ticket) throw new Error('チケットが見つかりません');
+  // Escalated への遷移が許可されているか確認
   if (!isValidTransition(ticket.status, 'Escalated')) {
     throw new Error(`現在のステータス「${ticket.status}」からエスカレーションできません`);
   }
 
+  // エスカレーション発生時刻
   const now = new Date();
+  // メッセージ組み立てに使うタイトルを取り出す
   const { title } = ticket;
 
+  // マーク・履歴・エージェント一斉通知を 1 トランザクションで実行
   await uow.run(async (r) => {
+    // チケットに Escalated フラグと理由/日時を書き込む
     await r.tickets.markEscalated(ticketId, { reason: trimmedReason, at: now });
+    // 変更履歴を残す
     await r.history.record({
       ticketId,
       changedById: session.user.id,
@@ -166,6 +235,7 @@ export async function escalateTicket(ticketId: string, reason: string) {
       oldValue: ticket.status,
       newValue: 'Escalated',
     });
+    // 全エージェントに「エスカレーションされました」通知を作成
     await Promise.all(
       agentIds.map((id) =>
         r.notifications.create({
@@ -178,40 +248,59 @@ export async function escalateTicket(ticketId: string, reason: string) {
     );
   });
 
+  // 全エージェントへ未読件数を一斉配信
   await broadcastUnreadCountToMany(agentIds);
+  // 詳細ページを再描画
   revalidatePath(`/tickets/${ticketId}`);
 }
 
+// チケットにコメントを追加するサーバーアクション
 export async function addComment(ticketId: string, body: string) {
+  // セッション取得
   const session = await auth();
+  // コメントはログイン済みなら (依頼者でも) 可
   assertAuthenticatedUser(session);
+  // 60 秒あたり 20 件までに制限
   enforceRateLimit(`ticket-comment:${session.user.id}`, { limit: 20, windowMs: 60_000 });
 
+  // 本文を Zod で検証
   const parsedBody = commentBodySchema.safeParse(body);
+  // 検証失敗なら日本語エラー
   if (!parsedBody.success) {
     throw new Error(parsedBody.error.issues[0]?.message ?? 'コメントが不正です');
   }
+  // 検証済み本文を取り出す
   const trimmedBody = parsedBody.data;
 
+  // 対象チケットを取得
   const ticket = await repos.tickets.findById(ticketId);
+  // 無ければエラー
   if (!ticket) throw new Error('チケットが見つかりません');
 
+  // 投稿者 ID とロールをまとめて抽出
   const authorId = session.user.id;
   const authorIsAgent = isAgent(session.user.role);
+  // エージェント、または自分が作成したチケットならコメント可
   const canComment = authorIsAgent || ticket.creatorId === authorId;
+  // 権限が無ければ拒否
   if (!canComment) {
     throw new Error('このチケットへのコメント権限がありません');
   }
 
+  // 通知対象 (依頼者/担当者/全エージェント など) を算出
   const recipientIds = await resolveCommentRecipients(ticket, authorId, authorIsAgent);
+  // 通知メッセージ (タイトル入り)
   const message = `チケット「${ticket.title}」に新しいコメントが追加されました`;
 
+  // コメント保存と通知生成を 1 トランザクションで実行
   await uow.run(async (r) => {
+    // コメント本体を保存
     await r.comments.create({
       ticketId,
       authorId,
       body: trimmedBody,
     });
+    // 対象者全員に通知を作成
     await Promise.all(
       recipientIds.map((id) =>
         r.notifications.create({
@@ -224,23 +313,31 @@ export async function addComment(ticketId: string, body: string) {
     );
   });
 
+  // 通知対象が 1 名以上いれば未読件数を一斉配信
   if (recipientIds.length > 0) await broadcastUnreadCountToMany(recipientIds);
+  // 詳細ページのキャッシュを無効化
   revalidatePath(`/tickets/${ticketId}`);
 }
 
+// コメント通知の送信先を決定するヘルパー
 async function resolveCommentRecipients(
   ticket: { creatorId: string; assigneeId: string | null },
   authorId: string,
   authorIsAgent: boolean,
 ): Promise<string[]> {
+  // 宛先候補を集める配列
   const candidates: string[] = [];
+  // エージェントがコメントした場合: 依頼者 (+ 担当者が居れば担当者)
   if (authorIsAgent) {
     candidates.push(ticket.creatorId);
     if (ticket.assigneeId) candidates.push(ticket.assigneeId);
   } else if (ticket.assigneeId) {
+    // 依頼者がコメントし担当者が決まっている場合は担当者のみ
     candidates.push(ticket.assigneeId);
   } else {
+    // 依頼者がコメントし担当者未定なら全エージェントに通知 (取りこぼし防止)
     candidates.push(...(await repos.users.listAgentIds()));
   }
+  // 重複排除し、コメント投稿者自身は除外して返す
   return Array.from(new Set(candidates)).filter((id) => id !== authorId);
 }


### PR DESCRIPTION
## Summary

CLAUDE.md の「1 行ごとに初心者でも意味がわかる日本語コメントを書く」ルール (#79) を既存コードに反映する 3 分割 PR の **2 本目**。  
今回は **Server Actions と API ルート** を対象に、実行行レベルの日本語コメントを追加した。

- PR1 (#80 済): コア & インフラ層 (`src/domain`, `src/types`, `src/lib`, `src/data`)
- **PR2 (本 PR)**: サーバーアクション & API ルート
- PR3 (予定): UI (App Router / components) とテスト

## 対象ファイル

- `src/features/auth/actions.ts`
- `src/features/faq/actions/faq-actions.ts`
- `src/features/notifications/actions/notification-actions.ts`
- `src/features/notifications/notify.ts`
- `src/features/tickets/actions/update-ticket.ts`
- `src/app/api/auth/[...nextauth]/route.ts`
- `src/app/api/notifications/stream/route.ts`
- `src/app/api/tickets/route.ts`

## 方針

- **コメント追加のみ**。ロジック・フォーマット・識別子・型・import の並び順は一切変更しない。
- 行末 `// ...` を基本とし、長文や遷移条件の補足は直前行に配置。
- `auth()` → 権限アサーション → レート制限 → バリデーション → `uow.run` (DB 更新 + 履歴 + 通知) → `broadcastUnreadCount` → `revalidatePath` という Mutation pattern を 1 行ずつ解説。
- SSE ルートは `ReadableStream` / keep-alive / 購読者 Map の関係を補足。

## Test plan

- [x] `npm run typecheck` — 緑
- [x] `npm run lint` — 緑
- [x] `npm run test` — 8 files / 65 tests 緑
- [x] `npx prettier --check` (変更ファイルのみ) — All matched files use Prettier code style
- [ ] GitHub Actions CI (Lint / Typecheck / Unit tests, Playwright E2E) — 本 PR 上で確認

https://claude.ai/code/session_01N1AvwVy6GMqssXL1JyT3ZL
