### PR TITLE
fix(docker): Prisma エンジン互換と Auth.js ホスト検証を解消

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN npm ci
 # Build
 # ビルドステージ (Next.js のプロダクションビルドを行う)
 FROM base AS builder
+# Prisma が要求する OpenSSL 3 を入れて、エンジン検出を成功させる
+RUN apk add --no-cache openssl
 # deps から node_modules を持ち込む
 COPY --from=deps /app/node_modules ./node_modules
 # ソース全体をコピー
@@ -30,6 +32,9 @@ FROM base AS runner
 ENV NODE_ENV=production
 # コンテナ内のタイムゾーンを日本時間 (JST) に設定 (Node.js のデフォルト TZ も日本時間に揃える)
 ENV TZ=Asia/Tokyo
+
+# Prisma クエリエンジンが必要とする OpenSSL 3 を導入
+RUN apk add --no-cache openssl
 
 # 専用グループ・ユーザーを作成 (root 実行を避けるため)
 RUN addgroup --system --gid 1001 nodejs
@@ -48,11 +53,8 @@ COPY --from=builder /app/src/generated ./src/generated
 # 起動後に prisma migrate / db seed を実行できるよう CLI と関連ファイルを同梱
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/prisma ./prisma
-COPY --from=builder /app/node_modules/.bin/prisma ./node_modules/.bin/prisma
-COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
-COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
-COPY --from=builder /app/node_modules/.bin/tsx ./node_modules/.bin/tsx
-COPY --from=builder /app/node_modules/tsx ./node_modules/tsx
+# Prisma CLI / tsx とその依存をまとめて取り込む (個別コピーでは依存解決が崩れるため)
+COPY --from=builder /app/node_modules ./node_modules
 
 # 非 root ユーザーで実行 (セキュリティ)
 USER nextjs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?set NEXTAUTH_SECRET in .env — see .env.example}
       # NextAuth が想定する自身のベース URL (デフォルトはローカル)
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
+      # Auth.js v5: リバースプロキシ/コンテナ環境ではホスト検証を信頼する
+      AUTH_TRUST_HOST: 'true'
     # db のヘルスチェックが green になってから起動する
     depends_on:
       db:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,8 +4,9 @@
 
 // 生成設定: Prisma クライアント (TS で DB を操作する SDK) の出力先を指定
 generator client {
-  provider = "prisma-client-js"
-  output   = "../src/generated/prisma" // src/generated/prisma 配下にクライアント本体と型が生成される
+  provider      = "prisma-client-js"
+  output        = "../src/generated/prisma" // src/generated/prisma 配下にクライアント本体と型が生成される
+  binaryTargets = ["native", "linux-musl-arm64-openssl-3.0.x", "linux-musl-openssl-3.0.x"]
 }
 
 // データソース設定: 接続先 DB の種類と接続文字列


### PR DESCRIPTION
## Summary
- Docker でビルドした Prisma クエリエンジンが `libssl.so.1.1` を要求して落ちる問題を、OpenSSL 3 導入と `binaryTargets` 追加で解消
- `docker compose exec app npx prisma ...` 実行時の wasm 不足 / 依存解決崩れを、runner ステージで `node_modules` 全体を取り込む形に変更して回避
- Auth.js v5 の `UntrustedHost` で middleware が認可判定できず `/tickets` が未ログインで素通りしていた問題を、`AUTH_TRUST_HOST=true` で修正
- Dockerfile が `COPY` する `public/` ディレクトリが存在せずビルドが落ちていたため、空ディレクトリを追加

## Why
ローカルで `docker compose up -d` → `prisma migrate / db seed` → `http://localhost:3000` の流れが通らない状態だったため、フレッシュ環境からそのままセットアップできるよう修正した。

## Changes
- `Dockerfile`: builder/runner で `apk add openssl` を追加。runner の prisma/tsx を個別コピーする方針をやめ `node_modules` 全体をコピー
- `prisma/schema.prisma`: `binaryTargets` に `linux-musl-arm64-openssl-3.0.x` / `linux-musl-openssl-3.0.x` を追加
- `docker-compose.yml`: `app` サービスに `AUTH_TRUST_HOST=true` を追加
- `public/.gitkeep`: Dockerfile の `COPY --from=builder /app/public ./public` のために空ディレクトリを保持

## Test plan
- [ ] `cp .env.example .env` し `NEXTAUTH_SECRET` を設定
- [ ] `docker compose up -d` がエラーなく完走する
- [ ] `docker compose exec app npx prisma db push` が成功する
- [ ] `docker compose exec app npx prisma db seed` が成功する
- [ ] 未ログインで `http://localhost:3000/tickets` にアクセスすると `/login` にリダイレクトされる
- [ ] シードユーザー (例: `agent1@example.com` / `password123`) でログインできる

🤖 Generated with [Claude Code](https://claude.com/claude-code)