### PR TITLE
feat: Phase 1 残項目 (スマホ最適化 / 簡易フォーム / タブ一覧)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,12 @@ jobs:
 
       - name: Run Playwright tests
         id: pw
-        run: npx playwright test --reporter=list,html 2>&1 | tee playwright.log
+        # set -o pipefail を明示: GitHub Actions の Linux bash デフォルトでも有効だが、
+        # 将来 defaults.run.shell を書き換えた場合に tee が exit 0 で失敗を握り潰すのを防ぐ
+        shell: bash
+        run: |
+          set -o pipefail
+          npx playwright test --reporter=list,html 2>&1 | tee playwright.log
 
       - name: Dump logs on failure
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/e2e/multitenant.spec.ts
+++ b/e2e/multitenant.spec.ts
@@ -168,8 +168,16 @@ test.describe('マルチテナント漏洩防止', () => {
     await login(page, DEFAULT_AGENT_EMAIL);
 
     await page.goto('/tickets');
+    // 不在判定はテキスト全体でカウント (絶対 0 であればよい)
     await expect(page.getByText(TENANT_B_TICKET_TITLE)).toHaveCount(0);
-    await expect(page.getByText(DEFAULT_TENANT_TICKET_TITLE)).toBeVisible();
+    // 存在判定はデスクトップテーブル側のリンクに絞る。
+    // /tickets はモバイルカード (md:hidden) とデスクトップテーブル (hidden md:block) を
+    // 同時 DOM 描画するため、getByText() だけでは複数要素にマッチして
+    // toBeVisible() が strict mode 違反を起こすことがある。
+    // CI の Playwright は Desktop Chrome (1280x720) で動くのでテーブル側に固定する
+    await expect(
+      page.getByRole('table').getByRole('link', { name: DEFAULT_TENANT_TICKET_TITLE }),
+    ).toBeVisible();
 
     const detailResponse = await page.goto(`/tickets/${TENANT_B_TICKET_ID}`);
     expect(detailResponse?.status()).toBe(404);
@@ -185,7 +193,10 @@ test.describe('マルチテナント漏洩防止', () => {
     await login(page, TENANT_B_AGENT_EMAIL);
 
     await page.goto('/tickets');
-    await expect(page.getByText(TENANT_B_TICKET_TITLE)).toBeVisible();
+    // 同上: テーブル側のリンクで存在を確認 (デュアル描画で strict mode 違反を避ける)
+    await expect(
+      page.getByRole('table').getByRole('link', { name: TENANT_B_TICKET_TITLE }),
+    ).toBeVisible();
     await expect(page.getByText(DEFAULT_TENANT_TICKET_TITLE)).toHaveCount(0);
   });
 

--- a/e2e/multitenant.spec.ts
+++ b/e2e/multitenant.spec.ts
@@ -222,4 +222,42 @@ test.describe('マルチテナント漏洩防止', () => {
     expect(result.status).toBe(422);
     expect(result.payload?.error).toMatch(/入力値/);
   });
+
+  // Pivot plan §3.1 / PR 本文の Lite モード仕様: 「同一テナント内の categoryId が送られても
+  // Lite モードでは保存しない (categoryId は null になる)」を回帰テストとして固定する。
+  // クロステナント検査だけでなく「Lite では category 機能そのものを提供しない」の方針が
+  // 仕様文と実装で別居しないようにするための防波堤
+  test('Liteテナントの依頼者が自テナントcategoryIdを直送してもcategoryIdはnullになる', async ({
+    page,
+  }) => {
+    // DB から default-tenant (Lite モード) のカテゴリ ID を 1 件取得
+    const defaultTenantCategory = await prisma.category.findFirstOrThrow({
+      where: { tenantId: 'default-tenant' },
+      select: { id: true },
+    });
+
+    await login(page, DEFAULT_REQUESTER_EMAIL);
+
+    // 自テナントの正規 categoryId を API に直送する
+    const result = await page.evaluate(async (categoryId) => {
+      const res = await fetch('/api/tickets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          title: 'E2E Lite自テナントcategoryId直送',
+          body: '同一テナントのcategoryIdでもLiteモードではnullに落とされることを確認する。',
+          priority: 'Medium',
+          categoryId,
+        }),
+      });
+      const payload = await res.json().catch(() => null);
+      return { status: res.status, payload };
+    }, defaultTenantCategory.id);
+
+    // 作成自体は成功する (クロステナントではないので 201)
+    expect(result.status).toBe(201);
+    // ただし保存時に Lite モードのため categoryId は null に正規化される
+    expect(result.payload?.categoryId).toBeNull();
+  });
 });

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -4,6 +4,8 @@ import { auth } from '@/lib/auth';
 import { Header } from '@/components/layout/Header';
 // 左サイドバー
 import { Sidebar } from '@/components/layout/Sidebar';
+// モバイル時のサイドバードロワー開閉状態を Header / Sidebar 間で共有する Provider
+import { MobileNavProvider } from '@/components/layout/MobileNavProvider';
 
 // (app) Route Group の共通レイアウト (認証後の画面骨格)
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
@@ -13,16 +15,21 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   const role = session?.user?.role ?? ('requester' as const);
 
   return (
-    // 画面全体: 左右レイアウト + 縦スクロール抑止 (背景は新トークン surface)
-    <div className="bg-surface flex h-screen overflow-hidden">
-      {/* サイドバー (権限に応じてメニューを出し分け) */}
-      <Sidebar role={role} />
-      {/* 右側: ヘッダー + メインコンテンツ */}
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <Header />
-        {/* 各ページの内容 (縦スクロール可) ─ 余白を広めに取り病院ロビー風の落ち着き */}
-        <main className="flex-1 overflow-y-auto p-6 sm:p-8">{children}</main>
+    // モバイルでのサイドバー開閉状態を Header (トグルボタン) と Sidebar (ドロワー本体) で共有する
+    // Provider は client コンポーネントだが、async な Header/Sidebar の親に置けるため
+    // children のレンダリング順序や Server Action 利用を妨げない
+    <MobileNavProvider>
+      {/* 画面全体: 左右レイアウト + 縦スクロール抑止 (背景は新トークン surface) */}
+      <div className="bg-surface flex h-screen overflow-hidden">
+        {/* サイドバー (権限に応じてメニューを出し分け。md 未満は Provider 状態でドロワー化) */}
+        <Sidebar role={role} />
+        {/* 右側: ヘッダー + メインコンテンツ */}
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <Header />
+          {/* 各ページの内容 (縦スクロール可) ─ モバイルは余白を控えめにする */}
+          <main className="flex-1 overflow-y-auto p-4 sm:p-6 md:p-8">{children}</main>
+        </div>
       </div>
-    </div>
+    </MobileNavProvider>
   );
 }

--- a/src/app/(app)/tickets/new/page.tsx
+++ b/src/app/(app)/tickets/new/page.tsx
@@ -4,6 +4,8 @@ import { auth } from '@/lib/auth';
 import { repos } from '@/data';
 // 新規チケット入力フォーム (Client Component)
 import { TicketForm } from '@/features/tickets/components/TicketForm';
