### PR TITLE
feat(tickets): Lite UI 適用 — StatusSelect / 一覧 / 詳細 / フィルタを getStatusLabel(mode) 経由に置換 (Phase 1)

### DIFF
--- a/src/app/(app)/tickets/[id]/page.tsx
+++ b/src/app/(app)/tickets/[id]/page.tsx
@@ -7,14 +7,17 @@ import { repos } from '@/data';
 // エージェント判定 (別名で衝突回避)
 import { isAgent as checkIsAgent } from '@/lib/role';
 // 表示用ラベル/カラークラス (ステータス/優先度/履歴) と履歴値変換ヘルパー
+// getStatusLabel はテナント mode (lite | pro) に応じて Lite/Pro ラベルを切り替える
 import {
-  STATUS_LABELS,
+  getStatusLabel,
   STATUS_COLORS,
   PRIORITY_LABELS,
   PRIORITY_COLORS,
   HISTORY_FIELD_LABELS,
   formatHistoryValue,
 } from '@/lib/constants';
+// 現在ログイン中のテナントの動作モード (lite | pro) を取得するヘルパー
+import { getCurrentTenantMode } from '@/lib/tenant';
 // 日本時間 (Asia/Tokyo) で日付・日時を文字列化するユーティリティ
 import { formatDateJP, formatDateTimeJP } from '@/lib/format-date';
 // ステータス変更プルダウン
