### PR TITLE
feat(tickets): Lite モードのステータス遷移を Server Action で強制 (Phase 1)

### DIFF
--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -11,7 +11,13 @@ import { broadcastUnreadCount, broadcastUnreadCountToMany } from '@/features/not
 // エージェント権限判定 (agent または admin のとき true)
 import { isAgent } from '@/lib/role';
 // ステータス遷移が許可されているか判定するドメイン関数 (mode 引数で Lite/Pro 切替)
-import { isValidTransition } from '@/domain/ticket-status';
+// および Lite モード専用の遷移表ガード / Lite ステータス型ガード
+import {
+  getAllowedLiteTransitions,
+  isLiteStatus,
+  isValidTransition,
+  type LiteStatus,
+} from '@/domain/ticket-status';
 // セッションの tenantId からテナント mode (lite | pro) を取得するヘルパー
 import { getCurrentTenantMode } from '@/lib/tenant';
 // 型のみインポート (優先度/ステータス)
@@ -63,8 +69,22 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
     if (!ticket) throw new Error('チケットが見つかりません');
     // 変更前後が同じなら何もしない (冪等)
     if (ticket.status === newStatus) return;
-    // 遷移表 (mode に応じて Lite/Pro) で許可されていない変更は拒否
-    if (!isValidTransition(ticket.status, newStatus, mode)) {
+    // Lite テナントでは newStatus を Lite 3 値 (Open / InProgress / Closed) に強制する
+    // 旧データ (Resolved / Escalated / WaitingForUser / New) からの off-ramp は許すが、
+    // Lite テナント上で「新規にそれら非 Lite ステータスへ落とす」操作は仕様違反 (Pivot plan §3.1 / §5.2)
+    if (mode === 'lite' && !isLiteStatus(newStatus)) {
+      throw new Error(`Lite モードでは「${newStatus}」へは変更できません`);
+    }
+    // 遷移許可判定:
+    // - Lite モードかつ from も Lite 3 値: 専用遷移表 (getAllowedLiteTransitions) を直接ガードに使う
+    //   (直前の isLiteStatus(newStatus) 判定で newStatus は LiteStatus が確定するが、
+    //    TS の制御フローを跨いだ narrow が効かないので as LiteStatus でローカルキャスト)
+    // - それ以外 (Pro モード / Lite × 非 Lite 始点の off-ramp): 従来どおり mode-aware な isValidTransition
+    const guardPassed =
+      mode === 'lite' && isLiteStatus(ticket.status)
+        ? getAllowedLiteTransitions(ticket.status).includes(newStatus as LiteStatus)
+        : isValidTransition(ticket.status, newStatus, mode);
+    if (!guardPassed) {
       throw new Error(
         `ステータスを「${ticket.status}」から「${newStatus}」に変更することはできません`,
       );

--- a/tests/features/update-ticket.test.ts
+++ b/tests/features/update-ticket.test.ts
@@ -247,9 +247,10 @@ describe('updateTicketStatus (Lite mode)', () => {
     await repos.tickets.updateStatus(ticketId, 'Open', null, TENANT);
     const { updateTicketStatus } = await import('@/features/tickets/actions/update-ticket');
 
-    // Lite では Escalated が遷移先に存在しないので拒否される
+    // Lite では Escalated は非 Lite ステータスなので、ターゲット制限ガードに弾かれる
+    // ("Lite モードでは「Escalated」へは変更できません" メッセージで reject)
     await expect(updateTicketStatus(ticketId, 'Escalated')).rejects.toThrow(
-      /変更することはできません/,
+      /Lite モードでは/,
     );
 
     // ステータスは Open のまま (ロールバック)
@@ -344,6 +345,25 @@ describe('updateTicketStatus (Lite mode)', () => {
     expect(ts).toBeLessThanOrEqual(after);
     // 古いタイムスタンプとは異なることも明示的に確認
     expect(ts).toBeGreaterThan(oldResolvedAt.getTime());
+  });
+
+  // Lite: 旧 Pro データの Resolved → WaitingForUser (Pro 表では許可) は新ターゲット制限で弾かれること
+  // (off-ramp は Lite 3 値 (Open / InProgress / Closed) へのみ許可するのが Pivot plan §3.1 / §5.2 の趣旨)
+  it('rejects legacy Resolved to WaitingForUser in Lite mode (target restriction)', async () => {
+    const { ticketId } = await seed();
+    setTenantToLite();
+    // 事前準備として Resolved + resolvedAt セット済みの状態にする (旧 Pro データを想定)
+    await repos.tickets.updateStatus(ticketId, 'Resolved', new Date(), TENANT);
+    const { updateTicketStatus } = await import('@/features/tickets/actions/update-ticket');
+
+    // WaitingForUser は Lite 3 値に含まれないので、ターゲット制限ガードで弾かれる
+    await expect(updateTicketStatus(ticketId, 'WaitingForUser')).rejects.toThrow(
+      /Lite モードでは/,
+    );
+
+    // ステータスは Resolved のまま (ロールバック)
+    const t = await repos.tickets.findById(ticketId, TENANT);
+    expect(t?.status).toBe('Resolved');
   });
 });
 

--- a/tests/ticket-status.test.ts
+++ b/tests/ticket-status.test.ts
@@ -161,3 +161,30 @@ describe('isValidTransition with tenant mode', () => {
     expect(isValidTransition('Open', 'Escalated', 'pro')).toBe(true);
   });
 });
