### PR TITLE
docs: src 外のファイルにも初心者向けコメント追加 (Prisma・設定・Docker)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,49 @@
+# ベースイメージ: 軽量な Alpine Linux 上の Node.js 20
 FROM node:20-alpine AS base
+# 作業ディレクトリ (以降のコマンドのカレント)
 WORKDIR /app
 
 # Install dependencies
+# 依存解決ステージ (キャッシュ最適化のため分離)
 FROM base AS deps
+# package.json と package-lock.json を先にコピー (依存変更が無ければキャッシュが効く)
 COPY package*.json ./
+# lockfile に従って厳密インストール (再現性重視)
 RUN npm ci
 
 # Build
+# ビルドステージ (Next.js のプロダクションビルドを行う)
 FROM base AS builder
+# deps から node_modules を持ち込む
 COPY --from=deps /app/node_modules ./node_modules
+# ソース全体をコピー
 COPY . .
+# Prisma クライアントを生成 (src/generated/prisma に出力)
 RUN npx prisma generate
+# Next.js を本番ビルド (standalone 出力に従う)
 RUN npm run build
 
 # Production runner
+# 実行ステージ (ビルド成果物だけを持つ最小イメージ)
 FROM base AS runner
+# 本番モード
 ENV NODE_ENV=production
 
+# 専用グループ・ユーザーを作成 (root 実行を避けるため)
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
+# 静的ファイル (画像/フォント等)
 COPY --from=builder /app/public ./public
+# Next.js standalone のサーバ本体 (server.js + 同梱の node_modules)
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+# Next.js が配信する静的ビルド成果物
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+# Prisma 生成物 (src/generated を相対パスで参照しているため)
 COPY --from=builder /app/src/generated ./src/generated
 
 # Prisma CLI, schema, migrations, and seed for DB setup commands
+# 起動後に prisma migrate / db seed を実行できるよう CLI と関連ファイルを同梱
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/node_modules/.bin/prisma ./node_modules/.bin/prisma
@@ -34,9 +52,14 @@ COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
 COPY --from=builder /app/node_modules/.bin/tsx ./node_modules/.bin/tsx
 COPY --from=builder /app/node_modules/tsx ./node_modules/tsx
 
+# 非 root ユーザーで実行 (セキュリティ)
 USER nextjs
+# コンテナが listen するポート (ドキュメント目的)
 EXPOSE 3000
+# Next.js が listen するポート
 ENV PORT=3000
+# 全 IP で listen (コンテナ外からアクセス可能に)
 ENV HOSTNAME="0.0.0.0"
 
+# 起動コマンド: standalone が生成した server.js を Node で起動
 CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,51 @@
+# docker compose で起動するサービス群の定義
 services:
+  # PostgreSQL データベースサービス
   db:
+    # 軽量な Alpine ベースの Postgres 16 公式イメージ
     image: postgres:16-alpine
+    # コンテナが落ちたら自動再起動 (ただし手動 stop は除く)
     restart: unless-stopped
+    # 初期化に使う環境変数 (DB 名/ユーザー/パスワード)
     environment:
       POSTGRES_DB: helpdesk_hub
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+    # データ永続化用ボリューム (コンテナを消してもデータが残る)
     volumes:
       - pgdata:/var/lib/postgresql/data
+    # ホストの 5432 をコンテナの 5432 に公開 (ローカルから DB クライアントで繋げる)
     ports:
       - '5432:5432'
+    # ヘルスチェック: pg_isready で接続可能か 5 秒おきに確認
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U postgres']
       interval: 5s
       timeout: 5s
       retries: 5
 
+  # Next.js アプリ本体のサービス
   app:
+    # カレントディレクトリの Dockerfile からビルド
     build: .
+    # 自動再起動
     restart: unless-stopped
+    # ホストの 3000 をコンテナの 3000 に公開
     ports:
       - '3000:3000'
+    # 実行時の環境変数
     environment:
