### PR TITLE
docs: 散文・ASCII 図を Mermaid 図に変換

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,28 +6,22 @@ Next.js 15 App Router をベースとしたフルスタック構成。Server Com
 
 ## システム構成
 
-```
-┌─────────────────────────────────────────────────┐
-│                   Browser                        │
-│  React 19 (Client Components + useTransition)   │
-└────────────────────┬────────────────────────────┘
-                     │ HTTP / Server Actions
-┌────────────────────▼────────────────────────────┐
-│              Next.js 15 (App Router)             │
-│                                                  │
-│  ┌──────────────┐  ┌────────────────────────┐   │
-│  │ Server       │  │ Server Actions          │   │
-│  │ Components   │  │ (mutations + revalidate)│   │
-│  └──────┬───────┘  └──────────┬─────────────┘   │
-│         │                     │                  │
-│  ┌──────▼─────────────────────▼─────────────┐   │
-│  │         Prisma Client (ORM)               │   │
-│  └──────────────────┬────────────────────────┘   │
-└─────────────────────┼──────────────────────────┘
-                      │
-┌─────────────────────▼──────────────────────────┐
-│               PostgreSQL                         │
-└────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    Browser["Browser<br/>React 19 (Client Components + useTransition)"]
+
+    subgraph NextJS["Next.js 15 (App Router)"]
+        SC["Server Components<br/>(データ取得)"]
+        SA["Server Actions<br/>(mutations + revalidate)"]
+        Prisma["Prisma Client (ORM)"]
+        SC --> Prisma
+        SA --> Prisma
+    end
+
+    DB[("PostgreSQL")]
+
+    Browser -- "HTTP / Server Actions" --> NextJS
+    Prisma --> DB
 ```
 
 ## ディレクトリ構成の考え方
@@ -42,10 +36,25 @@ Next.js 15 App Router をベースとしたフルスタック構成。Server Com
 
 ## 認証フロー
 
