### PR TITLE
feat(tickets): 変更履歴の値を日本語化 + 日時表示を JST に統一

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN npm run build
 FROM base AS runner
 # 本番モード
 ENV NODE_ENV=production
+# コンテナ内のタイムゾーンを日本時間 (JST) に設定 (Node.js のデフォルト TZ も日本時間に揃える)
+ENV TZ=Asia/Tokyo
 
 # 専用グループ・ユーザーを作成 (root 実行を避けるため)
 RUN addgroup --system --gid 1001 nodejs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       - '3000:3000'
     # 実行時の環境変数
     environment:
+      # コンテナのタイムゾーンを日本時間 (JST) に設定
+      TZ: Asia/Tokyo
       # DB 接続文字列 (db サービスの 5432 を指す)
       DATABASE_URL: postgresql://postgres:postgres@db:5432/helpdesk_hub
       # NextAuth の署名秘密鍵: 未設定なら起動を中止 (?: 構文で必須化)

--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -6,6 +6,8 @@ import { prisma } from '@/lib/prisma';
 import { markAllRead } from '@/features/notifications/actions/notification-actions';
 // 通知タイプの日本語ラベル定義
 import { NOTIFICATION_TYPE_LABELS } from '@/lib/constants';
+// 日本時間 (Asia/Tokyo) で日時を文字列化するユーティリティ
+import { formatDateTimeJP } from '@/lib/format-date';
 
 // /notifications : 自分宛の通知一覧ページ
 export default async function NotificationsPage() {
@@ -91,9 +93,10 @@ export default async function NotificationsPage() {
                     )}
                   </div>
                 </div>
-                {/* 受信日時 (日本語ロケール) */}
+                {/* 受信日時 (日本時間で表示) */}
                 <span className="shrink-0 text-xs text-slate-400">
-                  {n.createdAt.toLocaleString('ja-JP')}
+                  {/* 通知作成日時を日本時間で表示する */}
+                  {formatDateTimeJP(n.createdAt)}
                 </span>
               </div>
             </li>

--- a/src/app/(app)/tickets/[id]/page.tsx
+++ b/src/app/(app)/tickets/[id]/page.tsx
@@ -6,8 +6,17 @@ import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 // エージェント判定 (別名で衝突回避)
 import { isAgent as checkIsAgent } from '@/lib/role';
-// 表示用ラベル/カラークラス (ステータス/優先度/履歴)
-import { STATUS_LABELS, STATUS_COLORS, PRIORITY_LABELS, PRIORITY_COLORS, HISTORY_FIELD_LABELS } from '@/lib/constants';
+// 表示用ラベル/カラークラス (ステータス/優先度/履歴) と履歴値変換ヘルパー
+import {
+  STATUS_LABELS,
+  STATUS_COLORS,
+  PRIORITY_LABELS,
+  PRIORITY_COLORS,
+  HISTORY_FIELD_LABELS,
+  formatHistoryValue,
+} from '@/lib/constants';
+// 日本時間 (Asia/Tokyo) で日付・日時を文字列化するユーティリティ
+import { formatDateJP, formatDateTimeJP } from '@/lib/format-date';
 // ステータス変更プルダウン
 import { StatusSelect } from '@/features/tickets/components/StatusSelect';
 // 優先度変更プルダウン
