### PR TITLE
refactor(infra): 全 Repository Port を tenantId 必須化 (Phase 0 仕上げ)

### DIFF
--- a/e2e/multitenant.spec.ts
+++ b/e2e/multitenant.spec.ts
@@ -1,0 +1,214 @@
+// Playwright のテスト DSL と Page 型
+import { test, expect, Page } from '@playwright/test';
+// E2E 用に DB へ直接 fixture を投入するため Prisma Client を使う
+import { PrismaClient, Role } from '../src/generated/prisma';
+// ログイン可能なテストユーザーを作るためパスワードをハッシュ化する
+import { hash } from 'bcryptjs';
+
+// E2E 専用の第2テナント fixture ID 群
+const TENANT_B_ID = 'e2e-tenant-b';
+const TENANT_B_AGENT_EMAIL = 'e2e-tenant-b-agent@example.com';
+const TENANT_B_REQUESTER_EMAIL = 'e2e-tenant-b-requester@example.com';
+const TENANT_B_AGENT_ID = 'e2e-tenant-b-agent';
+const TENANT_B_REQUESTER_ID = 'e2e-tenant-b-requester';
+const TENANT_B_CATEGORY_ID = 'e2e-tenant-b-category';
+const TENANT_B_TICKET_ID = 'e2e-tenant-b-ticket';
+const TENANT_B_FAQ_ID = 'e2e-tenant-b-faq';
+const TENANT_B_NOTIFICATION_ID = 'e2e-tenant-b-notification';
+
+const TENANT_B_TICKET_TITLE = 'E2E テナントB専用チケット';
+const TENANT_B_FAQ_QUESTION = 'E2E テナントB専用FAQ質問';
+const TENANT_B_NOTIFICATION_MESSAGE = 'E2E テナントB専用通知';
+
+// 既存 seed 側のデフォルトテナントユーザー
+const DEFAULT_AGENT_EMAIL = 'agent1@example.com';
+const DEFAULT_REQUESTER_EMAIL = 'requester1@example.com';
+const DEFAULT_TENANT_TICKET_TITLE = 'VPN に接続できない';
+
+// DB 直接投入用 Prisma Client
+const prisma = new PrismaClient();
+
+// 共通ログイン手順
+async function login(page: Page, email: string) {
+  await page.goto('/login');
+  await page.getByLabel(/メールアドレス|Email/i).fill(email);
+  await page.getByLabel(/パスワード|Password/i).fill('password123');
+  await page.getByRole('button', { name: /ログイン/i }).click();
+  await page.waitForURL(/\/dashboard|\/tickets/);
+}
+
+// 第2テナント fixture を投入する
+async function seedTenantBFixture() {
+  const passwordHash = await hash('password123', 12);
+
+  await prisma.tenant.upsert({
+    where: { id: TENANT_B_ID },
+    update: {},
+    create: { id: TENANT_B_ID, name: 'E2E テナントB', mode: 'lite' },
+  });
+
+  const agentB = await prisma.user.upsert({
+    where: { email: TENANT_B_AGENT_EMAIL },
+    update: { passwordHash, role: Role.agent, tenantId: TENANT_B_ID },
+    create: {
+      id: TENANT_B_AGENT_ID,
+      email: TENANT_B_AGENT_EMAIL,
+      name: 'E2E テナントB 担当者',
+      passwordHash,
+      role: Role.agent,
+      tenantId: TENANT_B_ID,
+    },
+  });
+
+  const requesterB = await prisma.user.upsert({
+    where: { email: TENANT_B_REQUESTER_EMAIL },
+    update: { passwordHash, role: Role.requester, tenantId: TENANT_B_ID },
+    create: {
+      id: TENANT_B_REQUESTER_ID,
+      email: TENANT_B_REQUESTER_EMAIL,
+      name: 'E2E テナントB 依頼者',
+      passwordHash,
+      role: Role.requester,
+      tenantId: TENANT_B_ID,
+    },
+  });
+
+  await prisma.category.upsert({
+    where: { id: TENANT_B_CATEGORY_ID },
+    update: { name: 'E2E テナントBカテゴリ', tenantId: TENANT_B_ID },
+    create: { id: TENANT_B_CATEGORY_ID, name: 'E2E テナントBカテゴリ', tenantId: TENANT_B_ID },
+  });
+
+  await prisma.ticket.upsert({
+    where: { id: TENANT_B_TICKET_ID },
+    update: {
+      title: TENANT_B_TICKET_TITLE,
+      body: 'このチケットはテナントBからしか見えてはいけない。',
+      status: 'Resolved',
+      priority: 'Medium',
+      creatorId: requesterB.id,
+      assigneeId: agentB.id,
+      categoryId: TENANT_B_CATEGORY_ID,
+      tenantId: TENANT_B_ID,
+      resolvedAt: new Date(),
+    },
+    create: {
+      id: TENANT_B_TICKET_ID,
+      title: TENANT_B_TICKET_TITLE,
+      body: 'このチケットはテナントBからしか見えてはいけない。',
+      status: 'Resolved',
+      priority: 'Medium',
+      creatorId: requesterB.id,
+      assigneeId: agentB.id,
+      categoryId: TENANT_B_CATEGORY_ID,
+      tenantId: TENANT_B_ID,
+      resolvedAt: new Date(),
+    },
+  });
+
+  await prisma.faqCandidate.upsert({
+    where: { id: TENANT_B_FAQ_ID },
+    update: {
+      question: TENANT_B_FAQ_QUESTION,
+      answer: 'テナントB専用の回答。',
+      status: 'Candidate',
+      ticketId: TENANT_B_TICKET_ID,
+      createdById: agentB.id,
+      tenantId: TENANT_B_ID,
+    },
+    create: {
+      id: TENANT_B_FAQ_ID,
+      question: TENANT_B_FAQ_QUESTION,
+      answer: 'テナントB専用の回答。',
+      status: 'Candidate',
+      ticketId: TENANT_B_TICKET_ID,
+      createdById: agentB.id,
+      tenantId: TENANT_B_ID,
+    },
+  });
+
+  const defaultAgent = await prisma.user.findUniqueOrThrow({ where: { email: DEFAULT_AGENT_EMAIL } });
+
+  // userId はデフォルトテナントユーザー、tenantId はテナントBという不整合データを置く。
+  // これが画面に出ないことで NotificationRepository.list の tenantId スコープを検証する。
+  await prisma.notification.upsert({
+    where: { id: TENANT_B_NOTIFICATION_ID },
+    update: {
+      userId: defaultAgent.id,
+      tenantId: TENANT_B_ID,
+      ticketId: TENANT_B_TICKET_ID,
+      type: 'commented',
+      message: TENANT_B_NOTIFICATION_MESSAGE,
+      read: false,
+    },
+    create: {
+      id: TENANT_B_NOTIFICATION_ID,
+      userId: defaultAgent.id,
+      tenantId: TENANT_B_ID,
+      ticketId: TENANT_B_TICKET_ID,
+      type: 'commented',
+      message: TENANT_B_NOTIFICATION_MESSAGE,
+      read: false,
+    },
+  });
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('マルチテナント漏洩防止', () => {
+  test.beforeAll(async () => {
+    await seedTenantBFixture();
+  });
+
+  test.afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  test('テナントAの担当者からテナントBのチケット一覧・詳細・FAQ・通知が見えない', async ({ page }) => {
+    await login(page, DEFAULT_AGENT_EMAIL);
+
+    await page.goto('/tickets');
+    await expect(page.getByText(TENANT_B_TICKET_TITLE)).toHaveCount(0);
+    await expect(page.getByText(DEFAULT_TENANT_TICKET_TITLE)).toBeVisible();
+
+    const detailResponse = await page.goto(`/tickets/${TENANT_B_TICKET_ID}`);
+    expect(detailResponse?.status()).toBe(404);
+
+    await page.goto('/faq');
+    await expect(page.getByText(TENANT_B_FAQ_QUESTION)).toHaveCount(0);
+
+    await page.goto('/notifications');
+    await expect(page.getByText(TENANT_B_NOTIFICATION_MESSAGE)).toHaveCount(0);
+  });
+
+  test('テナントBの担当者はテナントBのチケットだけ見え、テナントAの代表チケットは見えない', async ({ page }) => {
+    await login(page, TENANT_B_AGENT_EMAIL);
+
+    await page.goto('/tickets');
+    await expect(page.getByText(TENANT_B_TICKET_TITLE)).toBeVisible();
+    await expect(page.getByText(DEFAULT_TENANT_TICKET_TITLE)).toHaveCount(0);
+  });
+
+  test('テナントAの依頼者はテナントBカテゴリIDでチケット作成できない', async ({ page }) => {
+    await login(page, DEFAULT_REQUESTER_EMAIL);
+
+    const result = await page.evaluate(async (categoryId) => {
+      const res = await fetch('/api/tickets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          title: 'E2E クロステナントカテゴリ攻撃',
+          body: '別テナントのカテゴリIDを指定して作成できないことを確認する。',
+          priority: 'Medium',
+          categoryId,
+        }),
+      });
+      const payload = await res.json().catch(() => null);
+      return { status: res.status, payload };
+    }, TENANT_B_CATEGORY_ID);
+
+    expect(result.status).toBe(422);
+    expect(result.payload?.error).toMatch(/入力値/);
+  });
+});

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -18,16 +18,19 @@ export default async function DashboardPage() {
 
   // ロール判定
   const isAgent = checkIsAgent(session.user.role);
+  // セッションから tenantId を取り出して以降の port 呼び出しに伝搬する
+  const tenantId = session.user.tenantId;
   // SLA 判定基準時刻 (現在時刻)
   const now = new Date();
 
-  // ダッシュボード用 3 指標を 1 メソッドで取得 (内部は groupBy で 3 クエリに集約)
+  // ダッシュボード用 3 指標を 1 メソッドで取得 (内部は groupBy で 3 クエリに集約、tenantId スコープ)
   // - byStatus: 7 状態それぞれの件数 (依頼者なら自身のチケットに限定)
-  // - slaOverdue / workload: 全件対象 (表示は呼び出し側で role 制御)
+  // - slaOverdue / workload: 当該テナント内全件対象 (表示は呼び出し側で role 制御)
   const stats = await repos.tickets.dashboardStats({
     creatorId: isAgent ? undefined : session.user.id,
     now,
     excludeStatusesForWorkload: ['Resolved', 'Closed'],
+    tenantId,
   });
 
   // SLA 超過件数 (依頼者には表示しないので 0 にしておく)
@@ -40,9 +43,9 @@ export default async function DashboardPage() {
     .filter((w) => w.assigneeId !== null)
     .map((w) => w.assigneeId as string);
 
-  // 担当者名を解決するため、ユーザー情報をまとめて取得 (port 経由)
+  // 担当者名を解決するため、当該テナント内のユーザー情報をまとめて取得 (port 経由)
   const assigneeNames =
-    assigneeIds.length > 0 ? await repos.users.findSummariesByIds(assigneeIds) : [];
+    assigneeIds.length > 0 ? await repos.users.findSummariesByIds(assigneeIds, tenantId) : [];
 
   // ID → 名前の辞書を作成
   const nameMap = Object.fromEntries(assigneeNames.map((u) => [u.id, u.name]));

--- a/src/app/(app)/faq/page.tsx
+++ b/src/app/(app)/faq/page.tsx
@@ -15,13 +15,13 @@ import { updateFaqStatus } from '@/features/faq/actions/faq-actions';
 export default async function FaqPage() {
   // セッション取得
   const session = await auth();
-  // 未ログインなら何も描画しない
-  if (!session?.user?.id) return null;
+  // 未ログイン or tenantId 不在なら何も描画しない
+  if (!session?.user?.id || !session.user.tenantId) return null;
   // 一般ユーザー (依頼者) は 404 で隠す
   if (!isAgent(session.user.role)) notFound();
 
-  // FAQ 候補を新しい順で全件取得 (元チケットと作成者名を含む、port 経由)
-  const faqs = await repos.faq.list();
+  // 当該テナントの FAQ 候補を新しい順で全件取得 (元チケットと作成者名を含む、port 経由)
+  const faqs = await repos.faq.list(session.user.tenantId);
 
   return (
     <div className="space-y-6">

--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -13,11 +13,15 @@ import { formatDateTimeJP } from '@/lib/format-date';
 export default async function NotificationsPage() {
   // セッション取得
   const session = await auth();
-  // 未ログインなら何も描画しない (middleware が先に弾くはずの保険)
-  if (!session?.user?.id) return null;
+  // 未ログイン or tenantId 不在なら何も描画しない (middleware が先に弾くはずの保険)
+  if (!session?.user?.id || !session.user.tenantId) return null;
 
-  // 自分宛の通知を最新 50 件取得 (チケットタイトル付き、port 経由)
-  const notifications = await repos.notifications.list(session.user.id, { limit: 50 });
+  // 自分宛の通知を最新 50 件取得 (チケットタイトル付き、tenantId スコープで port 経由)
+  const notifications = await repos.notifications.list(
+    session.user.id,
+    { limit: 50 },
+    session.user.tenantId,
+  );
 
   // 未読が 1 件でもあるかどうか (ボタン表示判定に使用)
   const hasUnread = notifications.some((n) => !n.read);

--- a/src/app/(app)/tickets/[id]/page.tsx
+++ b/src/app/(app)/tickets/[id]/page.tsx
@@ -51,12 +51,14 @@ export default async function TicketDetailPage({ params }: Props) {
   // ロール判定
   const isAgent = checkIsAgent(session.user.role);
 
-  // チケット本体 (関連データ込み) と担当者プルダウン用ユーザーを並列取得 (port 経由)
+  // セッションから tenantId を取り出して以降の port 呼び出しに伝搬する
+  const tenantId = session.user.tenantId;
+  // チケット本体 (関連データ込み) と担当者プルダウン用ユーザーを並列取得 (全て tenantId スコープ)
   const [ticket, agents] = await Promise.all([
     // 詳細用: 起票者/担当者/カテゴリ/コメント/履歴/FAQ 候補をまとめて取得
-    repos.tickets.findByIdWithDetail(id),
-    // エージェント時のみ担当者候補一覧を取得
-    isAgent ? repos.users.listAgents() : Promise.resolve([]),
+    repos.tickets.findByIdWithDetail(id, tenantId),
+    // エージェント時のみ担当者候補一覧を取得 (テナント内のみ)
+    isAgent ? repos.users.listAgents(tenantId) : Promise.resolve([]),
   ]);
 
   // チケットが存在しなければ 404

--- a/src/app/(app)/tickets/new/page.tsx
+++ b/src/app/(app)/tickets/new/page.tsx
@@ -1,3 +1,5 @@
+// セッション (ログイン中ユーザー) 取得
+import { auth } from '@/lib/auth';
 // データ層の Composition Root 経由でカテゴリ一覧を取得する (Prisma 直叩きを避ける)
 import { repos } from '@/data';
 // 新規チケット入力フォーム (Client Component)
@@ -5,8 +7,13 @@ import { TicketForm } from '@/features/tickets/components/TicketForm';
 
 // /tickets/new : 新規チケット作成ページ (Server Component)
 export default async function NewTicketPage() {
-  // フォームのカテゴリ選択肢として、全カテゴリを名前順で取得 (port 経由)
-  const categories = await repos.categories.list();
+  // セッション取得 (middleware で認証済みのはずだが防御的に確認)
+  const session = await auth();
+  // 未ログイン or tenantId 不在は描画しない (middleware が先に弾く想定)
+  if (!session?.user?.id || !session.user.tenantId) return null;
+
+  // フォームのカテゴリ選択肢として、当該テナント内のカテゴリを名前順で取得 (port 経由)
+  const categories = await repos.categories.list(session.user.tenantId);
 
   return (
     // 中央寄せの幅 max-w-2xl コンテナ

--- a/src/app/(app)/tickets/page.tsx
+++ b/src/app/(app)/tickets/page.tsx
@@ -79,17 +79,20 @@ export default async function TicketsPage({ searchParams }: Props) {
     assigneeId: normalizeAssigneeId(sp.assigneeId),
   };
 
-  // 表示用データを並列取得 (一覧/総件数/カテゴリ/担当者候補、port 経由)
+  // セッションから tenantId を取り出して以降の port 呼び出しに伝搬する
+  const tenantId = session.user.tenantId;
+  // 表示用データを並列取得 (一覧/総件数/カテゴリ/担当者候補、全て port + tenantId スコープ)
   const [tickets, total, categories, agents] = await Promise.all([
     repos.tickets.list({
       filter,
       page: { skip, take: PAGE_SIZE },
       sort: { field: 'createdAt', direction: 'desc' },
+      tenantId,
     }),
-    repos.tickets.count(filter),
-    repos.categories.list(),
+    repos.tickets.count(filter, tenantId),
+    repos.categories.list(tenantId),
     // 担当者プルダウン用ユーザーは agent/admin のみ (依頼者には不要)
-    isAgent ? repos.users.listAgents() : Promise.resolve([]),
+    isAgent ? repos.users.listAgents(tenantId) : Promise.resolve([]),
   ]);
 
   // 総ページ数を計算

--- a/src/app/api/notifications/stream/route.ts
+++ b/src/app/api/notifications/stream/route.ts
@@ -32,12 +32,14 @@ function sseEvent(eventName: string, data: unknown): Uint8Array {
 export async function GET(): Promise<Response> {
   // セッション取得
   const session = await auth();
-  // 未ログインなら 401 を返す (クライアントには JSON エラー)
-  if (!session?.user?.id) {
+  // 未ログイン or tenantId 不在なら 401 を返す (クライアントには JSON エラー)
+  if (!session?.user?.id || !session.user.tenantId) {
     return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
   }
   // 購読者 ID として使うログイン中ユーザーの ID
   const userId = session.user.id;
+  // 未読件数を引くテナントスコープ
+  const tenantId = session.user.tenantId;
 
   // ストリーム制御用のコントローラを外側スコープで保持
   let controller!: ReadableStreamDefaultController<Uint8Array>;
@@ -54,8 +56,8 @@ export async function GET(): Promise<Response> {
       addSubscriber(userId, controller);
 
       try {
-        // 最初に現在の未読件数を取得し
-        const initialCount = await getUnreadNotificationCount(userId);
+        // 最初に現在の未読件数を取得し (tenantId スコープ)
+        const initialCount = await getUnreadNotificationCount(userId, tenantId);
         // count イベントとして即時送信 (UI の初期表示用)
         controller.enqueue(sseEvent('count', { count: initialCount }));
       } catch {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -50,9 +50,9 @@ export async function Header() {
       <div className="flex items-center gap-4">
         {session?.user && (
           <>
-            {/* 通知ベル (未読件数取得中はフォールバックを表示) */}
+            {/* 通知ベル (未読件数取得中はフォールバックを表示、tenantId スコープ) */}
             <Suspense fallback={<span className="text-sm text-slate-500">通知</span>}>
-              <NotificationBell userId={session.user.id!} />
+              <NotificationBell userId={session.user.id!} tenantId={session.user.tenantId} />
             </Suspense>
             {/* ユーザー情報: アバター丸 + 氏名 + ロール pill */}
             <div className="flex items-center gap-2.5">

--- a/src/components/layout/NotificationBell.tsx
+++ b/src/components/layout/NotificationBell.tsx
@@ -4,9 +4,16 @@ import { getUnreadNotificationCount } from '@/lib/notifications';
 import { NotificationBellClient } from './NotificationBellClient';
 
 // サーバー側で初期未読件数を取得し、Client Component に渡すラッパー
-export async function NotificationBell({ userId }: { userId: string }) {
-  // 初回表示用の未読件数を DB から取得
-  const initialCount = await getUnreadNotificationCount(userId);
+// テナント越境の未読件数表示を防ぐため、userId と一緒に tenantId も親から渡してもらう
+export async function NotificationBell({
+  userId,
+  tenantId,
+}: {
+  userId: string;
+  tenantId: string;
+}) {
+  // 初回表示用の未読件数を当該テナントから取得 (Adapter 側で where に tenantId 注入)
+  const initialCount = await getUnreadNotificationCount(userId, tenantId);
   // 取得した値を Client Component に渡して描画 (以後は SSE で更新)
   return <NotificationBellClient initialCount={initialCount} userId={userId} />;
 }

--- a/src/data/adapters/memory/category-repository.memory.ts
+++ b/src/data/adapters/memory/category-repository.memory.ts
@@ -5,9 +5,10 @@ import type { Store } from './store';
 // メモリストアを使ったカテゴリリポジトリを生成するファクトリ関数
 export function makeCategoryRepo(store: Store): CategoryRepository {
   return {
-    // 全カテゴリを名前昇順で取得
-    async list() {
+    // 当該テナントのカテゴリを名前昇順で取得
+    async list(tenantId) {
       return [...store.categories.values()] // Map から配列化
+        .filter((c) => c.tenantId === tenantId) // テナントで絞る
         .map((c) => ({ id: c.id, name: c.name })) // 返却用に id/name だけ抽出
         .sort((a, b) => a.name.localeCompare(b.name)); // 名前でロケール順に並び替え
     },

--- a/src/data/adapters/memory/faq-repository.memory.ts
+++ b/src/data/adapters/memory/faq-repository.memory.ts
@@ -6,16 +6,19 @@ import { nextId, type Store } from './store';
 // メモリストアを使った FAQ リポジトリを生成する関数
 export function makeFaqRepo(store: Store): FaqRepository {
   return {
-    // ID で 1 件取得 (見つからなければ null)
-    async findById(id) {
+    // ID + tenantId で 1 件取得 (他テナントの ID なら null)
+    async findById(id, tenantId) {
       const row = store.faq.get(id); // Map から取得
-      return row ? { ...row } : null; // 破壊防止のため複製して返す
+      if (!row || row.tenantId !== tenantId) return null; // テナント不一致は null
+      return { ...row }; // 破壊防止のため複製して返す
     },
 
-    // 全 FAQ 候補を新しい順で一覧化 (関連チケット/作成者名を結合)
-    async list() {
-      // Map を配列化し、作成日時の降順で並べる
-      const rows = [...store.faq.values()].sort((a, b) => +b.createdAt - +a.createdAt);
+    // 当該テナントの FAQ 候補を新しい順で一覧化 (関連チケット/作成者名を結合)
+    async list(tenantId) {
+      // Map を配列化し、テナントで絞ったうえで作成日時の降順で並べる
+      const rows = [...store.faq.values()]
+        .filter((f) => f.tenantId === tenantId)
+        .sort((a, b) => +b.createdAt - +a.createdAt);
       // 関連チケットと作成者を引き当てて結合
       return rows.map<FaqListItem>((f) => {
         const ticket = store.tickets.get(f.ticketId); // 元チケット
@@ -54,10 +57,10 @@ export function makeFaqRepo(store: Store): FaqRepository {
       return row;
     },
 
-    // FAQ 候補の状態を更新 (候補/公開/却下)
-    async updateStatus(id, status) {
+    // FAQ 候補の状態を更新 (tenantId スコープ。テナント不一致なら no-op)
+    async updateStatus(id, status, tenantId) {
       const row = store.faq.get(id); // 更新対象を取得
-      if (!row) throw new Error(`faq candidate not found: ${id}`); // 無ければエラー
+      if (!row || row.tenantId !== tenantId) return; // 不在 or 他テナントなら何もしない
       // 状態と更新日時を書き換えて保存
       store.faq.set(id, { ...row, status, updatedAt: new Date() });
     },

--- a/src/data/adapters/memory/notification-repository.memory.ts
+++ b/src/data/adapters/memory/notification-repository.memory.ts
@@ -28,21 +28,22 @@ export function makeNotificationRepo(store: Store): NotificationRepository {
       return notification;
     },
 
-    // 指定ユーザーの未読件数をカウント
-    async countUnread(userId) {
+    // 指定ユーザーの未読件数をカウント (tenantId スコープ)
+    async countUnread(userId, tenantId) {
       let n = 0; // カウンタ
-      // 全通知を走査し、対象ユーザー & 未読のものを数える
+      // 全通知を走査し、テナント + 対象ユーザー + 未読のものを数える
       for (const n0 of store.notifications.values()) {
+        if (n0.tenantId !== tenantId) continue; // 他テナントは除外
         if (n0.userId === userId && !n0.read) n += 1;
       }
       // 件数を返す
       return n;
     },
 
-    // 指定ユーザーの通知を新しい順に limit 件取得 (関連チケット付き)
-    async list(userId, { limit }) {
+    // 指定ユーザーの通知を新しい順に limit 件取得 (関連チケット付き、tenantId スコープ)
+    async list(userId, { limit }, tenantId) {
       const rows = [...store.notifications.values()] // 全通知を配列化
-        .filter((n) => n.userId === userId) // 対象ユーザーのみ
+        .filter((n) => n.tenantId === tenantId && n.userId === userId) // テナント + ユーザー
         .sort((a, b) => +b.createdAt - +a.createdAt) // 新しい順にソート
         .slice(0, limit); // 先頭 limit 件に切る
       // 各通知に関連チケットの要約を結合して返す
@@ -55,7 +56,7 @@ export function makeNotificationRepo(store: Store): NotificationRepository {
       });
     },
 
-    // 指定ユーザーの未読通知を全て既読に更新
+    // 指定ユーザーの未読通知を全て既読に更新 (ユーザーは単一テナント帰属なので tenantId 不要)
     async markAllRead(userId) {
       // Map の全エントリを走査
       for (const [id, n] of store.notifications) {

--- a/src/data/adapters/memory/ticket-repository.memory.ts
+++ b/src/data/adapters/memory/ticket-repository.memory.ts
@@ -43,8 +43,10 @@ function attachRefs(ticket: Ticket, store: Store): TicketWithRefs {
   };
 }
 
-// 指定フィルタ条件に一致するかを判定するヘルパー
-function matchesFilter(t: Ticket, filter: TicketListFilter): boolean {
+// 指定フィルタ条件に一致するかを判定するヘルパー (tenantId は別途必須でチェック)
+function matchesFilter(t: Ticket, filter: TicketListFilter, tenantId: string): boolean {
+  // テナントスコープを最優先で確認 (他テナントの行は問答無用で除外)
+  if (t.tenantId !== tenantId) return false;
   // 起票者フィルター: 指定があり一致しなければ除外
   if (filter.creatorId !== undefined && t.creatorId !== filter.creatorId) return false;
   // 状態フィルター
@@ -76,22 +78,25 @@ function matchesFilter(t: Ticket, filter: TicketListFilter): boolean {
 // メモリストアを使ったチケットリポジトリを生成する関数
 export function makeTicketRepo(store: Store): TicketRepository {
   return {
-    // ID で最小フィールドのチケットを 1 件取得 (複製して返す)
-    async findById(id) {
+    // ID + tenantId で最小フィールドのチケットを 1 件取得 (複製して返す)
+    async findById(id, tenantId) {
       const t = store.tickets.get(id);
-      return t ? { ...t } : null;
+      // テナント不一致なら null (クロステナント参照を遮断)
+      if (!t || t.tenantId !== tenantId) return null;
+      return { ...t };
     },
 
-    // ID で起票者/担当者/カテゴリを結合したチケットを取得
-    async findByIdWithRefs(id) {
+    // ID + tenantId で起票者/担当者/カテゴリを結合したチケットを取得
+    async findByIdWithRefs(id, tenantId) {
       const t = store.tickets.get(id);
-      return t ? attachRefs(t, store) : null;
+      if (!t || t.tenantId !== tenantId) return null;
+      return attachRefs(t, store);
     },
 
-    // 詳細ページ用に、コメント/履歴/FAQ 候補を含むチケットを取得
-    async findByIdWithDetail(id) {
+    // 詳細ページ用に、コメント/履歴/FAQ 候補を含むチケットを取得 (tenantId スコープ)
+    async findByIdWithDetail(id, tenantId) {
       const t = store.tickets.get(id); // 本体取得
-      if (!t) return null; // 無ければ null
+      if (!t || t.tenantId !== tenantId) return null; // テナント不一致は null
       const withRefs = attachRefs(t, store); // 関連情報を結合
 
       // 対象チケットのコメントを古い順に整形
@@ -127,10 +132,10 @@ export function makeTicketRepo(store: Store): TicketRepository {
       return detail;
     },
 
-    // 一覧取得 (フィルタ/ソート/ページング)
-    async list({ filter, page, sort }) {
-      // フィルター適用
-      let rows = [...store.tickets.values()].filter((t) => matchesFilter(t, filter));
+    // 一覧取得 (フィルタ/ソート/ページング、tenantId スコープ)
+    async list({ filter, page, sort, tenantId }) {
+      // フィルター適用 (matchesFilter 内で tenantId も判定)
+      let rows = [...store.tickets.values()].filter((t) => matchesFilter(t, filter, tenantId));
       // ソート方向を決定 (既定は降順)
       const direction = sort?.direction ?? 'desc';
       // createdAt で並び替え
@@ -143,19 +148,19 @@ export function makeTicketRepo(store: Store): TicketRepository {
       return rows.map((t) => attachRefs(t, store));
     },
 
-    // 条件に一致する件数をカウント
-    async count(filter) {
+    // 条件に一致する件数をカウント (tenantId スコープ)
+    async count(filter, tenantId) {
       let n = 0; // カウンタ
       // 全チケットを走査し、条件一致を加算
       for (const t of store.tickets.values()) {
-        if (matchesFilter(t, filter)) n += 1;
+        if (matchesFilter(t, filter, tenantId)) n += 1;
       }
       // 件数を返す
       return n;
     },
 
-    // ダッシュボード一括取得 (status 別件数 / SLA 超過 / 担当者別ワークロード)
-    async dashboardStats({ creatorId, now, excludeStatusesForWorkload }) {
+    // ダッシュボード一括取得 (status 別件数 / SLA 超過 / 担当者別ワークロード、tenantId スコープ)
+    async dashboardStats({ creatorId, now, excludeStatusesForWorkload, tenantId }) {
       // 状態別件数を 0 で初期化 (該当なしも 0 として返す)
       const byStatus: Record<TicketStatus, number> = {
         New: 0,
@@ -172,6 +177,8 @@ export function makeTicketRepo(store: Store): TicketRepository {
       const workloadCounts = new Map<string | null, number>();
       // 全チケットを 1 度だけ走査して 3 指標を同時に集計
       for (const t of store.tickets.values()) {
+        // 当該テナント以外は集計対象外
+        if (t.tenantId !== tenantId) continue;
         // byStatus: 起票者フィルタ (creatorId 指定時のみ) を満たす場合に集計
         if (creatorId === undefined || t.creatorId === creatorId) {
           byStatus[t.status] += 1;
@@ -229,32 +236,33 @@ export function makeTicketRepo(store: Store): TicketRepository {
       return attachRefs(ticket, store);
     },
 
-    // 状態を更新 (併せて解決日時もセットする)
-    async updateStatus(id, status, resolvedAt) {
+    // 状態を更新 (tenantId スコープ。テナント不一致なら no-op = 0 件更新)
+    async updateStatus(id, status, resolvedAt, tenantId) {
       const t = store.tickets.get(id); // 対象取得
-      if (!t) throw new Error(`ticket not found: ${id}`); // 無ければエラー
+      // 不在 or テナント不一致は何もしない (Prisma の updateMany と同じ挙動)
+      if (!t || t.tenantId !== tenantId) return;
       // 新しい状態/解決日時/更新時刻で置き換え
       store.tickets.set(id, { ...t, status, resolvedAt, updatedAt: new Date() });
     },
 
-    // 優先度を更新
-    async updatePriority(id, priority) {
+    // 優先度を更新 (tenantId スコープ)
+    async updatePriority(id, priority, tenantId) {
       const t = store.tickets.get(id);
-      if (!t) throw new Error(`ticket not found: ${id}`);
+      if (!t || t.tenantId !== tenantId) return;
       store.tickets.set(id, { ...t, priority, updatedAt: new Date() });
     },
 
-    // 担当者を更新 (null で未アサインに戻す)
-    async updateAssignee(id, assigneeId) {
+    // 担当者を更新 (tenantId スコープ。null で未アサインに戻す)
+    async updateAssignee(id, assigneeId, tenantId) {
       const t = store.tickets.get(id);
-      if (!t) throw new Error(`ticket not found: ${id}`);
+      if (!t || t.tenantId !== tenantId) return;
       store.tickets.set(id, { ...t, assigneeId, updatedAt: new Date() });
     },
 
-    // エスカレーション扱いに更新 (状態 + 理由 + 実行時刻)
-    async markEscalated(id, args) {
+    // エスカレーション扱いに更新 (tenantId スコープ)
+    async markEscalated(id, args, tenantId) {
       const t = store.tickets.get(id);
-      if (!t) throw new Error(`ticket not found: ${id}`);
+      if (!t || t.tenantId !== tenantId) return;
       store.tickets.set(id, {
         ...t,
         status: 'Escalated',

--- a/src/data/adapters/memory/user-repository.memory.ts
+++ b/src/data/adapters/memory/user-repository.memory.ts
@@ -6,13 +6,13 @@ import type { Store } from './store';
 // メモリストアを使ったユーザーリポジトリを生成する関数
 export function makeUserRepo(store: Store): UserRepository {
   return {
-    // ID で 1 件取得 (見つからなければ null)
+    // ID で 1 件取得 (認証フロー用。tenantId スコープなし)
     async findById(id) {
       const u = store.users.get(id); // Map から取得
       return u ? { ...u } : null; // 破壊防止のためスプレッドで複製して返す
     },
 
-    // メールアドレスで 1 件取得 (線形検索)
+    // メールアドレスで 1 件取得 (ログイン用。テナント横断検索)
     async findByEmail(email) {
       // 全ユーザーを走査
       for (const u of store.users.values()) {
@@ -23,12 +23,13 @@ export function makeUserRepo(store: Store): UserRepository {
       return null;
     },
 
-    // agent または admin を名前順で一覧取得
-    async listAgents() {
+    // 当該テナント内の agent または admin を名前順で一覧取得
+    async listAgents(tenantId) {
       // 結果を入れる配列を準備
       const agents: UserSummary[] = [];
-      // 全ユーザーを走査し、エージェント系だけ抽出
+      // 全ユーザーを走査し、テナント一致かつエージェント系だけ抽出
       for (const u of store.users.values()) {
+        if (u.tenantId !== tenantId) continue; // 他テナントは除外
         if (u.role === 'agent' || u.role === 'admin') {
           agents.push({ id: u.id, name: u.name });
         }
@@ -39,26 +40,28 @@ export function makeUserRepo(store: Store): UserRepository {
       return agents;
     },
 
-    // agent または admin の ID だけを一覧取得 (通知一斉送信などに使用)
-    async listAgentIds() {
+    // 当該テナント内の agent または admin の ID だけを一覧取得
+    async listAgentIds(tenantId) {
       // 結果 ID 配列
       const ids: string[] = [];
-      // 全ユーザーを走査し、対象の ID を追加
+      // 全ユーザーを走査し、テナント一致かつ対象ロールの ID を追加
       for (const u of store.users.values()) {
+        if (u.tenantId !== tenantId) continue; // 他テナントは除外
         if (u.role === 'agent' || u.role === 'admin') ids.push(u.id);
       }
       // 結果を返す
       return ids;
     },
 
-    // 指定 ID 群に含まれるユーザーの概要をまとめて返す
-    async findSummariesByIds(ids) {
+    // 指定 ID 群に含まれる当該テナント内ユーザーの概要をまとめて返す
+    async findSummariesByIds(ids, tenantId) {
       // 検索効率化のため ID を Set にする
       const set = new Set(ids);
       // 結果配列
       const out: UserSummary[] = [];
-      // 全ユーザーを走査し、Set に含まれる ID だけ抽出
+      // 全ユーザーを走査し、テナント一致かつ ID 一致だけ抽出
       for (const u of store.users.values()) {
+        if (u.tenantId !== tenantId) continue; // 他テナントは除外
         if (set.has(u.id)) out.push({ id: u.id, name: u.name });
       }
       // 結果を返す

--- a/src/data/adapters/prisma/category-repository.prisma.ts
+++ b/src/data/adapters/prisma/category-repository.prisma.ts
@@ -5,10 +5,11 @@ import type { PrismaLike } from './types';
 // Prisma クライアントを使ったカテゴリリポジトリを生成する関数
 export function makeCategoryRepo(db: PrismaLike): CategoryRepository {
   return {
-    // 全カテゴリを名前昇順で取得
-    async list() {
-      // Prisma の findMany で全件取得 (select で列を限定)
+    // 当該テナントのカテゴリを名前昇順で取得
+    async list(tenantId) {
+      // Prisma の findMany で tenantId スコープのみ全件取得
       const rows = await db.category.findMany({
+        where: { tenantId }, // テナントスコープ (必須)
         orderBy: { name: 'asc' }, // 名前昇順
         select: { id: true, name: true }, // id と name だけ取得
       });

--- a/src/data/adapters/prisma/faq-repository.prisma.ts
+++ b/src/data/adapters/prisma/faq-repository.prisma.ts
@@ -6,15 +6,16 @@ import type { PrismaLike } from './types';
 // Prisma クライアントを使った FAQ リポジトリを生成する関数
 export function makeFaqRepo(db: PrismaLike): FaqRepository {
   return {
-    // ID で 1 件取得してドメイン型に変換
-    async findById(id) {
-      const row = await db.faqCandidate.findUnique({ where: { id } });
+    // ID + tenantId で 1 件取得 (他テナントの ID なら null)
+    async findById(id, tenantId) {
+      const row = await db.faqCandidate.findFirst({ where: { id, tenantId } });
       return row ? toFaq(row) : null;
     },
 
-    // 一覧取得 (新しい順、関連チケットと作成者を同梱)
-    async list() {
+    // 当該テナントの FAQ 候補一覧を取得 (新しい順、関連チケットと作成者を同梱)
+    async list(tenantId) {
       const rows = await db.faqCandidate.findMany({
+        where: { tenantId }, // テナントスコープ (必須)
         orderBy: { createdAt: 'desc' }, // 新しい順
         include: {
           // 関連チケットの最小情報を JOIN
@@ -46,9 +47,9 @@ export function makeFaqRepo(db: PrismaLike): FaqRepository {
       return toFaq(row);
     },
 
-    // 状態 (Candidate/Published/Rejected) を更新
-    async updateStatus(id, status) {
-      await db.faqCandidate.update({ where: { id }, data: { status } });
+    // 状態 (Candidate/Published/Rejected) を更新 (tenantId スコープ)
+    async updateStatus(id, status, tenantId) {
+      await db.faqCandidate.updateMany({ where: { id, tenantId }, data: { status } });
     },
   };
 }

--- a/src/data/adapters/prisma/notification-repository.prisma.ts
+++ b/src/data/adapters/prisma/notification-repository.prisma.ts
@@ -24,15 +24,15 @@ export function makeNotificationRepo(db: PrismaLike): NotificationRepository {
       return toNotification(row);
     },
 
-    // 未読件数を取得 (DB 側で count)
-    async countUnread(userId) {
-      return db.notification.count({ where: { userId, read: false } });
+    // 未読件数を取得 (DB 側で count、tenantId スコープ)
+    async countUnread(userId, tenantId) {
+      return db.notification.count({ where: { tenantId, userId, read: false } });
     },
 
-    // 指定ユーザーの通知を新しい順に limit 件取得 (関連チケット付き)
-    async list(userId, { limit }) {
+    // 指定ユーザーの通知を新しい順に limit 件取得 (関連チケット付き、tenantId スコープ)
+    async list(userId, { limit }, tenantId) {
       const rows = await db.notification.findMany({
-        where: { userId },
+        where: { tenantId, userId }, // テナント + ユーザーで絞る
         orderBy: { createdAt: 'desc' }, // 新しい順
         take: limit, // 件数上限
         include: { ticket: { select: { id: true, title: true } } }, // 関連チケットを JOIN
@@ -44,7 +44,7 @@ export function makeNotificationRepo(db: PrismaLike): NotificationRepository {
       }));
     },
 
-    // 指定ユーザーの未読を一括で既読に更新
+    // 指定ユーザーの未読を一括で既読に更新 (ユーザーは単一テナント帰属なので tenantId 不要)
     async markAllRead(userId) {
       await db.notification.updateMany({ where: { userId, read: false }, data: { read: true } });
     },

--- a/src/data/adapters/prisma/ticket-repository.prisma.ts
+++ b/src/data/adapters/prisma/ticket-repository.prisma.ts
@@ -14,10 +14,11 @@ import { toTicket, toTicketWithRefs, toUserSummary, toComment, toHistory } from 
 // Prisma クライアント共通型
 import type { PrismaLike } from './types';
 
-// ドメインのフィルター条件を Prisma の WhereInput に変換するヘルパー
-function buildWhere(f: TicketListFilter): Prisma.TicketWhereInput {
-  // 初期値は空 (条件なし)
-  const where: Prisma.TicketWhereInput = {};
+// ドメインのフィルター条件 + tenantId を Prisma の WhereInput に変換するヘルパー
+// tenantId は **必ず AND 条件として注入** し、テナント越境参照を遮断する
+function buildWhere(f: TicketListFilter, tenantId: string): Prisma.TicketWhereInput {
+  // テナントスコープを最初に確定 (他フィルタはこの上に積み上げる)
+  const where: Prisma.TicketWhereInput = { tenantId };
   // 各フィルタが指定されていれば条件を積み上げる
   if (f.creatorId !== undefined) where.creatorId = f.creatorId;
   if (f.status !== undefined) where.status = f.status;
@@ -48,22 +49,26 @@ const REFS_INCLUDE = {
 // Prisma クライアントを使ったチケットリポジトリを生成する関数
 export function makeTicketRepo(db: PrismaLike): TicketRepository {
   return {
-    // 最小フィールドのチケットを 1 件取得 (ドメイン型変換)
-    async findById(id) {
-      const row = await db.ticket.findUnique({ where: { id } });
+    // 最小フィールドのチケットを 1 件取得 (tenantId スコープ、他テナントの ID なら null)
+    async findById(id, tenantId) {
+      // findFirst で複合条件 (id + tenantId) の AND 一致を検索
+      const row = await db.ticket.findFirst({ where: { id, tenantId } });
       return row ? toTicket(row) : null;
     },
 
-    // 関連情報付きで 1 件取得 (一覧/詳細以外のユースケース)
-    async findByIdWithRefs(id) {
-      const row = await db.ticket.findUnique({ where: { id }, include: REFS_INCLUDE });
+    // 関連情報付きで 1 件取得 (tenantId スコープ)
+    async findByIdWithRefs(id, tenantId) {
+      const row = await db.ticket.findFirst({
+        where: { id, tenantId },
+        include: REFS_INCLUDE,
+      });
       return row ? toTicketWithRefs(row) : null;
     },
 
-    // 詳細ページ用: 関連 + コメント + 履歴 + FAQ 候補を一括取得
-    async findByIdWithDetail(id) {
-      const row = await db.ticket.findUnique({
-        where: { id },
+    // 詳細ページ用: 関連 + コメント + 履歴 + FAQ 候補を一括取得 (tenantId スコープ)
+    async findByIdWithDetail(id, tenantId) {
+      const row = await db.ticket.findFirst({
+        where: { id, tenantId },
         include: {
           ...REFS_INCLUDE, // 起票者/担当者/カテゴリ
           // コメントは古い順に、投稿者名を JOIN
@@ -97,10 +102,10 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
       };
     },
 
-    // 一覧取得 (フィルタ/ソート/ページング)
-    async list({ filter, page, sort }) {
+    // 一覧取得 (フィルタ/ソート/ページング、tenantId スコープ)
+    async list({ filter, page, sort, tenantId }) {
       const rows = await db.ticket.findMany({
-        where: buildWhere(filter), // ドメイン条件を Prisma 条件に変換
+        where: buildWhere(filter, tenantId), // tenantId を必ず注入
         orderBy: { createdAt: sort?.direction ?? 'desc' }, // 既定は降順
         skip: page.skip, // オフセット
         take: page.take, // ページサイズ
@@ -110,36 +115,39 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
       return rows.map(toTicketWithRefs);
     },
 
-    // 件数取得 (ページング用)
-    async count(filter) {
-      return db.ticket.count({ where: buildWhere(filter) });
+    // 件数取得 (tenantId スコープ)
+    async count(filter, tenantId) {
+      return db.ticket.count({ where: buildWhere(filter, tenantId) });
     },
 
-    // ダッシュボード一括取得 (status 別件数 / SLA 超過 / 担当者別ワークロード)
-    async dashboardStats({ creatorId, now, excludeStatusesForWorkload }) {
-      // 起票者フィルタ (省略時は空オブジェクト = 全件)
-      const baseWhere: Prisma.TicketWhereInput =
-        creatorId !== undefined ? { creatorId } : {};
+    // ダッシュボード一括取得 (status 別件数 / SLA 超過 / 担当者別ワークロード、tenantId スコープ)
+    async dashboardStats({ creatorId, now, excludeStatusesForWorkload, tenantId }) {
+      // ベース where: テナントを必ず固定し、起票者フィルタは byStatus 用にだけ適用
+      const baseWhere: Prisma.TicketWhereInput = { tenantId };
+      // 起票者フィルタを追加した where (byStatus 専用)
+      const byStatusWhere: Prisma.TicketWhereInput =
+        creatorId !== undefined ? { ...baseWhere, creatorId } : baseWhere;
       // 3 種類のクエリを並列実行 (1 ラウンドトリップ分の待ち時間で完了)
       const [grouped, slaOverdue, workload] = await Promise.all([
-        // status 別件数を 1 回の groupBy で取得
+        // status 別件数を 1 回の groupBy で取得 (byStatusWhere = テナント + 起票者)
         db.ticket.groupBy({
           by: ['status'],
-          where: baseWhere,
+          where: byStatusWhere,
           _count: { id: true },
         }),
-        // SLA 超過件数 (未解決かつ期限切れ)
+        // SLA 超過件数 (テナント内かつ未解決かつ期限切れ)
         db.ticket.count({
           where: {
+            ...baseWhere,
             resolutionDueAt: { lt: now },
             resolvedAt: null,
             status: { notIn: ['Resolved', 'Closed'] },
           },
         }),
-        // 担当者別の保持件数 (指定状態は除外)
+        // 担当者別の保持件数 (テナント内、指定状態は除外)
         db.ticket.groupBy({
           by: ['assigneeId'],
-          where: { status: { notIn: excludeStatusesForWorkload } },
+          where: { ...baseWhere, status: { notIn: excludeStatusesForWorkload } },
           _count: { id: true },
           orderBy: { _count: { id: 'desc' } },
         }),
@@ -188,25 +196,25 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
       return toTicketWithRefs(row);
     },
 
-    // 状態と解決日時を更新
-    async updateStatus(id, status, resolvedAt) {
-      await db.ticket.update({ where: { id }, data: { status, resolvedAt } });
+    // 状態と解決日時を更新 (tenantId スコープ。updateMany で id+tenantId AND 一致のみ更新)
+    async updateStatus(id, status, resolvedAt, tenantId) {
+      await db.ticket.updateMany({ where: { id, tenantId }, data: { status, resolvedAt } });
     },
 
-    // 優先度を更新
-    async updatePriority(id, priority) {
-      await db.ticket.update({ where: { id }, data: { priority } });
+    // 優先度を更新 (tenantId スコープ)
+    async updatePriority(id, priority, tenantId) {
+      await db.ticket.updateMany({ where: { id, tenantId }, data: { priority } });
     },
 
-    // 担当者を更新 (null で未アサインに戻す)
-    async updateAssignee(id, assigneeId) {
-      await db.ticket.update({ where: { id }, data: { assigneeId } });
+    // 担当者を更新 (tenantId スコープ、null で未アサインに戻す)
+    async updateAssignee(id, assigneeId, tenantId) {
+      await db.ticket.updateMany({ where: { id, tenantId }, data: { assigneeId } });
     },
 
-    // エスカレーション扱いに更新 (状態 + 理由 + 実行時刻)
-    async markEscalated(id, args) {
-      await db.ticket.update({
-        where: { id },
+    // エスカレーション扱いに更新 (tenantId スコープ)
+    async markEscalated(id, args, tenantId) {
+      await db.ticket.updateMany({
+        where: { id, tenantId },
         data: {
           status: 'Escalated',
           escalatedAt: args.at,

--- a/src/data/adapters/prisma/user-repository.prisma.ts
+++ b/src/data/adapters/prisma/user-repository.prisma.ts
@@ -6,22 +6,22 @@ import type { PrismaLike } from './types';
 // Prisma クライアントを使ったユーザーリポジトリを生成する関数
 export function makeUserRepo(db: PrismaLike): UserRepository {
   return {
-    // ID で 1 件取得し、ドメイン型 User に変換して返す
+    // ID で 1 件取得 (認証フロー用。tenantId スコープなしでテナント横断検索)
     async findById(id) {
       const row = await db.user.findUnique({ where: { id } }); // 主キー検索
       return row ? toUser(row) : null; // 見つかれば変換、無ければ null
     },
 
-    // メールアドレスで 1 件取得 (ログインで使用)
+    // メールアドレスで 1 件取得 (ログイン用。テナント横断検索)
     async findByEmail(email) {
       const row = await db.user.findUnique({ where: { email } }); // メール一致検索
       return row ? toUser(row) : null;
     },
 
-    // agent または admin の一覧を名前順で取得 (UserSummary に変換)
-    async listAgents() {
+    // 当該テナント内の agent または admin を名前順で取得 (担当者候補)
+    async listAgents(tenantId) {
       const rows = await db.user.findMany({
-        where: { role: { in: ['agent', 'admin'] } }, // agent か admin のみ
+        where: { tenantId, role: { in: ['agent', 'admin'] } }, // テナント + ロールで絞る
         select: { id: true, name: true }, // 必要列のみ
         orderBy: { name: 'asc' }, // 名前昇順
       });
@@ -29,22 +29,22 @@ export function makeUserRepo(db: PrismaLike): UserRepository {
       return rows.map(toUserSummary);
     },
 
-    // agent または admin の ID だけを取得 (通知一斉送信などに使用)
-    async listAgentIds() {
+    // 当該テナント内の agent または admin の ID だけを取得 (通知一斉送信用)
+    async listAgentIds(tenantId) {
       const rows = await db.user.findMany({
-        where: { role: { in: ['agent', 'admin'] } },
+        where: { tenantId, role: { in: ['agent', 'admin'] } }, // テナント + ロールで絞る
         select: { id: true }, // id だけ
       });
       // id の配列に変換して返す
       return rows.map((r) => r.id);
     },
 
-    // 指定 ID 配列に一致するユーザーの概要を一括取得
-    async findSummariesByIds(ids) {
+    // 指定 ID 配列に一致する当該テナント内ユーザーの概要を一括取得
+    async findSummariesByIds(ids, tenantId) {
       // 空配列で findMany を呼ぶと無駄なので早期 return
       if (ids.length === 0) return [];
       const rows = await db.user.findMany({
-        where: { id: { in: ids } }, // IN 検索
+        where: { tenantId, id: { in: ids } }, // テナント + IN 検索
         select: { id: true, name: true },
       });
       // UserSummary 形式に変換して返す

--- a/src/data/ports/category-repository.ts
+++ b/src/data/ports/category-repository.ts
@@ -5,9 +5,10 @@ export interface CategorySummary {
 }
 
 // カテゴリ取得用リポジトリの契約 (port)
+// 全メソッドが tenantId 必須化済み。テナント越境参照を Adapter 層で遮断する
 export interface CategoryRepository {
-  list(): Promise<CategorySummary[]>; // 全カテゴリを取得する
-  // ID 指定で 1 件取得。tenantId 必須でテナント越境参照を防止する
-  // (Phase 0: 全 Port を tenant スコープ化するまでの第一歩)
+  // 当該テナントのカテゴリ一覧を取得
+  list(tenantId: string): Promise<CategorySummary[]>;
+  // ID 指定で 1 件取得 (他テナントの ID なら null を返す)
   findById(id: string, tenantId: string): Promise<CategorySummary | null>;
 }

--- a/src/data/ports/faq-repository.ts
+++ b/src/data/ports/faq-repository.ts
@@ -17,9 +17,14 @@ export interface FaqListItem extends FaqCandidate {
 }
 
 // FAQ リポジトリの契約 (port)
+// 全メソッドが tenantId 必須化済み。テナント越境参照/更新を Adapter 層で遮断する
 export interface FaqRepository {
-  findById(id: string): Promise<FaqCandidate | null>; // ID で 1 件取得
-  list(): Promise<FaqListItem[]>; // 一覧取得
-  create(input: CreateFaqInput): Promise<FaqCandidate>; // 候補を作成
-  updateStatus(id: string, status: FaqStatus): Promise<void>; // 公開/却下などの状態更新
+  // ID + tenantId で 1 件取得 (他テナントの ID なら null)
+  findById(id: string, tenantId: string): Promise<FaqCandidate | null>;
+  // 当該テナントの FAQ 候補一覧を取得
+  list(tenantId: string): Promise<FaqListItem[]>;
+  // 候補を作成 (input.tenantId 必須)
+  create(input: CreateFaqInput): Promise<FaqCandidate>;
+  // 公開/却下などの状態更新 (tenantId スコープ。他テナントの ID なら 0 件更新で no-op)
+  updateStatus(id: string, status: FaqStatus, tenantId: string): Promise<void>;
 }

--- a/src/data/ports/notification-repository.ts
+++ b/src/data/ports/notification-repository.ts
@@ -16,9 +16,16 @@ export interface NotificationListItem extends Notification {
 }
 
 // 通知ストアの契約 (port)
+// 取得系 (countUnread / list) は **tenantId 必須**。クロステナント漏洩防止のため、
+// 通知を引くときは必ず「当該ユーザー かつ 当該テナント」でフィルタする。
+// markAllRead は単一ユーザースコープなので tenantId 不要 (User は単一テナントに帰属)。
 export interface NotificationRepository {
-  create(input: CreateNotificationInput): Promise<Notification>; // 通知を 1 件作成
-  countUnread(userId: string): Promise<number>; // 未読件数を取得
-  list(userId: string, opts: { limit: number }): Promise<NotificationListItem[]>; // 一覧取得
-  markAllRead(userId: string): Promise<void>; // 全通知を既読にする
+  create(input: CreateNotificationInput): Promise<Notification>; // 通知を 1 件作成 (input.tenantId 必須)
+  countUnread(userId: string, tenantId: string): Promise<number>; // 未読件数を取得
+  list(
+    userId: string,
+    opts: { limit: number },
+    tenantId: string,
+  ): Promise<NotificationListItem[]>; // 一覧取得
+  markAllRead(userId: string): Promise<void>; // 全通知を既読にする (ユーザースコープのみ)
 }

--- a/src/data/ports/ticket-repository.ts
+++ b/src/data/ports/ticket-repository.ts
@@ -64,35 +64,52 @@ export interface MarkEscalatedInput {
 }
 
 // チケットリポジトリの契約 (port)
+// 全メソッドの ID 系引数は tenantId 必須化済。テナント越境参照/更新を Adapter 層で遮断する
 export interface TicketRepository {
-  findById(id: string): Promise<Ticket | null>; // ID で 1 件取得 (最小フィールド)
-  findByIdWithRefs(id: string): Promise<TicketWithRefs | null>; // 関連ユーザー/カテゴリ付きで 1 件取得
-  findByIdWithDetail(id: string): Promise<TicketDetail | null>; // 詳細ページ用に 1 件取得
+  // ID + tenantId で 1 件取得 (最小フィールド)。他テナントの ID なら null を返す
+  findById(id: string, tenantId: string): Promise<Ticket | null>;
+  // ID + tenantId で関連ユーザー/カテゴリ付きで 1 件取得
+  findByIdWithRefs(id: string, tenantId: string): Promise<TicketWithRefs | null>;
+  // ID + tenantId で詳細ページ用に 1 件取得 (コメント/履歴/FAQ 候補を同梱)
+  findByIdWithDetail(id: string, tenantId: string): Promise<TicketDetail | null>;
 
-  // 一覧取得 (絞り込み + ページング + ソート)
+  // 一覧取得 (絞り込み + ページング + ソート、tenantId スコープ)
   list(args: {
     filter: TicketListFilter;
     page: Page;
     sort?: Sort<'createdAt'>;
+    tenantId: string; // テナントスコープ (必須)
   }): Promise<TicketWithRefs[]>;
 
-  count(filter: TicketListFilter): Promise<number>; // 件数取得 (ページング用)
+  // 件数取得 (ページング用、tenantId スコープ)
+  count(filter: TicketListFilter, tenantId: string): Promise<number>;
 
   /**
    * ダッシュボード用の一括統計取得。
    * - `creatorId` は **`byStatus` にのみ作用** する (依頼者ロール向けスコープ)
    * - `slaOverdue` / `workload` は常に全件対象 (担当者向け指標)。
    *   呼び出し側が role で表示制御する前提
+   * - `tenantId` で当該テナント内のチケットだけを集計対象に絞る
    */
   dashboardStats(args: {
     creatorId?: string; // byStatus を起票者で絞る (省略時は全件)
     now: Date; // SLA 超過判定の基準時刻
     excludeStatusesForWorkload: TicketStatus[]; // ワークロード集計で除外する状態
+    tenantId: string; // テナントスコープ (必須)
   }): Promise<DashboardStats>; // 上記 3 指標をまとめて返す
 
-  create(input: CreateTicketInput): Promise<TicketWithRefs>; // 新規作成
-  updateStatus(id: string, status: TicketStatus, resolvedAt: Date | null): Promise<void>; // 状態更新
-  updatePriority(id: string, priority: Priority): Promise<void>; // 優先度更新
-  updateAssignee(id: string, assigneeId: string | null): Promise<void>; // 担当者更新
-  markEscalated(id: string, args: MarkEscalatedInput): Promise<void>; // エスカレーション状態にする
+  create(input: CreateTicketInput): Promise<TicketWithRefs>; // 新規作成 (input.tenantId 必須)
+  // 状態更新 (tenantId スコープ。他テナントの ID なら 0 件更新で no-op)
+  updateStatus(
+    id: string,
+    status: TicketStatus,
+    resolvedAt: Date | null,
+    tenantId: string,
+  ): Promise<void>;
+  // 優先度更新 (tenantId スコープ)
+  updatePriority(id: string, priority: Priority, tenantId: string): Promise<void>;
+  // 担当者更新 (tenantId スコープ。null で未アサイン)
+  updateAssignee(id: string, assigneeId: string | null, tenantId: string): Promise<void>;
+  // エスカレーション状態にする (tenantId スコープ)
+  markEscalated(id: string, args: MarkEscalatedInput, tenantId: string): Promise<void>;
 }

--- a/src/data/ports/user-repository.ts
+++ b/src/data/ports/user-repository.ts
@@ -2,11 +2,14 @@
 import type { User, UserSummary } from '@/domain/types';
 
 // ユーザー取得系リポジトリの契約 (port)
+// 認証フローで使う findById / findByEmail は **tenantId スコープなし** (どのテナントに
+// 属するかを判定するためにこそユーザーを引くので、ここで scope を強制すると鶏卵問題になる)。
+// 一方、UI から候補を引く系のメソッドは全て tenantId 必須でクロステナント漏洩を防ぐ。
 export interface UserRepository {
-  findById(id: string): Promise<User | null>; // ID 指定で 1 件取得
-  findByEmail(email: string): Promise<User | null>; // メール指定で 1 件取得 (ログインで利用)
-  /** Agents and admins. */
-  listAgents(): Promise<UserSummary[]>; // agent と admin の一覧 (アサイン候補)
-  listAgentIds(): Promise<string[]>; // agent と admin の ID だけの一覧 (通知用)
-  findSummariesByIds(ids: string[]): Promise<UserSummary[]>; // ID 配列から概要をまとめて取得
+  findById(id: string): Promise<User | null>; // ID 指定で 1 件取得 (認証用、テナント横断)
+  findByEmail(email: string): Promise<User | null>; // メール指定で 1 件取得 (ログイン用、テナント横断)
+  /** Agents and admins in the given tenant. */
+  listAgents(tenantId: string): Promise<UserSummary[]>; // 当該テナント内の agent/admin 一覧
+  listAgentIds(tenantId: string): Promise<string[]>; // 当該テナント内の agent/admin の ID だけ
+  findSummariesByIds(ids: string[], tenantId: string): Promise<UserSummary[]>; // テナント内 ID 配列から概要
 }

--- a/src/features/faq/actions/faq-actions.ts
+++ b/src/features/faq/actions/faq-actions.ts
@@ -19,12 +19,14 @@ import { faqCandidateSchema } from '@/lib/validations/faq';
 export async function createFaqCandidate(ticketId: string, question: string, answer: string) {
   // ログインセッションを取得
   const session = await auth();
-  // 未ログインなら即エラー (認可前チェック)
-  if (!session?.user?.id) throw new Error('Unauthorized');
+  // 未ログイン or tenantId 不在なら即エラー (認可前チェック)
+  if (!session?.user?.id || !session.user.tenantId) throw new Error('Unauthorized');
   // エージェント/管理者でなければ操作禁止
   if (!isAgent(session.user.role)) {
     throw new Error('エージェントまたは管理者のみ実行できます');
   }
+  // セッションから tenantId を取り出して以降の where 句注入に使う
+  const tenantId = session.user.tenantId;
   // ユーザー単位で 60 秒あたり最大 10 件までに制限 (連打防止)
   enforceRateLimit(`faq-create:${session.user.id}`, { limit: 10, windowMs: 60_000 });
 
@@ -35,8 +37,8 @@ export async function createFaqCandidate(ticketId: string, question: string, ans
     throw new Error(parsed.error.issues[0]?.message ?? 'FAQ候補の入力値が不正です');
   }
 
-  // 対象チケットを取得 (port 経由)
-  const ticket = await repos.tickets.findById(ticketId);
+  // 対象チケットを tenantId スコープで取得 (port 経由)
+  const ticket = await repos.tickets.findById(ticketId, tenantId);
   // 無ければエラー
   if (!ticket) throw new Error('チケットが見つかりません');
   // 解決済み以外は FAQ 化不可
@@ -64,26 +66,28 @@ export async function createFaqCandidate(ticketId: string, question: string, ans
 export async function updateFaqStatus(faqId: string, status: 'Published' | 'Rejected') {
   // セッション取得
   const session = await auth();
-  // 未ログインなら拒否
-  if (!session?.user?.id) throw new Error('Unauthorized');
+  // 未ログイン or tenantId 不在なら拒否
+  if (!session?.user?.id || !session.user.tenantId) throw new Error('Unauthorized');
   // エージェント/管理者以外は拒否
   if (!isAgent(session.user.role)) {
     throw new Error('エージェントまたは管理者のみ実行できます');
   }
+  // セッションから tenantId を取り出して以降の where 句注入に使う
+  const tenantId = session.user.tenantId;
   // 60 秒あたり 20 回までに制限
   enforceRateLimit(`faq-update:${session.user.id}`, { limit: 20, windowMs: 60_000 });
 
-  // 対象 FAQ 候補を取得 (port 経由)
-  const faq = await repos.faq.findById(faqId);
-  // 見つからなければエラー
+  // 対象 FAQ 候補を tenantId スコープで取得 (port 経由)
+  const faq = await repos.faq.findById(faqId, tenantId);
+  // 見つからない or 他テナントの ID ならエラー
   if (!faq) throw new Error('FAQ候補が見つかりません');
   // 既に公開/却下済みのものは対象外
   if (faq.status !== 'Candidate') {
     throw new Error('候補ステータスのFAQのみ公開・却下できます');
   }
 
-  // 状態を更新 (port 経由)
-  await repos.faq.updateStatus(faqId, status);
+  // 状態を更新 (tenantId スコープで where に注入、port 経由)
+  await repos.faq.updateStatus(faqId, status, tenantId);
   // FAQ 一覧のキャッシュを無効化
   revalidatePath('/faq');
 }

--- a/src/features/notifications/notify.ts
+++ b/src/features/notifications/notify.ts
@@ -16,20 +16,26 @@ import { repos } from '@/data';
 // SSE の送信関数
 import { broadcast } from '@/lib/sse-subscribers';
 
-// 指定ユーザー 1 人に対して未読件数を再計算して配信する
-export async function broadcastUnreadCount(userId: string): Promise<void> {
+// 指定ユーザー × テナントの未読件数を再計算して配信する
+// 通知は必ずテナント単位なので、count 取得時も同じ tenantId スコープで集計する
+export async function broadcastUnreadCount(userId: string, tenantId: string): Promise<void> {
   // キャッシュされた未読件数を無効化 (次の取得で再計算させる)
   revalidateTag(`notification-count-${userId}`);
-  // 最新件数を直接 DB から数える
-  const count = await repos.notifications.countUnread(userId);
+  // 最新件数を直接 DB から数える (tenantId スコープ)
+  const count = await repos.notifications.countUnread(userId, tenantId);
   // 取得した件数を SSE で即時配信
   broadcast(userId, count);
 }
 
-// 複数ユーザー向けにまとめて未読件数を再配信するヘルパー
-export async function broadcastUnreadCountToMany(userIds: Iterable<string>): Promise<void> {
+// 複数ユーザー向けにまとめて未読件数を再配信するヘルパー (全員が同一テナント前提)
+// チケット起点の通知扇形 (担当者通知/エスカレーション通知/コメント通知) ではチケットの
+// テナントに属するユーザーだけが対象なので、テナントは 1 つで足りる
+export async function broadcastUnreadCountToMany(
+  userIds: Iterable<string>,
+  tenantId: string,
+): Promise<void> {
   // 重複 ID を除去した配列に変換 (同じユーザーに 2 度配信しないため)
   const unique = Array.from(new Set(userIds));
-  // 並列に全ユーザーへ配信
-  await Promise.all(unique.map(broadcastUnreadCount));
+  // 並列に全ユーザーへ配信 (同じテナントを伝搬)
+  await Promise.all(unique.map((uid) => broadcastUnreadCount(uid, tenantId)));
 }

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -25,6 +25,8 @@ import type { Session } from 'next-auth';
 function assertAuthenticatedUser(session: Session | null): asserts session is Session {
   // ユーザー ID が無ければ未ログインとみなしてエラー
   if (!session?.user?.id) throw new Error('Unauthorized');
+  // tenantId 不在は middleware で弾く想定だが、Server Action でも防御的にチェック
+  if (!session.user.tenantId) throw new Error('Unauthorized');
 }
 
 // セッションがエージェント/管理者権限を持つことを保証するアサーション関数
@@ -43,14 +45,16 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
   const session = await auth();
   // エージェント以上の権限を要求
   assertAgentRole(session);
+  // セッションから tenantId を取り出して以降の where 句注入に使う
+  const tenantId = session.user.tenantId;
   // 10 秒あたり 10 回までに制限 (チケット単位)
   enforceRateLimit(`ticket-status:${session.user.id}:${ticketId}`, { limit: 10, windowMs: 10_000 });
 
   // 1 トランザクションでチケット更新と履歴記録を実行
   await uow.run(async (r) => {
-    // 対象チケットを取得
-    const ticket = await r.tickets.findById(ticketId);
-    // 見つからなければエラー
+    // 対象チケットを tenantId スコープで取得
+    const ticket = await r.tickets.findById(ticketId, tenantId);
+    // 見つからない or 他テナントの ID ならエラー
     if (!ticket) throw new Error('チケットが見つかりません');
     // 変更前後が同じなら何もしない (冪等)
     if (ticket.status === newStatus) return;
@@ -69,8 +73,8 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
           ? null
           : ticket.resolvedAt;
 
-    // ステータスと解決日時を更新
-    await r.tickets.updateStatus(ticketId, newStatus, resolvedAt);
+    // ステータスと解決日時を更新 (tenantId スコープで where に注入)
+    await r.tickets.updateStatus(ticketId, newStatus, resolvedAt, tenantId);
     // 変更履歴を残す (誰が/どの項目を/旧値→新値)
     await r.history.record({
       ticketId,
@@ -91,6 +95,8 @@ export async function updateTicketPriority(ticketId: string, newPriority: Priori
   const session = await auth();
   // エージェント以上のみ実行可
   assertAgentRole(session);
+  // テナントスコープ用に tenantId を取り出す
+  const tenantId = session.user.tenantId;
   // 10 秒あたり 10 回までに制限
   enforceRateLimit(`ticket-priority:${session.user.id}:${ticketId}`, {
     limit: 10,
@@ -99,15 +105,15 @@ export async function updateTicketPriority(ticketId: string, newPriority: Priori
 
   // 1 トランザクションで更新と履歴記録
   await uow.run(async (r) => {
-    // チケットを取得
-    const ticket = await r.tickets.findById(ticketId);
+    // チケットを tenantId スコープで取得
+    const ticket = await r.tickets.findById(ticketId, tenantId);
     // 無ければエラー
     if (!ticket) throw new Error('チケットが見つかりません');
     // 変更無しならスキップ
     if (ticket.priority === newPriority) return;
 
-    // 優先度を更新
-    await r.tickets.updatePriority(ticketId, newPriority);
+    // 優先度を更新 (tenantId スコープで where に注入)
+    await r.tickets.updatePriority(ticketId, newPriority, tenantId);
     // 履歴を記録
     await r.history.record({
       ticketId,
@@ -128,6 +134,8 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
   const session = await auth();
   // エージェント以上のみ実行可
   assertAgentRole(session);
+  // テナントスコープ用に tenantId を取り出す
+  const tenantId = session.user.tenantId;
   // 10 秒あたり 10 回までに制限
   enforceRateLimit(`ticket-assignee:${session.user.id}:${ticketId}`, {
     limit: 10,
@@ -135,17 +143,24 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
   });
 
   // チケット (既存担当者含む) と新担当者候補を並列で取得
+  // チケットは tenantId スコープで引き、ユーザーはテナント横断 (後段でテナント一致を検証)
   const [ticket, newUser] = await Promise.all([
-    repos.tickets.findByIdWithRefs(ticketId),
+    repos.tickets.findByIdWithRefs(ticketId, tenantId),
     newAssigneeId ? repos.users.findById(newAssigneeId) : Promise.resolve(null),
   ]);
 
   // チケットが無ければエラー
   if (!ticket) throw new Error('チケットが見つかりません');
-  // 担当者を付ける場合は相手の存在とロールを確認
+  // 担当者を付ける場合は相手の存在 / ロール / テナント一致を確認
   if (newAssigneeId) {
-    // ユーザー未存在 or エージェント/管理者でない場合は拒否理由を特定
-    const reason = !newUser ? 'not-found' : !isAgent(newUser.role) ? 'not-agent' : null;
+    // 拒否理由を特定 (内部診断用、レスポンス本文には漏らさない)
+    const reason = !newUser
+      ? 'not-found'
+      : !isAgent(newUser.role)
+        ? 'not-agent'
+        : newUser.tenantId !== tenantId
+          ? 'cross-tenant' // 別テナントのユーザーを割り当てようとした
+          : null;
     if (reason) {
       // 診断用ログ (不正割当の調査向け)
       console.warn('[updateTicketAssignee] rejected', { ticketId, newAssigneeId, reason });
@@ -159,8 +174,8 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
 
   // 担当者更新・履歴記録・通知作成を 1 トランザクションで実行
   await uow.run(async (r) => {
-    // 担当者を差し替え (解除は null)
-    await r.tickets.updateAssignee(ticketId, newAssigneeId);
+    // 担当者を差し替え (解除は null。tenantId スコープで where に注入)
+    await r.tickets.updateAssignee(ticketId, newAssigneeId, tenantId);
     // 変更履歴を残す
     await r.history.record({
       ticketId,
@@ -182,8 +197,8 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
     }
   });
 
-  // 新担当者に未読件数を SSE で即時配信
-  if (newAssigneeId) await broadcastUnreadCount(newAssigneeId);
+  // 新担当者に未読件数を SSE で即時配信 (テナントを伝搬)
+  if (newAssigneeId) await broadcastUnreadCount(newAssigneeId, tenantId);
   // 詳細ページのキャッシュを無効化
   revalidatePath(`/tickets/${ticketId}`);
 }
@@ -194,6 +209,8 @@ export async function escalateTicket(ticketId: string, reason: string) {
   const session = await auth();
   // エージェント以上のみ実行可
   assertAgentRole(session);
+  // テナントスコープ用に tenantId を取り出す
+  const tenantId = session.user.tenantId;
   // エスカレーションは全エージェントに通知が飛ぶため、通常操作より厳しく制限
   // (60 秒あたり 5 回まで)
   enforceRateLimit(`ticket-escalate:${session.user.id}`, { limit: 5, windowMs: 60_000 });
@@ -207,10 +224,10 @@ export async function escalateTicket(ticketId: string, reason: string) {
   // 検証済み (trim 等済み) の理由を取り出す
   const trimmedReason = parsedReason.data;
 
-  // チケット本体と通知対象の全エージェント ID 一覧を並列取得
+  // チケット本体と通知対象の全エージェント ID 一覧をテナントスコープで並列取得
   const [ticket, agentIds] = await Promise.all([
-    repos.tickets.findById(ticketId),
-    repos.users.listAgentIds(),
+    repos.tickets.findById(ticketId, tenantId),
+    repos.users.listAgentIds(tenantId),
   ]);
 
   // チケットが無ければエラー
@@ -227,8 +244,8 @@ export async function escalateTicket(ticketId: string, reason: string) {
 
   // マーク・履歴・エージェント一斉通知を 1 トランザクションで実行
   await uow.run(async (r) => {
-    // チケットに Escalated フラグと理由/日時を書き込む
-    await r.tickets.markEscalated(ticketId, { reason: trimmedReason, at: now });
+    // チケットに Escalated フラグと理由/日時を書き込む (tenantId スコープ)
+    await r.tickets.markEscalated(ticketId, { reason: trimmedReason, at: now }, tenantId);
     // 変更履歴を残す
     await r.history.record({
       ticketId,
@@ -252,8 +269,8 @@ export async function escalateTicket(ticketId: string, reason: string) {
     );
   });
 
-  // 全エージェントへ未読件数を一斉配信
-  await broadcastUnreadCountToMany(agentIds);
+  // 全エージェントへ未読件数を一斉配信 (テナントを伝搬)
+  await broadcastUnreadCountToMany(agentIds, tenantId);
   // 詳細ページを再描画
   revalidatePath(`/tickets/${ticketId}`);
 }
@@ -264,6 +281,8 @@ export async function addComment(ticketId: string, body: string) {
   const session = await auth();
   // コメントはログイン済みなら (依頼者でも) 可
   assertAuthenticatedUser(session);
+  // テナントスコープ用に tenantId を取り出す
+  const tenantId = session.user.tenantId;
   // 60 秒あたり 20 件までに制限
   enforceRateLimit(`ticket-comment:${session.user.id}`, { limit: 20, windowMs: 60_000 });
 
@@ -276,8 +295,8 @@ export async function addComment(ticketId: string, body: string) {
   // 検証済み本文を取り出す
   const trimmedBody = parsedBody.data;
 
-  // 対象チケットを取得
-  const ticket = await repos.tickets.findById(ticketId);
+  // 対象チケットを tenantId スコープで取得
+  const ticket = await repos.tickets.findById(ticketId, tenantId);
   // 無ければエラー
   if (!ticket) throw new Error('チケットが見つかりません');
 
@@ -291,8 +310,8 @@ export async function addComment(ticketId: string, body: string) {
     throw new Error('このチケットへのコメント権限がありません');
   }
 
-  // 通知対象 (依頼者/担当者/全エージェント など) を算出
-  const recipientIds = await resolveCommentRecipients(ticket, authorId, authorIsAgent);
+  // 通知対象 (依頼者/担当者/全エージェント など) を算出 (tenantId 伝搬)
+  const recipientIds = await resolveCommentRecipients(ticket, authorId, authorIsAgent, tenantId);
   // 通知メッセージ (タイトル入り)
   const message = `チケット「${ticket.title}」に新しいコメントが追加されました`;
 
@@ -319,8 +338,8 @@ export async function addComment(ticketId: string, body: string) {
     );
   });
 
-  // 通知対象が 1 名以上いれば未読件数を一斉配信
-  if (recipientIds.length > 0) await broadcastUnreadCountToMany(recipientIds);
+  // 通知対象が 1 名以上いれば未読件数を一斉配信 (テナントを伝搬)
+  if (recipientIds.length > 0) await broadcastUnreadCountToMany(recipientIds, tenantId);
   // 詳細ページのキャッシュを無効化
   revalidatePath(`/tickets/${ticketId}`);
 }
@@ -330,6 +349,7 @@ async function resolveCommentRecipients(
   ticket: { creatorId: string; assigneeId: string | null },
   authorId: string,
   authorIsAgent: boolean,
+  tenantId: string,
 ): Promise<string[]> {
   // 宛先候補を集める配列
   const candidates: string[] = [];
@@ -341,8 +361,8 @@ async function resolveCommentRecipients(
     // 依頼者がコメントし担当者が決まっている場合は担当者のみ
     candidates.push(ticket.assigneeId);
   } else {
-    // 依頼者がコメントし担当者未定なら全エージェントに通知 (取りこぼし防止)
-    candidates.push(...(await repos.users.listAgentIds()));
+    // 依頼者がコメントし担当者未定なら全エージェントに通知 (取りこぼし防止、テナント内のみ)
+    candidates.push(...(await repos.users.listAgentIds(tenantId)));
   }
   // 重複排除し、コメント投稿者自身は除外して返す
   return Array.from(new Set(candidates)).filter((id) => id !== authorId);

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -3,12 +3,17 @@ import { unstable_cache } from 'next/cache';
 // データ層の Composition Root から通知リポジトリ束を読み込む (Prisma 直叩きを避ける)
 import { repos } from '@/data';
 
-// 指定ユーザーの未読通知件数を取得する関数 (60 秒キャッシュ)
-export function getUnreadNotificationCount(userId: string): Promise<number> {
+// 指定ユーザー × テナントの未読通知件数を取得する関数 (60 秒キャッシュ)
+// 未読件数はテナント単位でも区切られる (ユーザーは単一テナントだが、Adapter 側の where 句に
+// tenantId 注入を強制するため引数として伝搬させる)
+export function getUnreadNotificationCount(userId: string, tenantId: string): Promise<number> {
   // unstable_cache で「同じタグなら 60 秒は使い回す」キャッシュ関数を生成し即呼び出す
   return unstable_cache(
-    (id: string) => repos.notifications.countUnread(id), // 実際の DB カウント (port 経由)
-    ['notification-count'], // キャッシュキーのプレフィックス
-    { tags: [`notification-count-${userId}`], revalidate: 60 }, // 無効化用タグと再検証間隔 (秒)
-  )(userId);
+    // 実際の DB カウント (port 経由、tenantId スコープ)
+    (id: string, tid: string) => repos.notifications.countUnread(id, tid),
+    // キャッシュキーのプレフィックス
+    ['notification-count'],
+    // 無効化用タグ (markAllRead / broadcast 側でも同じタグを使用) と再検証間隔 (秒)
+    { tags: [`notification-count-${userId}`], revalidate: 60 },
+  )(userId, tenantId);
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,9 @@ import { auth } from '@/lib/auth';
 import { NextResponse } from 'next/server';
 import { isAgent } from '@/lib/role';
 
+// 認証ミドルウェア
+// - ログイン状態のチェック (未ログインは /login に飛ばす or API は 401 を返す)
+// - tenantId 不在セッションを強制的にリログインさせる (Phase 0 マルチテナント化の前提)
 export default auth((req) => {
   const isLoggedIn = !!req.auth;
   const isAuthPage = req.nextUrl.pathname.startsWith('/login');
@@ -14,10 +17,21 @@ export default auth((req) => {
     if (!isLoggedIn) {
       return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
     }
+    // ログイン済みでも tenantId が無いセッションは Phase 0 移行以前のもの。
+    // Server Action / Page では tenantId を where に注入するので、ここで弾いてリログインを促す。
+    if (!req.auth?.user?.tenantId) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
     return NextResponse.next();
   }
 
   if (!isLoggedIn && !isAuthPage) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+
+  // 認証済み HTML 遷移でも tenantId 不在なら /login に戻す (旧 JWT 互換性のセーフティネット)
+  // 通常は auth.ts の jwt callback が補完するが、補完失敗時の最後の砦としてここでも判定する
+  if (isLoggedIn && !isAuthPage && !req.auth?.user?.tenantId) {
     return NextResponse.redirect(new URL('/login', req.url));
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -36,6 +36,12 @@ export default auth((req) => {
   }
 
   if (isLoggedIn && isAuthPage) {
+    // tenantId 不在の旧 JWT 補完失敗セッションが /login に到達した場合は
+    // dashboard/tickets に戻さない (アプリ画面側で再度 /login に弾かれてループするため)。
+    // ログイン画面をそのまま表示してパスワード再入力 → 新 JWT 発行を促す
+    if (!req.auth?.user?.tenantId) {
+      return NextResponse.next();
+    }
     const role = req.auth?.user?.role;
     return NextResponse.redirect(new URL(isAgent(role) ? '/dashboard' : '/tickets', req.url));
   }

--- a/tests/data/ticket-repository.contract.test.ts
+++ b/tests/data/ticket-repository.contract.test.ts
@@ -7,8 +7,10 @@ import type { User } from '@/domain/types';
 // 共通契約テストとそのコンテキスト型
 import { runTicketRepositoryContract, type ContractContext } from './ticket-repository.contract';
 
-// 全テストで共有するテナント ID (マルチテナント化後はあらゆる行で必須)
+// 主に使うテナント ID (マルチテナント化後はあらゆる行で必須)
 const TENANT_ID = 'default-tenant';
+// クロステナント回帰テスト用のもう 1 つのテナント ID
+const SECOND_TENANT_ID = 'tenant-b';
 
 // メモリ実装向けに ContractContext を組み立てる
 function makeMemoryContext(): ContractContext {
@@ -61,7 +63,46 @@ function makeMemoryContext(): ContractContext {
     };
   };
 
-  return { repos, uow, seedBasicFixture };
+  // クロステナント回帰テスト用に、もう 1 つのテナントを丸ごと用意する
+  const seedSecondTenant: ContractContext['seedSecondTenant'] = async () => {
+    const now = new Date();
+    // テナント B を投入 (mode は lite で十分)
+    store.tenants.set(SECOND_TENANT_ID, {
+      id: SECOND_TENANT_ID,
+      name: '別組織',
+      mode: 'lite',
+      industry: null,
+      createdAt: now,
+    });
+    // テナント B 専属の依頼者ユーザーを 1 名作る
+    const requesterId = 'u-b-req-1';
+    store.users.set(requesterId, {
+      id: requesterId,
+      email: `${requesterId}@example.com`,
+      name: '田中 一郎',
+      passwordHash: 'x',
+      role: 'requester',
+      tenantId: SECOND_TENANT_ID, // 必ずテナント B のスコープに紐づけ
+      createdAt: now,
+      updatedAt: now,
+    });
+    // テナント B 専属のカテゴリも 1 件作る
+    const categoryId = 'cat-b-1';
+    store.categories.set(categoryId, {
+      id: categoryId,
+      name: '別組織カテゴリ',
+      createdAt: now,
+      tenantId: SECOND_TENANT_ID,
+    });
+    // クロステナント検証用の最小セット (テナント ID / 依頼者 / カテゴリ ID) を返す
+    return {
+      tenantId: SECOND_TENANT_ID,
+      requester: store.users.get(requesterId)!,
+      categoryId,
+    };
+  };
+
+  return { repos, uow, seedBasicFixture, seedSecondTenant };
 }
 
 // メモリアダプタが TicketRepository 契約を満たしているかを実行

--- a/tests/data/ticket-repository.contract.ts
+++ b/tests/data/ticket-repository.contract.ts
@@ -14,6 +14,9 @@ import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
 // シード返り値で使うユーザー型
 import type { User } from '@/domain/types';
 
+// 既定で使うテナント ID (旧テストは単一テナントを前提に書かれているのでここで共通化)
+const TENANT_ID = 'default-tenant';
+
 // 契約テストが利用する文脈 (アダプタ別に差し替え可能)
 export interface ContractContext {
   repos: Repos;
@@ -25,6 +28,11 @@ export interface ContractContext {
     agentB: User;
     categoryId: string;
   }>;
+  /**
+   * Seeds an additional, isolated tenant ('tenant-b') with one requester user.
+   * Used by cross-tenant regression tests to verify Adapter-side scoping.
+   */
+  seedSecondTenant: () => Promise<{ tenantId: string; requester: User; categoryId: string }>;
 }
 
 // アダプタごとに渡される ContractContext で同一テストを実行する関数
@@ -50,14 +58,14 @@ export function runTicketRepositoryContract(
         priority: 'High',
         creatorId: requester.id,
         categoryId,
-        tenantId: 'default-tenant',
+        tenantId: TENANT_ID,
       });
       // 初期ステータスは New、作成者も正しく結びつく
       expect(created.status).toBe('New');
       expect(created.creator.id).toBe(requester.id);
 
-      // ID で取り直して内容が一致すること
-      const found = await ctx.repos.tickets.findById(created.id);
+      // ID + tenantId で取り直して内容が一致すること
+      const found = await ctx.repos.tickets.findById(created.id, TENANT_ID);
       expect(found?.title).toBe('ログインできません');
       expect(found?.priority).toBe('High');
     });
@@ -72,7 +80,7 @@ export function runTicketRepositoryContract(
         priority: 'Low',
         creatorId: requester.id,
         categoryId,
-        tenantId: 'default-tenant',
+        tenantId: TENANT_ID,
       });
       // メモリ実装で createdAt が同一にならないよう少し待つ
       await new Promise((r) => setTimeout(r, 2));
@@ -83,13 +91,14 @@ export function runTicketRepositoryContract(
         priority: 'Medium',
         creatorId: agentA.id,
         categoryId,
-        tenantId: 'default-tenant',
+        tenantId: TENANT_ID,
       });
 
-      // 依頼者で絞ると古い方だけが返る
+      // 依頼者で絞ると古い方だけが返る (tenantId 必須)
       const requesterOnly = await ctx.repos.tickets.list({
         filter: { creatorId: requester.id },
         page: { skip: 0, take: 50 },
+        tenantId: TENANT_ID,
       });
       expect(requesterOnly.map((t) => t.id)).toEqual([t1.id]);
 
@@ -97,6 +106,7 @@ export function runTicketRepositoryContract(
       const all = await ctx.repos.tickets.list({
         filter: {},
         page: { skip: 0, take: 50 },
+        tenantId: TENANT_ID,
       });
       expect(all.map((t) => t.id)).toEqual([t2.id, t1.id]);
     });
@@ -111,7 +121,7 @@ export function runTicketRepositoryContract(
         priority: 'Medium',
         creatorId: requester.id,
         categoryId,
-        tenantId: 'default-tenant',
+        tenantId: TENANT_ID,
       });
       // 本文に小文字の "vpn" を含む
       await ctx.repos.tickets.create({
@@ -120,7 +130,7 @@ export function runTicketRepositoryContract(
         priority: 'Low',
         creatorId: requester.id,
         categoryId,
-        tenantId: 'default-tenant',
+        tenantId: TENANT_ID,
       });
       // どちらにも含まないノイズ
       await ctx.repos.tickets.create({
@@ -129,20 +139,24 @@ export function runTicketRepositoryContract(
         priority: 'Low',
         creatorId: requester.id,
         categoryId,
-        tenantId: 'default-tenant',
+        tenantId: TENANT_ID,
       });
 
       // "VPN" 大文字小文字無視で 2 件ヒット
       const result = await ctx.repos.tickets.list({
         filter: { text: { contains: 'VPN', caseInsensitive: true } },
         page: { skip: 0, take: 50 },
+        tenantId: TENANT_ID,
       });
       expect(result).toHaveLength(2);
 
       // count でも 2 件
-      const countResult = await ctx.repos.tickets.count({
-        text: { contains: 'VPN', caseInsensitive: true },
-      });
+      const countResult = await ctx.repos.tickets.count(
+        {
+          text: { contains: 'VPN', caseInsensitive: true },
+        },
+        TENANT_ID,
+      );
       expect(countResult).toBe(2);
     });
 
@@ -156,9 +170,9 @@ export function runTicketRepositoryContract(
         priority: 'Low',
         creatorId: requester.id,
         categoryId,
-        tenantId: 'default-tenant',
+        tenantId: TENANT_ID,
       });
-      await ctx.repos.tickets.updateAssignee(assigned.id, agentA.id);
+      await ctx.repos.tickets.updateAssignee(assigned.id, agentA.id, TENANT_ID);
       // 担当者なしのチケット
       const unassigned = await ctx.repos.tickets.create({
         title: 'B',
@@ -166,12 +180,13 @@ export function runTicketRepositoryContract(
         priority: 'Low',
         creatorId: requester.id,
         categoryId,
-        tenantId: 'default-tenant',
+        tenantId: TENANT_ID,
       });
 
       const result = await ctx.repos.tickets.list({
         filter: { assigneeId: null },
         page: { skip: 0, take: 50 },
+        tenantId: TENANT_ID,
       });
       // 未割当の 1 件だけが返る
       expect(result.map((t) => t.id)).toEqual([unassigned.id]);
@@ -187,13 +202,13 @@ export function runTicketRepositoryContract(
         priority: 'Medium',
         creatorId: requester.id,
         categoryId,
-        tenantId: 'default-tenant',
+        tenantId: TENANT_ID,
       });
 
       // ステータス更新 + 履歴記録 + 例外、を 1 つの uow で実行
       await expect(
         ctx.uow.run(async (r) => {
-          await r.tickets.updateStatus(ticket.id, 'Open', null);
+          await r.tickets.updateStatus(ticket.id, 'Open', null, TENANT_ID);
           await r.history.record({
             ticketId: ticket.id,
             changedById: requester.id,
@@ -207,7 +222,7 @@ export function runTicketRepositoryContract(
       ).rejects.toThrow('boom');
 
       // ステータスは変わらず New のまま
-      const after = await ctx.repos.tickets.findById(ticket.id);
+      const after = await ctx.repos.tickets.findById(ticket.id, TENANT_ID);
       expect(after?.status).toBe('New');
     });
 
@@ -221,18 +236,18 @@ export function runTicketRepositoryContract(
         priority: 'Low',
         creatorId: requester.id,
         categoryId,
-        tenantId: 'default-tenant',
+        tenantId: TENANT_ID,
       });
 
       // 取得して書き換えても、内部状態に影響しないことを期待
-      const leaked = await ctx.repos.tickets.findById(created.id);
+      const leaked = await ctx.repos.tickets.findById(created.id, TENANT_ID);
       if (leaked) {
         (leaked as { title: string }).title = 'MUTATED';
         (leaked as { status: 'New' | 'Open' }).status = 'Open';
       }
 
       // 再取得すると元の値が保たれている
-      const reread = await ctx.repos.tickets.findById(created.id);
+      const reread = await ctx.repos.tickets.findById(created.id, TENANT_ID);
       expect(reread?.title).toBe('original');
       expect(reread?.status).toBe('New');
     });
@@ -252,7 +267,7 @@ export function runTicketRepositoryContract(
         priority: 'High',
         creatorId: requester.id,
         categoryId,
-        tenantId: 'default-tenant',
+        tenantId: TENANT_ID,
         resolutionDueAt: yesterday,
       });
       // requester: Open 1 件 (期限内、agentA に割当)
@@ -262,11 +277,11 @@ export function runTicketRepositoryContract(
         priority: 'Medium',
         creatorId: requester.id,
         categoryId,
-        tenantId: 'default-tenant',
+        tenantId: TENANT_ID,
         resolutionDueAt: tomorrow,
       });
-      await ctx.repos.tickets.updateStatus(t2.id, 'Open', null);
-      await ctx.repos.tickets.updateAssignee(t2.id, agentA.id);
+      await ctx.repos.tickets.updateStatus(t2.id, 'Open', null, TENANT_ID);
+      await ctx.repos.tickets.updateAssignee(t2.id, agentA.id, TENANT_ID);
       // agentA 起票の Resolved 1 件 (ワークロード集計から除外される)
       const t3 = await ctx.repos.tickets.create({
         title: 't3',
@@ -274,15 +289,16 @@ export function runTicketRepositoryContract(
         priority: 'Low',
         creatorId: agentA.id,
         categoryId,
-        tenantId: 'default-tenant',
+        tenantId: TENANT_ID,
       });
-      await ctx.repos.tickets.updateAssignee(t3.id, agentB.id);
-      await ctx.repos.tickets.updateStatus(t3.id, 'Resolved', new Date());
+      await ctx.repos.tickets.updateAssignee(t3.id, agentB.id, TENANT_ID);
+      await ctx.repos.tickets.updateStatus(t3.id, 'Resolved', new Date(), TENANT_ID);
 
-      // creatorId 未指定 = 全件対象 (担当者ビュー)
+      // creatorId 未指定 = テナント内全件対象 (担当者ビュー)
       const all = await ctx.repos.tickets.dashboardStats({
         now,
         excludeStatusesForWorkload: ['Resolved', 'Closed'],
+        tenantId: TENANT_ID,
       });
       // byStatus: New 1 件 / Open 1 件 / Resolved 1 件、その他は 0
       expect(all.byStatus.New).toBe(1);
@@ -303,6 +319,7 @@ export function runTicketRepositoryContract(
         creatorId: requester.id,
         now,
         excludeStatusesForWorkload: ['Resolved', 'Closed'],
+        tenantId: TENANT_ID,
       });
       // byStatus は requester のチケット 2 件のみ
       expect(mine.byStatus.New).toBe(1);
@@ -310,6 +327,163 @@ export function runTicketRepositoryContract(
       expect(mine.byStatus.Resolved).toBe(0);
       // SLA 超過 / ワークロードは全件対象 (呼び出し側で表示制御する前提)
       expect(mine.slaOverdue).toBe(1);
+    });
+
+    // --- ここからクロステナント回帰テスト (Phase 0 仕上げ PR で追加) ---
+
+    // テナント A のチケットがテナント B からは findById で取れないこと
+    it('findById does not leak tickets across tenants', async () => {
+      const { requester: rA, categoryId: catA } = await ctx.seedBasicFixture();
+      // テナント A 側に 1 件作成
+      const ticketA = await ctx.repos.tickets.create({
+        title: 'A の社内',
+        body: 'b',
+        priority: 'Low',
+        creatorId: rA.id,
+        categoryId: catA,
+        tenantId: TENANT_ID,
+      });
+      // テナント B を別途用意
+      const { tenantId: tenantB } = await ctx.seedSecondTenant();
+
+      // A の ID をテナント B のスコープで引いても null が返る (クロステナント遮断)
+      const leak = await ctx.repos.tickets.findById(ticketA.id, tenantB);
+      expect(leak).toBeNull();
+
+      // 正しいテナントなら当然取れる
+      const sane = await ctx.repos.tickets.findById(ticketA.id, TENANT_ID);
+      expect(sane?.id).toBe(ticketA.id);
+    });
+
+    // テナント A のチケットがテナント B からは list / count に出てこないこと
+    it('list and count do not leak tickets across tenants', async () => {
+      const { requester: rA, categoryId: catA } = await ctx.seedBasicFixture();
+      // テナント A 側に 2 件作成
+      await ctx.repos.tickets.create({
+        title: 'A-1',
+        body: 'b',
+        priority: 'Low',
+        creatorId: rA.id,
+        categoryId: catA,
+        tenantId: TENANT_ID,
+      });
+      await ctx.repos.tickets.create({
+        title: 'A-2',
+        body: 'b',
+        priority: 'Low',
+        creatorId: rA.id,
+        categoryId: catA,
+        tenantId: TENANT_ID,
+      });
+      // テナント B 側に 1 件作成
+      const { tenantId: tenantB, requester: rB, categoryId: catB } = await ctx.seedSecondTenant();
+      await ctx.repos.tickets.create({
+        title: 'B-1',
+        body: 'b',
+        priority: 'Low',
+        creatorId: rB.id,
+        categoryId: catB,
+        tenantId: tenantB,
+      });
+
+      // テナント A 視点では A のチケット 2 件だけが見える
+      const listedA = await ctx.repos.tickets.list({
+        filter: {},
+        page: { skip: 0, take: 50 },
+        tenantId: TENANT_ID,
+      });
+      expect(listedA.map((t) => t.title).sort()).toEqual(['A-1', 'A-2']);
+      // count も同じ件数
+      expect(await ctx.repos.tickets.count({}, TENANT_ID)).toBe(2);
+
+      // テナント B 視点では B のチケット 1 件だけが見える
+      const listedB = await ctx.repos.tickets.list({
+        filter: {},
+        page: { skip: 0, take: 50 },
+        tenantId: tenantB,
+      });
+      expect(listedB.map((t) => t.title)).toEqual(['B-1']);
+      expect(await ctx.repos.tickets.count({}, tenantB)).toBe(1);
+    });
+
+    // 他テナントの ID を指定した update 系メソッドが no-op (=データ未改変) であること
+    it('write methods refuse to mutate rows owned by another tenant', async () => {
+      const { requester: rA, agentA, categoryId: catA } = await ctx.seedBasicFixture();
+      // テナント A に 1 件作成 (初期 New / 担当者なし / 優先度 Low)
+      const ticketA = await ctx.repos.tickets.create({
+        title: 'A の社内',
+        body: 'b',
+        priority: 'Low',
+        creatorId: rA.id,
+        categoryId: catA,
+        tenantId: TENANT_ID,
+      });
+      // テナント B を用意 (チケット A への影響を確認するために使う)
+      const { tenantId: tenantB } = await ctx.seedSecondTenant();
+
+      // テナント B のスコープから A のチケットを更新しようとしても適用されないことを確認
+      await ctx.repos.tickets.updateStatus(ticketA.id, 'Open', null, tenantB);
+      await ctx.repos.tickets.updatePriority(ticketA.id, 'High', tenantB);
+      await ctx.repos.tickets.updateAssignee(ticketA.id, agentA.id, tenantB);
+      await ctx.repos.tickets.markEscalated(
+        ticketA.id,
+        { reason: 'cross-tenant attempt', at: new Date() },
+        tenantB,
+      );
+
+      // A 側の状態は一切変わっていないこと (status=New, priority=Low, assignee=null)
+      const fresh = await ctx.repos.tickets.findById(ticketA.id, TENANT_ID);
+      expect(fresh?.status).toBe('New');
+      expect(fresh?.priority).toBe('Low');
+      expect(fresh?.assigneeId).toBeNull();
+      expect(fresh?.escalatedAt).toBeNull();
+    });
+
+    // dashboardStats が他テナントのチケットを集計に含めないこと
+    it('dashboardStats scopes aggregates to the given tenant', async () => {
+      const { requester: rA, categoryId: catA } = await ctx.seedBasicFixture();
+      // テナント A: New 1 件
+      await ctx.repos.tickets.create({
+        title: 'A',
+        body: 'b',
+        priority: 'Low',
+        creatorId: rA.id,
+        categoryId: catA,
+        tenantId: TENANT_ID,
+      });
+      // テナント B: New 2 件
+      const { tenantId: tenantB, requester: rB, categoryId: catB } = await ctx.seedSecondTenant();
+      await ctx.repos.tickets.create({
+        title: 'B-1',
+        body: 'b',
+        priority: 'Low',
+        creatorId: rB.id,
+        categoryId: catB,
+        tenantId: tenantB,
+      });
+      await ctx.repos.tickets.create({
+        title: 'B-2',
+        body: 'b',
+        priority: 'Low',
+        creatorId: rB.id,
+        categoryId: catB,
+        tenantId: tenantB,
+      });
+
+      // テナント A のダッシュボードには New 1 件しか出ない
+      const statsA = await ctx.repos.tickets.dashboardStats({
+        now: new Date(),
+        excludeStatusesForWorkload: ['Resolved', 'Closed'],
+        tenantId: TENANT_ID,
+      });
+      expect(statsA.byStatus.New).toBe(1);
+      // テナント B のダッシュボードには New 2 件しか出ない
+      const statsB = await ctx.repos.tickets.dashboardStats({
+        now: new Date(),
+        excludeStatusesForWorkload: ['Resolved', 'Closed'],
+        tenantId: tenantB,
+      });
+      expect(statsB.byStatus.New).toBe(2);
     });
   });
 }

--- a/tests/features/update-ticket.test.ts
+++ b/tests/features/update-ticket.test.ts
@@ -14,6 +14,8 @@ let uow: UnitOfWork;
 // セッションのユーザー ID と権限 (テスト中に書き換えてシナリオを変える)
 let sessionUserId = 'u-agt-1';
 let sessionRole: 'requester' | 'agent' | 'admin' = 'agent';
+// テナントスコープ (テストは単一テナント前提で固定)
+const TENANT = 'default-tenant';
 
 // @/data モジュールを差し替え。getter で参照することで、テスト中の上書きを反映
 vi.mock('@/data', () => ({
@@ -117,7 +119,7 @@ describe('updateTicketStatus (provider-agnostic)', () => {
 
     await updateTicketStatus(ticketId, 'Open');
 
-    const t = await repos.tickets.findById(ticketId);
+    const t = await repos.tickets.findById(ticketId, TENANT);
     // 反映されている
     expect(t?.status).toBe('Open');
     // 履歴 1 件 (status / New → Open)
@@ -132,7 +134,7 @@ describe('updateTicketStatus (provider-agnostic)', () => {
   it('rejects an invalid transition and rolls back history', async () => {
     const { ticketId } = await seed();
     // 事前に Closed にしておく
-    await repos.tickets.updateStatus(ticketId, 'Closed', null);
+    await repos.tickets.updateStatus(ticketId, 'Closed', null, TENANT);
     const { updateTicketStatus } = await import('@/features/tickets/actions/update-ticket');
 
     // Closed → InProgress は遷移表で禁止されている
@@ -140,7 +142,7 @@ describe('updateTicketStatus (provider-agnostic)', () => {
       /変更することはできません/,
     );
 
-    const t = await repos.tickets.findById(ticketId);
+    const t = await repos.tickets.findById(ticketId, TENANT);
     // ステータスは変わらない
     expect(t?.status).toBe('Closed');
     // 履歴も残っていない
@@ -162,7 +164,7 @@ describe('updateTicketStatus (provider-agnostic)', () => {
   it('sets resolvedAt when transitioning to Resolved', async () => {
     const { ticketId } = await seed();
     // 事前に Open に
-    await repos.tickets.updateStatus(ticketId, 'Open', null);
+    await repos.tickets.updateStatus(ticketId, 'Open', null, TENANT);
     const { updateTicketStatus } = await import('@/features/tickets/actions/update-ticket');
 
     // 期待時刻範囲を取るため呼び出し前後の時刻を測る
@@ -170,7 +172,7 @@ describe('updateTicketStatus (provider-agnostic)', () => {
     await updateTicketStatus(ticketId, 'Resolved');
     const after = Date.now();
 
-    const t = await repos.tickets.findById(ticketId);
+    const t = await repos.tickets.findById(ticketId, TENANT);
     expect(t?.status).toBe('Resolved');
     expect(t?.resolvedAt).toBeInstanceOf(Date);
     const ts = t!.resolvedAt!.getTime();
@@ -181,12 +183,12 @@ describe('updateTicketStatus (provider-agnostic)', () => {
   // Resolved → Open に戻すと resolvedAt がクリアされる
   it('clears resolvedAt when reopening from Resolved', async () => {
     const { ticketId } = await seed();
-    await repos.tickets.updateStatus(ticketId, 'Resolved', new Date());
+    await repos.tickets.updateStatus(ticketId, 'Resolved', new Date(), TENANT);
     const { updateTicketStatus } = await import('@/features/tickets/actions/update-ticket');
 
     await updateTicketStatus(ticketId, 'Open');
 
-    const t = await repos.tickets.findById(ticketId);
+    const t = await repos.tickets.findById(ticketId, TENANT);
     expect(t?.status).toBe('Open');
     expect(t?.resolvedAt).toBeNull();
   });
@@ -194,12 +196,12 @@ describe('updateTicketStatus (provider-agnostic)', () => {
   // Resolved に関係しない遷移では resolvedAt は変化しない
   it('leaves resolvedAt untouched for transitions not involving Resolved', async () => {
     const { ticketId } = await seed();
-    await repos.tickets.updateStatus(ticketId, 'Open', null);
+    await repos.tickets.updateStatus(ticketId, 'Open', null, TENANT);
     const { updateTicketStatus } = await import('@/features/tickets/actions/update-ticket');
 
     await updateTicketStatus(ticketId, 'InProgress');
 
-    const t = await repos.tickets.findById(ticketId);
+    const t = await repos.tickets.findById(ticketId, TENANT);
     expect(t?.status).toBe('InProgress');
     expect(t?.resolvedAt).toBeNull();
   });
@@ -214,7 +216,7 @@ describe('updateTicketAssignee (provider-agnostic)', () => {
 
     await updateTicketAssignee(ticketId, 'u-agt-2');
 
-    const t = await repos.tickets.findById(ticketId);
+    const t = await repos.tickets.findById(ticketId, TENANT);
     expect(t?.assigneeId).toBe('u-agt-2');
 
     // 履歴 1 件 (assignee / null → 鈴木)
@@ -260,7 +262,7 @@ describe('addComment (provider-agnostic)', () => {
   // 依頼者がコメント、担当者ありなら担当者だけに通知
   it('notifies the assignee when a requester comments on an assigned ticket', async () => {
     const { ticketId } = await seed();
-    await repos.tickets.updateAssignee(ticketId, 'u-agt-2');
+    await repos.tickets.updateAssignee(ticketId, 'u-agt-2', TENANT);
     sessionUserId = 'u-req-1';
     sessionRole = 'requester';
     const { addComment } = await import('@/features/tickets/actions/update-ticket');
@@ -314,7 +316,7 @@ describe('addComment (provider-agnostic)', () => {
   // エージェントがコメント、担当者ありなら依頼者と担当者の両方に通知
   it('notifies both creator and assignee when a different agent comments', async () => {
     const { ticketId } = await seed();
-    await repos.tickets.updateAssignee(ticketId, 'u-agt-2');
+    await repos.tickets.updateAssignee(ticketId, 'u-agt-2', TENANT);
     const { addComment } = await import('@/features/tickets/actions/update-ticket');
 
     await addComment(ticketId, '対応を引き継ぎます');
@@ -329,7 +331,7 @@ describe('addComment (provider-agnostic)', () => {
   // 投稿者自身には通知しない (重複通知の防止)
   it('does not notify the commenter themselves', async () => {
     const { ticketId } = await seed();
-    await repos.tickets.updateAssignee(ticketId, 'u-agt-1');
+    await repos.tickets.updateAssignee(ticketId, 'u-agt-1', TENANT);
     // 担当者と投稿者が同一 (u-agt-1)
     const { addComment } = await import('@/features/tickets/actions/update-ticket');
 
@@ -371,13 +373,13 @@ describe('escalateTicket (provider-agnostic)', () => {
   it('marks escalated, records history, and notifies every agent', async () => {
     const { ticketId } = await seed();
     // Open 状態からエスカレーション (遷移表で許可されている)
-    await repos.tickets.updateStatus(ticketId, 'Open', null);
+    await repos.tickets.updateStatus(ticketId, 'Open', null, TENANT);
     const { escalateTicket } = await import('@/features/tickets/actions/update-ticket');
 
     // 前後空白を含めて渡し、保存時にトリムされていることも確認
     await escalateTicket(ticketId, '  対応困難  ');
 
-    const t = await repos.tickets.findById(ticketId);
+    const t = await repos.tickets.findById(ticketId, TENANT);
     expect(t?.status).toBe('Escalated');
     expect(t?.escalationReason).toBe('対応困難');
     expect(t?.escalatedAt).toBeInstanceOf(Date);

--- a/tests/features/update-ticket.test.ts
+++ b/tests/features/update-ticket.test.ts
@@ -255,6 +255,43 @@ describe('updateTicketAssignee (provider-agnostic)', () => {
     expect([...store.histories.values()]).toHaveLength(0);
     expect([...store.notifications.values()]).toHaveLength(0);
   });
+
+  // 別テナント所属のエージェントを担当者にしようとしても同じメッセージで拒否 (cross-tenant 遮断)
+  it('refuses to assign an agent who belongs to a different tenant', async () => {
+    const { ticketId } = await seed();
+    // テナント B 側にエージェントを 1 名作る (ロールは agent、テナントだけ違う)
+    const now = new Date();
+    store.tenants.set('tenant-b', {
+      id: 'tenant-b',
+      name: '別組織',
+      mode: 'lite',
+      industry: null,
+      createdAt: now,
+    });
+    // 別テナントのエージェントを store に直接投入
+    store.users.set('u-b-agt-1', {
+      id: 'u-b-agt-1',
+      email: 'u-b-agt-1@example.com',
+      name: '別組織の担当',
+      passwordHash: 'x',
+      role: 'agent',
+      tenantId: 'tenant-b', // 既定テナントとは別
+      createdAt: now,
+      updatedAt: now,
+    });
+    const { updateTicketAssignee } = await import('@/features/tickets/actions/update-ticket');
+
+    // 別テナントのエージェント ID を渡すと一般的な拒否メッセージが返る (内部理由は漏らさない)
+    await expect(updateTicketAssignee(ticketId, 'u-b-agt-1')).rejects.toThrow(
+      /指定された担当者を設定できません/,
+    );
+    // 履歴や通知が一切作られていないこと (拒否時は副作用なし)
+    expect([...store.histories.values()]).toHaveLength(0);
+    expect([...store.notifications.values()]).toHaveLength(0);
+    // 当該チケットの担当者欄も書き換わっていない
+    const t = await repos.tickets.findById(ticketId, TENANT);
+    expect(t?.assigneeId).toBeNull();
+  });
 });
 
 // コメント追加アクションの通知ルート (誰に通知が飛ぶか) の仕様


### PR DESCRIPTION
## Summary

`docs/smb-dx-pivot-plan.md` §5.1 Phase 0 マルチテナント基盤の **仕上げ**。
前 PR (#99) で追加した `tenantId` カラムを実際に **where 句で強制**する層を導入し、
クロステナント漏洩を Adapter 層で遮断する。

### Port シグネチャ (主要)

| Port | 変更 |
|------|------|
| `TicketRepository` | `findById` / `findByIdWithRefs` / `findByIdWithDetail` / `list` / `count` / `dashboardStats` / `updateStatus` / `updatePriority` / `updateAssignee` / `markEscalated` 全てに `tenantId` 必須化 |
| `UserRepository` | `listAgents` / `listAgentIds` / `findSummariesByIds` に `tenantId` 必須化。`findById` / `findByEmail` は認証フロー専用なので **据え置き** (テナント横断検索) |
| `CategoryRepository` | `list` / `findById` どちらも `tenantId` 必須 |
| `FaqRepository` | `findById` / `list` / `updateStatus` に `tenantId` 必須化 |
| `NotificationRepository` | `countUnread` / `list` に `tenantId` 必須。`markAllRead(userId)` はユーザースコープで十分なため据え置き |

### Adapter 実装

- **Prisma**: 取得系は `findFirst({ where: { id, tenantId } })`、書き換え系は `updateMany({ where: { id, tenantId } })` で「他テナントの ID なら 0 件更新で no-op」。
- **Memory**: テナント不一致行は filter / 早期 return で除外。Prisma と同じセマンティクス。

### 呼び出し側

全 Server Action / Page / API Route で `session.user.tenantId` を取り出して port に伝搬:

- `src/features/tickets/actions/update-ticket.ts` — 全アクション (status / priority / assignee / escalate / comment) に `tenantId` 注入。担当者割当時は別テナントユーザーを `cross-tenant` 拒否
- `src/features/faq/actions/faq-actions.ts` — FAQ 候補作成・公開/却下に `tenantId` 注入
- `src/features/notifications/notify.ts` — `broadcastUnreadCount(ToMany)` に `tenantId` 引数を追加
- `src/lib/notifications.ts` — `getUnreadNotificationCount(userId, tenantId)` に拡張
- `src/components/layout/NotificationBell.tsx` / `Header.tsx` — `tenantId` を伝搬
- `src/app/(app)/dashboard|tickets|tickets/[id]|tickets/new|notifications|faq/page.tsx` — 全 page で `session.user.tenantId` を取り出して port 呼び出しに渡す
- `src/app/api/notifications/stream/route.ts` — `tenantId` 取得後に未読件数を引く

### Middleware

`src/middleware.ts`: `session.user.tenantId` 不在 (旧 JWT 補完失敗エッジケース) を防御的に弾く:
- API → `401 { error: '認証が必要です' }`
- HTML → `/login` リダイレクト

### テスト

- `tests/data/ticket-repository.contract.ts` に **4 本のクロステナント回帰テスト**を追加 (memory + 将来の Prisma 両方で実行可):
  1. `findById` がテナント越境で `null`
  2. `list` / `count` が他テナントを含まない
  3. 全 `update*` / `markEscalated` が他テナント ID なら no-op
  4. `dashboardStats` が `tenantId` でスコープされる
- `ContractContext` に `seedSecondTenant` ヘルパーを追加 (もう 1 テナント + 1 ユーザー + 1 カテゴリ)
- 既存契約テスト + `tests/features/update-ticket.test.ts` を新シグネチャに合わせて更新

### 不変点

- `TicketHistory` / `TicketComment` は **独自の `tenantId` カラムなし** (親 `Ticket.tenantId` 経由で辿る、CLAUDE.md §マルチテナント方針通り)。よって `record` / `comments.create` のシグネチャは変更不要。

## Test plan

- [x] `npm run lint` — エラーなし
- [x] `npm run typecheck` — エラーなし
- [x] `npm run test` — 68 件 PASS (うち 4 件が新規クロステナント回帰)
- [ ] E2E (`npm run test:e2e`) — ローカル DB 起動環境で要確認
- [ ] dev サーバーで実機確認:
  - [ ] 既存のデフォルトテナント単体で全画面 (ダッシュボード/一覧/詳細/新規/FAQ/通知) が動く
  - [ ] テナント B を seed で追加し、テナント A ユーザーから B のチケット/カテゴリ/FAQ/通知が**完全に**見えないこと
  - [ ] テナント A ユーザーが URL パラメータで B のチケット ID を直叩きしても 404 になること
  - [ ] 別テナントのユーザーを担当者に割当しようとして「指定された担当者を設定できません」で拒否されること

https://claude.ai/code/session_01QD81uSmt3wEZKKnoUgRbAk

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD81uSmt3wEZKKnoUgRbAk)_