-```
-ブラウザ → /login → Credentials認証 → JWT セッション
-未認証で保護ページアクセス → middleware → /login リダイレクト
-JWT にユーザー ID・ロールを格納 → session.user.id / session.user.role
+```mermaid
+sequenceDiagram
+    actor User as ブラウザ
+    participant MW as middleware
+    participant Login as /login
+    participant Auth as Auth.js (Credentials)
+    participant App as 保護ページ
+
+    Note over User,App: 1. 通常ログイン
+    User->>Login: アクセス
+    Login->>Auth: メール / パスワード送信
+    Auth->>Auth: bcrypt 検証 + JWT 発行
+    Auth-->>User: Set-Cookie (JWT)<br/>id / role を格納
+    User->>App: 以降のリクエスト
+
+    Note over User,App: 2. 未認証で保護ページにアクセス
+    User->>MW: GET /tickets 等
+    MW->>MW: JWT 検証 → 失敗
+    MW-->>User: 302 /login へリダイレクト
 ```
 
 ## データミューテーション
@@ -70,6 +79,31 @@ Server Actions (`'use server'`) を使用。クライアントから直接呼び
 ### ポート / アダプタ構成
 
 Issue [#60](https://github.com/izumacha/helpdesk-hub/issues/60) に基づき、SSE 配信経路は `src/data/ports/notification-broadcaster.ts` のポートに抽象化されています。
+
+```mermaid
+flowchart LR
+    Browser["Browser<br/>EventSource"]
+
+    subgraph App["Next.js プロセス"]
+        Stream["/api/notifications/stream<br/>(GET)"]
+        Action["Server Actions<br/>createNotification / markAllRead"]
+        Facade["src/lib/sse-subscribers.ts<br/>(後方互換 facade)"]
+        Port{{"NotificationBroadcaster (ポート)<br/>addSubscriber / removeSubscriber / broadcast"}}
+        Memory["InMemory アダプタ<br/>プロセス内 Map<br/>(default)"]
+        Redis(["Redis pub/sub アダプタ<br/>(差し替え候補)"]):::future
+        Pg(["PostgreSQL LISTEN/NOTIFY<br/>(差し替え候補)"]):::future
+    end
+
+    Browser <-- "SSE (server-sent events)" --> Stream
+    Stream -- "addSubscriber / removeSubscriber" --> Facade
+    Action -- "broadcast(userId, count)" --> Facade
+    Facade --> Port
+    Port --> Memory
+    Port -.-> Redis
+    Port -.-> Pg
+
+    classDef future stroke-dasharray: 5 5,color:#666;
+```
 
 - ポート: `NotificationBroadcaster` — `addSubscriber` / `removeSubscriber` / `broadcast` の 3 メソッド。
 - デフォルトアダプタ: `createInMemoryNotificationBroadcaster`（`src/data/adapters/memory/notification-broadcaster.memory.ts`）。プロセス内 `Map` で購読者を管理する従来の実装。

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -82,25 +82,39 @@
 
 ## 5. ステータス遷移
 
-### ステータス
+ステータスは 7 種類（`New` / `Open` / `Waiting for User` / `In Progress` / `Escalated` / `Resolved` / `Closed`）。許可される遷移を以下に示す。これ以外の遷移はサーバ側で拒否する。
 
-- New
-- Open
-- Waiting for User
-- In Progress
-- Escalated
-- Resolved
-- Closed
+```mermaid
+stateDiagram-v2
+    [*] --> New : チケット登録
+    New --> Open
+    New --> WaitingForUser
+    New --> InProgress
+    New --> Resolved
+    New --> Closed
+    Open --> InProgress
+    Open --> WaitingForUser
+    Open --> Escalated
+    Open --> Resolved
+    Open --> Closed
+    WaitingForUser --> Open
+    WaitingForUser --> InProgress
+    WaitingForUser --> Resolved
+    WaitingForUser --> Closed
+    InProgress --> WaitingForUser
+    InProgress --> Escalated
+    InProgress --> Resolved
+    InProgress --> Closed
+    Escalated --> InProgress
+    Escalated --> Resolved
+    Escalated --> Closed
+    Resolved --> Open : 再オープン
+    Resolved --> Closed
+    Closed --> Open : 再オープン
+    Closed --> [*]
+```
 
-### 許可遷移
-
-- New → Open, Waiting for User, In Progress, Resolved, Closed
-- Open → In Progress, Waiting for User, Escalated, Resolved, Closed
-- Waiting for User → Open, In Progress, Resolved, Closed
-- In Progress → Waiting for User, Escalated, Resolved, Closed
-- Escalated → In Progress, Resolved, Closed
-- Resolved → Open（再オープン）, Closed
-- Closed → Open（再オープン）
+> 実装上の単一の真実は `src/domain/ticket-status.ts` の `ALLOWED_TRANSITIONS`。`docs/er-diagram.md` および `docs/overview.md` の遷移図も同じ表に基づく。
 
 ## 6. 非機能要件
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -19,8 +19,26 @@
 
 ### 2.1 Server Actions（ミューテーション）
 
-- `src/lib/rate-limit.ts` による **プロセス内 Map** の簡易スライディングウィンドウです。
-- 目的は「状態変更・コメント・エスカレーション等を連打して通知を洪水化」するのを防ぐことです。
+`src/lib/rate-limit.ts` の **プロセス内 Map** によるスライディングウィンドウで、状態変更・コメント・エスカレーション等の連打による通知洪水を防ぎます。
+
+```mermaid
+flowchart LR
+    Client["Client<br/>(フォーム送信 / ボタン連打)"]
+    Action["Server Action"]
+    Limiter{{"rate-limit.ts<br/>プロセス内 Map<br/>スライディングウィンドウ"}}
+    OK["DB 更新 + 通知発火"]
+    NG["拒否 (Error throw)"]
+
+    SharedStore[("共有ストア<br/>Redis 等<br/>(複数インスタンス時の置き換え先)")]:::future
+
+    Client --> Action
+    Action -- "key = userId + action" --> Limiter
+    Limiter -- "上限以内" --> OK
+    Limiter -- "上限超過" --> NG
+    Limiter -.-> SharedStore
+
+    classDef future stroke-dasharray: 5 5,color:#666;
+```
 
 **制約**
 

--- a/docs/version-integration.md
+++ b/docs/version-integration.md
@@ -4,6 +4,20 @@
 
 ## 対象バージョン
 
+```mermaid
+flowchart TD
+    V1["Version 1: プロダクト定義<br/>README"]
+    V2["Version 2: 要件定義<br/>requirements.md"]
+    V3["Version 3: 実装タスク<br/>issue-backlog.md"]
+    V4["Version 4: 統合基準<br/>version-integration.md (本書)"]
+
+    V1 -. "目的・対象ユーザー・<br/>利用シーン・3 フェーズ戦略" .-> V2
+    V2 -. "スコープ・画面・<br/>エンティティ・状態遷移・<br/>非機能要件" .-> V3
+    V4 -- "命名規約・正本指定・<br/>差分解消ルール" --> V1
+    V4 --> V2
+    V4 --> V3
+```
+
 - **Version 1: プロダクト定義**（README）
   - 目的、対象ユーザー、利用シーン、3フェーズ戦略
 - **Version 2: 要件定義**（requirements）
@@ -54,12 +68,37 @@
 
 ## 4バージョン統合後の正本ルール
 
+```mermaid
+flowchart LR
+    Req["機能要件<br/>docs/requirements.md"]
+    Backlog["実装順序<br/>docs/issue-backlog.md"]
+    Readme["外部説明<br/>README.md"]
+    Self["差分調停<br/>docs/version-integration.md"]
+
+    Req --- Backlog
+    Req --- Readme
+    Self -- "矛盾時の裁定" --> Req
+    Self -- "矛盾時の裁定" --> Backlog
+    Self -- "矛盾時の裁定" --> Readme
+```
+
 1. **機能要件の正本**: `docs/requirements.md`
 2. **実装順序の正本**: `docs/issue-backlog.md`
 3. **外部説明の正本**: `README.md`
 4. **差分調停の正本**: `docs/version-integration.md`
 
 ## 差分が出たときの優先順位
+
+```mermaid
+flowchart TD
+    P1["1. セキュリティ / 権限境界"]
+    P2["2. 状態遷移の業務ルール"]
+    P3["3. データ整合性 (監査ログ含む)"]
+    P4["4. UI / UX"]
+    P5["5. 文言・命名"]
+
+    P1 -- "上位を優先" --> P2 --> P3 --> P4 --> P5
+```
 
 1. セキュリティ/権限境界（最優先）
 2. 状態遷移の業務ルール


### PR DESCRIPTION
## Summary

`docs/` 配下の Markdown ドキュメントで、ASCII 罫線図・箇条書きで表現されていた図化候補を Mermaid 図に変換しました。`screen-flow.md` / `er-diagram.md` / `overview.md` で既に使われている記法に揃えています。

## 変更内容

### `docs/architecture.md`（3 図追加）

- **システム構成**: ASCII 罫線図 → `flowchart TB`（Browser → Next.js (Server Components / Server Actions) → Prisma → PostgreSQL のレイヤ構造）
- **認証フロー**: 散文 → `sequenceDiagram`（通常ログイン経路と、未認証で保護ページにアクセスした場合の middleware リダイレクト経路を 1 図に統合）
- **SSE ポート/アダプタ構成**: 散文 → `flowchart LR`（`NotificationBroadcaster` ポートと InMemory / Redis pub/sub / PostgreSQL LISTEN/NOTIFY アダプタの差し替え可能性を可視化。差し替え候補は破線スタイルで未実装であることを示す）

### `docs/requirements.md`（1 図）

- **ステータス遷移**: 7 ステータス × 許可遷移の箇条書き → `stateDiagram-v2`。`docs/er-diagram.md` / `docs/overview.md` の既存図と完全に一致しており、`src/domain/ticket-status.ts` の `ALLOWED_TRANSITIONS` を単一の真実とする旨も追記。

### `docs/security.md`（1 図）

- **レート制限**: 散文 → `flowchart LR`。Server Action → `rate-limit.ts`（プロセス内 Map）→ 許可/拒否のフローと、複数インスタンス時の Redis 等共有ストアへの差し替えポイントを破線で表示。

### `docs/version-integration.md`（3 図）

- **対象バージョン**: 4 ドキュメント（README / requirements / issue-backlog / 本書）の関係 → `flowchart TD`
- **正本ルール**: 各正本と統合基準ドキュメントの裁定関係 → `flowchart LR`
- **差分優先順位**: セキュリティ → 状態遷移 → データ整合 → UI/UX → 文言の順位 → `flowchart TD`

## 変換しなかったもの

- `issue-backlog.md`：明示的な依存関係が記述されていないため Mermaid 化しても新情報を生まない
- `pr-review-report.md`：表とコメントが主体で、Gantt 化に必要な日付情報がない
- `implementation-notes.md` / `self-review.md` / `github-issues.md`：図化候補なし
- `architecture.md` / `overview.md` の RBAC や各種テーブル：表として十分機能している

## Test plan

- [ ] GitHub の Files Changed タブで全 8 つの新規 Mermaid ブロックが正しくレンダリングされることを確認
- [ ] `requirements.md` の `stateDiagram-v2` が `er-diagram.md` および `overview.md` の既存図と完全一致していることを確認（`src/domain/ticket-status.ts` の `ALLOWED_TRANSITIONS` と矛盾しない）
- [ ] 既存の Mermaid 図（screen-flow / er-diagram / overview）への regression がないことを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDuTmGiFy59vB2CC87aQ9Z)_