@@ -122,7 +131,8 @@ export default async function TicketDetailPage({ params }: Props) {
                     <div className="mb-1 flex items-center gap-2">
                       <span className="text-sm font-medium text-gray-700">{c.author.name}</span>
                       <span className="text-xs text-gray-400">
-                        {c.createdAt.toLocaleString('ja-JP')}
+                        {/* コメント投稿日時を日本時間で表示する */}
+                        {formatDateTimeJP(c.createdAt)}
                       </span>
                     </div>
                     <p className="whitespace-pre-wrap text-sm text-gray-700">{c.body}</p>
@@ -145,14 +155,17 @@ export default async function TicketDetailPage({ params }: Props) {
                 {ticket.histories.map((h) => (
                   <li key={h.id} className="flex items-start gap-2 text-sm text-gray-600">
                     <span className="mt-0.5 text-xs text-gray-400">
-                      {h.createdAt.toLocaleString('ja-JP')}
+                      {/* 履歴記録日時を日本時間で表示する */}
+                      {formatDateTimeJP(h.createdAt)}
                     </span>
                     <span>
                       <span className="font-medium">{h.changedBy.name}</span> が{' '}
                       <span className="font-medium">
                         {HISTORY_FIELD_LABELS[h.field] ?? h.field}
                       </span>{' '}
-                      を「{h.oldValue ?? '―'}」→「{h.newValue ?? '―'}」に変更
+                      {/* oldValue / newValue を field 種別に応じて日本語ラベル化する */}
+                      を「{formatHistoryValue(h.field, h.oldValue)}」→「
+                      {formatHistoryValue(h.field, h.newValue)}」に変更
                     </span>
                   </li>
                 ))}
@@ -231,7 +244,8 @@ export default async function TicketDetailPage({ params }: Props) {
               <div>
                 <dt className="font-medium text-gray-500">作成日</dt>
                 <dd className="mt-1 text-gray-700">
-                  {ticket.createdAt.toLocaleDateString('ja-JP')}
+                  {/* チケット作成日を日本時間 (年月日) で表示する */}
+                  {formatDateJP(ticket.createdAt)}
                 </dd>
               </div>
 
@@ -241,7 +255,8 @@ export default async function TicketDetailPage({ params }: Props) {
                   <dt className="font-medium text-gray-500">解決期限</dt>
                   <dd className="mt-1 flex items-center gap-2">
                     <span className="text-gray-700">
-                      {ticket.resolutionDueAt.toLocaleDateString('ja-JP')}
+                      {/* SLA 解決期限を日本時間 (年月日) で表示する */}
+                      {formatDateJP(ticket.resolutionDueAt)}
                     </span>
                     {/* 警告/超過などの状態バッジ (none/ok 以外で表示) */}
                     {slaState !== 'none' && slaState !== 'ok' && (
@@ -260,7 +275,8 @@ export default async function TicketDetailPage({ params }: Props) {
                 <div>
                   <dt className="font-medium text-gray-500">エスカレーション日時</dt>
                   <dd className="mt-1 text-gray-700">
-                    {ticket.escalatedAt.toLocaleString('ja-JP')}
+                    {/* エスカレーション発生日時を日本時間で表示する */}
+                    {formatDateTimeJP(ticket.escalatedAt)}
                   </dd>
                   {ticket.escalationReason && (
                     <dd className="mt-1 text-xs text-gray-500">{ticket.escalationReason}</dd>

--- a/src/app/(app)/tickets/[id]/page.tsx
+++ b/src/app/(app)/tickets/[id]/page.tsx
@@ -152,23 +152,28 @@ export default async function TicketDetailPage({ params }: Props) {
               <p className="text-sm text-gray-400">変更履歴はありません</p>
             ) : (
               <ul className="space-y-2">
-                {ticket.histories.map((h) => (
-                  <li key={h.id} className="flex items-start gap-2 text-sm text-gray-600">
-                    <span className="mt-0.5 text-xs text-gray-400">
-                      {/* 履歴記録日時を日本時間で表示する */}
-                      {formatDateTimeJP(h.createdAt)}
-                    </span>
-                    <span>
-                      <span className="font-medium">{h.changedBy.name}</span> が{' '}
-                      <span className="font-medium">
-                        {HISTORY_FIELD_LABELS[h.field] ?? h.field}
-                      </span>{' '}
-                      {/* oldValue / newValue を field 種別に応じて日本語ラベル化する */}
-                      を「{formatHistoryValue(h.field, h.oldValue)}」→「
-                      {formatHistoryValue(h.field, h.newValue)}」に変更
-                    </span>
-                  </li>
-                ))}
+                {ticket.histories.map((h) => {
+                  // 旧値・新値を field 種別に応じて日本語ラベル化しておく (JSX 内の改行で余計な空白が入らないよう変数化)
+                  const oldLabel = formatHistoryValue(h.field, h.oldValue);
+                  // 新値ラベル
+                  const newLabel = formatHistoryValue(h.field, h.newValue);
+                  return (
+                    <li key={h.id} className="flex items-start gap-2 text-sm text-gray-600">
+                      <span className="mt-0.5 text-xs text-gray-400">
+                        {/* 履歴記録日時を日本時間で表示する */}
+                        {formatDateTimeJP(h.createdAt)}
+                      </span>
+                      <span>
+                        <span className="font-medium">{h.changedBy.name}</span> が{' '}
+                        <span className="font-medium">
+                          {HISTORY_FIELD_LABELS[h.field] ?? h.field}
+                        </span>{' '}
+                        {/* 鍵括弧の直後に改行を入れると JSX が半角空白を挿入するため一行で書く */}
+                        を「{oldLabel}」→「{newLabel}」に変更
+                      </span>
+                    </li>
+                  );
+                })}
               </ul>
             )}
           </section>

--- a/src/app/(app)/tickets/page.tsx
+++ b/src/app/(app)/tickets/page.tsx
@@ -10,6 +10,8 @@ import { prisma } from '@/lib/prisma';
 import { isAgent as checkIsAgent } from '@/lib/role';
 // ステータス/優先度の日本語ラベルとカラークラス
 import { STATUS_LABELS, STATUS_COLORS, PRIORITY_LABELS, PRIORITY_COLORS } from '@/lib/constants';
+// 日本時間 (Asia/Tokyo) で日付を文字列化するユーティリティ
+import { formatDateJP } from '@/lib/format-date';
 // 検索フィルタフォーム (Client Component)
 import { TicketFilters } from '@/features/tickets/components/TicketFilters';
 // Prisma が生成した型 (where 構築と enum 検証用)
@@ -208,9 +210,10 @@ export default async function TicketsPage({ searchParams }: Props) {
                   <td className="px-5 py-3.5 text-slate-500">
                     {ticket.assignee?.name ?? '未割当'}
                   </td>
-                  {/* 作成日 (日付のみ) */}
+                  {/* 作成日 (日付のみ・日本時間) */}
                   <td className="px-5 py-3.5 text-slate-400">
-                    {ticket.createdAt.toLocaleDateString('ja-JP')}
+                    {/* 一覧の作成日を日本時間 (年月日) で表示する */}
+                    {formatDateJP(ticket.createdAt)}
                   </td>
                 </tr>
               ))}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -69,3 +69,16 @@ export const NOTIFICATION_TYPE_LABELS: Record<string, string> = {
   commented: 'コメント',
   statusChanged: 'ステータス変更',
 };
+
+// 変更履歴の oldValue / newValue を field 種別に応じて日本語表示に変換する関数
+// status / escalation はステータス enum、priority は優先度 enum、assignee はユーザー名がそのまま入る
+export function formatHistoryValue(field: string, value: string | null): string {
+  // 値が null の場合は欠損プレースホルダ「―」を返す (担当者の初回割当など)
+  if (value === null) return '―';
+  // status / escalation はステータス enum 値なので STATUS_LABELS で日本語化する
+  if (field === 'status' || field === 'escalation') return STATUS_LABELS[value] ?? value;
+  // priority は優先度 enum 値なので PRIORITY_LABELS で日本語化する
+  if (field === 'priority') return PRIORITY_LABELS[value] ?? value;
+  // assignee はユーザー名そのものが入っているので変換せずに返す
+  return value;
+}

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -1,0 +1,14 @@
+// 日本時間 (Asia/Tokyo) を明示してフォーマットする共通関数群
+// サーバ/ブラウザの OS タイムゾーンに依存せず常に JST 表示を保証する
+
+// 年月日と時分秒まで日本語ロケール + 日本時間で文字列化する関数
+export function formatDateTimeJP(date: Date): string {
+  // toLocaleString に locale と timeZone を渡して JST へ変換する
+  return date.toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' });
+}
+
+// 年月日のみを日本語ロケール + 日本時間で文字列化する関数
+export function formatDateJP(date: Date): string {
+  // toLocaleDateString に locale と timeZone を渡して JST へ変換する
+  return date.toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' });
+}


### PR DESCRIPTION
## Summary

- チケット詳細の **変更履歴セクション** で `oldValue` / `newValue` が `Open` / `InProgress` のように英語の enum 値で表示されていた問題を修正。`formatHistoryValue(field, value)` を `src/lib/constants.ts` に追加し、`status` / `escalation` は `STATUS_LABELS`、`priority` は `PRIORITY_LABELS` で日本語化、`assignee` はユーザー名のまま表示するようにした。
- 日時表示を **常に日本時間 (Asia/Tokyo)** に統一。`src/lib/format-date.ts` を新設し `formatDateTimeJP` / `formatDateJP` を提供。`toLocaleString('ja-JP')` / `toLocaleDateString('ja-JP')` を使っていた 7 箇所 (チケット一覧・詳細 ×5・通知一覧) を置換。`timeZone: 'Asia/Tokyo'` を明示しているため、サーバー OS の TZ に依存しない。
- 二重防御として `Dockerfile` に `ENV TZ=Asia/Tokyo`、`docker-compose.yml` の `app.environment` に `TZ: Asia/Tokyo` を追加。Node.js プロセス全体のデフォルト TZ も JST に揃う。

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (65 tests pass)
- [ ] `docker compose up -d` でアプリを起動し、チケット詳細でステータス変更 → 履歴が「`オープン`」→「`対応中`」と表示されることを確認
- [ ] 同画面で日時が JST (例: `2026/5/6 23:30:00`) で表示されることを確認
- [ ] `/notifications` の受信日時、`/tickets` 一覧の作成日が JST で表示されることを確認

https://claude.ai/code/session_016HS6SauBVG542vYwCM5gdT

---
_Generated by [Claude Code](https://claude.ai/code/session_016HS6SauBVG542vYwCM5gdT)_