+      # DB 接続文字列 (db サービスの 5432 を指す)
       DATABASE_URL: postgresql://postgres:postgres@db:5432/helpdesk_hub
+      # NextAuth の署名秘密鍵: 未設定なら起動を中止 (?: 構文で必須化)
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?set NEXTAUTH_SECRET in .env — see .env.example}
+      # NextAuth が想定する自身のベース URL (デフォルトはローカル)
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
+    # db のヘルスチェックが green になってから起動する
     depends_on:
       db:
         condition: service_healthy
 
+# 名前付きボリュームの宣言 (永続データ用)
 volumes:
   pgdata:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,18 +1,25 @@
+// Next.js が用意する Core Web Vitals 向け ESLint ルール集
 import nextCoreWebVitals from 'eslint-config-next/core-web-vitals';
+// Next.js + TypeScript 用の ESLint ルール集
 import nextTypescript from 'eslint-config-next/typescript';
 
+// ESLint 9 のフラットコンフィグ (配列で複数のルール塊を結合する書き方)
 const config = [
   {
+    // Lint 対象から除外するパス (生成物・依存・成果物)
     ignores: [
-      '.next/**',
-      'node_modules/**',
-      'src/generated/**',
-      'playwright-report/**',
-      'test-results/**',
+      '.next/**',              // Next.js のビルド出力
+      'node_modules/**',       // npm の依存パッケージ
+      'src/generated/**',      // Prisma の生成物
+      'playwright-report/**',  // Playwright のレポート
+      'test-results/**',       // E2E のスクリーンショット等
     ],
   },
+  // Next 推奨ルールを展開してマージ
   ...nextCoreWebVitals,
+  // TypeScript 向けルールを展開してマージ
   ...nextTypescript,
 ];
 
+// ESLint が読み取れるよう default export
 export default config;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
+// Next.js 設定ファイルの型 (補完と型安全のため)
 import type { NextConfig } from 'next';
 
+// Next.js のビルド/実行時の挙動を切り替える設定オブジェクト
 const nextConfig: NextConfig = {
+  // standalone: 必要最小限のサーバ + 依存だけをまとめた出力 (Docker 配布用)
   output: 'standalone',
 };
 
+// Next.js が読み取れるよう default export
 export default nextConfig;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,18 +1,31 @@
+// Playwright の設定ヘルパーと既製のデバイス設定
 import { defineConfig, devices } from '@playwright/test';
 
