### PR TITLE
feat(domain): Lite モード 3 ステータス遷移表と getStatusLabel(status, mode) 追加 (Phase 1)

### DIFF
--- a/src/domain/ticket-status.ts
+++ b/src/domain/ticket-status.ts
@@ -27,3 +27,40 @@ export function getAllowedTransitions(from: TicketStatus): TicketStatus[] {
   // 許可表からそのまま返す (配列を共有するので呼び出し側で変更しないこと)
   return ALLOWED_TRANSITIONS[from];
 }
+
+// --- Lite モード (SMB 向け簡易モード) 用の縮約ステータスと遷移表 ---
+// docs/smb-dx-pivot-plan.md §3.1 / §5.2 に対応。DB の TicketStatus enum は据え置き、
+// Lite テナントの UI/業務上は 3 値だけ使う方針。
+// 既存 Pro モード遷移表 (上記 ALLOWED_TRANSITIONS) には一切触れず追加のみ行う。
+
+// Lite で扱う 3 ステータス。as const で readonly tuple 化し、型派生に使う
+export const LITE_STATUSES = ['Open', 'InProgress', 'Closed'] as const;
+
+// 上の tuple から union 型を導出 ('Open' | 'InProgress' | 'Closed')
+export type LiteStatus = (typeof LITE_STATUSES)[number];
+
+// Lite モードの遷移表 (Pivot plan §5.2)。自己遷移は不可、Closed → Open のみ再オープン許可
+const ALLOWED_TRANSITIONS_LITE: Record<LiteStatus, LiteStatus[]> = {
+  Open: ['InProgress', 'Closed'], // 未対応から対応中か完了へ
+  InProgress: ['Open', 'Closed'], // 対応中から未対応に戻す or 完了へ
+  Closed: ['Open'], // 完了から再オープンのみ (Pro モードと整合)
+};
+
+// 任意の TicketStatus が Lite で扱える 3 値のいずれかかを判定する型ガード関数
+// (テナント mode 切替直後に旧データが Lite で表示されるケースなどで使用)
+export function isLiteStatus(status: TicketStatus): status is LiteStatus {
+  // 配列が readonly tuple なので includes は string キャストで判定
+  return (LITE_STATUSES as readonly string[]).includes(status);
+}
+
+// Lite モード版: 現在状態 from から次状態 to に遷移してよいかを true/false で返す
+export function isValidLiteTransition(from: LiteStatus, to: LiteStatus): boolean {
+  // 許可表を参照し、to が含まれていれば遷移可能
+  return ALLOWED_TRANSITIONS_LITE[from].includes(to);
+}
+
+// Lite モード版: 現在状態 from から遷移できる次状態の一覧を配列で返す (UI プルダウン用)
+export function getAllowedLiteTransitions(from: LiteStatus): LiteStatus[] {
+  // 許可表からそのまま返す (配列を共有するので呼び出し側で変更しないこと)
+  return ALLOWED_TRANSITIONS_LITE[from];
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,10 +1,14 @@
 // チケット状態型をインポート
 import type { TicketStatus } from '@/generated/prisma';
+// Lite モードの 3 値型と型ガード関数を取り込み、mode-aware ラベル関数で使う
+import { isLiteStatus, type LiteStatus } from '@/domain/ticket-status';
+// テナントモード型 (lite | pro) を取り込み、mode-aware ラベル関数で使う
+import type { TenantMode } from '@/domain/types';
 
 // FAQ 候補化を許可するチケット状態一覧 (解決済みのみ候補化可能)
 export const FAQ_ELIGIBLE_STATUSES: readonly TicketStatus[] = ['Resolved'];
 
-// チケット状態の英語キーに対応する日本語表示ラベル
+// チケット状態の英語キーに対応する日本語表示ラベル (Pro モード、現行 7 値)
 export const STATUS_LABELS: Record<string, string> = {
   New: '新規',
   Open: 'オープン',
@@ -14,6 +18,29 @@ export const STATUS_LABELS: Record<string, string> = {
   Resolved: '解決済み',
   Closed: 'クローズ',
 };
+
+// Lite モード用の状態ラベル (Pivot plan §3.1 の用語表に基づきカタカナ・英語を排除)
+// Lite テナントは UI 上で「未対応 / 対応中 / 完了」だけを使う
+export const LITE_STATUS_LABELS: Record<LiteStatus, string> = {
+  Open: '未対応', // 受付済みだがまだ着手していない (Lite では「未対応」と呼ぶ)
+  InProgress: '対応中', // 担当者が作業中
+  Closed: '完了', // 対応が終わった状態
+};
+
+// テナントモードに応じて状態ラベルを返す mode-aware 関数
+// - mode === 'lite': まず LITE_STATUS_LABELS を引く。Lite 用 3 値以外 (例: 旧データの
+//   Escalated / Resolved 等) が来た場合は Pro ラベルにフォールバックして安全に表示する
+//   (テナントを Pro → Lite に切り替えた直後のエッジケース防御)
+// - mode === 'pro': 既存どおり STATUS_LABELS をそのまま返す
+export function getStatusLabel(status: TicketStatus, mode: TenantMode): string {
+  // Lite モードかつ Lite 対応の 3 値なら Lite ラベルを返す (型ガードで LiteStatus に narrow)
+  if (mode === 'lite' && isLiteStatus(status)) {
+    return LITE_STATUS_LABELS[status];
+  }
+  // それ以外 (Pro モード or Lite で非対応ステータス) は Pro ラベルにフォールバック
+  // 未知のキーは status 文字列をそのまま返して画面が空にならないようにする
+  return STATUS_LABELS[status] ?? status;
+}
 
 // 優先度キーに対応する日本語表示ラベル
 export const PRIORITY_LABELS: Record<string, string> = {

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -1,0 +1,40 @@
+// Vitest のテスト DSL
+import { describe, expect, it } from 'vitest';
+
+// テスト対象: mode-aware の状態ラベル取得関数
+import { getStatusLabel, LITE_STATUS_LABELS, STATUS_LABELS } from '../src/lib/constants';
+
+// getStatusLabel の挙動を Pro / Lite 両モードで検証する
+describe('getStatusLabel', () => {
+  // Pro モードでは現行の STATUS_LABELS と完全一致を返すこと
+  it('returns the Pro label for every TicketStatus when mode is pro', () => {
+    // Pro モードで使うすべてのステータスを順に検証
+    expect(getStatusLabel('New', 'pro')).toBe(STATUS_LABELS.New);
+    expect(getStatusLabel('Open', 'pro')).toBe(STATUS_LABELS.Open);
+    expect(getStatusLabel('WaitingForUser', 'pro')).toBe(STATUS_LABELS.WaitingForUser);
+    expect(getStatusLabel('InProgress', 'pro')).toBe(STATUS_LABELS.InProgress);
+    expect(getStatusLabel('Escalated', 'pro')).toBe(STATUS_LABELS.Escalated);
+    expect(getStatusLabel('Resolved', 'pro')).toBe(STATUS_LABELS.Resolved);
+    expect(getStatusLabel('Closed', 'pro')).toBe(STATUS_LABELS.Closed);
+  });
+
+  // Lite モードでは 3 ステータスに「未対応 / 対応中 / 完了」が返ること
+  it('returns the Lite label for Lite statuses when mode is lite', () => {
+    // Lite で扱う 3 値が pivot plan §3.1 の用語表どおりに返る
+    expect(getStatusLabel('Open', 'lite')).toBe('未対応');
+    expect(getStatusLabel('InProgress', 'lite')).toBe('対応中');
+    expect(getStatusLabel('Closed', 'lite')).toBe('完了');
+    // LITE_STATUS_LABELS 経由で見ても同じこと (DRY 担保)
+    expect(getStatusLabel('Open', 'lite')).toBe(LITE_STATUS_LABELS.Open);
+  });
+
+  // Lite モードで非 Lite ステータスを渡すと Pro ラベルにフォールバックすること
+  it('falls back to Pro label in lite mode for non-Lite statuses', () => {
+    // テナント mode を Pro → Lite に切り替えた直後など、Lite 対象外データが残るケース
+    // 画面が空にならず、技術用語であっても Pro ラベルを返して表示を守る
+    expect(getStatusLabel('New', 'lite')).toBe(STATUS_LABELS.New);
+    expect(getStatusLabel('WaitingForUser', 'lite')).toBe(STATUS_LABELS.WaitingForUser);
+    expect(getStatusLabel('Escalated', 'lite')).toBe(STATUS_LABELS.Escalated);
+    expect(getStatusLabel('Resolved', 'lite')).toBe(STATUS_LABELS.Resolved);
+  });
+});

--- a/tests/ticket-status.test.ts
+++ b/tests/ticket-status.test.ts
@@ -1,8 +1,14 @@
 // Vitest のテスト DSL
 import { describe, expect, it } from 'vitest';
 
-// 遷移可否判定と遷移先一覧取得を提供するドメイン関数
-import { getAllowedTransitions, isValidTransition } from '../src/domain/ticket-status';
+// 遷移可否判定と遷移先一覧取得を提供するドメイン関数 (Pro / Lite 両方)
+import {
+  getAllowedLiteTransitions,
+  getAllowedTransitions,
+  isLiteStatus,
+  isValidLiteTransition,
+  isValidTransition,
+} from '../src/domain/ticket-status';
 
 // チケットステータスの遷移ルール (= 仕様の単一真実) を守れているかのテスト
 describe('ticket status transition rules', () => {
@@ -41,5 +47,57 @@ describe('ticket status transition rules', () => {
   it('returns empty array for Closed (except Open)', () => {
     const allowed = getAllowedTransitions('Closed');
     expect(allowed).toEqual(['Open']);
+  });
+});
+
+// Lite モード (SMB 向け簡易モード) の 3 ステータス遷移ルール (Pivot plan §5.2)
+describe('Lite ticket status transition rules', () => {
+  // Open から InProgress / Closed への遷移は許可されること
+  it('allows Open to transition to InProgress or Closed', () => {
+    // Open から行ける状態の集合を取得
+    const allowed = getAllowedLiteTransitions('Open');
+    // 必須の遷移先 (InProgress / Closed) が含まれていること
+    expect(allowed).toContain('InProgress');
+    expect(allowed).toContain('Closed');
+    // 個別判定も true を返すこと
+    expect(isValidLiteTransition('Open', 'InProgress')).toBe(true);
+    expect(isValidLiteTransition('Open', 'Closed')).toBe(true);
+  });
+
+  // 自己遷移 (Open → Open など) は不可であること
+  it('rejects self-transitions in Lite mode', () => {
+    // Open → Open はループに見えるので不可
+    expect(isValidLiteTransition('Open', 'Open')).toBe(false);
+    // InProgress → InProgress も同様に不可
+    expect(isValidLiteTransition('InProgress', 'InProgress')).toBe(false);
+    // Closed → Closed も不可 (再オープンしてから完了し直すルートを取る)
+    expect(isValidLiteTransition('Closed', 'Closed')).toBe(false);
+  });
+
+  // InProgress からは Open に戻す or Closed へ完了の 2 経路が許可されること
+  it('allows InProgress to transition back to Open or forward to Closed', () => {
+    // 対応中→未対応に戻すケースと、対応中→完了で終わらせるケースを許可
+    expect(isValidLiteTransition('InProgress', 'Open')).toBe(true);
+    expect(isValidLiteTransition('InProgress', 'Closed')).toBe(true);
+  });
+
+  // Closed からの遷移先は Open (再オープン) のみであること
+  it('returns only Open as transition target from Closed', () => {
+    // Lite モードでも完了状態からは再オープンのみ許可 (Pro モードと整合)
+    expect(getAllowedLiteTransitions('Closed')).toEqual(['Open']);
+    expect(isValidLiteTransition('Closed', 'Open')).toBe(true);
+  });
+
+  // isLiteStatus が 3 値で true、Lite 対象外の Pro ステータスで false を返すこと
+  it('isLiteStatus returns true only for Open / InProgress / Closed', () => {
+    // Lite で扱う 3 値はすべて true
+    expect(isLiteStatus('Open')).toBe(true);
+    expect(isLiteStatus('InProgress')).toBe(true);
+    expect(isLiteStatus('Closed')).toBe(true);
+    // 残り 4 値 (Pro 専用) はすべて false
+    expect(isLiteStatus('New')).toBe(false);
+    expect(isLiteStatus('WaitingForUser')).toBe(false);
+    expect(isLiteStatus('Escalated')).toBe(false);
+    expect(isLiteStatus('Resolved')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

`docs/smb-dx-pivot-plan.md` **Phase 1 (Lite モード MVP) の最初の薄い PR**。
計画書 §3.1 / §5.2 に従い、後続の Lite モード UI 化 (フォーム簡素化 / 用語差替 /
タブ一覧 / スマホ最適化 / 添付 / マジックリンク) が依拠するドメイン層だけを
**UI を一切触らず** 追加する。

## 追加内容

### `src/domain/ticket-status.ts` (modify、既存 Pro モード遷移表は **据え置き**)

- `LITE_STATUSES`: `['Open', 'InProgress', 'Closed'] as const`
- `LiteStatus` 型 (上 tuple から派生)
- `ALLOWED_TRANSITIONS_LITE`: Pivot plan §5.2 で確定した縮約遷移表
  - `Open` → `InProgress` / `Closed`
  - `InProgress` → `Open` / `Closed`
  - `Closed` → `Open` (Pro と整合する再オープン許可)
  - 自己遷移は **不可**
- `isLiteStatus(status)`: 型ガード関数
- `isValidLiteTransition(from, to)`: Lite 遷移許可判定
- `getAllowedLiteTransitions(from)`: UI プルダウン用

### `src/lib/constants.ts` (modify、既存 `STATUS_LABELS` 等は **据え置き**)

- `LITE_STATUS_LABELS`: `{ Open: '未対応', InProgress: '対応中', Closed: '完了' }` (Pivot plan §3.1 用語表)
- `getStatusLabel(status: TicketStatus, mode: TenantMode): string`:
  - Pro モード → 既存 `STATUS_LABELS`
  - Lite モード + Lite 対応の 3 値 → `LITE_STATUS_LABELS`
  - Lite モード + 非対応ステータス (Escalated 等) → **Pro ラベルにフォールバック** (テナント mode 切替直後の残データ防御)

### テスト

- `tests/ticket-status.test.ts`: 既存 5 件は据え置き、**新規 describe** `'Lite ticket status transition rules'` に 5 件追加
- `tests/constants.test.ts`: **新規ファイル**、`getStatusLabel` を Pro / Lite / フォールバックの 3 ケースで検証

## 含めないもの (後続 PR)

- `StatusSelect` / Page / Form が `getStatusLabel` を経由するように変更 → 次の「Lite UI 適用 PR」
- `updateTicketStatus` Server Action で `getAllowedLiteTransitions` をガードに使う → 「Lite 遷移強制 PR」
- 簡易フォーム / タブ一覧 / スマホ最適化 / 添付 / マジックリンク認証 → 各 Phase 1 残項目

## Test plan

- [x] `npm run lint` 0 issue
- [x] `npm run typecheck` 0 error
- [x] `npm run test` 77 PASS (既存 69 + 新規 8)
- [x] E2E スコープ対象外 (UI 不変、Pro モードのまま動く)

https://claude.ai/code/session_01QD81uSmt3wEZKKnoUgRbAk

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD81uSmt3wEZKKnoUgRbAk)_