@@ -53,12 +56,14 @@ export default async function TicketDetailPage({ params }: Props) {
 
   // セッションから tenantId を取り出して以降の port 呼び出しに伝搬する
   const tenantId = session.user.tenantId;
-  // チケット本体 (関連データ込み) と担当者プルダウン用ユーザーを並列取得 (全て tenantId スコープ)
-  const [ticket, agents] = await Promise.all([
+  // チケット本体・担当者候補・テナント mode を並列取得 (全て tenantId スコープ)
+  const [ticket, agents, mode] = await Promise.all([
     // 詳細用: 起票者/担当者/カテゴリ/コメント/履歴/FAQ 候補をまとめて取得
     repos.tickets.findByIdWithDetail(id, tenantId),
     // エージェント時のみ担当者候補一覧を取得 (テナント内のみ)
     isAgent ? repos.users.listAgents(tenantId) : Promise.resolve([]),
+    // テナントの動作モード (lite | pro) を取得し、ステータス表記を Lite/Pro で切り替える
+    getCurrentTenantMode(tenantId),
   ]);
 
   // チケットが存在しなければ 404
@@ -70,7 +75,9 @@ export default async function TicketDetailPage({ params }: Props) {
   // SLA 状態 (none/ok/warning/overdue) を計算
   const slaState = getSlaState(ticket.resolutionDueAt, ticket.resolvedAt);
   // エスカレーション可能か (エージェント && 現状から Escalated への遷移許可あり)
-  const canEscalate = isAgent && getAllowedTransitions(ticket.status).includes('Escalated');
+  // Pro モードの遷移表を参照する (Lite モードでは Escalated 自体が UI 上は存在しない)
+  const canEscalate =
+    isAgent && mode === 'pro' && getAllowedTransitions(ticket.status, 'pro').includes('Escalated');
   // FAQ 候補化可能か (エージェント && 解決済み && 既存 FAQ 候補なし)
   const canAddFaq = isAgent && ticket.status === 'Resolved' && !ticket.faqCandidate;
 
@@ -132,9 +139,10 @@ export default async function TicketDetailPage({ params }: Props) {
               <ul className="space-y-2">
                 {ticket.histories.map((h) => {
                   // 旧値・新値を field 種別に応じて日本語ラベル化しておく (JSX 内の改行で余計な空白が入らないよう変数化)
-                  const oldLabel = formatHistoryValue(h.field, h.oldValue);
+                  // mode を渡すと status/escalation 行が Lite/Pro 表記に切り替わる
+                  const oldLabel = formatHistoryValue(h.field, h.oldValue, mode);
                   // 新値ラベル
-                  const newLabel = formatHistoryValue(h.field, h.newValue);
+                  const newLabel = formatHistoryValue(h.field, h.newValue, mode);
                   return (
                     <li key={h.id} className="flex items-start gap-2 text-sm text-gray-600">
                       <span className="mt-0.5 text-xs text-gray-400">
@@ -163,18 +171,18 @@ export default async function TicketDetailPage({ params }: Props) {
             <h2 className="mb-4 text-sm font-semibold text-gray-500">詳細</h2>
 
             <dl className="space-y-3 text-sm">
-              {/* ステータス (エージェントは変更プルダウン付き) */}
+              {/* ステータス (エージェントは変更プルダウン付き、ラベルはテナント mode で切替) */}
               <div>
                 <dt className="font-medium text-gray-500">ステータス</dt>
                 <dd className="mt-1">
                   <span
                     className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[ticket.status] ?? ''}`}
                   >
-                    {STATUS_LABELS[ticket.status] ?? ticket.status}
+                    {getStatusLabel(ticket.status, mode)}
                   </span>
                   {isAgent && (
                     <div className="mt-1">
-                      <StatusSelect ticketId={ticket.id} current={ticket.status} />
+                      <StatusSelect ticketId={ticket.id} current={ticket.status} mode={mode} />
                     </div>
                   )}
                 </dd>

--- a/src/app/(app)/tickets/page.tsx
+++ b/src/app/(app)/tickets/page.tsx
@@ -8,8 +8,10 @@ import { auth } from '@/lib/auth';
 import { repos } from '@/data';
 // エージェント判定 (別名で衝突回避)
 import { isAgent as checkIsAgent } from '@/lib/role';
-// ステータス/優先度の日本語ラベルとカラークラス
-import { STATUS_LABELS, STATUS_COLORS, PRIORITY_LABELS, PRIORITY_COLORS } from '@/lib/constants';
+// ステータスの日本語ラベルを mode (lite | pro) に応じて返す mode-aware ヘルパーと、色/優先度ラベル
+import { getStatusLabel, STATUS_COLORS, PRIORITY_LABELS, PRIORITY_COLORS } from '@/lib/constants';
+// 現在ログイン中のテナントの動作モード (lite | pro) を取得するヘルパー
+import { getCurrentTenantMode } from '@/lib/tenant';
 // 日本時間 (Asia/Tokyo) で日付を文字列化するユーティリティ
 import { formatDateJP } from '@/lib/format-date';
 // 検索フィルタフォーム (Client Component)
@@ -81,8 +83,8 @@ export default async function TicketsPage({ searchParams }: Props) {
 
   // セッションから tenantId を取り出して以降の port 呼び出しに伝搬する
   const tenantId = session.user.tenantId;
-  // 表示用データを並列取得 (一覧/総件数/カテゴリ/担当者候補、全て port + tenantId スコープ)
-  const [tickets, total, categories, agents] = await Promise.all([
+  // 表示用データを並列取得 (一覧/総件数/カテゴリ/担当者候補/テナント mode、全て port + tenantId スコープ)
+  const [tickets, total, categories, agents, mode] = await Promise.all([
     repos.tickets.list({
       filter,
       page: { skip, take: PAGE_SIZE },
@@ -93,6 +95,8 @@ export default async function TicketsPage({ searchParams }: Props) {
     repos.categories.list(tenantId),
     // 担当者プルダウン用ユーザーは agent/admin のみ (依頼者には不要)
     isAgent ? repos.users.listAgents(tenantId) : Promise.resolve([]),
+    // テナントの動作モード (lite | pro) を取得し、ステータス表記を Lite/Pro で切り替える
+    getCurrentTenantMode(tenantId),
   ]);
 
   // 総ページ数を計算
@@ -118,9 +122,9 @@ export default async function TicketsPage({ searchParams }: Props) {
         </Link>
       </div>
 
-      {/* 検索フィルタ (Client Component を Suspense で安全にラップ) */}
+      {/* 検索フィルタ (Client Component を Suspense で安全にラップ、テナント mode をそのまま伝搬) */}
       <Suspense>
-        <TicketFilters categories={categories} agents={agents} isAgent={isAgent} />
+        <TicketFilters categories={categories} agents={agents} isAgent={isAgent} mode={mode} />
       </Suspense>
 
       {/* 件数表示 (落ち着いたグレー) */}
@@ -169,12 +173,12 @@ export default async function TicketsPage({ searchParams }: Props) {
                       {ticket.title}
                     </Link>
                   </td>
-                  {/* ステータスバッジ */}
+                  {/* ステータスバッジ (テナント mode に応じて Lite/Pro ラベルを切替) */}
                   <td className="px-5 py-3.5">
                     <span
                       className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_COLORS[ticket.status] ?? ''}`}
                     >
-                      {STATUS_LABELS[ticket.status] ?? ticket.status}
+                      {getStatusLabel(ticket.status, mode)}
                     </span>
                   </td>
                   {/* 優先度 (色付きテキスト) */}

--- a/src/domain/ticket-status.ts
+++ b/src/domain/ticket-status.ts
@@ -1,5 +1,7 @@
 // チケット状態 (TicketStatus) の型を Prisma (DB 操作ライブラリ) が生成した定義から読み込む
 import type { TicketStatus } from '@/generated/prisma';
+// テナントモード型 (lite | pro) を取り込み、mode-aware な遷移取得関数で使う
+import type { TenantMode } from '@/domain/types';
 
 // Source of truth for ticket status transitions. Mirrors `docs/requirements.html` §5
 // including `Closed → Open`（再オープン）which is an explicit product requirement,
@@ -23,8 +25,16 @@ export function isValidTransition(from: TicketStatus, to: TicketStatus): boolean
 }
 
 // 現在状態 from から遷移できる次状態の一覧を配列で返す関数 (UI のプルダウン生成用)
-export function getAllowedTransitions(from: TicketStatus): TicketStatus[] {
-  // 許可表からそのまま返す (配列を共有するので呼び出し側で変更しないこと)
+// - mode 省略 / 'pro' の場合は従来どおり Pro 用 7 値遷移表 (ALLOWED_TRANSITIONS) を引く
+// - mode === 'lite' かつ from が Lite 3 値のいずれかなら Lite 用遷移表を引く
+// - mode === 'lite' でも from が非 Lite (例: 旧データの Escalated/Resolved 等) なら Pro 表に
+//   フォールバックして「Lite に戻すための経路」を確保する (Pivot Plan §5.2)
+export function getAllowedTransitions(from: TicketStatus, mode: TenantMode = 'pro'): TicketStatus[] {
+  // Lite モードかつ from が Lite 対応 3 値なら Lite 遷移表を返す (型ガードで narrow)
+  if (mode === 'lite' && isLiteStatus(from)) {
+    return ALLOWED_TRANSITIONS_LITE[from];
+  }
+  // それ以外は Pro 遷移表をそのまま返す (配列を共有するので呼び出し側で変更しないこと)
   return ALLOWED_TRANSITIONS[from];
 }
 

--- a/src/domain/ticket-status.ts
+++ b/src/domain/ticket-status.ts
@@ -19,9 +19,14 @@ const ALLOWED_TRANSITIONS: Record<TicketStatus, TicketStatus[]> = {
 };
 
 // 現在状態 from から次状態 to に遷移してよいかを true/false で返す関数
-export function isValidTransition(from: TicketStatus, to: TicketStatus): boolean {
-  // 許可表を参照し、to が含まれていれば遷移可能
-  return ALLOWED_TRANSITIONS[from].includes(to);
+// mode 省略時は従来どおり Pro 表を引く (後方互換)。Lite テナントから呼ぶ場合は 'lite' を渡す。
+export function isValidTransition(
+  from: TicketStatus,
+  to: TicketStatus,
+  mode: TenantMode = 'pro',
+): boolean {
+  // mode-aware な遷移先一覧を引き、to が含まれていれば遷移可能
+  return getAllowedTransitions(from, mode).includes(to);
 }
 
 // 現在状態 from から遷移できる次状態の一覧を配列で返す関数 (UI のプルダウン生成用)

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -10,8 +10,10 @@ import { repos, uow } from '@/data';
 import { broadcastUnreadCount, broadcastUnreadCountToMany } from '@/features/notifications/notify';
 // エージェント権限判定 (agent または admin のとき true)
 import { isAgent } from '@/lib/role';
-// ステータス遷移が許可されているか判定するドメイン関数
+// ステータス遷移が許可されているか判定するドメイン関数 (mode 引数で Lite/Pro 切替)
 import { isValidTransition } from '@/domain/ticket-status';
+// セッションの tenantId からテナント mode (lite | pro) を取得するヘルパー
+import { getCurrentTenantMode } from '@/lib/tenant';
 // 型のみインポート (優先度/ステータス)
 import type { Priority, TicketStatus } from '@/domain/types';
 // レート制限 (連打防止) の共通ヘルパー
@@ -47,6 +49,9 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
   assertAgentRole(session);
   // セッションから tenantId を取り出して以降の where 句注入に使う
   const tenantId = session.user.tenantId;
+  // テナントの動作モード (lite | pro) を取得し、遷移表の切替に使う
+  // UI (StatusSelect) が表示する選択肢と整合させ、Lite で許される InProgress→Open 等を弾かないようにする
+  const mode = await getCurrentTenantMode(tenantId);
   // 10 秒あたり 10 回までに制限 (チケット単位)
   enforceRateLimit(`ticket-status:${session.user.id}:${ticketId}`, { limit: 10, windowMs: 10_000 });
 
@@ -58,8 +63,8 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
     if (!ticket) throw new Error('チケットが見つかりません');
     // 変更前後が同じなら何もしない (冪等)
     if (ticket.status === newStatus) return;
-    // 遷移表で許可されていない変更は拒否
-    if (!isValidTransition(ticket.status, newStatus)) {
+    // 遷移表 (mode に応じて Lite/Pro) で許可されていない変更は拒否
+    if (!isValidTransition(ticket.status, newStatus, mode)) {
       throw new Error(
         `ステータスを「${ticket.status}」から「${newStatus}」に変更することはできません`,
       );
@@ -224,16 +229,18 @@ export async function escalateTicket(ticketId: string, reason: string) {
   // 検証済み (trim 等済み) の理由を取り出す
   const trimmedReason = parsedReason.data;
 
-  // チケット本体と通知対象の全エージェント ID 一覧をテナントスコープで並列取得
-  const [ticket, agentIds] = await Promise.all([
+  // チケット本体・通知対象の全エージェント ID 一覧・テナント mode をテナントスコープで並列取得
+  const [ticket, agentIds, mode] = await Promise.all([
     repos.tickets.findById(ticketId, tenantId),
     repos.users.listAgentIds(tenantId),
+    // Lite モードでは Escalated 自体が UI 上存在しないので、サーバー側でも mode-aware に弾く
+    getCurrentTenantMode(tenantId),
   ]);
 
   // チケットが無ければエラー
   if (!ticket) throw new Error('チケットが見つかりません');
-  // Escalated への遷移が許可されているか確認
-  if (!isValidTransition(ticket.status, 'Escalated')) {
+  // Escalated への遷移が許可されているか確認 (Lite では遷移表に Escalated が無いので必ず弾かれる)
+  if (!isValidTransition(ticket.status, 'Escalated', mode)) {
     throw new Error(`現在のステータス「${ticket.status}」からエスカレーションできません`);
   }
 

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -70,11 +70,17 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
       );
     }
 
-    // Resolved に遷移したら解決日時を現在時刻に、Resolved から離れる場合はクリア、それ以外は据え置き
+    // 「完了」とみなすステータスを mode に応じて決定する
+    // - Pro: 'Resolved' (従来どおり「解決済み」が完了扱い)
+    // - Lite: 'Closed' (Lite UI の「完了」は Closed に対応するため、ここで resolvedAt をセット)
+    // これがズレると Lite の完了済みチケットでも resolvedAt=null のままになり、SLA が常に
+    // 期限切れ扱いになる (getSlaState は resolvedAt がある場合のみ 'ok' を返すため)
+    const completionStatus: TicketStatus = mode === 'lite' ? 'Closed' : 'Resolved';
+    // 完了ステータスに遷移したら解決日時を現在時刻に、完了から離れる場合はクリア、それ以外は据え置き
     const resolvedAt =
-      newStatus === 'Resolved'
+      newStatus === completionStatus
         ? new Date()
-        : ticket.status === 'Resolved'
+        : ticket.status === completionStatus
           ? null
           : ticket.resolvedAt;
 

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -70,19 +70,24 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
       );
     }
 
-    // 「完了」とみなすステータスを mode に応じて決定する
-    // - Pro: 'Resolved' (従来どおり「解決済み」が完了扱い)
-    // - Lite: 'Closed' (Lite UI の「完了」は Closed に対応するため、ここで resolvedAt をセット)
-    // これがズレると Lite の完了済みチケットでも resolvedAt=null のままになり、SLA が常に
-    // 期限切れ扱いになる (getSlaState は resolvedAt がある場合のみ 'ok' を返すため)
-    const completionStatus: TicketStatus = mode === 'lite' ? 'Closed' : 'Resolved';
-    // 完了ステータスに遷移したら解決日時を現在時刻に、完了から離れる場合はクリア、それ以外は据え置き
-    const resolvedAt =
-      newStatus === completionStatus
-        ? new Date()
-        : ticket.status === completionStatus
-          ? null
-          : ticket.resolvedAt;
+    // 「完了」とみなすステータス集合を mode に応じて決定する
+    // - Pro: ['Resolved'] (従来どおり「解決済み」が完了扱い)
+    // - Lite: ['Closed', 'Resolved'] — Lite UI の「完了」は Closed に対応するが、Lite 遷移表が
+    //   Lite 非対応ステータス (例: 旧 Pro データの Resolved) から Pro 表へフォールバックするため、
+    //   Lite テナントでも Resolved が残っている可能性がある。両方を完了扱いにしておくことで、
+    //   ・新規完了 (Closed) で resolvedAt をセット
+    //   ・旧 Resolved データの再オープン (Resolved → Open) で resolvedAt をクリア
+    //   の両方を一貫して扱える。
+    // これがズレると Lite 完了済みチケットでも resolvedAt=null のまま (SLA 期限切れ表示)、
+    // または再オープン後も resolvedAt が残る (SLA 解決済み表示) などの不整合が起きる。
+    const completionStatuses: TicketStatus[] =
+      mode === 'lite' ? ['Closed', 'Resolved'] : ['Resolved'];
+    // 完了集合に入る遷移なら現在時刻に、完了集合から離れる場合はクリア、それ以外は据え置き
+    const resolvedAt = completionStatuses.includes(newStatus)
+      ? new Date()
+      : completionStatuses.includes(ticket.status)
+        ? null
+        : ticket.resolvedAt;
 
     // ステータスと解決日時を更新 (tenantId スコープで where に注入)
     await r.tickets.updateStatus(ticketId, newStatus, resolvedAt, tenantId);

--- a/src/features/tickets/components/StatusSelect.tsx
+++ b/src/features/tickets/components/StatusSelect.tsx
@@ -4,25 +4,28 @@
 import { useTransition } from 'react';
 // ステータス更新サーバーアクション
 import { updateTicketStatus } from '@/features/tickets/actions/update-ticket';
-// ステータスの日本語ラベル
-import { STATUS_LABELS } from '@/lib/constants';
-// 現ステータスから許可される遷移先一覧を返すドメイン関数
+// ステータスの日本語ラベルを mode (lite | pro) に応じて返す mode-aware ヘルパー
+import { getStatusLabel } from '@/lib/constants';
+// 現ステータスから許可される遷移先一覧を返すドメイン関数 (mode に応じて Lite/Pro 表を切替)
 import { getAllowedTransitions } from '@/domain/ticket-status';
 // ステータス型 (Prisma 生成)
 import type { TicketStatus } from '@/generated/prisma';
+// テナントモード型 (lite | pro)。ラベルと遷移表の切替に使う
+import type { TenantMode } from '@/domain/types';
 
-// 受け取る props (チケット ID と現在ステータス)
+// 受け取る props (チケット ID と現在ステータスと、表示切替用テナントモード)
 interface Props {
   ticketId: string;
   current: TicketStatus;
+  mode: TenantMode;
 }
 
 // ステータスを切り替えるプルダウン (許可された遷移のみ表示)
-export function StatusSelect({ ticketId, current }: Props) {
+export function StatusSelect({ ticketId, current, mode }: Props) {
   // 送信中フラグ + トランジション
   const [isPending, startTransition] = useTransition();
-  // 現状から遷移可能な次状態の一覧
-  const allowed = getAllowedTransitions(current);
+  // 現状から遷移可能な次状態の一覧 (mode に応じて Lite なら 3 値遷移表、Pro なら 7 値遷移表)
+  const allowed = getAllowedTransitions(current, mode);
 
   // 選択変更でアクションを呼ぶ
   function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
@@ -40,14 +43,14 @@ export function StatusSelect({ ticketId, current }: Props) {
       disabled={isPending}
       className="rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none disabled:opacity-50"
     >
-      {/* 現在値はプレースホルダ的に disabled で表示 */}
+      {/* 現在値はプレースホルダ的に disabled で表示 (mode に応じて Lite/Pro ラベル) */}
       <option value={current} disabled>
-        {STATUS_LABELS[current] ?? current}
+        {getStatusLabel(current, mode)}
       </option>
-      {/* 許可された遷移先のみを option として並べる */}
+      {/* 許可された遷移先のみを option として並べる (mode に応じて Lite/Pro ラベル) */}
       {allowed.map((s) => (
         <option key={s} value={s}>
-          {STATUS_LABELS[s] ?? s}
+          {getStatusLabel(s, mode)}
         </option>
       ))}
     </select>

--- a/src/features/tickets/components/TicketFilters.tsx
+++ b/src/features/tickets/components/TicketFilters.tsx
@@ -4,24 +4,29 @@
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 // 非ブロッキング更新/メモ化/ref 用フック
 import { useTransition, useCallback, useRef } from 'react';
-// ステータス/優先度の日本語ラベル
-import { STATUS_LABELS, PRIORITY_LABELS } from '@/lib/constants';
+// ステータスの日本語ラベルを mode (lite | pro) に応じて返す mode-aware ヘルパーと優先度ラベル
+import { getStatusLabel, PRIORITY_LABELS } from '@/lib/constants';
+// Lite モードで使う 3 ステータス (未対応 / 対応中 / 完了) の定義
+import { LITE_STATUSES } from '@/domain/ticket-status';
 // 列挙型 (Prisma 生成)
 import type { TicketStatus, Priority } from '@/generated/prisma';
+// テナントモード型 (lite | pro)。フィルタ選択肢とラベルの切替に使う
+import type { TenantMode } from '@/domain/types';
 
 // プルダウン項目用の最小限の型
 type Category = { id: string; name: string };
 type Agent = { id: string; name: string };
 
-// 受け取る props (絞り込み候補と権限フラグ)
+// 受け取る props (絞り込み候補と権限フラグ、テナントの動作モード)
 interface Props {
   categories: Category[];
   agents: Agent[];
   isAgent: boolean;
+  mode: TenantMode;
 }
 
-// プルダウンに並べるステータス/優先度の順序
-const ALL_STATUSES: TicketStatus[] = [
+// プルダウンに並べる Pro モード用ステータス/優先度の順序 (7 値)
+const ALL_STATUSES_PRO: TicketStatus[] = [
   'New',
   'Open',
   'WaitingForUser',
@@ -37,7 +42,9 @@ const fieldBaseClass =
   'rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 transition focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30';
 
 // チケット一覧ページの絞り込み (URL クエリと同期)
-export function TicketFilters({ categories, agents, isAgent }: Props) {
+export function TicketFilters({ categories, agents, isAgent, mode }: Props) {
+  // テナントが Lite なら 3 値、Pro なら従来 7 値をフィルタ候補として使う
+  const statusOptions: TicketStatus[] = mode === 'lite' ? [...LITE_STATUSES] : ALL_STATUSES_PRO;
   // ルーター/現在パス/検索クエリ
   const router = useRouter();
   const pathname = usePathname();
@@ -106,9 +113,9 @@ export function TicketFilters({ categories, agents, isAgent }: Props) {
           className={fieldBaseClass}
         >
           <option value="">すべてのステータス</option>
-          {ALL_STATUSES.map((s) => (
+          {statusOptions.map((s) => (
             <option key={s} value={s}>
-              {STATUS_LABELS[s] ?? s}
+              {getStatusLabel(s, mode)}
             </option>
           ))}
         </select>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -99,11 +99,18 @@ export const NOTIFICATION_TYPE_LABELS: Record<string, string> = {
 
 // 変更履歴の oldValue / newValue を field 種別に応じて日本語表示に変換する関数
 // status / escalation はステータス enum、priority は優先度 enum、assignee はユーザー名がそのまま入る
-export function formatHistoryValue(field: string, value: string | null): string {
+// mode を渡すと status/escalation のラベルをテナントの動作モードに合わせて切り替える (Lite なら 3 値)
+// (旧呼び出し互換のため mode 省略時は 'pro' = 現行 7 値表記をデフォルトとする)
+export function formatHistoryValue(
+  field: string,
+  value: string | null,
+  mode: TenantMode = 'pro',
+): string {
   // 値が null の場合は欠損プレースホルダ「―」を返す (担当者の初回割当など)
   if (value === null) return '―';
-  // status / escalation はステータス enum 値なので STATUS_LABELS で日本語化する
-  if (field === 'status' || field === 'escalation') return STATUS_LABELS[value] ?? value;
+  // status / escalation はステータス enum 値なので mode-aware な getStatusLabel で日本語化する
+  if (field === 'status' || field === 'escalation')
+    return getStatusLabel(value as TicketStatus, mode);
   // priority は優先度 enum 値なので PRIORITY_LABELS で日本語化する
   if (field === 'priority') return PRIORITY_LABELS[value] ?? value;
   // assignee はユーザー名そのものが入っているので変換せずに返す

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -1,0 +1,28 @@
+// セッションからログインユーザーの tenantId を取得するための NextAuth 関数
+import { auth } from '@/lib/auth';
+// Composition Root からテナント取得用リポジトリ束を取り込む
+import { repos } from '@/data';
+// テナントモード型 (lite | pro) をドメイン層から取り込む
+import type { TenantMode } from '@/domain/types';
+
+// 現在ログイン中のテナントの mode (lite | pro) を取得するヘルパー
+// - 引数 tenantId が渡されればその値で Tenant を引く (page で既に session を取っているケース向けの最適化)
+// - 引数が無ければ auth() でセッションを引き、その tenantId を使う
+// - セッション無し / Tenant が見つからない場合は安全側に倒して 'lite' を返す (DB 既定値と一致)
+export async function getCurrentTenantMode(tenantId?: string): Promise<TenantMode> {
+  // 呼び出し側が tenantId を持っていれば二重に session を読まないようそのまま使う
+  let resolvedTenantId = tenantId;
+  // tenantId が渡っていない場合のみ NextAuth のセッションから引き出す
+  if (!resolvedTenantId) {
+    // セッションを取得 (未ログインなら null)
+    const session = await auth();
+    // セッションが無い / tenantId が無い場合は既定 mode (lite) を返して終了
+    if (!session?.user?.tenantId) return 'lite';
+    // セッションから取り出した tenantId を以降の処理で利用する
+    resolvedTenantId = session.user.tenantId;
+  }
+  // Tenant リポジトリ (port 経由) で tenantId から Tenant 本体を取得
+  const tenant = await repos.tenants.findById(resolvedTenantId);
+  // Tenant が見つからなければ既定 mode (lite) にフォールバック (削除/不整合への防御)
+  return tenant?.mode ?? 'lite';
+}

--- a/tests/features/update-ticket.test.ts
+++ b/tests/features/update-ticket.test.ts
@@ -298,6 +298,53 @@ describe('updateTicketStatus (Lite mode)', () => {
     expect(t?.status).toBe('Open');
     expect(t?.resolvedAt).toBeNull();
   });
+
+  // Lite: 旧 Pro データの Resolved → Open (Pro 表フォールバックで許可) でも resolvedAt がクリアされること
+  // (Lite では Resolved/Closed 両方を completionStatuses として扱う設計の検証)
+  it('clears resolvedAt when reopening from legacy Resolved in Lite mode', async () => {
+    const { ticketId } = await seed();
+    setTenantToLite();
+    // 事前準備として Resolved + resolvedAt セット済みの状態にする (旧 Pro データを想定)
+    await repos.tickets.updateStatus(ticketId, 'Resolved', new Date(), TENANT);
+    const { updateTicketStatus } = await import('@/features/tickets/actions/update-ticket');
+
+    // Lite モードでも Resolved は LiteStatus に含まれないため Pro 遷移表へフォールバック、
+    // Pro['Resolved'] には 'Open' が含まれるので遷移は許可される
+    await updateTicketStatus(ticketId, 'Open');
+
+    // 反映と resolvedAt クリアを確認 (SLA 表示が「解決済み残存」にならないことの担保)
+    const t = await repos.tickets.findById(ticketId, TENANT);
+    expect(t?.status).toBe('Open');
+    expect(t?.resolvedAt).toBeNull();
+  });
+
+  // Lite: 旧 Pro データの Resolved → Closed (Pro 表フォールバックで許可) では resolvedAt が新しい時刻で更新されること
+  // (両方とも completionStatuses に含まれるため、終端状態間の移動として今の時刻で再記録する)
+  it('updates resolvedAt when moving from legacy Resolved to Closed in Lite mode', async () => {
+    const { ticketId } = await seed();
+    setTenantToLite();
+    // 古い resolvedAt (10 分前) を持つ Resolved の状態を作る
+    const oldResolvedAt = new Date(Date.now() - 10 * 60 * 1000);
+    await repos.tickets.updateStatus(ticketId, 'Resolved', oldResolvedAt, TENANT);
+    const { updateTicketStatus } = await import('@/features/tickets/actions/update-ticket');
+
+    // 呼び出し前後の時刻を測って resolvedAt の妥当性を検証
+    const before = Date.now();
+    // Pro 表フォールバックで Resolved → Closed が許可される
+    await updateTicketStatus(ticketId, 'Closed');
+    const after = Date.now();
+
+    // 反映確認
+    const t = await repos.tickets.findById(ticketId, TENANT);
+    expect(t?.status).toBe('Closed');
+    // resolvedAt が新しい時刻で上書きされている (古い 10 分前の値ではない)
+    expect(t?.resolvedAt).toBeInstanceOf(Date);
+    const ts = t!.resolvedAt!.getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+    // 古いタイムスタンプとは異なることも明示的に確認
+    expect(ts).toBeGreaterThan(oldResolvedAt.getTime());
+  });
 });
 
 // 担当者更新アクションの仕様

--- a/tests/features/update-ticket.test.ts
+++ b/tests/features/update-ticket.test.ts
@@ -256,6 +256,48 @@ describe('updateTicketStatus (Lite mode)', () => {
     const t = await repos.tickets.findById(ticketId, TENANT);
     expect(t?.status).toBe('Open');
   });
+
+  // Lite: 対応中 → 完了 (InProgress → Closed) で resolvedAt が現在時刻にセットされること
+  // (Lite UI の「完了」は Closed なので SLA が 'ok' 扱いになるための前提)
+  it('sets resolvedAt when transitioning to Closed in Lite mode', async () => {
+    const { ticketId } = await seed();
+    setTenantToLite();
+    // 事前準備として InProgress 状態にする (resolvedAt は null のまま)
+    await repos.tickets.updateStatus(ticketId, 'InProgress', null, TENANT);
+    const { updateTicketStatus } = await import('@/features/tickets/actions/update-ticket');
+
+    // 呼び出し前後の時刻を測って resolvedAt の妥当性を検証
+    const before = Date.now();
+    await updateTicketStatus(ticketId, 'Closed');
+    const after = Date.now();
+
+    // 反映確認
+    const t = await repos.tickets.findById(ticketId, TENANT);
+    expect(t?.status).toBe('Closed');
+    // resolvedAt が Date でセットされている
+    expect(t?.resolvedAt).toBeInstanceOf(Date);
+    // 計測した範囲内に収まる
+    const ts = t!.resolvedAt!.getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  // Lite: 完了 → 未対応 (Closed → Open) で resolvedAt がクリアされること (再オープン時の戻し)
+  it('clears resolvedAt when reopening from Closed in Lite mode', async () => {
+    const { ticketId } = await seed();
+    setTenantToLite();
+    // 事前準備として Closed + resolvedAt セット済みの状態にする
+    await repos.tickets.updateStatus(ticketId, 'Closed', new Date(), TENANT);
+    const { updateTicketStatus } = await import('@/features/tickets/actions/update-ticket');
+
+    // Closed → Open は Lite 遷移表で許可されているので成功する
+    await updateTicketStatus(ticketId, 'Open');
+
+    // 反映と resolvedAt クリアを確認
+    const t = await repos.tickets.findById(ticketId, TENANT);
+    expect(t?.status).toBe('Open');
+    expect(t?.resolvedAt).toBeNull();
+  });
 });
 
 // 担当者更新アクションの仕様

--- a/tests/features/update-ticket.test.ts
+++ b/tests/features/update-ticket.test.ts
@@ -49,10 +49,12 @@ vi.mock('@/lib/sse-subscribers', () => ({
 async function seed() {
   const now = new Date();
   // まずデフォルトテナントを投入 (User/Category/Ticket の FK 先として必要)
+  // 既存テストは Pro 専用ステータス (New / Resolved / Escalated 等) の遷移を検証するため
+  // テナント mode は 'pro' で固定 (Lite 専用の挙動は後段の describe ブロックで mode を上書きして検証)
   store.tenants.set('default-tenant', {
     id: 'default-tenant',
     name: 'デフォルト組織',
-    mode: 'lite',
+    mode: 'pro',
     industry: null,
     createdAt: now,
   });
@@ -204,6 +206,55 @@ describe('updateTicketStatus (provider-agnostic)', () => {
     const t = await repos.tickets.findById(ticketId, TENANT);
     expect(t?.status).toBe('InProgress');
     expect(t?.resolvedAt).toBeNull();
+  });
+});
+
+// Lite モード (mode: 'lite') のテナントから呼び出した場合の遷移検証
+// (UI の StatusSelect が見せる選択肢とサーバ側検証が一致することを確認)
+describe('updateTicketStatus (Lite mode)', () => {
+  // テナント mode を 'lite' に差し替えるヘルパー (seed 後に呼ぶ)
+  function setTenantToLite() {
+    // 既存の default-tenant エントリを取り出す (seed 済み前提)
+    const t = store.tenants.get('default-tenant');
+    // 念のため見つからなければ assert (テスト前提崩壊の早期検知)
+    if (!t) throw new Error('seed missing default-tenant');
+    // mode フィールドだけ 'lite' に書き換えて再格納
+    store.tenants.set('default-tenant', { ...t, mode: 'lite' });
+  }
+
+  // Lite: 対応中 → 未対応 (InProgress → Open) は Lite 遷移表で許可されているので成功すること
+  it('allows InProgress to Open in Lite mode (Pro table rejects this)', async () => {
+    const { ticketId } = await seed();
+    // テナントを Lite に切り替えてから事前ステータスを InProgress に
+    setTenantToLite();
+    // 事前準備として InProgress 状態にしておく (Pro 表でも New→InProgress は許可される)
+    await repos.tickets.updateStatus(ticketId, 'InProgress', null, TENANT);
+    const { updateTicketStatus } = await import('@/features/tickets/actions/update-ticket');
+
+    // Lite では InProgress → Open は許可されるので成功する
+    await updateTicketStatus(ticketId, 'Open');
+
+    // 反映確認
+    const t = await repos.tickets.findById(ticketId, TENANT);
+    expect(t?.status).toBe('Open');
+  });
+
+  // Lite: 未対応 → エスカレーション (Open → Escalated) は Lite 遷移表に Escalated が無いため失敗すること
+  it('rejects Open to Escalated in Lite mode (Pro table would allow this)', async () => {
+    const { ticketId } = await seed();
+    setTenantToLite();
+    // 事前準備として Open 状態にしておく
+    await repos.tickets.updateStatus(ticketId, 'Open', null, TENANT);
+    const { updateTicketStatus } = await import('@/features/tickets/actions/update-ticket');
+
+    // Lite では Escalated が遷移先に存在しないので拒否される
+    await expect(updateTicketStatus(ticketId, 'Escalated')).rejects.toThrow(
+      /変更することはできません/,
+    );
+
+    // ステータスは Open のまま (ロールバック)
+    const t = await repos.tickets.findById(ticketId, TENANT);
+    expect(t?.status).toBe('Open');
   });
 });
 

--- a/tests/ticket-status.test.ts
+++ b/tests/ticket-status.test.ts
@@ -101,3 +101,38 @@ describe('Lite ticket status transition rules', () => {
     expect(isLiteStatus('Resolved')).toBe(false);
   });
 });
+
+// getAllowedTransitions(from, mode) の mode 引数 (Lite/Pro) 分岐テスト
+describe('getAllowedTransitions with tenant mode', () => {
+  // mode 省略時は従来どおり Pro 遷移表を返すこと (後方互換)
+  it('defaults to Pro transitions when mode is omitted', () => {
+    // mode 引数なしで呼ぶと従来の Pro 7 値遷移表が返る
+    expect(getAllowedTransitions('Open')).toContain('Escalated');
+    expect(getAllowedTransitions('Open')).toContain('WaitingForUser');
+  });
+
+  // mode='pro' を明示しても Pro 遷移表を返すこと
+  it("returns Pro transitions when mode is 'pro'", () => {
+    // Pro 指定時は Escalated/WaitingForUser など 7 値の遷移先が含まれる
+    expect(getAllowedTransitions('Open', 'pro')).toContain('Escalated');
+    expect(getAllowedTransitions('InProgress', 'pro')).toContain('WaitingForUser');
+  });
+
+  // mode='lite' かつ Lite 対応ステータスなら Lite 3 値遷移表を返すこと
+  it("returns Lite transitions when mode is 'lite' and status is Lite-compatible", () => {
+    // Open (未対応) からは InProgress / Closed のみ (Escalated は含まれない)
+    expect(getAllowedTransitions('Open', 'lite')).toEqual(['InProgress', 'Closed']);
+    // InProgress (対応中) からは Open / Closed のみ (Resolved/Escalated は含まれない)
+    expect(getAllowedTransitions('InProgress', 'lite')).toEqual(['Open', 'Closed']);
+    // Closed (完了) からは Open (再オープン) のみ
+    expect(getAllowedTransitions('Closed', 'lite')).toEqual(['Open']);
+  });
+
+  // mode='lite' でも from が Lite 非対応 (旧データ) なら Pro 遷移表にフォールバックすること
+  it("falls back to Pro transitions when mode is 'lite' but status is not in Lite set", () => {
+    // 旧データの Escalated/Resolved/WaitingForUser/New 等は Pro 表を引いて経路を確保する
+    expect(getAllowedTransitions('Escalated', 'lite')).toEqual(getAllowedTransitions('Escalated'));
+    expect(getAllowedTransitions('Resolved', 'lite')).toEqual(getAllowedTransitions('Resolved'));
+    expect(getAllowedTransitions('New', 'lite')).toEqual(getAllowedTransitions('New'));
+  });
+});

--- a/tests/ticket-status.test.ts
+++ b/tests/ticket-status.test.ts
@@ -136,3 +136,28 @@ describe('getAllowedTransitions with tenant mode', () => {
     expect(getAllowedTransitions('New', 'lite')).toEqual(getAllowedTransitions('New'));
   });
 });
+
+// isValidTransition(from, to, mode) の mode 引数 (Lite/Pro) 分岐テスト
+describe('isValidTransition with tenant mode', () => {
+  // Lite モード: InProgress → Open は Lite 表で許可されているので true
+  it("allows InProgress → Open when mode is 'lite'", () => {
+    expect(isValidTransition('InProgress', 'Open', 'lite')).toBe(true);
+  });
+
+  // Pro モード: InProgress → Open は Pro 表に Open が無いので false
+  it("rejects InProgress → Open when mode is 'pro' (default)", () => {
+    // mode='pro' を明示しても、省略しても結果は同じ (省略時は 'pro' がデフォルト)
+    expect(isValidTransition('InProgress', 'Open', 'pro')).toBe(false);
+    expect(isValidTransition('InProgress', 'Open')).toBe(false);
+  });
+
+  // Lite モード: Open → Escalated は Lite 表に Escalated が無いので false
+  it("rejects Open → Escalated when mode is 'lite'", () => {
+    expect(isValidTransition('Open', 'Escalated', 'lite')).toBe(false);
+  });
+
+  // Pro モード: Open → Escalated は Pro 表で許可されているので true
+  it("allows Open → Escalated when mode is 'pro'", () => {
+    expect(isValidTransition('Open', 'Escalated', 'pro')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`docs/smb-dx-pivot-plan.md` の **Phase 1（Lite MVP）/ §3.1 用語簡素化 / §5.2 UI 表示仕様** 対応。
PR #101 でドメイン層に追加済みの `getStatusLabel(status, mode)` / `LITE_STATUS_LABELS` を UI に配線し、Lite テナントのチケット表記を「**未対応 / 対応中 / 完了**」に統一する。DB の `TicketStatus` enum・既存 Pro 遷移表は据え置き。

## Changes

1. **`src/lib/tenant.ts` (新規)** — `getCurrentTenantMode(tenantId?)` ヘルパーを追加。`session.user.tenantId` から `repos.tenants.findById` で `Tenant.mode` を引き、見つからない場合は安全側 (`'lite'`) にフォールバック。
2. **`src/domain/ticket-status.ts`** — `getAllowedTransitions(from, mode?)` と `isValidTransition(from, to, mode?)` に `mode` 引数を追加。`'lite'` かつ `from` が Lite 3 値なら `ALLOWED_TRANSITIONS_LITE` を引き、それ以外は Pro 表にフォールバック。`mode` 省略時は従来どおり Pro 表 (後方互換)。
3. **`src/lib/constants.ts`** — `formatHistoryValue(field, value, mode?)` に `mode` 引数を追加し、内部で `getStatusLabel(value, mode)` を使うように。デフォルト `'pro'` で旧呼出し互換。
4. **`src/features/tickets/components/StatusSelect.tsx`** — `mode` prop を追加し、ラベル/遷移先を `getStatusLabel(s, mode)` / `getAllowedTransitions(current, mode)` 経由に置換。
5. **`src/features/tickets/components/TicketFilters.tsx`** — `mode` prop を追加し、Lite 時は絞り込み候補を `LITE_STATUSES` の 3 値に絞り、ラベルも mode-aware に。
6. **`src/app/(app)/tickets/page.tsx`** — `Promise.all` に `getCurrentTenantMode(tenantId)` を追加し、テーブルのステータスバッジと `TicketFilters` に `mode` を伝搬。
7. **`src/app/(app)/tickets/[id]/page.tsx`** — 同上で `mode` を取得し、詳細パネルのステータスバッジ・`StatusSelect`・履歴値変換 (`formatHistoryValue`) に伝搬。Lite モードではエスカレーション操作を非表示に。
8. **`src/features/tickets/actions/update-ticket.ts`** — `updateTicketStatus` / `escalateTicket` 内で `getCurrentTenantMode(tenantId)` を取得し `isValidTransition(..., mode)` を mode-aware に。`completionStatuses = mode === 'lite' ? ['Closed', 'Resolved'] : ['Resolved']` で `resolvedAt` の set/clear を mode 対応に統一（Lite UI の「完了」=`Closed` でも SLA `'ok'` 扱いになる + 旧 Pro データ `Resolved` の再オープンで `resolvedAt` がクリアされる）。
9. **`tests/ticket-status.test.ts`** — `getAllowedTransitions` / `isValidTransition` の新シグネチャ（Lite / Pro / 旧データのフォールバック）をカバーする 8 ケースを追加。
10. **`tests/features/update-ticket.test.ts`** — `describe('updateTicketStatus (Lite mode)')` を新設し、Lite テナントでの遷移許可・拒否・`resolvedAt` set/clear/upsert を含む 6 ケースを追加。seed の tenant mode を `'pro'` に固定（既存テストは Pro 専用ステータスの遷移を検証するため）。

## 設計上のポイント

- **fallback 方針**: `getStatusLabel` と同様に、Lite テナントでも旧データの非 Lite ステータス（`Escalated` 等）は Pro ラベル/遷移表にフォールバックして経路を切らない。
- **UI ↔ サーバの mode 一貫性**: `StatusSelect` の選択肢、`updateTicketStatus` の検証、`resolvedAt` セット条件、`escalateTicket` の許可判定すべてが同一の `mode` で切り替わる。
- **dashboard/page.tsx** の `STATUS_LABELS` 直接参照は本 PR のスコープ外（Lite 用ダッシュボード設計と合わせて別 PR）。
- **`PrioritySelect` / `TicketForm`** は mode 非依存のため変更なし。

## Test plan

- [x] `npm run lint` — エラーなし
- [x] `npm run typecheck` — エラーなし
- [x] `npm run test` — **91 件合格**（`ticket-status.test.ts` 10 → 18 件、`tests/features/update-ticket.test.ts` 17 → 23 件、計 +14 件）
- [x] `npm run test:e2e` — CI (`Playwright E2E`) green。既存セレクタは Lite 化で壊れていないことを確認
- [x] 手動: Lite テナント（default、`mode=lite`）の `/tickets` 一覧で `?status=Open` フィルタ時にバッジが「未対応」のみ、`?status=InProgress` で「対応中」のみ、`?status=Closed` で「完了」のみと表示されることを確認 ✅
- [x] 手動: フィルタドロップダウンが Lite モードで `[すべてのステータス, 未対応, 対応中, 完了]` の 4 項目のみになることを確認 ✅
- [x] 手動: Pro テナント（`UPDATE Tenant SET mode='pro' WHERE id='default-tenant';`）に切り替えるとフィルタが従来 7 値（`新規, オープン, ユーザー待ち, 対応中, エスカレーション, 解決済み, クローズ` + すべて）に戻ることを確認 ✅
- [x] 手動: Lite テナントでエージェントがチケット詳細の `StatusSelect` プルダウンを開いたとき、Lite 遷移表どおりの選択肢のみ並ぶことを確認（例: `Closed` 状態のチケットでは `[完了, 未対応]` のみ）✅
- [x] 手動: Lite テナントで `InProgress → Closed` を実行後、DB の `resolvedAt` が現在時刻 (action 実行から 337ms 以内) でセットされ、詳細ページの SLA バッジが「期限切れ/期限間近」表示にならないことを確認 ✅

> 手動確認は Playwright スクリプトで自動化（chromium ヘッドレス、PostgreSQL 直接接続で mode 切替）。ローカル環境（`npm run dev` + Postgres + seed）で全 5 シナリオ通過。

## レビュー履歴

レビュー指摘を受けて 3 ラウンドの修正を実施：
1. `5359e76` — Lite UI ↔ Server Action 遷移検証のズレを修正（`isValidTransition` を mode-aware に）
2. `938ff82` — Lite の `Closed` で `resolvedAt` がセットされない問題を修正
3. `8f8313b` — Lite + 旧 Pro データ `Resolved` 再オープン時に `resolvedAt` が残る問題を修正

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJjj18oQ7CaAoyYwSEauq3)_