+// Playwright の設定を defineConfig で記述してエクスポート
 export default defineConfig({
+  // E2E テストの置き場所
   testDir: './e2e',
+  // テストファイル間を並列実行する (高速化)
   fullyParallel: true,
+  // CI 環境で .only が残っていたら失敗にする (うっかり 1 件だけ実行を防ぐ)
   forbidOnly: !!process.env.CI,
+  // CI ではリトライ 2 回、ローカルは 0 (フレーキー対策は CI のみ)
   retries: process.env.CI ? 2 : 0,
+  // CI ではワーカー 1 (リソース節約)、ローカルは自動
   workers: process.env.CI ? 1 : undefined,
+  // 結果レポートは HTML 形式
   reporter: 'html',
+  // 全テスト共通のオプション
   use: {
+    // 接続先 URL: 環境変数があればそれを優先、なければローカル dev サーバ
     baseURL: process.env.BASE_URL ?? 'http://localhost:3000',
+    // 1 度目失敗時にトレース (実行記録) を取る → 失敗時のデバッグが楽
     trace: 'on-first-retry',
   },
+  // プロジェクト設定 (ブラウザ別の組み合わせ)
   projects: [
     {
+      // chromium のみ使う (Firefox / WebKit は省略してコスト削減)
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,7 +1,11 @@
+// PostCSS (CSS の前処理ツール) の設定オブジェクト
 const config = {
+  // 適用するプラグイン一覧
   plugins: {
+    // Tailwind CSS v4 の PostCSS プラグインを有効化 (オプションは無し)
     '@tailwindcss/postcss': {},
   },
 };
 
+// PostCSS が読み取れるよう default export
 export default config;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,210 +1,220 @@
 // This is your Prisma schema file,
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
+// Prisma スキーマ: DB のテーブル定義と TS 型を 1 枚で管理するファイル
 
+// 生成設定: Prisma クライアント (TS で DB を操作する SDK) の出力先を指定
 generator client {
   provider = "prisma-client-js"
-  output   = "../src/generated/prisma"
+  output   = "../src/generated/prisma" // src/generated/prisma 配下にクライアント本体と型が生成される
 }
 
+// データソース設定: 接続先 DB の種類と接続文字列
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider = "postgresql" // 使用する DB は PostgreSQL
+  url      = env("DATABASE_URL") // 接続先は環境変数 DATABASE_URL から読む
 }
 
 // ─────────────────────────────────────────────
-// Enums
+// Enums (列挙型: 取り得る値を列挙して固定する)
 // ─────────────────────────────────────────────
 
+// ユーザーの役割 (権限)
 enum Role {
-  requester
-  agent
-  admin
+  requester // 一般依頼者 (自分のチケットしか見えない)
+  agent // ヘルプデスク担当者 (全チケットの操作権限あり)
+  admin // 管理者 (全権限)
 }
 
+// チケットの状態 (ワークフロー上のステータス)
 enum TicketStatus {
-  New
-  Open
-  WaitingForUser
-  InProgress
-  Escalated
-  Resolved
-  Closed
+  New // 新規受付 (担当未割当)
+  Open // 受付完了 (担当者アサイン済み・対応未着手)
+  WaitingForUser // ユーザー回答待ち
+  InProgress // 対応中
+  Escalated // 上位担当へエスカレーション済み
+  Resolved // 解決済み (依頼者が確認すると Closed になる)
+  Closed // クローズ (完了)
 }
 
+// チケットの優先度
 enum Priority {
-  Low
-  Medium
-  High
+  Low // 低
+  Medium // 中 (デフォルト)
+  High // 高
 }
 
+// 履歴に記録できる変更フィールドの種類
 enum HistoryField {
-  status
-  priority
-  assignee
-  escalation
+  status // ステータス変更
+  priority // 優先度変更
+  assignee // 担当者変更
+  escalation // エスカレーション (理由付き)
 }
 
+// FAQ 候補の状態
 enum FaqStatus {
-  Candidate
-  Published
-  Rejected
+  Candidate // 候補 (未公開)
+  Published // 公開
+  Rejected // 却下
 }
 
+// 通知種別
 enum NotificationType {
-  assigned
-  escalated
-  commented
-  statusChanged
+  assigned // 担当割当通知
+  escalated // エスカレーション通知
+  commented // コメント追加通知
+  statusChanged // ステータス変更通知
 }
 
 // ─────────────────────────────────────────────
-// User
+// User (ユーザー)
 // ─────────────────────────────────────────────
 
 model User {
-  id           String   @id @default(cuid())
-  email        String   @unique
-  name         String
-  passwordHash String
-  role         Role     @default(requester)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id           String   @id @default(cuid()) // 主キー: cuid で生成 (衝突しにくい ID)
+  email        String   @unique // メールアドレス (一意制約)
+  name         String // 表示名
+  passwordHash String // bcrypt でハッシュ化したパスワード (平文を保存しない)
+  role         Role     @default(requester) // 役割 (デフォルトは依頼者)
+  createdAt    DateTime @default(now()) // 作成日時 (自動で現在時刻)
+  updatedAt    DateTime @updatedAt // 更新日時 (Prisma が自動更新)
 
   // Relations
-  createdTickets  Ticket[]        @relation("TicketCreator")
-  assignedTickets Ticket[]        @relation("TicketAssignee")
-  comments        TicketComment[]
-  histories       TicketHistory[]
-  faqCandidates   FaqCandidate[]
-  notifications   Notification[]
+  createdTickets  Ticket[]        @relation("TicketCreator") // このユーザーが作ったチケット
+  assignedTickets Ticket[]        @relation("TicketAssignee") // このユーザーが担当のチケット
+  comments        TicketComment[] // このユーザーが投稿したコメント
+  histories       TicketHistory[] // このユーザーが起こした履歴イベント
+  faqCandidates   FaqCandidate[] // このユーザーが作成した FAQ 候補
+  notifications   Notification[] // このユーザー宛の通知
 }
 
 // ─────────────────────────────────────────────
-// Category
+// Category (チケットのカテゴリ)
 // ─────────────────────────────────────────────
 
 model Category {
-  id        String   @id @default(cuid())
-  name      String   @unique
-  createdAt DateTime @default(now())
+  id        String   @id @default(cuid()) // 主キー
+  name      String   @unique // カテゴリ名 (一意)
+  createdAt DateTime @default(now()) // 作成日時
 
-  tickets Ticket[]
+  tickets Ticket[] // このカテゴリに紐づくチケット
 }
 
 // ─────────────────────────────────────────────
-// Ticket
+// Ticket (問い合わせチケット本体)
 // ─────────────────────────────────────────────
 
 model Ticket {
-  id        String       @id @default(cuid())
-  title     String
-  body      String
-  status    TicketStatus @default(New)
-  priority  Priority     @default(Medium)
-  createdAt DateTime     @default(now())
-  updatedAt DateTime     @updatedAt
+  id        String       @id @default(cuid()) // 主キー
+  title     String // 件名
+  body      String // 本文
+  status    TicketStatus @default(New) // ステータス (デフォルト: New)
+  priority  Priority     @default(Medium) // 優先度 (デフォルト: Medium)
+  createdAt DateTime     @default(now()) // 作成日時
+  updatedAt DateTime     @updatedAt // 更新日時 (自動)
 
-  // SLA
-  firstResponseDueAt DateTime?
-  resolutionDueAt    DateTime?
-  firstRespondedAt   DateTime?
-  resolvedAt         DateTime?
+  // SLA (サービス品質保証: いつまでに対応すべきかの期限)
+  firstResponseDueAt DateTime? // 初回応答期限
+  resolutionDueAt    DateTime? // 解決期限
+  firstRespondedAt   DateTime? // 実際の初回応答日時
+  resolvedAt         DateTime? // 解決日時
 
-  // Escalation
-  escalatedAt      DateTime?
-  escalationReason String?
+  // Escalation (エスカレーション情報)
+  escalatedAt      DateTime? // エスカレーション発生日時
+  escalationReason String? // エスカレーションの理由 (必須メモ)
 
-  // Foreign keys
-  creatorId  String
-  assigneeId String?
-  categoryId String?
+  // Foreign keys (外部キー)
+  creatorId  String // 作成者のユーザー ID
+  assigneeId String? // 担当者のユーザー ID (未割当のとき null)
+  categoryId String? // カテゴリ ID (未分類のとき null)
 
-  // Relations
-  creator       User            @relation("TicketCreator", fields: [creatorId], references: [id])
-  assignee      User?           @relation("TicketAssignee", fields: [assigneeId], references: [id])
-  category      Category?       @relation(fields: [categoryId], references: [id])
-  comments      TicketComment[]
-  histories     TicketHistory[]
-  faqCandidate  FaqCandidate?
-  notifications Notification[]
+  // Relations (リレーション)
+  creator       User            @relation("TicketCreator", fields: [creatorId], references: [id]) // 作成者ユーザー
+  assignee      User?           @relation("TicketAssignee", fields: [assigneeId], references: [id]) // 担当者ユーザー
+  category      Category?       @relation(fields: [categoryId], references: [id]) // カテゴリ
+  comments      TicketComment[] // 紐づくコメント一覧
+  histories     TicketHistory[] // 紐づく履歴一覧
+  faqCandidate  FaqCandidate? // 紐づく FAQ 候補 (1:1)
+  notifications Notification[] // このチケットを参照する通知
 
-  @@index([creatorId])
-  @@index([assigneeId])
-  @@index([status])
-  @@index([categoryId])
-  @@index([createdAt(sort: Desc)])
+  // 検索性能向上のためのインデックス
+  @@index([creatorId]) // 作成者で絞り込む一覧用
+  @@index([assigneeId]) // 担当者で絞り込む一覧用
+  @@index([status]) // ステータス集計用
+  @@index([categoryId]) // カテゴリで絞り込む一覧用
+  @@index([createdAt(sort: Desc)]) // 新着順ソート用
 }
 
 // ─────────────────────────────────────────────
-// FaqCandidate
+// FaqCandidate (FAQ 候補: チケットから蓄積する Q&A)
 // ─────────────────────────────────────────────
 
 model FaqCandidate {
-  id        String    @id @default(cuid())
-  question  String
-  answer    String
-  status    FaqStatus @default(Candidate)
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
+  id        String    @id @default(cuid()) // 主キー
+  question  String // 質問文
+  answer    String // 回答文
+  status    FaqStatus @default(Candidate) // 候補/公開/却下
+  createdAt DateTime  @default(now()) // 作成日時
+  updatedAt DateTime  @updatedAt // 更新日時
 
-  ticketId    String @unique
-  createdById String
+  ticketId    String @unique // 元になったチケット (1 チケット 1 候補)
+  createdById String // 作成者 (エージェント)
 
-  ticket    Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade)
-  createdBy User   @relation(fields: [createdById], references: [id])
+  ticket    Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade) // チケット削除時に一緒に消す
+  createdBy User   @relation(fields: [createdById], references: [id]) // 作成者リレーション
 }
 
 // ─────────────────────────────────────────────
-// Notification
+// Notification (ユーザー宛の通知)
 // ─────────────────────────────────────────────
 
 model Notification {
-  id        String           @id @default(cuid())
-  type      NotificationType
-  message   String
-  read      Boolean          @default(false)
-  createdAt DateTime         @default(now())
+  id        String           @id @default(cuid()) // 主キー
+  type      NotificationType // 通知種別
+  message   String // 表示メッセージ
+  read      Boolean          @default(false) // 既読フラグ
+  createdAt DateTime         @default(now()) // 作成日時
 
-  userId   String
-  ticketId String?
+  userId   String // 通知を受け取るユーザー
+  ticketId String? // 関連チケット (任意)
 
-  user   User    @relation(fields: [userId], references: [id], onDelete: Cascade)
-  ticket Ticket? @relation(fields: [ticketId], references: [id], onDelete: SetNull)
+  user   User    @relation(fields: [userId], references: [id], onDelete: Cascade) // ユーザー削除時に通知も消す
+  ticket Ticket? @relation(fields: [ticketId], references: [id], onDelete: SetNull) // チケット削除時は紐づけだけ外す
 
-  @@index([userId, read])
-  @@index([userId, createdAt(sort: Desc)])
+  @@index([userId, read]) // 未読件数を高速に数えるため
+  @@index([userId, createdAt(sort: Desc)]) // ユーザー別の新着順表示用
 }
 
 // ─────────────────────────────────────────────
-// TicketComment
+// TicketComment (チケットへのコメント)
 // ─────────────────────────────────────────────
 
 model TicketComment {
-  id        String   @id @default(cuid())
-  body      String
-  createdAt DateTime @default(now())
+  id        String   @id @default(cuid()) // 主キー
+  body      String // コメント本文
+  createdAt DateTime @default(now()) // 投稿日時
 
-  ticketId String
-  authorId String
+  ticketId String // 紐づくチケット ID
+  authorId String // 投稿者ユーザー ID
 
-  ticket Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade)
-  author User   @relation(fields: [authorId], references: [id])
+  ticket Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade) // 親チケット削除時に一緒に消す
+  author User   @relation(fields: [authorId], references: [id]) // 投稿者
 }
 
 // ─────────────────────────────────────────────
