### PR TITLE
ci(infra): push 時に本人名義で @codex review を投稿するワークフロー追加

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,34 @@
+# PR ブランチへの push 時に、本人 GitHub アカウント名義で `@codex review` を投稿し
+# Codex の自動レビューを起動するワークフロー。
+# bot 名義 (github-actions[bot]) のコメントは Codex の接続ユーザーに解決されず
+# レビューが起動しないため、本人の PAT (CODEX_REVIEW_TOKEN) を使って投稿する。
+name: Codex Review
+
+on:
+  pull_request:
+    # synchronize: 既存 PR ブランチへ追加 push したとき。
+    # PR 作成時 (opened) は Codex の automatic reviews が自動でレビューするため対象外。
+    types: [synchronize]
+
+# 同一 PR で連続 push したときは、古い実行をキャンセルして最新だけを残す。
+concurrency:
+  group: codex-review-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  request-codex-review:
+    name: Request Codex review
+    runs-on: ubuntu-latest
+    # fork からの PR は secret (PAT) を参照できずコメント投稿に失敗するためスキップする。
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    # GITHUB_TOKEN は使わず PAT で認証するため、既定トークンの権限は不要。
+    permissions: {}
+    steps:
+      - name: Post @codex review comment as the repo owner
+        env:
+          # 本人アカウントの PAT。これで投稿するとコメント作者が本人になり Codex が解決できる。
+          GH_TOKEN: ${{ secrets.CODEX_REVIEW_TOKEN }}
+          # コメント対象の PR 番号。
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        # PR に `@codex review` とコメントして Codex の自動レビューを起動する。
+        run: gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "@codex review"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,11 +177,13 @@ Zod schemas live in `src/lib/validations/` (currently `ticket.ts`). Use `safePar
   - scope: tickets, faq, notifications, auth, infra 等
 - 1 コミット = 1 論理変更。Prisma スキーマ変更とマイグレーションは同一コミットに含める。
 
-### Codex レビュー（PR 作成時・push 時にコメント追加）
+### Codex レビュー（PR 作成時・push 時にレビュー起動）
 
-- **PR を新規作成したとき、および PR ブランチへ push したときは、その PR に `@codex review` というコメントを追加**して Codex の自動レビューを起動すること。
-- コメントは Claude Code 自身（GitHub 連携ツール経由）で投稿する。`github-actions[bot]` 名義の自動コメントは Codex 側の接続ユーザーに解決されずレビューが起動しないため、ワークフローからの自動投稿は使わない。
-- Codex 連携（https://chatgpt.com/codex/cloud/settings/connectors ）が未接続の場合はレビューが返らないので、接続状況を前提に投稿する。
+- **PR 作成時**: Codex の automatic reviews（クラウドコネクタ側設定）が自動でレビューするため、追加のコメントは不要。
+- **PR ブランチへ push したとき (synchronize)**: `.github/workflows/codex-review.yml` が `@codex review` コメントを自動投稿してレビューを起動する。投稿は **本人 GitHub アカウントの PAT（secret `CODEX_REVIEW_TOKEN`）** で行う。`github-actions[bot]` 名義のコメントは Codex 側の接続ユーザーに解決されずレビューが起動しないため、必ず PAT を使う。
+- `CODEX_REVIEW_TOKEN` には `pull-requests: write` 権限の PAT を登録する。未登録だとワークフローのコメント投稿が失敗する。
+- 手動で追加レビューが欲しいときは Claude Code 自身（GitHub 連携ツール経由）で `@codex review` を投稿してよい（これも本人/連携ユーザー名義になるため解決される）。
+- Codex 連携（https://chatgpt.com/codex/cloud/settings/connectors ）が未接続の場合はレビューが返らないので、接続状況を前提にする。
 
 ## CI (GitHub Actions)
 


### PR DESCRIPTION
## Summary
- PR ブランチへの push (`synchronize`) 時に、**本人 GitHub アカウントの PAT（secret `CODEX_REVIEW_TOKEN`）** を使って `@codex review` を自動投稿するワークフロー `.github/workflows/codex-review.yml` を追加。
- `github-actions[bot]` 名義のコメントは Codex の接続ユーザーに解決されずレビューが起動しないため、本人名義（PAT）で投稿することで Codex に判定させる。
- CLAUDE.md の Codex レビュー運用記述を新方式に更新。

## 設計
- トリガー: `pull_request` の `synchronize` のみ（PR 作成時は Codex の automatic reviews が既にカバー）。
- `concurrency` で連続 push 時は最新実行のみ残す。
- fork PR は secret を参照できないため `if` でスキップ。
- `GITHUB_TOKEN` は使わず PAT で認証するため `permissions: {}`。

## 前提（マージ前に必要）
- リポジトリ secret **`CODEX_REVIEW_TOKEN`**（`pull-requests: write` 権限の PAT）の登録が必要。未登録だとワークフローのコメント投稿が失敗する。
- Codex 連携（ChatGPT クラウドコネクタ）が接続済みであること。

## Test plan
- [ ] `CODEX_REVIEW_TOKEN` 登録後、PR ブランチへ追加 push し、本人名義の `@codex review` コメントが投稿されることを確認
- [ ] その結果、Codex が実レビューを返すことを確認

https://claude.ai/code/session_017mdL5oh3FfmBUmGCftA3zD

---
_Generated by [Claude Code](https://claude.ai/code/session_017mdL5oh3FfmBUmGCftA3zD)_