+
+// updateTicketStatus に組み込まれた Lite ターゲット制限ガードの根拠となるドメイン不変条件
+// (Server Action 側で「Lite モードでは newStatus を必ず Lite 3 値に限定」する判定の前提)
+describe('Lite mode target restriction invariants', () => {
+  // 非 Lite ステータス (Resolved / Escalated / WaitingForUser / New) は isLiteStatus で false となり、
+  // Lite テナント上で新規にこれらへ遷移する操作が Server Action のガードで弾かれることを保証する
+  it('isLiteStatus rejects every non-Lite status (Lite テナント上で新規セット不可)', () => {
+    // Pro 専用 4 値が全て false であることを 1 件ずつ確認 (どれか 1 つでも漏れると抜け穴になる)
+    expect(isLiteStatus('Resolved')).toBe(false);
+    expect(isLiteStatus('Escalated')).toBe(false);
+    expect(isLiteStatus('WaitingForUser')).toBe(false);
+    expect(isLiteStatus('New')).toBe(false);
+  });
+
+  // getAllowedLiteTransitions の戻り値は常に Lite 3 値の中に閉じていなければならない
+  // (Server Action がこの結果を直接ガードに使うため、戻り値に非 Lite が混ざると Lite 制限が破綻する)
+  it('getAllowedLiteTransitions returns only Lite statuses for every Lite from-state', () => {
+    // Lite 3 値の各 from について、許可される to が全て isLiteStatus を満たすことを確認
+    for (const from of ['Open', 'InProgress', 'Closed'] as const) {
+      const targets = getAllowedLiteTransitions(from);
+      for (const to of targets) {
+        // 1 つでも非 Lite が混ざれば false で fail させる
+        expect(isLiteStatus(to)).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`docs/smb-dx-pivot-plan.md` §3.1 / §5.2 対応。`updateTicketStatus` Server Action に `getAllowedLiteTransitions` をガードとして組み込み、Lite テナントのステータス遷移を仕様どおりに固める。

これまで `isValidTransition(from, to, mode)` 経由でガードしていたが、内部の `getAllowedTransitions` は `from` が Lite 外 (旧データの `Resolved` / `Escalated` / `WaitingForUser` / `New`) の場合 Pro 表へフォールバックする。この off-ramp 経路により、**Lite テナント上でも `WaitingForUser → Resolved` 等の非 Lite ターゲットへ新規遷移できる抜け穴**があった。

## 変更点

`src/features/tickets/actions/update-ticket.ts::updateTicketStatus` のガードを 2 段化:

1. `mode === 'lite' && !isLiteStatus(newStatus)` → reject (**新ガード: ターゲット制限**)
2. 遷移許可判定:
   - `mode === 'lite' && isLiteStatus(ticket.status)` → `getAllowedLiteTransitions(from).includes(to)` を直接ガード
   - それ以外 (Pro / Lite × 非 Lite 始点) → 従来どおり `isValidTransition(from, to, mode)`

`completionStatuses` 周りは未変更 (旧 `Resolved` の off-ramp で `resolvedAt` クリアが引き続き必要)。

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 94 tests pass
  - 既存 Lite テスト `rejects Open to Escalated in Lite mode` のエラーメッセージ regex を新ガードの文言 (`/Lite モードでは/`) に追従
  - `tests/ticket-status.test.ts` に Lite ターゲット制限不変条件の describe を追加
  - `tests/features/update-ticket.test.ts` に新規 integration テスト `rejects legacy Resolved to WaitingForUser in Lite mode (target restriction)` を追加
- [ ] 手動: Lite テナントで `Open → InProgress → Closed → Open` がブラウザから通る
- [ ] 手動: 旧 `Resolved` チケット仕込み → `Resolved → Open` は通り、`Resolved → WaitingForUser` は新ガードで弾かれる
- [ ] 手動: Pro テナントの `Open → Escalated` 等の従来挙動に回帰なし

---
_Generated by [Claude Code](https://claude.ai/code/session_013douN2H8yXM3Po5pyM6B41)_