-// TicketHistory
+// TicketHistory (チケットの変更履歴)
 // ─────────────────────────────────────────────
 
 model TicketHistory {
-  id        String       @id @default(cuid())
-  field     HistoryField
-  oldValue  String?
-  newValue  String?
-  createdAt DateTime     @default(now())
+  id        String       @id @default(cuid()) // 主キー
+  field     HistoryField // 変更されたフィールド種別
+  oldValue  String? // 変更前の値 (文字列化)
+  newValue  String? // 変更後の値 (文字列化)
+  createdAt DateTime     @default(now()) // 変更日時
 
-  ticketId    String
-  changedById String
+  ticketId    String // 対象チケット
+  changedById String // 変更を行ったユーザー
 
-  ticket    Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade)
-  changedBy User   @relation(fields: [changedById], references: [id])
+  ticket    Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade) // 親チケット削除時に履歴も削除
+  changedBy User   @relation(fields: [changedById], references: [id]) // 変更者
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,8 +1,12 @@
+// Prisma の生成クライアントと Role 列挙型 (役割) を取り込む
 import { PrismaClient, Role } from '../src/generated/prisma';
+// パスワードをハッシュ化するためのライブラリ (平文で DB に保存しないため)
 import { hash } from 'bcryptjs';
 
+// DB へ接続するクライアントのインスタンスを作成
 const prisma = new PrismaClient();
 
