### PR TITLE
feat(tickets): escalateTicket に Lite モード明示ガードを追加 (Phase 1)

### DIFF
--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -260,11 +260,10 @@ export async function escalateTicket(ticketId: string, reason: string) {
   // 検証済み (trim 等済み) の理由を取り出す
   const trimmedReason = parsedReason.data;
 
-  // チケット本体・通知対象の全エージェント ID 一覧・テナント mode をテナントスコープで並列取得
-  const [ticket, agentIds, mode] = await Promise.all([
+  // 先にチケット本体とテナント mode を並列取得 (Lite ガード判定に必要な最小集合)
+  // 通知用 agentIds は Pro 経路確定後に取得することで Lite 早期 throw 時の無駄な DB アクセスを回避する
+  const [ticket, mode] = await Promise.all([
     repos.tickets.findById(ticketId, tenantId),
-    repos.users.listAgentIds(tenantId),
-    // Lite モードでは Escalated 自体が UI 上存在しないので、サーバー側でも mode-aware に弾く
     getCurrentTenantMode(tenantId),
   ]);
 
@@ -281,6 +280,9 @@ export async function escalateTicket(ticketId: string, reason: string) {
   if (!isValidTransition(ticket.status, 'Escalated', mode)) {
     throw new Error(`現在のステータス「${ticket.status}」からエスカレーションできません`);
   }
+
+  // ここから先は Pro 経路確定。通知対象の全エージェント ID をテナントスコープで取得
+  const agentIds = await repos.users.listAgentIds(tenantId);
 
   // エスカレーション発生時刻
   const now = new Date();

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -270,7 +270,14 @@ export async function escalateTicket(ticketId: string, reason: string) {
 
   // チケットが無ければエラー
   if (!ticket) throw new Error('チケットが見つかりません');
-  // Escalated への遷移が許可されているか確認 (Lite では遷移表に Escalated が無いので必ず弾かれる)
+  // Lite モードではエスカレーション機能そのものを提供しない (Pivot plan §3.1 / §5.2)
+  // - UI 側 (src/app/(app)/tickets/[id]/page.tsx) でも mode==='pro' でしかボタンを出さない
+  // - 二重防御として Server Action にも明示ガードを置き、将来の遷移表変更で偶発的に
+  //   Lite テナントでエスカレーションが通る回帰を防ぐ
+  if (mode === 'lite') {
+    throw new Error('Lite モードではエスカレーションは利用できません');
+  }
+  // Escalated への遷移が許可されているか確認 (Pro 経路の現在ステータス判定として残す)
   if (!isValidTransition(ticket.status, 'Escalated', mode)) {
     throw new Error(`現在のステータス「${ticket.status}」からエスカレーションできません`);
   }

--- a/tests/features/update-ticket.test.ts
+++ b/tests/features/update-ticket.test.ts
@@ -590,4 +590,30 @@ describe('escalateTicket (provider-agnostic)', () => {
       expect(n.ticketId).toBe(ticketId);
     }
   });
+
+  // Lite モードではエスカレーション機能そのものが提供されないこと (Pivot plan §3.1 / §5.2)
+  it('rejects escalation in Lite mode', async () => {
+    const { ticketId } = await seed();
+    // テナントを Lite に切り替え (UI ではボタンが出ないが、Server Action 直叩きの防御を検証)
+    // setTenantToLite は別 describe スコープにあるためインラインで mode を書き換える
+    const tenant = store.tenants.get('default-tenant');
+    if (!tenant) throw new Error('seed missing default-tenant');
+    store.tenants.set('default-tenant', { ...tenant, mode: 'lite' });
+    // 既存ステータスを Open にしておく (Pro なら Open → Escalated が通る遷移)
+    await repos.tickets.updateStatus(ticketId, 'Open', null, TENANT);
+    const { escalateTicket } = await import('@/features/tickets/actions/update-ticket');
+
+    // Lite ガードによる拒否 (エラー文言で確認)
+    await expect(escalateTicket(ticketId, '緊急対応必要')).rejects.toThrow(
+      /Lite モードでは/,
+    );
+
+    // 副作用がないこと: ステータス維持・理由・日時はすべて未書き込み
+    const t = await repos.tickets.findById(ticketId, TENANT);
+    expect(t?.status).toBe('Open');
+    expect(t?.escalationReason).toBeNull();
+    expect(t?.escalatedAt).toBeNull();
+    // 通知も作られていない
+    expect([...store.notifications.values()]).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

`docs/smb-dx-pivot-plan.md` §3.1 / §5.2 対応。[PR #103](https://github.com/izumacha/helpdesk-hub/pull/103) のフォローアップで、セルフレビュー時に残課題として挙げた `escalateTicket` の Lite ガード明示化を実施。

これまで `escalateTicket` は `isValidTransition(from, 'Escalated', mode)` 経由で Lite を**結果的に**拒否していたが、その拒否は遷移表 (`ALLOWED_TRANSITIONS` / `ALLOWED_TRANSITIONS_LITE`) の構造に偶然依存した副作用的なもので、コードを読んでも「Lite はエスカレーション機能そのものを持たない」という意図が伝わらなかった。

## 変更点

`src/features/tickets/actions/update-ticket.ts::escalateTicket` の `!ticket` チェック直後・`isValidTransition` 直前に Lite 明示ガードを 1 ブロック追加:

```ts
if (mode === 'lite') {
  throw new Error('Lite モードではエスカレーションは利用できません');
}
```

- 既存の `isValidTransition` チェックは Pro 経路の現在ステータス判定 (例: Resolved → Escalated の禁止) として残す
- UI (`src/app/(app)/tickets/[id]/page.tsx`) は既に `mode === 'pro'` のときのみボタン表示 — 本変更は二重防御
- import 追加なし、本体ロジック (uow / 履歴 / 通知) も無変更

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 95 tests pass (escalateTicket describe に Lite 拒否ケース 1 件追加)
  - 新規 `rejects escalation in Lite mode`: Lite テナントの Open チケットに対し `escalateTicket` を呼ぶと `/Lite モードでは/` で reject、ステータス/理由/日時/通知が全て副作用なしを確認
- 手動確認 / E2E: UI は元々 `mode === 'pro'` でしかボタンを出さないので不要

---
_Generated by [Claude Code](https://claude.ai/code/session_013douN2H8yXM3Po5pyM6B41)_