+// 現在ログイン中のテナントの動作モード (lite | pro) を取得するヘルパー
+import { getCurrentTenantMode } from '@/lib/tenant';
 
 // /tickets/new : 新規チケット作成ページ (Server Component)
 export default async function NewTicketPage() {
@@ -12,22 +14,29 @@ export default async function NewTicketPage() {
   // 未ログイン or tenantId 不在は描画しない (middleware が先に弾く想定)
   if (!session?.user?.id || !session.user.tenantId) return null;
 
-  // フォームのカテゴリ選択肢として、当該テナント内のカテゴリを名前順で取得 (port 経由)
-  const categories = await repos.categories.list(session.user.tenantId);
+  // セッションから tenantId を取り出し以降の port 呼び出しに伝搬する
+  const tenantId = session.user.tenantId;
+  // カテゴリ一覧とテナント mode を並列取得 (Lite なら mode によって UI を切替)
+  const [categories, mode] = await Promise.all([
+    repos.categories.list(tenantId),
+    getCurrentTenantMode(tenantId),
+  ]);
 
   return (
     // 中央寄せの幅 max-w-2xl コンテナ
     <div className="mx-auto max-w-2xl">
-      {/* ページヘッダー: タイトル + サブテキスト */}
+      {/* ページヘッダー: タイトル + サブテキスト (Lite/Pro でサブテキストを切替) */}
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-slate-900">問い合わせ 新規登録</h1>
         <p className="mt-1 text-sm text-slate-500">
-          内容はサポート担当者に通知され、対応状況を追跡できます。
+          {mode === 'lite'
+            ? '件名・内容・期限だけで登録できます。'
+            : '内容はサポート担当者に通知され、対応状況を追跡できます。'}
         </p>
       </div>
-      {/* 白カードに包んでフォームを描画 (健診の問診票のような落ち着き) */}
-      <div className="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-100">
-        <TicketForm categories={categories} />
+      {/* 白カードに包んでフォームを描画 (モバイルは余白を控えめに) */}
+      <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 sm:p-8">
+        <TicketForm categories={categories} mode={mode} />
       </div>
     </div>
   );

--- a/src/app/(app)/tickets/page.tsx
+++ b/src/app/(app)/tickets/page.tsx
@@ -16,6 +16,8 @@ import { getCurrentTenantMode } from '@/lib/tenant';
 import { formatDateJP } from '@/lib/format-date';
 // 検索フィルタフォーム (Client Component)
 import { TicketFilters } from '@/features/tickets/components/TicketFilters';
+// 「自分の未対応 / 期限切れ / すべて」タブナビ (Client Component)
+import { TicketTabs, type TicketTabId } from '@/features/tickets/components/TicketTabs';
 // Prisma が生成した列挙型 (URL クエリの型ガード用)
 import type { TicketStatus, Priority } from '@/generated/prisma';
 // データ層が公開しているチケット一覧フィルタ型 (port 経由クエリの引数)
@@ -46,8 +48,17 @@ interface Props {
     priority?: string;
     categoryId?: string;
     assigneeId?: string;
+    // 一覧の絞り込みタブ ('mine' = 自分の未対応 / 'overdue' = 期限切れ / 未指定/'all' = 全件)
+    tab?: string;
     page?: string;
   }>;
+}
+
+// クエリの tab 文字列を TicketTabId に正規化する (不正値は 'all')
+function parseTabParam(raw: string | undefined): TicketTabId {
+  // 'mine' か 'overdue' に完全一致する場合のみ採用、それ以外は既定の 'all'
+  if (raw === 'mine' || raw === 'overdue') return raw;
+  return 'all';
 }
 
 // /tickets : チケット一覧ページ (検索/フィルタ + ページング)
@@ -64,6 +75,8 @@ export default async function TicketsPage({ searchParams }: Props) {
   // 要求ページ番号と DB の skip 件数を計算
   const requestedPage = parsePageParam(sp.page);
   const skip = (requestedPage - 1) * PAGE_SIZE;
+  // タブ ID を正規化 ('all' / 'mine' / 'overdue' のいずれか)
+  const tab = parseTabParam(sp.tab);
 
   // データ層に渡す TicketListFilter を組み立てる
   const filter: TicketListFilter = {
@@ -80,6 +93,21 @@ export default async function TicketsPage({ searchParams }: Props) {
     // 担当者絞り込み (URL クエリの 'unassigned' をここで null に正規化)
     assigneeId: normalizeAssigneeId(sp.assigneeId),
   };
+
+  // タブ別の追加フィルタを上書き適用する
+  // - mine: 「自分の未対応」= ステータスが Open または InProgress
+  //   - エージェントは「担当が自分」のもの
+  //   - 依頼者は creatorId 既定 (自分のチケット) で自動的に絞り込まれているため status だけ追加
+  // - overdue: 期限切れ + 未解決 (status=Resolved/Closed は除外)
+  if (tab === 'mine') {
+    filter.statusIn = ['Open', 'InProgress'];
+    if (isAgent) {
+      filter.assigneeId = session.user.id;
+    }
+  } else if (tab === 'overdue') {
+    // 現在時刻基準で期限超過判定を行う
+    filter.overdue = { now: new Date() };
+  }
 
   // セッションから tenantId を取り出して以降の port 呼び出しに伝搬する
   const tenantId = session.user.tenantId;
@@ -121,6 +149,11 @@ export default async function TicketsPage({ searchParams }: Props) {
           ＋ 新規登録
         </Link>
       </div>
+
+      {/* タブナビ (自分の未対応 / 期限切れ / すべて)。Lite/Pro どちらでも常に表示する */}
+      <Suspense>
+        <TicketTabs />
+      </Suspense>
 
       {/* 検索フィルタ (Client Component を Suspense で安全にラップ、テナント mode をそのまま伝搬) */}
       <Suspense>

--- a/src/app/(app)/tickets/page.tsx
+++ b/src/app/(app)/tickets/page.tsx
@@ -130,77 +130,126 @@ export default async function TicketsPage({ searchParams }: Props) {
       {/* 件数表示 (落ち着いたグレー) */}
       <p className="text-sm text-slate-500">{total} 件</p>
 
-      {/* 一覧テーブル (0 件時は空状態メッセージ) */}
+      {/* 一覧 (0 件時は空状態 / それ以外は md 以上でテーブル、md 未満でカード列を出し分け) */}
       {tickets.length === 0 ? (
         // 0 件時の空状態 (柔らかなカード) ─ 病院待合室の余白感
         <div className="rounded-2xl bg-white py-20 text-center text-slate-400 ring-1 ring-slate-200">
           <p className="text-sm">条件に一致する問い合わせはありません</p>
         </div>
       ) : (
-        <div className="overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-slate-100">
-          <table className="min-w-full divide-y divide-slate-100 text-sm">
-            <thead className="bg-slate-50/80">
-              <tr>
-                <th className="px-5 py-3 text-left text-[11px] font-semibold tracking-wider text-slate-500 uppercase">
-                  件名
-                </th>
-                <th className="px-5 py-3 text-left text-[11px] font-semibold tracking-wider text-slate-500 uppercase">
-                  ステータス
-                </th>
-                <th className="px-5 py-3 text-left text-[11px] font-semibold tracking-wider text-slate-500 uppercase">
-                  優先度
-                </th>
-                <th className="px-5 py-3 text-left text-[11px] font-semibold tracking-wider text-slate-500 uppercase">
-                  カテゴリ
-                </th>
-                <th className="px-5 py-3 text-left text-[11px] font-semibold tracking-wider text-slate-500 uppercase">
-                  担当者
-                </th>
-                <th className="px-5 py-3 text-left text-[11px] font-semibold tracking-wider text-slate-500 uppercase">
-                  作成日
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-slate-100">
-              {tickets.map((ticket) => (
-                <tr key={ticket.id} className="transition hover:bg-teal-50/40">
-                  {/* 件名: 詳細ページへのリンク */}
-                  <td className="px-5 py-3.5">
-                    <Link
-                      href={`/tickets/${ticket.id}`}
-                      className="font-medium text-slate-900 transition hover:text-teal-700"
-                    >
-                      {ticket.title}
-                    </Link>
-                  </td>
-                  {/* ステータスバッジ (テナント mode に応じて Lite/Pro ラベルを切替) */}
-                  <td className="px-5 py-3.5">
-                    <span
-                      className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_COLORS[ticket.status] ?? ''}`}
-                    >
-                      {getStatusLabel(ticket.status, mode)}
-                    </span>
-                  </td>
-                  {/* 優先度 (色付きテキスト) */}
-                  <td className={`px-5 py-3.5 ${PRIORITY_COLORS[ticket.priority] ?? ''}`}>
-                    {PRIORITY_LABELS[ticket.priority] ?? ticket.priority}
-                  </td>
-                  {/* カテゴリ名 (なければ "―") */}
-                  <td className="px-5 py-3.5 text-slate-500">{ticket.category?.name ?? '―'}</td>
-                  {/* 担当者名 (なければ "未割当") */}
-                  <td className="px-5 py-3.5 text-slate-500">
-                    {ticket.assignee?.name ?? '未割当'}
-                  </td>
-                  {/* 作成日 (日付のみ・日本時間) */}
-                  <td className="px-5 py-3.5 text-slate-400">
-                    {/* 一覧の作成日を日本時間 (年月日) で表示する */}
-                    {formatDateJP(ticket.createdAt)}
-                  </td>
+        <>
+          {/* デスクトップ用テーブル (md 以上で表示。情シス向けの密度の高い一覧) */}
+          <div className="hidden overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-slate-100 md:block">
+            <table className="min-w-full divide-y divide-slate-100 text-sm">
+              <thead className="bg-slate-50/80">
+                <tr>
+                  <th className="px-5 py-3 text-left text-[11px] font-semibold tracking-wider text-slate-500 uppercase">
+                    件名
+                  </th>
+                  <th className="px-5 py-3 text-left text-[11px] font-semibold tracking-wider text-slate-500 uppercase">
+                    ステータス
+                  </th>
+                  <th className="px-5 py-3 text-left text-[11px] font-semibold tracking-wider text-slate-500 uppercase">
+                    優先度
+                  </th>
+                  <th className="px-5 py-3 text-left text-[11px] font-semibold tracking-wider text-slate-500 uppercase">
+                    カテゴリ
+                  </th>
+                  <th className="px-5 py-3 text-left text-[11px] font-semibold tracking-wider text-slate-500 uppercase">
+                    担当者
+                  </th>
+                  <th className="px-5 py-3 text-left text-[11px] font-semibold tracking-wider text-slate-500 uppercase">
+                    作成日
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {tickets.map((ticket) => (
+                  <tr key={ticket.id} className="transition hover:bg-teal-50/40">
+                    {/* 件名: 詳細ページへのリンク */}
+                    <td className="px-5 py-3.5">
+                      <Link
+                        href={`/tickets/${ticket.id}`}
+                        className="font-medium text-slate-900 transition hover:text-teal-700"
+                      >
+                        {ticket.title}
+                      </Link>
+                    </td>
+                    {/* ステータスバッジ (テナント mode に応じて Lite/Pro ラベルを切替) */}
+                    <td className="px-5 py-3.5">
+                      <span
+                        className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_COLORS[ticket.status] ?? ''}`}
+                      >
+                        {getStatusLabel(ticket.status, mode)}
+                      </span>
+                    </td>
+                    {/* 優先度 (色付きテキスト) */}
+                    <td className={`px-5 py-3.5 ${PRIORITY_COLORS[ticket.priority] ?? ''}`}>
+                      {PRIORITY_LABELS[ticket.priority] ?? ticket.priority}
+                    </td>
+                    {/* カテゴリ名 (なければ "―") */}
+                    <td className="px-5 py-3.5 text-slate-500">{ticket.category?.name ?? '―'}</td>
+                    {/* 担当者名 (なければ "未割当") */}
+                    <td className="px-5 py-3.5 text-slate-500">
+                      {ticket.assignee?.name ?? '未割当'}
+                    </td>
+                    {/* 作成日 (日付のみ・日本時間) */}
+                    <td className="px-5 py-3.5 text-slate-400">
+                      {/* 一覧の作成日を日本時間 (年月日) で表示する */}
+                      {formatDateJP(ticket.createdAt)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {/* モバイル用カード (md 未満で表示。1 件 1 カードで全要素を縦に積む) */}
+          <ul className="space-y-3 md:hidden">
+            {tickets.map((ticket) => (
+              <li
+                key={ticket.id}
+                // 白カード + 影 + 境界線で 1 件をひとまとまりに見せる
+                className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-slate-100"
+              >
+                {/* 件名: カード全体をタップ領域にするためブロックリンク化 */}
+                <Link
+                  href={`/tickets/${ticket.id}`}
+                  className="block text-base font-medium text-slate-900 transition hover:text-teal-700"
+                >
+                  {ticket.title}
+                </Link>
+                {/* バッジ行: ステータス + 優先度 (折り返し可能) */}
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <span
+                    className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_COLORS[ticket.status] ?? ''}`}
+                  >
+                    {getStatusLabel(ticket.status, mode)}
+                  </span>
+                  <span
+                    className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${PRIORITY_COLORS[ticket.priority] ?? ''}`}
+                  >
+                    {PRIORITY_LABELS[ticket.priority] ?? ticket.priority}
+                  </span>
+                </div>
+                {/* メタ情報行: カテゴリ / 担当者 / 作成日 (ラベル付きで小さく) */}
+                <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1.5 text-xs text-slate-500">
+                  <div className="col-span-2 flex justify-between">
+                    <dt className="text-slate-400">カテゴリ</dt>
+                    <dd className="text-slate-600">{ticket.category?.name ?? '―'}</dd>
+                  </div>
+                  <div className="col-span-2 flex justify-between">
+                    <dt className="text-slate-400">担当者</dt>
+                    <dd className="text-slate-600">{ticket.assignee?.name ?? '未割当'}</dd>
+                  </div>
+                  <div className="col-span-2 flex justify-between">
+                    <dt className="text-slate-400">作成日</dt>
+                    <dd className="text-slate-600">{formatDateJP(ticket.createdAt)}</dd>
+                  </div>
+                </dl>
+              </li>
+            ))}
+          </ul>
+        </>
       )}
 
       {/* 総ページ数が 2 以上のときのみページャを表示 */}

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -45,19 +45,15 @@ export async function POST(req: Request) {
   // 検証済みの値を分解 (body は変数名衝突を避けてリネーム)
   const { title, body: ticketBody, priority, categoryId, dueDate } = parsed.data;
 
-  // テナントの動作モードを取得し、Lite モード時の入力強制ルールを適用する
-  const mode = await getCurrentTenantMode(session.user.tenantId);
-  // Lite モードでは優先度を UI から選ばせず Medium 固定とする (Pivot plan §3.1)
-  // - Lite フォームは「件名 / 内容 / 期限日」のみで priority フィールドを描画しないため、
-  //   API 単体で叩かれた場合の防御として既定値に強制する
-  const effectivePriority = mode === 'lite' ? 'Medium' : priority;
-  // Lite モードではカテゴリも非表示。UI から送られないが、外部から送られた値は無視する
-  const effectiveCategoryId = mode === 'lite' ? undefined : categoryId;
-
   // カテゴリ指定がある場合は存在確認 (現在のテナント内のカテゴリのみ許可)
-  if (effectiveCategoryId) {
+  // ── mode に関わらずクロステナント検査は必ず走らせる。
+  // Lite モードでも「UI から送られないので無視」と黙って drop してしまうと、
+  // 外部から他テナントの categoryId が送られたときにクロステナント漏洩防止テスト
+  // (e2e/multitenant.spec.ts) が破綻する。Lite UI 自体は categoryId フィールドを
+  // 持たないので、正規ルートではそもそも categoryId が undefined で届く
+  if (categoryId) {
     // テナントスコープでカテゴリを取得 (他テナントの ID は null になる)
-    const category = await repos.categories.findById(effectiveCategoryId, session.user.tenantId);
+    const category = await repos.categories.findById(categoryId, session.user.tenantId);
     // 存在しない、または他テナントなら 422 (Zod 風の issues を返す)
     if (!category) {
       return NextResponse.json(
@@ -76,6 +72,14 @@ export async function POST(req: Request) {
     }
   }
 
+  // テナントの動作モードを取得し、Lite モード時の入力強制ルールを適用する
+  // ── ここから先は「自テナント内で正規の値しか残っていない」前提でモード適用する
+  const mode = await getCurrentTenantMode(session.user.tenantId);
+  // Lite モードでは優先度を UI から選ばせず Medium 固定とする (Pivot plan §3.1)
+  // - Lite フォームは「件名 / 内容 / 期限日」のみで priority フィールドを描画しないため、
+  //   API 単体で叩かれた場合の防御として既定値に強制する
+  const effectivePriority = mode === 'lite' ? 'Medium' : priority;
+
   // 作成時刻 (SLA 期限の計算基準)
   const now = new Date();
   // 解決期限の決定:
@@ -92,7 +96,7 @@ export async function POST(req: Request) {
     title,
     body: ticketBody,
     priority: effectivePriority,
-    categoryId: effectiveCategoryId ?? null,
+    categoryId: categoryId ?? null,
     // 作成者は現在のログインユーザー
     creatorId: session.user.id,
     // 起票元のテナント (マルチテナント化のキー)

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -8,6 +8,8 @@ import { repos } from '@/data';
 import { calculateResolutionDueAt } from '@/lib/sla';
 // 新規チケット入力の Zod スキーマ
 import { createTicketSchema } from '@/lib/validations/ticket';
+// テナントの動作モード (lite | pro) を取得するヘルパー
+import { getCurrentTenantMode } from '@/lib/tenant';
 
 // POST /api/tickets : 新規チケットを作成する HTTP エンドポイント
 export async function POST(req: Request) {
@@ -39,12 +41,21 @@ export async function POST(req: Request) {
   }
 
   // 検証済みの値を分解 (body は変数名衝突を避けてリネーム)
-  const { title, body: ticketBody, priority, categoryId } = parsed.data;
+  const { title, body: ticketBody, priority, categoryId, dueDate } = parsed.data;
+
+  // テナントの動作モードを取得し、Lite モード時の入力強制ルールを適用する
+  const mode = await getCurrentTenantMode(session.user.tenantId);
+  // Lite モードでは優先度を UI から選ばせず Medium 固定とする (Pivot plan §3.1)
+  // - Lite フォームは「件名 / 内容 / 期限日」のみで priority フィールドを描画しないため、
+  //   API 単体で叩かれた場合の防御として既定値に強制する
+  const effectivePriority = mode === 'lite' ? 'Medium' : priority;
+  // Lite モードではカテゴリも非表示。UI から送られないが、外部から送られた値は無視する
+  const effectiveCategoryId = mode === 'lite' ? undefined : categoryId;
 
   // カテゴリ指定がある場合は存在確認 (現在のテナント内のカテゴリのみ許可)
-  if (categoryId) {
+  if (effectiveCategoryId) {
     // テナントスコープでカテゴリを取得 (他テナントの ID は null になる)
-    const category = await repos.categories.findById(categoryId, session.user.tenantId);
+    const category = await repos.categories.findById(effectiveCategoryId, session.user.tenantId);
     // 存在しない、または他テナントなら 422 (Zod 風の issues を返す)
     if (!category) {
       return NextResponse.json(
@@ -65,18 +76,26 @@ export async function POST(req: Request) {
 
   // 作成時刻 (SLA 期限の計算基準)
   const now = new Date();
+  // 解決期限の決定:
+  // - dueDate が指定されていれば、その日付の終端 (23:59:59.999) を resolutionDueAt とする
+  //   (Lite モードでユーザーが「今日まで」と入れたら当日中いっぱい OK の意図に合わせる)
+  // - 指定が無ければ従来どおり priority ベースで自動計算
+  const resolutionDueAt = dueDate
+    ? new Date(`${dueDate}T23:59:59.999`)
+    : calculateResolutionDueAt(effectivePriority, now);
+
   // リポジトリ経由でチケットを作成
   const ticket = await repos.tickets.create({
     title,
     body: ticketBody,
-    priority,
-    categoryId: categoryId ?? null,
+    priority: effectivePriority,
+    categoryId: effectiveCategoryId ?? null,
     // 作成者は現在のログインユーザー
     creatorId: session.user.id,
     // 起票元のテナント (マルチテナント化のキー)
     tenantId: session.user.tenantId,
-    // 優先度に応じた解決期限を計算
-    resolutionDueAt: calculateResolutionDueAt(priority, now),
+    // 上で決定した解決期限 (ユーザー指定 or 自動計算)
+    resolutionDueAt,
   });
 
   // 作成された行を 201 で返す

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -79,6 +79,11 @@ export async function POST(req: Request) {
   // - Lite フォームは「件名 / 内容 / 期限日」のみで priority フィールドを描画しないため、
   //   API 単体で叩かれた場合の防御として既定値に強制する
   const effectivePriority = mode === 'lite' ? 'Medium' : priority;
+  // Lite モードではカテゴリ機能を提供しないため保存時に null へ落とす。
+  // ── 検査は mode に関わらず必ず手前で実行済みなので、ここで弾かれるのは
+  //   「自テナントの正規 categoryId だが Lite モードでは保存しない」ケースのみ。
+  //   他テナントの categoryId はこの行に到達する前に 422 で返している。
+  const effectiveCategoryId = mode === 'lite' ? null : (categoryId ?? null);
 
   // 作成時刻 (SLA 期限の計算基準)
   const now = new Date();
@@ -96,7 +101,8 @@ export async function POST(req: Request) {
     title,
     body: ticketBody,
     priority: effectivePriority,
-    categoryId: categoryId ?? null,
+    // Lite では null 強制、Pro では検査済みの categoryId をそのまま保存
+    categoryId: effectiveCategoryId,
     // 作成者は現在のログインユーザー
     creatorId: session.user.id,
     // 起票元のテナント (マルチテナント化のキー)

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -10,6 +10,8 @@ import { calculateResolutionDueAt } from '@/lib/sla';
 import { createTicketSchema } from '@/lib/validations/ticket';
 // テナントの動作モード (lite | pro) を取得するヘルパー
 import { getCurrentTenantMode } from '@/lib/tenant';
+// 'YYYY-MM-DD' を JST 終端 Date に変換するヘルパー (サーバ TZ 非依存)
+import { endOfDayJST } from '@/lib/format-date';
 
 // POST /api/tickets : 新規チケットを作成する HTTP エンドポイント
 export async function POST(req: Request) {
@@ -77,11 +79,12 @@ export async function POST(req: Request) {
   // 作成時刻 (SLA 期限の計算基準)
   const now = new Date();
   // 解決期限の決定:
-  // - dueDate が指定されていれば、その日付の終端 (23:59:59.999) を resolutionDueAt とする
-  //   (Lite モードでユーザーが「今日まで」と入れたら当日中いっぱい OK の意図に合わせる)
+  // - dueDate が指定されていれば、その日付の JST 終端 (23:59:59.999 +09:00) を resolutionDueAt とする
+  //   サーバ/CI/本番の TZ に依存しないよう endOfDayJST を経由する (UTC 環境でも JST 解釈になる)
   // - 指定が無ければ従来どおり priority ベースで自動計算
+  // - endOfDayJST が null (= 形式不正) なら Zod が手前で弾いているはずだが、防御的に自動計算へフォールバック
   const resolutionDueAt = dueDate
-    ? new Date(`${dueDate}T23:59:59.999`)
+    ? (endOfDayJST(dueDate) ?? calculateResolutionDueAt(effectivePriority, now))
     : calculateResolutionDueAt(effectivePriority, now);
 
   // リポジトリ経由でチケットを作成

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,6 +4,8 @@ import { Suspense } from 'react';
 import { auth } from '@/lib/auth';
 // 通知ベル (未読件数バッジ付きリンク)
 import { NotificationBell } from './NotificationBell';
+// モバイル用ハンバーガーボタン (md 未満でサイドバードロワーを開閉する)
+import { MobileNavToggle } from './MobileNavToggle';
 // ログアウト用サーバーアクション
 import { logout } from '@/features/auth/actions';
 
@@ -43,18 +45,18 @@ export async function Header() {
       : 'bg-teal-50 text-teal-800 ring-1 ring-teal-200';
 
   return (
-    <header className="flex h-16 items-center justify-between border-b border-slate-200 bg-white/85 px-6 backdrop-blur">
-      {/* 左側は将来用 (今は空) */}
-      <div />
-      {/* 右側: ログイン中ユーザー向けのコントロール群 */}
-      <div className="flex items-center gap-4">
+    <header className="flex h-16 items-center justify-between border-b border-slate-200 bg-white/85 px-4 backdrop-blur sm:px-6">
+      {/* 左側: モバイル時のみ表示するハンバーガーボタン (デスクトップは Sidebar 常時表示) */}
+      <MobileNavToggle />
+      {/* 右側: ログイン中ユーザー向けのコントロール群 (モバイルでは間隔を狭くする) */}
+      <div className="flex items-center gap-2 sm:gap-4">
         {session?.user && (
           <>
             {/* 通知ベル (未読件数取得中はフォールバックを表示、tenantId スコープ) */}
             <Suspense fallback={<span className="text-sm text-slate-500">通知</span>}>
               <NotificationBell userId={session.user.id!} tenantId={session.user.tenantId} />
             </Suspense>
-            {/* ユーザー情報: アバター丸 + 氏名 + ロール pill */}
+            {/* ユーザー情報: アバター丸 + 氏名 + ロール pill (モバイルではアバターのみ) */}
             <div className="flex items-center gap-2.5">
               {/* イニシャルを表示する円形アバター (ティール背景) */}
               <span
@@ -63,10 +65,14 @@ export async function Header() {
               >
                 {getInitials(session.user.name)}
               </span>
-              {/* 氏名 */}
-              <span className="text-sm font-medium text-slate-700">{session.user.name}</span>
-              {/* ロールを示す小さな pill */}
-              <span className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${rolePillClass}`}>
+              {/* 氏名 (モバイルでは省略してアバターだけにする) */}
+              <span className="hidden text-sm font-medium text-slate-700 sm:inline">
+                {session.user.name}
+              </span>
+              {/* ロールを示す小さな pill (モバイルでは省略) */}
+              <span
+                className={`hidden rounded-full px-2 py-0.5 text-[11px] font-medium sm:inline ${rolePillClass}`}
+              >
                 {roleLabel}
               </span>
             </div>
@@ -74,7 +80,7 @@ export async function Header() {
             <form action={logout}>
               <button
                 type="submit"
-                className="rounded-lg px-3 py-1.5 text-sm text-slate-600 transition hover:bg-slate-100 hover:text-slate-900"
+                className="rounded-lg px-2 py-1.5 text-sm text-slate-600 transition hover:bg-slate-100 hover:text-slate-900 sm:px-3"
               >
                 ログアウト
               </button>

--- a/src/components/layout/MobileNavProvider.tsx
+++ b/src/components/layout/MobileNavProvider.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+// React の Context 機能と状態フック・コールバック型を取り込む
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+
+// モバイルナビゲーション (サイドバードロワー) の開閉状態と操作関数の契約
+interface MobileNavContextValue {
+  // 現在ドロワーが開いているか (true で開いている)
+  open: boolean;
+  // ドロワーを開く関数
+  openNav: () => void;
+  // ドロワーを閉じる関数
+  closeNav: () => void;
+  // 開閉を反転させる関数 (ハンバーガーボタン用)
+  toggleNav: () => void;
+}
+
+// Context 本体 (初期値は undefined にしておき、Provider 外利用時に検知できるようにする)
+const MobileNavContext = createContext<MobileNavContextValue | undefined>(undefined);
+
+// Provider コンポーネント: アプリ全体 (認証後レイアウト) をラップしてドロワー状態を共有する
+export function MobileNavProvider({ children }: { children: React.ReactNode }) {
+  // ドロワーの開閉状態を持つ (初期値は閉じている)
+  const [open, setOpen] = useState(false);
+
+  // 「開く」関数: open を true に変更する (useCallback で再生成を抑制)
+  const openNav = useCallback(() => setOpen(true), []);
+  // 「閉じる」関数: open を false に変更する
+  // (ページ遷移時に閉じる挙動は Sidebar 側の Link onClick から呼び出して実現する。
+  //  ここで pathname を effect 監視すると set-state-in-effect 警告になるため)
+  const closeNav = useCallback(() => setOpen(false), []);
+  // 「切替」関数: 現在値を反転させる (前回値から true/false を反転)
+  const toggleNav = useCallback(() => setOpen((prev) => !prev), []);
+
+  // 開いている間は背面のスクロールを止める (ドロワーだけが動く UX に揃える)
+  useEffect(() => {
+    // 元の overflow 値を保存しておく (アンマウント時に復元するため)
+    const originalOverflow = document.body.style.overflow;
+    // 開いている場合のみ body のスクロールを止める
+    if (open) {
+      document.body.style.overflow = 'hidden';
+    }
+    // クリーンアップ: アンマウントまたは open 変化時に元の値に戻す
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [open]);
+
+  // 子に対して状態と操作関数を渡す
+  return (
+    <MobileNavContext.Provider value={{ open, openNav, closeNav, toggleNav }}>
+      {children}
+    </MobileNavContext.Provider>
+  );
+}
+
+// Context を参照するためのカスタムフック
+// Provider 外で呼ばれた場合は明示的にエラーにして検出を早める
+export function useMobileNav(): MobileNavContextValue {
+  // Context を取得
+  const ctx = useContext(MobileNavContext);
+  // Provider にラップされていない場所からの呼び出しを禁止する
+  if (!ctx) {
+    throw new Error('useMobileNav は MobileNavProvider の子要素でのみ利用できます');
+  }
+  // 取得した値を返す
+  return ctx;
+}

--- a/src/components/layout/MobileNavToggle.tsx
+++ b/src/components/layout/MobileNavToggle.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+// モバイルナビ Context (ドロワー開閉状態) を取り出すためのフック
+import { useMobileNav } from './MobileNavProvider';
+
+// ヘッダー左端に表示するハンバーガーボタン
+// - md (768px) 以上では非表示 (デスクトップは Sidebar が常時見えている)
+// - md 未満では押下でドロワーを開閉する
+export function MobileNavToggle() {
+  // Context からドロワー状態と切替関数を取り出す
+  const { open, toggleNav } = useMobileNav();
+
+  return (
+    <button
+      type="button"
+      // ハンバーガーボタン本体: md 以上では非表示、軽量な丸角ボタン
+      className="-ml-1 inline-flex h-10 w-10 items-center justify-center rounded-lg text-slate-600 transition hover:bg-slate-100 hover:text-slate-900 md:hidden"
+      // 押下でドロワーを開閉する
+      onClick={toggleNav}
+      // 現在の状態を支援技術にも伝える (展開済みかどうか)
+      aria-expanded={open}
+      // 操作対象のドロワー要素 ID (Sidebar 側で同じ id を付与する)
+      aria-controls="mobile-sidebar"
+      // スクリーンリーダー向けのラベル (開閉状態に応じて表記を切替)
+      aria-label={open ? 'メニューを閉じる' : 'メニューを開く'}
+    >
+      {/* 開いているときは X 印、閉じているときはハンバーガーアイコンを SVG で描画 */}
+      {open ? (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          {/* X 印 (閉じるアイコン): 左上→右下 + 右上→左下 の 2 本線 */}
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      ) : (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          {/* ハンバーガーアイコン: 上中下の 3 本横線 */}
+          <line x1="3" y1="6" x2="21" y2="6" />
+          <line x1="3" y1="12" x2="21" y2="12" />
+          <line x1="3" y1="18" x2="21" y2="18" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -12,6 +12,8 @@ import { isAgent } from '@/lib/role';
 import type { Role } from '@/generated/prisma';
 // 共通ブランドマーク
 import { Logo } from '@/components/brand/Logo';
+// モバイルナビ Context (ハンバーガーで開閉するドロワー状態)
+import { useMobileNav } from './MobileNavProvider';
 
 // サイドバーが受け取る props (現在のロール)
 interface Props {
@@ -27,12 +29,15 @@ const navItems = [
   { href: '/notifications', label: '通知' },
 ];
 
-// 左サイドバー (折りたたみ + 役割別メニュー出し分け)
+// 左サイドバー (折りたたみ + 役割別メニュー出し分け + モバイルドロワー)
 export function Sidebar({ role }: Props) {
   // 現在の URL パス (アクティブ強調に使う)
   const pathname = usePathname();
-  // 折りたたみ状態 (true で幅を縮める)
+  // デスクトップ向けの折りたたみ状態 (true で幅を縮める)。モバイル開閉とは直交
   const [collapsed, setCollapsed] = useState(false);
+  // モバイルドロワーの開閉状態と「閉じる」関数を Context から取得
+  // (md 未満ではこの open に従って画面外/画面内へスライドする)
+  const { open: mobileOpen, closeNav } = useMobileNav();
 
   // 権限に応じて表示できる項目だけに絞り込む
   const visibleItems = navItems.filter((item) => !item.agentOnly || isAgent(role));
@@ -49,52 +54,85 @@ export function Sidebar({ role }: Props) {
   };
 
   return (
-    // 折りたたみで幅を切り替えるサイドバー本体 (柔らかな白 + 右ボーダー)
-    <aside
-      className={`flex flex-col border-r border-slate-200 bg-white/90 backdrop-blur transition-all duration-200 ${collapsed ? 'w-14' : 'w-60'}`}
-    >
-      {/* ヘッダー領域 (ブランドマーク + 折りたたみボタン) */}
-      <div className="flex h-16 items-center justify-between border-b border-slate-200 px-3">
-        {/* 折りたたみ時はワードマークを隠し、シンボルだけ表示 */}
-        <Logo showWordmark={!collapsed} size={collapsed ? 28 : 30} />
-        {/* 折りたたみ切り替えボタン (アイコン文字で軽量に) */}
-        <button
-          onClick={() => setCollapsed(!collapsed)}
-          className="ml-auto rounded-md p-1 text-slate-400 transition hover:bg-slate-100 hover:text-slate-700"
-          aria-label={collapsed ? 'サイドバーを展開' : 'サイドバーを折りたたむ'}
-        >
-          {collapsed ? '›' : '‹'}
-        </button>
-      </div>
-      {/* 折りたたみ時はメニュー本体を非表示 */}
-      {!collapsed && (
-        <nav className="flex-1 space-y-1 px-3 py-5">
-          {visibleItems.map((item) => {
-            // この項目が現在のページかどうか
-            const isActive = isItemActive(item.href);
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                // アクティブ項目はティールで強調 (左にバー風アクセント)
-                className={`relative block rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-teal-50 text-teal-800 ring-1 ring-teal-100 before:absolute before:top-1/2 before:left-0 before:h-5 before:w-1 before:-translate-y-1/2 before:rounded-r before:bg-teal-600'
-                    : 'text-slate-600 hover:bg-teal-50/60 hover:text-teal-800'
-                }`}
-              >
-                {item.label}
-              </Link>
-            );
-          })}
-        </nav>
+    // ラッパー: モバイル時のバックドロップ + ドロワーを内包する
+    // (デスクトップでは何もせずサイドバーをそのまま左端に配置)
+    <>
+      {/* モバイル用の背景オーバーレイ: 開いている時のみ表示し、押下で閉じる */}
+      {mobileOpen && (
+        <div
+          // 半透明の黒で背面を覆い、ドロワー以外を視覚的に分離する
+          className="fixed inset-0 z-30 bg-slate-900/30 backdrop-blur-sm md:hidden"
+          // 押下で閉じる (背景クリックで閉じる一般的な UX)
+          onClick={closeNav}
+          // 支援技術には装飾要素として無視させる
+          aria-hidden="true"
+        />
       )}
-      {/* フッター: 折りたたみ時以外は小さなバージョン情報風テキスト */}
-      {!collapsed && (
-        <div className="border-t border-slate-200 px-4 py-3 text-[11px] text-slate-400">
-          © HelpDesk Hub
+      {/* 折りたたみで幅を切り替えるサイドバー本体 (柔らかな白 + 右ボーダー)
+          - md 未満: fixed 配置 + translate-x でスライドイン/アウト (mobileOpen 連動)
+          - md 以上: relative 配置 + 常時表示 (collapsed で幅切替) */}
+      <aside
+        // モバイルドロワー時に MobileNavToggle の aria-controls から参照される ID
+        id="mobile-sidebar"
+        className={`fixed inset-y-0 left-0 z-40 flex flex-col border-r border-slate-200 bg-white/95 backdrop-blur transition-all duration-200 md:relative md:translate-x-0 ${
+          // モバイル時の表示/非表示制御 (true = 画面内, false = 画面外左)
+          mobileOpen ? 'translate-x-0 shadow-2xl' : '-translate-x-full'
+        } ${
+          // 幅切替: モバイルではフル幅相当 (w-64) を確保、md 以上は collapsed に応じて w-14/w-60 を切替
+          collapsed ? 'w-64 md:w-14' : 'w-64 md:w-60'
+        }`}
+        // モバイルナビゲーションを意味するランドマーク
+        aria-label="メインナビゲーション"
+      >
+        {/* ヘッダー領域 (ブランドマーク + 折りたたみボタン) */}
+        <div className="flex h-16 items-center justify-between border-b border-slate-200 px-3">
+          {/* 折りたたみ時はワードマークを隠し、シンボルだけ表示
+              (モバイル時は collapsed の値に関わらずワードマーク表示にしたいので md 未満は常に true 相当扱い)
+              ここでは showWordmark に !collapsed を渡し、デスクトップ折りたたみ時のみ非表示にする */}
+          <Logo showWordmark={!collapsed} size={collapsed ? 28 : 30} />
+          {/* 折りたたみ切り替えボタン (md 以上でのみ表示。モバイルでは Header のハンバーガーが担当) */}
+          <button
+            onClick={() => setCollapsed(!collapsed)}
+            className="ml-auto hidden rounded-md p-1 text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 md:block"
+            aria-label={collapsed ? 'サイドバーを展開' : 'サイドバーを折りたたむ'}
+          >
+            {collapsed ? '›' : '‹'}
+          </button>
         </div>
-      )}
-    </aside>
+        {/* 折りたたみ時はメニュー本体を非表示 (デスクトップのみ。モバイルではドロワー幅 w-64 で常に展開表示) */}
+        {!collapsed && (
+          <nav className="flex-1 space-y-1 px-3 py-5">
+            {visibleItems.map((item) => {
+              // この項目が現在のページかどうか
+              const isActive = isItemActive(item.href);
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  // メニュータップで遷移と同時にモバイルドロワーを閉じる
+                  // (Provider 側の useEffect で pathname を監視するとリンタが set-state-in-effect 警告を出すため、
+                  //  ユーザー操作起点で明示的に閉じる方が安全)
+                  onClick={closeNav}
+                  // アクティブ項目はティールで強調 (左にバー風アクセント)
+                  className={`relative block rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
+                    isActive
+                      ? 'bg-teal-50 text-teal-800 ring-1 ring-teal-100 before:absolute before:top-1/2 before:left-0 before:h-5 before:w-1 before:-translate-y-1/2 before:rounded-r before:bg-teal-600'
+                      : 'text-slate-600 hover:bg-teal-50/60 hover:text-teal-800'
+                  }`}
+                >
+                  {item.label}
+                </Link>
+              );
+            })}
+          </nav>
+        )}
+        {/* フッター: 折りたたみ時以外は小さなバージョン情報風テキスト */}
+        {!collapsed && (
+          <div className="border-t border-slate-200 px-4 py-3 text-[11px] text-slate-400">
+            © HelpDesk Hub
+          </div>
+        )}
+      </aside>
+    </>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -84,12 +84,19 @@ export function Sidebar({ role }: Props) {
         // モバイルナビゲーションを意味するランドマーク
         aria-label="メインナビゲーション"
       >
-        {/* ヘッダー領域 (ブランドマーク + 折りたたみボタン) */}
+        {/* ヘッダー領域 (ブランドマーク + 折りたたみボタン)
+            ブランドマーク: モバイル (md 未満) では collapsed を無視して常にワードマーク表示し、
+            md 以上でのみ collapsed に応じてシンボル化する。
+            "hidden md:block" / "md:hidden" の併用で md ブレークポイントを境に切り替える */}
         <div className="flex h-16 items-center justify-between border-b border-slate-200 px-3">
-          {/* 折りたたみ時はワードマークを隠し、シンボルだけ表示
-              (モバイル時は collapsed の値に関わらずワードマーク表示にしたいので md 未満は常に true 相当扱い)
-              ここでは showWordmark に !collapsed を渡し、デスクトップ折りたたみ時のみ非表示にする */}
-          <Logo showWordmark={!collapsed} size={collapsed ? 28 : 30} />
+          {/* モバイル: 常にワードマーク + 通常サイズ (collapsed の影響を受けない) */}
+          <div className="md:hidden">
+            <Logo showWordmark size={30} />
+          </div>
+          {/* デスクトップ: collapsed に応じてワードマーク表示・サイズを切り替える */}
+          <div className="hidden md:block">
+            <Logo showWordmark={!collapsed} size={collapsed ? 28 : 30} />
+          </div>
           {/* 折りたたみ切り替えボタン (md 以上でのみ表示。モバイルでは Header のハンバーガーが担当) */}
           <button
             onClick={() => setCollapsed(!collapsed)}
@@ -99,39 +106,44 @@ export function Sidebar({ role }: Props) {
             {collapsed ? '›' : '‹'}
           </button>
         </div>
-        {/* 折りたたみ時はメニュー本体を非表示 (デスクトップのみ。モバイルではドロワー幅 w-64 で常に展開表示) */}
-        {!collapsed && (
-          <nav className="flex-1 space-y-1 px-3 py-5">
-            {visibleItems.map((item) => {
-              // この項目が現在のページかどうか
-              const isActive = isItemActive(item.href);
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  // メニュータップで遷移と同時にモバイルドロワーを閉じる
-                  // (Provider 側の useEffect で pathname を監視するとリンタが set-state-in-effect 警告を出すため、
-                  //  ユーザー操作起点で明示的に閉じる方が安全)
-                  onClick={closeNav}
-                  // アクティブ項目はティールで強調 (左にバー風アクセント)
-                  className={`relative block rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
-                    isActive
-                      ? 'bg-teal-50 text-teal-800 ring-1 ring-teal-100 before:absolute before:top-1/2 before:left-0 before:h-5 before:w-1 before:-translate-y-1/2 before:rounded-r before:bg-teal-600'
-                      : 'text-slate-600 hover:bg-teal-50/60 hover:text-teal-800'
-                  }`}
-                >
-                  {item.label}
-                </Link>
-              );
-            })}
-          </nav>
-        )}
-        {/* フッター: 折りたたみ時以外は小さなバージョン情報風テキスト */}
-        {!collapsed && (
-          <div className="border-t border-slate-200 px-4 py-3 text-[11px] text-slate-400">
-            © HelpDesk Hub
-          </div>
-        )}
+        {/* メニュー本体は常に DOM に描画する。
+            collapsed の効果は md 以上だけに限定 (md:hidden) し、モバイルでは必ず表示する。
+            これにより「デスクトップで折りたたみ → 画面幅を縮める → ハンバーガーで開く」のフローで
+            メニューが空になる不具合を防ぐ */}
+        <nav
+          className={`flex-1 space-y-1 px-3 py-5 ${collapsed ? 'md:hidden' : ''}`}
+        >
+          {visibleItems.map((item) => {
+            // この項目が現在のページかどうか
+            const isActive = isItemActive(item.href);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                // メニュータップで遷移と同時にモバイルドロワーを閉じる
+                // (Provider 側の useEffect で pathname を監視するとリンタが set-state-in-effect 警告を出すため、
+                //  ユーザー操作起点で明示的に閉じる方が安全)
+                onClick={closeNav}
+                // アクティブ項目はティールで強調 (左にバー風アクセント)
+                className={`relative block rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
+                  isActive
+                    ? 'bg-teal-50 text-teal-800 ring-1 ring-teal-100 before:absolute before:top-1/2 before:left-0 before:h-5 before:w-1 before:-translate-y-1/2 before:rounded-r before:bg-teal-600'
+                    : 'text-slate-600 hover:bg-teal-50/60 hover:text-teal-800'
+                }`}
+              >
+                {item.label}
+              </Link>
+            );
+          })}
+        </nav>
+        {/* フッター: 同様にモバイルでは常時表示、md 以上でのみ collapsed の影響を受ける */}
+        <div
+          className={`border-t border-slate-200 px-4 py-3 text-[11px] text-slate-400 ${
+            collapsed ? 'md:hidden' : ''
+          }`}
+        >
+          © HelpDesk Hub
+        </div>
       </aside>
     </>
   );

--- a/src/data/adapters/memory/ticket-repository.memory.ts
+++ b/src/data/adapters/memory/ticket-repository.memory.ts
@@ -49,14 +49,24 @@ function matchesFilter(t: Ticket, filter: TicketListFilter, tenantId: string): b
   if (t.tenantId !== tenantId) return false;
   // 起票者フィルター: 指定があり一致しなければ除外
   if (filter.creatorId !== undefined && t.creatorId !== filter.creatorId) return false;
-  // 状態フィルター
+  // 状態フィルター (単一)
   if (filter.status !== undefined && t.status !== filter.status) return false;
+  // 状態フィルター (複数)。Lite「自分の未対応」など Open OR InProgress に使う
+  if (filter.statusIn && filter.statusIn.length > 0 && !filter.statusIn.includes(t.status))
+    return false;
   // 優先度フィルター
   if (filter.priority !== undefined && t.priority !== filter.priority) return false;
   // カテゴリフィルター
   if (filter.categoryId !== undefined && t.categoryId !== filter.categoryId) return false;
   // 担当者フィルター (undefined は無指定、null は未アサインのみ)
   if (filter.assigneeId !== undefined && t.assigneeId !== filter.assigneeId) return false;
+  // 期限切れフィルター: 期限あり / 期限超過 / 未解決 / 終息状態でない
+  if (filter.overdue) {
+    if (!t.resolutionDueAt) return false;
+    if (t.resolutionDueAt >= filter.overdue.now) return false;
+    if (t.resolvedAt !== null) return false;
+    if (t.status === 'Resolved' || t.status === 'Closed') return false;
+  }
   // テキスト検索フィルター (title または body の部分一致)
   if (filter.text) {
     // 大文字小文字を無視する場合は両方小文字化する

--- a/src/data/adapters/prisma/ticket-repository.prisma.ts
+++ b/src/data/adapters/prisma/ticket-repository.prisma.ts
@@ -22,10 +22,21 @@ function buildWhere(f: TicketListFilter, tenantId: string): Prisma.TicketWhereIn
   // 各フィルタが指定されていれば条件を積み上げる
   if (f.creatorId !== undefined) where.creatorId = f.creatorId;
   if (f.status !== undefined) where.status = f.status;
+  // 複数状態の OR 絞り込み (Lite モードの「自分の未対応」で Open/InProgress を一度に取るため)
+  if (f.statusIn && f.statusIn.length > 0) where.status = { in: f.statusIn };
   if (f.priority !== undefined) where.priority = f.priority;
   if (f.categoryId !== undefined) where.categoryId = f.categoryId;
   // 担当者条件: null は未アサインのみ、文字列は完全一致
   if (f.assigneeId !== undefined) where.assigneeId = f.assigneeId;
+  // 期限切れフィルタ (Lite モードの「期限切れ」タブで使用)
+  // - resolutionDueAt < now (期限を過ぎている)
+  // - resolvedAt IS NULL (まだ解決していない)
+  // - status が Resolved/Closed でない (業務上の終息状態は除外)
+  if (f.overdue) {
+    where.resolutionDueAt = { lt: f.overdue.now };
+    where.resolvedAt = null;
+    where.status = { notIn: ['Resolved', 'Closed'] };
+  }
   // テキスト検索: title または body に contains を OR 条件で適用
   if (f.text) {
     // 大文字小文字を無視する場合は Prisma の 'insensitive' モードを指定

--- a/src/data/ports/ticket-repository.ts
+++ b/src/data/ports/ticket-repository.ts
@@ -16,6 +16,7 @@ export interface TicketListFilter {
   /** Searches title OR body. */
   text?: TextFilter; // タイトルまたは本文の部分一致
   status?: TicketStatus; // 状態で絞る
+  statusIn?: TicketStatus[]; // 複数状態の OR 絞り込み (例: Open or InProgress)
   priority?: Priority; // 優先度で絞る
   categoryId?: string; // カテゴリで絞る
   /**
@@ -23,6 +24,13 @@ export interface TicketListFilter {
    * otherwise = exact match on assigneeId.
    */
   assigneeId?: string | null; // 担当者条件 (null は未アサインのみ)
+  /**
+   * 期限切れ未解決のみを取得するフィルタ (Lite モードの「期限切れ」タブで使用)。
+   * `now` 時点で `resolutionDueAt < now` かつ `resolvedAt IS NULL`、
+   * かつ業務上「終わった」扱いの status (Resolved/Closed) は除外する。
+   * 省略時はフィルタなし。
+   */
+  overdue?: { now: Date };
 }
 
 // チケット詳細画面用の型 (コメント/履歴/FAQ 候補を同梱)

--- a/src/features/tickets/components/TicketFilters.tsx
+++ b/src/features/tickets/components/TicketFilters.tsx
@@ -45,6 +45,9 @@ const fieldBaseClass =
 export function TicketFilters({ categories, agents, isAgent, mode }: Props) {
   // テナントが Lite なら 3 値、Pro なら従来 7 値をフィルタ候補として使う
   const statusOptions: TicketStatus[] = mode === 'lite' ? [...LITE_STATUSES] : ALL_STATUSES_PRO;
+  // Lite モードかどうか (true ならフィルタをキーワード検索のみに縮約する)
+  // Pivot plan §3.1「Lite はフリーワード検索のみ」要件に対応
+  const isLite = mode === 'lite';
   // ルーター/現在パス/検索クエリ
   const router = useRouter();
   const pathname = usePathname();
@@ -73,7 +76,7 @@ export function TicketFilters({ categories, agents, isAgent, mode }: Props) {
     [pathname, router, searchParams],
   );
 
-  // 「リセット」: パスのみへ遷移して全クエリを消す
+  // 「リセット」: パスのみへ遷移して全クエリを消す (tab クエリも消えるが既定タブに戻す挙動でよい)
   const handleReset = () => {
     startTransition(() => router.push(pathname));
   };
@@ -106,61 +109,66 @@ export function TicketFilters({ categories, agents, isAgent, mode }: Props) {
         >
           検索
         </button>
-        {/* ステータス絞り込み */}
-        <select
-          value={searchParams.get('status') ?? ''}
-          onChange={(e) => update('status', e.target.value)}
-          className={fieldBaseClass}
-        >
-          <option value="">すべてのステータス</option>
-          {statusOptions.map((s) => (
-            <option key={s} value={s}>
-              {getStatusLabel(s, mode)}
-            </option>
-          ))}
-        </select>
-        {/* 優先度絞り込み */}
-        <select
-          value={searchParams.get('priority') ?? ''}
-          onChange={(e) => update('priority', e.target.value)}
-          className={fieldBaseClass}
-        >
-          <option value="">すべての優先度</option>
-          {ALL_PRIORITIES.map((p) => (
-            <option key={p} value={p}>
-              {PRIORITY_LABELS[p] ?? p}
-            </option>
-          ))}
-        </select>
-        {/* カテゴリ絞り込み */}
-        <select
-          value={searchParams.get('categoryId') ?? ''}
-          onChange={(e) => update('categoryId', e.target.value)}
-          className={fieldBaseClass}
-        >
-          <option value="">すべてのカテゴリ</option>
-          {categories.map((c) => (
-            <option key={c.id} value={c.id}>
-              {c.name}
-            </option>
-          ))}
-        </select>
-        {/* 担当者絞り込み (エージェントのみ表示) */}
-        {isAgent && (
-          <select
-            value={searchParams.get('assigneeId') ?? ''}
-            onChange={(e) => update('assigneeId', e.target.value)}
-            className={fieldBaseClass}
-          >
-            <option value="">すべての担当者</option>
-            {/* 未割当のチケットのみ */}
-            <option value="unassigned">未割当</option>
-            {agents.map((a) => (
-              <option key={a.id} value={a.id}>
-                {a.name}
-              </option>
-            ))}
-          </select>
+        {/* Lite モードではキーワード検索のみに縮約し、以下のプルダウン群は非表示にする */}
+        {!isLite && (
+          <>
+            {/* ステータス絞り込み */}
+            <select
+              value={searchParams.get('status') ?? ''}
+              onChange={(e) => update('status', e.target.value)}
+              className={fieldBaseClass}
+            >
+              <option value="">すべてのステータス</option>
+              {statusOptions.map((s) => (
+                <option key={s} value={s}>
+                  {getStatusLabel(s, mode)}
+                </option>
+              ))}
+            </select>
+            {/* 優先度絞り込み */}
+            <select
+              value={searchParams.get('priority') ?? ''}
+              onChange={(e) => update('priority', e.target.value)}
+              className={fieldBaseClass}
+            >
+              <option value="">すべての優先度</option>
+              {ALL_PRIORITIES.map((p) => (
+                <option key={p} value={p}>
+                  {PRIORITY_LABELS[p] ?? p}
+                </option>
+              ))}
+            </select>
+            {/* カテゴリ絞り込み */}
+            <select
+              value={searchParams.get('categoryId') ?? ''}
+              onChange={(e) => update('categoryId', e.target.value)}
+              className={fieldBaseClass}
+            >
+              <option value="">すべてのカテゴリ</option>
+              {categories.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+            {/* 担当者絞り込み (エージェントのみ表示) */}
+            {isAgent && (
+              <select
+                value={searchParams.get('assigneeId') ?? ''}
+                onChange={(e) => update('assigneeId', e.target.value)}
+                className={fieldBaseClass}
+              >
+                <option value="">すべての担当者</option>
+                {/* 未割当のチケットのみ */}
+                <option value="unassigned">未割当</option>
+                {agents.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.name}
+                  </option>
+                ))}
+              </select>
+            )}
+          </>
         )}
         {/* リセットボタン (ghost スタイル) */}
         <button

--- a/src/features/tickets/components/TicketForm.tsx
+++ b/src/features/tickets/components/TicketForm.tsx
@@ -12,13 +12,17 @@ import { useRouter } from 'next/navigation';
 import { createTicketSchema, type CreateTicketFormValues } from '@/lib/validations/ticket';
 // 優先度の日本語ラベル
 import { PRIORITY_LABELS } from '@/lib/constants';
+// テナントモード型 (lite | pro)。Lite では入力項目を 3 つに絞る
+import type { TenantMode } from '@/domain/types';
 
 // プルダウン項目用の最小型 (id と name)
 type Category = { id: string; name: string };
 
-// 受け取る props (カテゴリ候補一覧)
+// 受け取る props (カテゴリ候補一覧 + テナント mode)
 interface Props {
   categories: Category[];
+  // テナントの動作モード。'lite' (既定) では件名/内容/期限日のみ表示する
+  mode: TenantMode;
 }
 
 // 入力欄に共通で当てるベースクラス (フォーカス時のティールリングを統一)
@@ -37,11 +41,13 @@ function RequiredPill() {
 }
 
 // 新規チケット作成フォーム (POST /api/tickets を呼ぶ)
-export function TicketForm({ categories }: Props) {
+export function TicketForm({ categories, mode }: Props) {
   // 登録成功後の遷移用ルーター
   const router = useRouter();
   // サーバー側エラー (フォーム検証エラーとは別) の保持
   const [serverError, setServerError] = useState<string | null>(null);
+  // Lite モードフラグ (件名/内容/期限日のみの簡易フォームに切替)
+  const isLite = mode === 'lite';
   // react-hook-form の各種ヘルパー
   const {
     register,
@@ -50,7 +56,7 @@ export function TicketForm({ categories }: Props) {
   } = useForm<CreateTicketFormValues>({
     // Zod でフォームの値を検証
     resolver: zodResolver(createTicketSchema),
-    // 優先度の初期値は Medium
+    // 優先度の初期値は Medium (Lite では UI から選ばせず常に Medium のまま送る)
     defaultValues: { priority: 'Medium' as const },
   });
 
@@ -122,35 +128,67 @@ export function TicketForm({ categories }: Props) {
         {errors.body && <p className="mt-1.5 text-xs text-rose-600">{errors.body.message}</p>}
       </div>
 
-      {/* カテゴリ (選択任意) */}
-      <div>
-        <label htmlFor="categoryId" className="mb-1.5 block text-sm font-medium text-slate-700">
-          カテゴリ
-        </label>
-        <select id="categoryId" {...register('categoryId')} className={fieldBaseClass}>
-          <option value="">選択しない</option>
-          {categories.map((c) => (
-            <option key={c.id} value={c.id}>
-              {c.name}
-            </option>
-          ))}
-        </select>
-      </div>
+      {/* 期限日 (Lite モードのみ表示。Pro はカテゴリ/優先度で自動 SLA を使うため非表示) */}
+      {isLite && (
+        <div>
+          <label htmlFor="dueDate" className="mb-1.5 block text-sm font-medium text-slate-700">
+            いつまでに
+          </label>
+          <input
+            id="dueDate"
+            // YYYY-MM-DD 形式で値が送られる (Zod 側で同じ形式を期待)
+            type="date"
+            {...register('dueDate')}
+            aria-invalid={errors.dueDate ? 'true' : 'false'}
+            className={`${fieldBaseClass} ${errors.dueDate ? fieldErrorClass : ''}`}
+          />
+          {/* 期限日の検証エラー (形式不正・実在しない日付など) */}
+          {errors.dueDate && (
+            <p className="mt-1.5 text-xs text-rose-600">{errors.dueDate.message}</p>
+          )}
+          {/* 補足: 任意項目であることを明示 (Lite では SLA 自動計算より明示入力を優先) */}
+          <p className="mt-1 text-xs text-slate-400">
+            未入力の場合は自動で期限を設定します
+          </p>
+        </div>
+      )}
 
-      {/* 優先度 */}
-      <div>
-        <label htmlFor="priority" className="mb-1.5 block text-sm font-medium text-slate-700">
-          優先度
-        </label>
-        <select id="priority" {...register('priority')} className={fieldBaseClass}>
-          {/* PRIORITY_LABELS の [値, 表示名] を順に並べる */}
-          {Object.entries(PRIORITY_LABELS).map(([value, label]) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
-          ))}
-        </select>
-      </div>
+      {/* カテゴリ (Pro モードのみ。Lite では非表示) */}
+      {!isLite && (
+        <div>
+          <label htmlFor="categoryId" className="mb-1.5 block text-sm font-medium text-slate-700">
+            カテゴリ
+          </label>
+          <select id="categoryId" {...register('categoryId')} className={fieldBaseClass}>
+            <option value="">選択しない</option>
+            {categories.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* 優先度 (Pro モードのみ。Lite では Medium 固定送信のため hidden で保持) */}
+      {!isLite ? (
+        <div>
+          <label htmlFor="priority" className="mb-1.5 block text-sm font-medium text-slate-700">
+            優先度
+          </label>
+          <select id="priority" {...register('priority')} className={fieldBaseClass}>
+            {/* PRIORITY_LABELS の [値, 表示名] を順に並べる */}
+            {Object.entries(PRIORITY_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : (
+        // Lite モードでも Zod スキーマが priority を必須とするため hidden で初期値を保持
+        <input type="hidden" {...register('priority')} value="Medium" />
+      )}
 
       {/* サーバー由来エラー (API レスポンス) ─ 柔らかなロゼ枠 */}
       {serverError && (

--- a/src/features/tickets/components/TicketForm.tsx
+++ b/src/features/tickets/components/TicketForm.tsx
@@ -23,7 +23,7 @@ interface Props {
 
 // 入力欄に共通で当てるベースクラス (フォーカス時のティールリングを統一)
 const fieldBaseClass =
-  'block w-full rounded-lg border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 transition focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30';
+  'block w-full rounded-lg border border-slate-200 bg-white px-4 py-2.5 text-base text-slate-900 placeholder:text-slate-400 transition focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/30 sm:text-sm';
 // 入力エラー時に追加で当てる枠色
 const fieldErrorClass = 'border-rose-400 focus:border-rose-500 focus:ring-rose-500/30';
 

--- a/src/features/tickets/components/TicketTabs.tsx
+++ b/src/features/tickets/components/TicketTabs.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+// クライアント遷移付きリンク
+import Link from 'next/link';
+// 現在 URL のクエリパラメータを読み取るフック (アクティブタブ判定用)
+import { useSearchParams } from 'next/navigation';
+
+// タブ識別子のリテラル型 (一覧ページの ?tab=... と対応)
+// - 'all'     : 既定 (絞り込みなし、全件)
+// - 'mine'    : 自分の未対応 (担当者または起票者として Open / InProgress)
+// - 'overdue' : 期限切れ (resolutionDueAt < now かつ未解決)
+export type TicketTabId = 'all' | 'mine' | 'overdue';
+
+// タブ 1 つ分の表示メタ
+interface TabDef {
+  id: TicketTabId;
+  label: string;
+}
+
+// 並べるタブの一覧 (Pivot plan §3.1「自分の未対応 / 期限切れ・今日まで」相当)
+const TABS: TabDef[] = [
+  { id: 'all', label: 'すべて' },
+  { id: 'mine', label: '自分の未対応' },
+  { id: 'overdue', label: '期限切れ' },
+];
+
+// 受け取る props (なし — 状態は URL クエリから読むため)
+// 一覧ページ /tickets の上に水平方向に並ぶタブナビゲーションを描画する
+export function TicketTabs() {
+  // 現在の URL クエリ (?tab=... を読み取って active 判定に使う)
+  const searchParams = useSearchParams();
+  // 現在のタブ ID。未指定 / 不正値は 'all' にフォールバック
+  const currentRaw = searchParams.get('tab');
+  const current: TicketTabId = (TABS.some((t) => t.id === currentRaw) ? currentRaw : 'all') as TicketTabId;
+
+  // 指定タブへ遷移するための URL を組み立てるヘルパー
+  // - tab パラメータだけ差し替え、他のクエリ (q など) は維持する
+  // - タブを切り替えると検索結果のページ番号 (page) はリセットする
+  function tabHref(tabId: TicketTabId): string {
+    // 既存クエリを複製
+    const params = new URLSearchParams(searchParams.toString());
+    // 'all' は既定なのでクエリから削る (URL を綺麗に保つ)
+    if (tabId === 'all') {
+      params.delete('tab');
+    } else {
+      params.set('tab', tabId);
+    }
+    // タブ切替時は page を必ず先頭に戻す
+    params.delete('page');
+    // クエリが空なら "?" は付けない
+    const qs = params.toString();
+    return qs ? `/tickets?${qs}` : '/tickets';
+  }
+
+  return (
+    // タブナビ本体: 横並び、下線でアクティブを強調する一般的なタブ UI
+    <nav className="flex gap-1 border-b border-slate-200 text-sm" aria-label="一覧の絞り込みタブ">
+      {TABS.map((tab) => {
+        // この項目がアクティブかどうか
+        const isActive = tab.id === current;
+        return (
+          <Link
+            key={tab.id}
+            href={tabHref(tab.id)}
+            // アクティブな項目はティールの下線で強調、非アクティブは控えめなグレー
+            className={`-mb-px border-b-2 px-3 py-2.5 font-medium transition-colors ${
+              isActive
+                ? 'border-teal-600 text-teal-800'
+                : 'border-transparent text-slate-500 hover:border-slate-300 hover:text-slate-700'
+            }`}
+            // 現在のページかどうかを支援技術に伝える
+            aria-current={isActive ? 'page' : undefined}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -12,3 +12,39 @@ export function formatDateJP(date: Date): string {
   // toLocaleDateString に locale と timeZone を渡して JST へ変換する
   return date.toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' });
 }
+
+// 'YYYY-MM-DD' 形式の文字列を「その日の JST 終端 (23:59:59.999)」を表す Date に変換する関数
+// - サーバが UTC/JST どちらで動いていても結果が変わらないよう、明示的に +09:00 オフセットを付与する
+// - 失敗 (形式不正・実在しない日付) 時は null を返す。呼び出し側は事前に Zod 検証済みの値を渡す前提
+export function endOfDayJST(yyyyMmDd: string): Date | null {
+  // 入力形式チェック (Zod 側でも検証しているがダブルセーフ)
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(yyyyMmDd);
+  if (!m) return null;
+  // 年・月・日を数値化 (groups は regex マッチで保証されているので decimal parse)
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+  // ISO 8601 形式の文字列を +09:00 オフセット付きで組み立てる
+  // 例: 2026-05-17 → 2026-05-17T23:59:59.999+09:00 (UTC では 2026-05-17T14:59:59.999Z)
+  const d = new Date(`${yyyyMmDd}T23:59:59.999+09:00`);
+  // 不正な値 (パース失敗) は NaN になる
+  if (Number.isNaN(d.getTime())) return null;
+  // JS の Date は 2026-02-31 のような不正日付をロールオーバーで受け入れてしまう
+  // (例: 2026-02-31 → 2026-03-03)。入力した y/m/d と Date 側の y/m/d (JST) が
+  // 一致するかを確認することで実在しない日付を弾く
+  // 'Asia/Tokyo' で年月日を取り出して比較する (サーバ TZ 非依存)
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(d);
+  // formatToParts は型ごとに分解した配列を返す。値だけ取り出して数値比較する
+  const valueOf = (type: 'year' | 'month' | 'day') =>
+    Number(parts.find((p) => p.type === type)?.value);
+  // 一致しなければロールオーバーが起きている = 不正日付
+  if (valueOf('year') !== year || valueOf('month') !== month || valueOf('day') !== day) {
+    return null;
+  }
+  return d;
+}

--- a/src/lib/validations/ticket.ts
+++ b/src/lib/validations/ticket.ts
@@ -1,6 +1,22 @@
 // Zod (スキーマ検証ライブラリ) をインポート
 import { z } from 'zod';
 
+// YYYY-MM-DD 文字列が実在する日付か (例: 2026-02-31 は false) を判定するヘルパー
+// JavaScript の Date コンストラクタは存在しない日付を自動的にロールオーバーするため、
+// 入力された年月日と Date オブジェクトから再構築した年月日が一致するかを確認する
+function isRealCalendarDate(yyyyMmDd: string): boolean {
+  // 入力を年・月・日の数値に分解 (フォーマットは事前 regex で保証済み)
+  const [yearStr, monthStr, dayStr] = yyyyMmDd.split('-');
+  // 数値に変換 (月は 0 始まりに揃える)
+  const year = Number(yearStr);
+  const month = Number(monthStr) - 1;
+  const day = Number(dayStr);
+  // ローカルタイム基準で Date オブジェクトを構築
+  const d = new Date(year, month, day);
+  // 入力値と構築後の値が一致すれば実在する日付
+  return d.getFullYear() === year && d.getMonth() === month && d.getDate() === day;
+}
+
 // チケット新規作成フォームの入力検証スキーマ
 export const createTicketSchema = z.object({
   // タイトル: 1〜200 文字の文字列
@@ -17,6 +33,19 @@ export const createTicketSchema = z.object({
     .transform((v) => v || undefined),
   // 優先度は Low/Medium/High のいずれか
   priority: z.enum(['Low', 'Medium', 'High']),
+  // 期限日 (Lite モードの簡易フォーム用、任意): YYYY-MM-DD 形式の文字列
+  // - <input type="date"> から空文字で送られて来ることがあるので空は undefined に正規化
+  // - 形式と実在日付の両方を検証する (例: 2026-02-31 のような不正値を弾く)
+  dueDate: z
+    .string()
+    .optional()
+    .refine((v) => v === undefined || v === '' || /^\d{4}-\d{2}-\d{2}$/.test(v), {
+      message: '期限日の形式が正しくありません',
+    })
+    .refine((v) => v === undefined || v === '' || isRealCalendarDate(v), {
+      message: '期限日が正しい日付ではありません',
+    })
+    .transform((v) => (v ? v : undefined)),
 });
 
 // スキーマから TypeScript 型を生成 (変換後の型)

--- a/tests/data/ticket-repository.contract.ts
+++ b/tests/data/ticket-repository.contract.ts
@@ -485,5 +485,114 @@ export function runTicketRepositoryContract(
       });
       expect(statsB.byStatus.New).toBe(2);
     });
+
+    // --- Lite モード追加フィルタ (statusIn / overdue) の契約 ---
+
+    // statusIn を渡すと指定した複数ステータスのチケットだけが取得できる
+    it('list with statusIn returns tickets matching any of the given statuses', async () => {
+      const { requester, categoryId } = await ctx.seedBasicFixture();
+      // New 状態のチケットを 1 件
+      const tNew = await ctx.repos.tickets.create({
+        title: 'new',
+        body: 'b',
+        priority: 'Low',
+        creatorId: requester.id,
+        categoryId,
+        tenantId: TENANT_ID,
+      });
+      // Open に遷移させたチケットを 1 件
+      const tOpen = await ctx.repos.tickets.create({
+        title: 'open',
+        body: 'b',
+        priority: 'Low',
+        creatorId: requester.id,
+        categoryId,
+        tenantId: TENANT_ID,
+      });
+      await ctx.repos.tickets.updateStatus(tOpen.id, 'Open', null, TENANT_ID);
+      // InProgress に遷移させたチケットを 1 件
+      const tInProgress = await ctx.repos.tickets.create({
+        title: 'in-progress',
+        body: 'b',
+        priority: 'Low',
+        creatorId: requester.id,
+        categoryId,
+        tenantId: TENANT_ID,
+      });
+      await ctx.repos.tickets.updateStatus(tInProgress.id, 'Open', null, TENANT_ID);
+      await ctx.repos.tickets.updateStatus(tInProgress.id, 'InProgress', null, TENANT_ID);
+
+      // statusIn=[Open, InProgress] で 2 件 (Open と InProgress) が返り New は除外される
+      const result = await ctx.repos.tickets.list({
+        filter: { statusIn: ['Open', 'InProgress'] },
+        page: { skip: 0, take: 50 },
+        tenantId: TENANT_ID,
+      });
+      const ids = result.map((t) => t.id).sort();
+      expect(ids).toEqual([tOpen.id, tInProgress.id].sort());
+      expect(ids).not.toContain(tNew.id);
+    });
+
+    // overdue フィルタが期限超過 + 未解決のみを返すこと
+    it('list with overdue filter returns only past-due, unresolved tickets', async () => {
+      const { requester, categoryId } = await ctx.seedBasicFixture();
+      // 基準時刻を未来側に設定 (作成済みチケットの期限を相対的に過去にする)
+      const now = new Date('2030-06-01T00:00:00Z');
+      const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+      const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+
+      // 期限超過 + 未解決のチケット (Open 状態) → ヒット対象
+      const overdueUnresolved = await ctx.repos.tickets.create({
+        title: 'overdue-open',
+        body: 'b',
+        priority: 'High',
+        creatorId: requester.id,
+        categoryId,
+        tenantId: TENANT_ID,
+        resolutionDueAt: yesterday,
+      });
+      await ctx.repos.tickets.updateStatus(overdueUnresolved.id, 'Open', null, TENANT_ID);
+      // 期限超過だが解決済み (Resolved) → 除外
+      const overdueResolved = await ctx.repos.tickets.create({
+        title: 'overdue-resolved',
+        body: 'b',
+        priority: 'High',
+        creatorId: requester.id,
+        categoryId,
+        tenantId: TENANT_ID,
+        resolutionDueAt: yesterday,
+      });
+      await ctx.repos.tickets.updateStatus(overdueResolved.id, 'Open', null, TENANT_ID);
+      await ctx.repos.tickets.updateStatus(overdueResolved.id, 'Resolved', new Date(), TENANT_ID);
+      // 期限が未来 → 除外
+      await ctx.repos.tickets.create({
+        title: 'future-due',
+        body: 'b',
+        priority: 'Low',
+        creatorId: requester.id,
+        categoryId,
+        tenantId: TENANT_ID,
+        resolutionDueAt: tomorrow,
+      });
+      // 期限なし → 除外
+      await ctx.repos.tickets.create({
+        title: 'no-due',
+        body: 'b',
+        priority: 'Low',
+        creatorId: requester.id,
+        categoryId,
+        tenantId: TENANT_ID,
+      });
+
+      // overdue フィルタで期限超過 + 未解決のみが返る
+      const overdue = await ctx.repos.tickets.list({
+        filter: { overdue: { now } },
+        page: { skip: 0, take: 50 },
+        tenantId: TENANT_ID,
+      });
+      expect(overdue.map((t) => t.id)).toEqual([overdueUnresolved.id]);
+      // count も同じ件数
+      expect(await ctx.repos.tickets.count({ overdue: { now } }, TENANT_ID)).toBe(1);
+    });
   });
 }

--- a/tests/format-date.test.ts
+++ b/tests/format-date.test.ts
@@ -1,0 +1,37 @@
+// Vitest のテスト DSL
+import { describe, expect, it } from 'vitest';
+// 検証対象 (YYYY-MM-DD → JST 終端 Date 変換ヘルパー)
+import { endOfDayJST } from '@/lib/format-date';
+
+// JST 終端 Date 変換の境界値テスト
+describe('endOfDayJST', () => {
+  // 正常な YYYY-MM-DD は JST 23:59:59.999 (= UTC 14:59:59.999) になる
+  it('returns a Date at 23:59:59.999 JST (= 14:59:59.999 UTC)', () => {
+    const d = endOfDayJST('2026-05-17');
+    expect(d).not.toBeNull();
+    // toISOString は UTC 表記で返るため、JST 23:59 は UTC 14:59 に対応
+    expect(d!.toISOString()).toBe('2026-05-17T14:59:59.999Z');
+  });
+
+  // 形式不正 (区切り違い) は null を返す
+  it('returns null for malformed date string', () => {
+    expect(endOfDayJST('2026/05/17')).toBeNull();
+    expect(endOfDayJST('2026-5-17')).toBeNull();
+    expect(endOfDayJST('not-a-date')).toBeNull();
+  });
+
+  // 実在しない日付 (2 月 31 日) は null を返す
+  // (JS の Date は不正値で NaN になるので endOfDayJST はそれを拾う)
+  it('returns null for impossible calendar date', () => {
+    const d = endOfDayJST('2026-02-31');
+    // JS の Date(`2026-02-31T...`) は Invalid Date になるので null
+    expect(d).toBeNull();
+  });
+
+  // 月の境界 (年末) も正しく扱える
+  it('handles end-of-year correctly', () => {
+    const d = endOfDayJST('2026-12-31');
+    // JST 12/31 23:59:59 → UTC 12/31 14:59:59
+    expect(d!.toISOString()).toBe('2026-12-31T14:59:59.999Z');
+  });
+});

--- a/tests/validations/ticket.test.ts
+++ b/tests/validations/ticket.test.ts
@@ -34,6 +34,40 @@ describe('createTicketSchema', () => {
     const r = createTicketSchema.safeParse({ ...base, title: 'a'.repeat(201) });
     expect(r.success).toBe(false);
   });
+
+  // dueDate 省略時は undefined に正規化されて通る (Lite フォームで未入力のケース)
+  it('accepts input without dueDate', () => {
+    const r = createTicketSchema.safeParse(base);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.dueDate).toBeUndefined();
+  });
+
+  // dueDate に空文字が来ても undefined 扱いで通る (HTML <input type="date"> が空のとき)
+  it('treats empty-string dueDate as undefined', () => {
+    const r = createTicketSchema.safeParse({ ...base, dueDate: '' });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.dueDate).toBeUndefined();
+  });
+
+  // 正しい YYYY-MM-DD は受理し、文字列として保持する
+  it('accepts a valid YYYY-MM-DD dueDate', () => {
+    const r = createTicketSchema.safeParse({ ...base, dueDate: '2026-12-31' });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.dueDate).toBe('2026-12-31');
+  });
+
+  // 形式不正 (区切りが違う) は拒否し、メッセージで形式を示唆する
+  it('rejects a malformed dueDate', () => {
+    const r = createTicketSchema.safeParse({ ...base, dueDate: '2026/12/31' });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error.issues[0].message).toMatch(/期限日/);
+  });
+
+  // 実在しない日付 (2 月 31 日) は拒否する
+  it('rejects an impossible calendar date', () => {
+    const r = createTicketSchema.safeParse({ ...base, dueDate: '2026-02-31' });
+    expect(r.success).toBe(false);
+  });
 });
 
 // コメント本文スキーマ


### PR DESCRIPTION
## Summary

`docs/smb-dx-pivot-plan.md` Phase 1 残項目のうち、依存が浅く Lite UI 完成に直結する 3 件を実装。レビュー指摘 (TZ 依存 / モバイルメニュー欠落 / クロステナント検査 / Lite モード categoryId 仕様) もすべて後続コミットで解消済み。

- **スマホ最適化** (`feat(ui): モバイルドロワー + 一覧カード化...`)
  - `MobileNavProvider` / `MobileNavToggle` を新設し、Header と Sidebar 間で開閉状態を共有
  - Sidebar は md 未満で fixed ドロワーに切替 (背景タップ / メニュータップで自動クローズ)
  - 問い合わせ一覧は md 未満カード型 / md 以上テーブルで排他表示
  - `TicketForm` 入力欄を `text-base sm:text-sm` にし iOS でのフォーカス時自動拡大を抑止
- **Lite モード簡易フォーム** (`feat(tickets): Lite モード簡易フォーム...`)
  - `createTicketSchema` に任意 `dueDate` (YYYY-MM-DD) を追加し実在日付を厳格検証
  - `TicketForm` に `mode` prop を追加、Lite では「件名 / 内容 / 期限日」のみ表示
  - `POST /api/tickets` で Lite モード時は `priority='Medium'` 強制 / `categoryId` 保存値 null
  - `dueDate` 指定時は **`endOfDayJST(yyyyMmDd)`** 経由で `+09:00` 付きの JST 終端を `resolutionDueAt` に設定 (サーバ TZ 非依存)
- **タブ一覧** (`feat(tickets): タブ一覧...`)
  - `TicketListFilter` に `statusIn[]` / `overdue {now}` を追加 (port 契約拡張、Prisma/メモリ両 Adapter 実装)
  - `TicketTabs` を新設し `/tickets?tab=mine|overdue|all` に対応
  - Lite モードの `TicketFilters` はキーワード検索のみに縮約
- **レビュー指摘 fix** (複数コミット)
  - TZ 非依存化 (`endOfDayJST`) / Sidebar collapsed の md 限定 / E2E locator scope / CI explicit pipefail
  - Lite モードでも categoryId のクロステナント検査を必ず通す (セキュリティ回帰修正)
  - Lite モードでは自テナント categoryId も保存時に null へ落とす (仕様一致)
  - E2E 回帰テスト追加 (cross-tenant 422 / lite self-tenant 201 + null)

## Test plan

### 自動テスト (CI で実行)

- [x] `npm run lint` (eslint flat config) — green
- [x] `npm run typecheck` (tsc --noEmit) — green
- [x] `npm run test` — **106 件 green** (新規追加: `dueDate` Zod 5 件 / `endOfDayJST` 4 件 / `statusIn` 契約 1 件 / `overdue` 契約 1 件)
- [x] `npm run test:e2e` Playwright (CI 上) — **16 件 green** (Lite モード categoryId null 回帰テスト含む)
- [x] `npm run build` 本番ビルド — green (全ルート生成成功)

### 実ブラウザ目視確認

セッション環境内の Chromium バイナリで Playwright スクリプトを実行し、3 viewport × 主要画面 + ドロワー操作を撮影 (計 12 枚)。確認結果:

- [x] **Chrome 375px (iPhone X 相当)**: `/tickets`, `/tickets/new`, `/dashboard` 表示崩れなし
  - 一覧がカード型に切替、テーブル非表示
  - タブ「すべて / 自分の未対応 / 期限切れ」表示
  - `/tickets/new` が Lite フォーム (タイトル / 内容 / いつまでに + サブテキスト「件名・内容・期限だけで登録できます」)
  - ヘッダ左にハンバーガーボタン、サイドバー非表示
- [x] **Chrome 768px (md ブレークポイント境界)**: サイドバー常時表示に切替、テーブル型一覧
- [x] **Chrome 1280px (デスクトップ)**: サイドバー (w-60) + テーブル型一覧 (件名/ステータス/優先度/カテゴリ/担当者/作成日)
- [x] **サイドバードロワー**: 
  - ハンバーガー押下でスライドイン (右側にバックドロップ)
  - バックドロップタップで自動クローズ
  - ドロワー内メニュータップで遷移 + ドロワー自動クローズ (`MobileNavProvider` の closeNav が onClick から呼ばれる)

確認環境:
- Chromium 141.0.7390.37 / Linux (Playwright executablePath 経由でセッション環境内バイナリを使用)
- DB: PostgreSQL 16 (テナント mode=lite で確認)

注: スクリーンショット 12 枚はチャット上で別途共有済み (このリポジトリにはコミットしていません)。

### TZ 修正の end-to-end 確認

- [x] `dueDate=2026-05-17` で投稿 → DB の `resolutionDueAt` = `2026-05-17 14:59:59.999 UTC` = JST `2026-05-17 23:59:59.999`

### Lite/Pro categoryId end-to-end 確認 (curl)

- [x] Lite + 自テナント categoryId → 201, `categoryId: null` (仕様どおり drop)
- [x] Pro + 自テナント categoryId → 201, `categoryId: <保存>`
- [x] Lite/Pro + 他テナント categoryId → 422

### 未確認 (実機が必要)

- [ ] **iOS Safari (実機)** でのフォーカス時拡大の有無
  - リモートセッション環境では iOS Safari を起動できないため未確認
  - `text-base sm:text-sm` クラスが入力欄に適用されていることは HTML 出力で確認済み (375px 表示にも入力時の自動拡大は Chromium 上では発生せず)
  - merge 前に実機 iPhone Safari で `/tickets/new` の入力欄フォーカス時に画面が拡大しないこと、もしくは実機での確認が難しい場合は手元の iOS Simulator での確認を推奨

## 関連方針

- 計画書: `docs/smb-dx-pivot-plan.md` §3.1 Phase 1
- Phase 1 残 2 項目 (添付 / マジックリンク認証) は外部依存 (ストレージ / SMTP) があるため別 PR とする
- 後続 PR (`test(e2e): responsive viewport regression を追加`) で `page.setViewportSize()` ベースの自動回帰テスト + 成功時の screenshot 保存設定を入れる予定 (今回手動撮影した 12 枚と同じ観点を CI で固定化)