+// 投入するチケット用カテゴリの一覧 (画面の選択肢になる)
 const CATEGORIES = [
   'ネットワーク・接続',
   'ハードウェア',
@@ -12,62 +16,80 @@ const CATEGORIES = [
   'その他',
 ];
 
+// シード処理本体 (上から順に DB に書き込む)
 async function main() {
+  // 全ユーザー共通のパスワード "password123" をハッシュ化
   const password = await hash('password123', 12);
 
   // ── Users ────────────────────────────────────────────
+  // 依頼者ユーザー1: メールが一致すれば何もせず、無ければ新規作成 (upsert)
   const requester1 = await prisma.user.upsert({
     where: { email: 'requester1@example.com' },
     update: {},
     create: { email: 'requester1@example.com', name: '田中 花子', passwordHash: password, role: Role.requester },
   });
+  // 依頼者ユーザー2
   const requester2 = await prisma.user.upsert({
     where: { email: 'requester2@example.com' },
     update: {},
     create: { email: 'requester2@example.com', name: '鈴木 一郎', passwordHash: password, role: Role.requester },
   });
+  // 依頼者ユーザー3
   const requester3 = await prisma.user.upsert({
     where: { email: 'requester3@example.com' },
     update: {},
     create: { email: 'requester3@example.com', name: '伊藤 直子', passwordHash: password, role: Role.requester },
   });
+  // エージェント1 (ヘルプデスク担当者)
   const agent1 = await prisma.user.upsert({
     where: { email: 'agent1@example.com' },
     update: {},
     create: { email: 'agent1@example.com', name: '佐藤 健太', passwordHash: password, role: Role.agent },
   });
+  // エージェント2
   const agent2 = await prisma.user.upsert({
     where: { email: 'agent2@example.com' },
     update: {},
     create: { email: 'agent2@example.com', name: '山田 美咲', passwordHash: password, role: Role.agent },
   });
+  // エージェント3
   const agent3 = await prisma.user.upsert({
     where: { email: 'agent3@example.com' },
     update: {},
     create: { email: 'agent3@example.com', name: '中村 大輔', passwordHash: password, role: Role.agent },
   });
+  // 管理者ユーザー (admin ロール)
   const admin = await prisma.user.upsert({
     where: { email: 'admin@example.com' },
     update: {},
     create: { email: 'admin@example.com', name: '管理者', passwordHash: password, role: Role.admin },
   });
 
+  // 進捗ログ
   console.log('✅ Users seeded');
 
   // ── Categories ───────────────────────────────────────
+  // カテゴリを名前 → レコードで引けるよう Map 風オブジェクトを用意
   const cats: Record<string, { id: string }> = {};
+  // 定義済みカテゴリ名を順番に upsert (重複作成を防ぐ)
   for (const name of CATEGORIES) {
     cats[name] = await prisma.category.upsert({ where: { name }, update: {}, create: { name } });
   }
   console.log('✅ Categories seeded');
 
+  // 現在時刻と相対日付ヘルパー (期限/解決日時の計算用)
   const now = new Date();
+  // 24 時間前
   const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  // 3 日前
   const threeDaysAgo = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000);
+  // 2 日後
   const twoDaysLater = new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000);
+  // 10 時間後
   const tenHoursLater = new Date(now.getTime() + 10 * 60 * 60 * 1000);
 
   // ── Tickets ──────────────────────────────────────────
+  // 投入するチケットの定義一覧 (status / priority / 担当者などをバリエーション付きで用意)
   const ticketDefs = [
     {
       id: 'seed-t-01',
@@ -178,6 +200,7 @@ async function main() {
     },
   ];
 
+  // 各定義をチケットテーブルへ upsert (再実行しても重複しない)
   for (const def of ticketDefs) {
     await prisma.ticket.upsert({
       where: { id: def.id },
@@ -189,6 +212,7 @@ async function main() {
   console.log('✅ Tickets seeded');
 
   // ── Comments ─────────────────────────────────────────
+  // 各チケットに紐づくコメントの定義 (やり取りの履歴を再現)
   const commentDefs = [
     { ticketId: 'seed-t-02', authorId: agent1.id, body: '確認します。メールアドレスを教えてください。' },
     { ticketId: 'seed-t-02', authorId: requester2.id, body: 'suzuki@example.com です。よろしくお願いします。' },
@@ -198,6 +222,7 @@ async function main() {
     { ticketId: 'seed-t-06', authorId: requester1.id, body: 'PC-TANAKA-001 です。' },
   ];
 
+  // ticketId/authorId/body の組が無ければ新規作成 (重複登録を避ける)
   for (const c of commentDefs) {
     const exists = await prisma.ticketComment.findFirst({
       where: { ticketId: c.ticketId, authorId: c.authorId, body: c.body },
@@ -208,6 +233,7 @@ async function main() {
   console.log('✅ Comments seeded');
 
   // ── Histories ─────────────────────────────────────────
+  // 変更履歴 (担当変更・ステータス変更・エスカレーション) の定義
   const historyDefs = [
     { ticketId: 'seed-t-02', changedById: admin.id, field: 'assignee' as const, oldValue: null, newValue: agent1.name },
     { ticketId: 'seed-t-03', changedById: agent1.id, field: 'status' as const, oldValue: 'Open', newValue: 'Resolved' },
@@ -215,6 +241,7 @@ async function main() {
     { ticketId: 'seed-t-09', changedById: admin.id, field: 'assignee' as const, oldValue: null, newValue: agent3.name },
   ];
 
+  // 同一の (ticketId, changedById, field) があれば追加しない
   for (const h of historyDefs) {
     const exists = await prisma.ticketHistory.findFirst({
       where: { ticketId: h.ticketId, changedById: h.changedById, field: h.field },
@@ -225,6 +252,7 @@ async function main() {
   console.log('✅ Histories seeded');
 
   // ── FAQ Candidate ────────────────────────────────────
+  // seed-t-03 の FAQ 候補 (公開済み) が無ければ作る
   const faqExists = await prisma.faqCandidate.findFirst({ where: { ticketId: 'seed-t-03' } });
   if (!faqExists) {
     await prisma.faqCandidate.create({
@@ -238,6 +266,7 @@ async function main() {
     });
   }
 
+  // seed-t-08 の FAQ 候補 (未公開、Candidate ステータス)
   const faqExists2 = await prisma.faqCandidate.findFirst({ where: { ticketId: 'seed-t-08' } });
   if (!faqExists2) {
     await prisma.faqCandidate.create({
@@ -251,6 +280,7 @@ async function main() {
     });
   }
 
+  // 完了メッセージとログイン用情報の表示
   console.log('✅ FAQ candidates seeded');
   console.log('\nSeed completed!\nDefault password: password123');
   console.log('Users:', [
@@ -260,6 +290,7 @@ async function main() {
   ].join(', '));
 }
 
+// メイン処理を実行: 失敗したら終了コード 1、最後に必ず DB 接続を閉じる
 main()
   .catch((e) => { console.error(e); process.exit(1); })
   .finally(async () => { await prisma.$disconnect(); });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,20 @@
+// Vitest 設定ヘルパー (defineConfig は補完を効かせるため)
 import { defineConfig } from 'vitest/config';
+// パス解決用 (Node 標準 path モジュール)
 import path from 'path';
 
+// Vitest の設定を defineConfig で記述してエクスポート
 export default defineConfig({
+  // テスト全体に効くオプション
   test: {
+    // Node 環境でテストを実行 (DOM が要るときは 'jsdom' に変える)
     environment: 'node',
+    // 拾うテストファイルのパターン (tests/ 配下の *.test.ts のみ)
     include: ['tests/**/*.test.ts'],
   },
+  // モジュール解決設定
   resolve: {
+    // パスエイリアス: '@/foo' を 'src/foo' に解決 (tsconfig と一致させる)
     alias: {
       '@': path.resolve(__dirname, './src'),
     },


### PR DESCRIPTION
## Summary

PR #80 / #81 / #82 で `src/` と `tests/` / `e2e/` への適用が完了済み。本 PR ではリポジトリルート直下の設定ファイル類と Prisma 関連にも CLAUDE.md「1 行ごとに初心者でも意味がわかる日本語コメント」ルールを適用する。

## Files changed

| ファイル | 内容 |
| --- | --- |
| `prisma/seed.ts` | upsert 群 / Date ヘルパー / ticketDefs / commentDefs / historyDefs / FAQ candidate 投入の各ブロックに行コメント |
| `prisma/schema.prisma` | enum 値・model 各フィールド・relation・@@index の意味を 1 行ずつ補足 (`prisma format` で位置揃えのみ自動整形) |
| `next.config.ts` | standalone 出力の意図を補足 |
| `vitest.config.ts` | environment / include / alias の意味を 1 行ずつ |
| `playwright.config.ts` | fullyParallel / forbidOnly / retries / workers / projects の各オプション説明 |
| `eslint.config.mjs` | flat config の構造と ignores 各エントリの理由 |
| `postcss.config.mjs` | Tailwind CSS v4 PostCSS プラグインを有効化している点 |
| `Dockerfile` | base/deps/builder/runner の各ステージとレイヤキャッシュの狙い |
| `docker-compose.yml` | db / app の各オプション、`?:`/`:-` 構文の必須・デフォルト挙動 |

## Scope rules

- **コメント追加のみ**。ロジック・識別子・型・import の並びは未変更。
- `prisma format` がフィールド側コメントの位置揃えのみ自動整形 (内容は変えていない)。
- Prisma クライアント生成 (`npm run db:generate`) は再実行済み、`tsc --noEmit` 通過。

## Verification

```
npx prisma format    # OK (位置揃えのみ)
npm run db:generate  # OK
npm run typecheck    # OK
npm run lint         # OK
npm run test         # 65 passed (8 files)
```

## Test plan

- [ ] CI: Lint / Typecheck / Unit tests がグリーン
- [ ] CI: Playwright E2E がグリーン (Dockerfile/compose は CI では使われないが、念のため通常 E2E が壊れていないか確認)
- [ ] レビュアーが `prisma/schema.prisma` を抜き取り確認し、`prisma format` 由来の差分とコメント由来の差分が分けて理解できるか目視

https://claude.ai/code/session_01N1AvwVy6GMqssXL1JyT3ZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1AvwVy6GMqssXL1JyT3ZL)_