### PR TITLE
fix(notifications): markAllRead に tenantId を必須化（クロステナント既読化を防止）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,7 @@ Zod schemas live in `src/lib/validations/` (currently `ticket.ts`). Use `safePar
   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/helpdesk_hub_contract RUN_PRISMA_CONTRACT=1 npm run test:contract
   ```
   CI 上では PostgreSQL サービスコンテナが毎ジョブ新規起動されるため `helpdesk_hub` をそのまま使い、専用ジョブ `prisma-contract` が同じ `prisma db push` → `test:contract` を実行する。
+- `test:contract` は `tests/data/*.contract.prisma.test.ts` グロブで **すべての Prisma 契約スイート** (`ticket-repository` / `notification-repository` など) をまとめて選択する。新しい Prisma 契約テストを足すときはこの命名 (`*.contract.prisma.test.ts`) に揃えれば自動で対象に含まれる。各ファイルが `beforeEach` で同じ DB を `TRUNCATE` するため、`--no-file-parallelism` でファイルを **直列実行** し、並列実行による相互フィクスチャ破壊 (flaky) を防いでいる。
 - Playwright is chromium-only, `fullyParallel: true`, retries only in CI. Selectors are regex-based against Japanese copy (`/ログイン/i`, `/メールアドレス|Email/i`) — match that style.
 
 ## Conventions to respect
@@ -196,5 +197,5 @@ Zod schemas live in `src/lib/validations/` (currently `ticket.ts`). Use `safePar
 ## CI (GitHub Actions)
 
 - `.github/workflows/ci.yml` が lint → typecheck → test → E2E を実行する。PR を出す前にローカルで `npm run lint && npm run typecheck && npm run test` を通すこと。
-- 専用ジョブ `prisma-contract` が PostgreSQL サービスコンテナ上で `npm run test:contract` を回す（`RUN_PRISMA_CONTRACT=1` を CI 側で設定）。本番 Prisma アダプタの契約（クロステナント分離 §3.3/§5.6 を含む）はここで担保する。
+- 専用ジョブ `prisma-contract` が PostgreSQL サービスコンテナ上で `npm run test:contract` を回す（`RUN_PRISMA_CONTRACT=1` を CI 側で設定）。本番 Prisma アダプタの契約（`ticket-repository` のクロステナント分離 §3.3/§5.6 と `notification-repository` の tenant スコープ `markAllRead` を含む）はここで担保する。`test:contract` は `tests/data/*.contract.prisma.test.ts` を `--no-file-parallelism` で直列実行する（共有 DB の TRUNCATE 競合回避）。
 - E2E は CI 上で PostgreSQL サービスコンテナを使う。ローカルでは `docker compose up db` で DB を起動してから `npm run test:e2e`。

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "test": "vitest run",
-    "test:contract": "vitest run tests/data/ticket-repository.contract.prisma.test.ts",
+    "test:contract": "vitest run --no-file-parallelism tests/data/*.contract.prisma.test.ts",
     "test:e2e": "playwright test",
     "db:seed": "tsx prisma/seed.ts",
     "db:migrate": "prisma migrate dev",

--- a/src/data/adapters/memory/notification-repository.memory.ts
+++ b/src/data/adapters/memory/notification-repository.memory.ts
@@ -56,12 +56,12 @@ export function makeNotificationRepo(store: Store): NotificationRepository {
       });
     },
 
-    // 指定ユーザーの未読通知を全て既読に更新 (ユーザーは単一テナント帰属なので tenantId 不要)
-    async markAllRead(userId) {
+    // 指定ユーザーの未読通知を全て既読に更新 (tenantId を条件に含めてクロステナント既読化を防ぐ)
+    async markAllRead(userId, tenantId) {
       // Map の全エントリを走査
       for (const [id, n] of store.notifications) {
-        // 対象ユーザーかつ未読のものだけ read: true にして書き換え
-        if (n.userId === userId && !n.read) {
+        // 同じテナント かつ 対象ユーザー かつ 未読のものだけ read: true にして書き換え
+        if (n.tenantId === tenantId && n.userId === userId && !n.read) {
           store.notifications.set(id, { ...n, read: true });
         }
       }

--- a/src/data/adapters/prisma/notification-repository.prisma.ts
+++ b/src/data/adapters/prisma/notification-repository.prisma.ts
@@ -44,9 +44,13 @@ export function makeNotificationRepo(db: PrismaLike): NotificationRepository {
       }));
     },
 
-    // 指定ユーザーの未読を一括で既読に更新 (ユーザーは単一テナント帰属なので tenantId 不要)
-    async markAllRead(userId) {
-      await db.notification.updateMany({ where: { userId, read: false }, data: { read: true } });
+    // 指定ユーザーの未読を一括で既読に更新 (tenantId を必ず where に含めてクロステナント既読化を防ぐ)
+    async markAllRead(userId, tenantId) {
+      // userId + tenantId + 未読 の 3 条件に一致する行だけを read: true に更新する
+      await db.notification.updateMany({
+        where: { userId, tenantId, read: false }, // テナントを跨いだ既読化を防ぐためテナントも条件に入れる
+        data: { read: true }, // 既読フラグを立てる
+      });
     },
   };
 }

--- a/src/data/ports/notification-repository.ts
+++ b/src/data/ports/notification-repository.ts
@@ -16,9 +16,10 @@ export interface NotificationListItem extends Notification {
 }
 
 // 通知ストアの契約 (port)
-// 取得系 (countUnread / list) は **tenantId 必須**。クロステナント漏洩防止のため、
-// 通知を引くときは必ず「当該ユーザー かつ 当該テナント」でフィルタする。
-// markAllRead は単一ユーザースコープなので tenantId 不要 (User は単一テナントに帰属)。
+// 取得系・更新系すべて **tenantId 必須**。クロステナント漏洩防止のため、
+// 通知を引く / 書き換えるときは必ず「当該ユーザー かつ 当該テナント」でフィルタする。
+// markAllRead も tenantId 必須でクロステナント既読化を防ぐ
+// (userId を偽装されても他テナント由来の通知まで既読にできないようにする)。
 export interface NotificationRepository {
   create(input: CreateNotificationInput): Promise<Notification>; // 通知を 1 件作成 (input.tenantId 必須)
   countUnread(userId: string, tenantId: string): Promise<number>; // 未読件数を取得
@@ -27,5 +28,5 @@ export interface NotificationRepository {
     opts: { limit: number },
     tenantId: string,
   ): Promise<NotificationListItem[]>; // 一覧取得
-  markAllRead(userId: string): Promise<void>; // 全通知を既読にする (ユーザースコープのみ)
+  markAllRead(userId: string, tenantId: string): Promise<void>; // 全通知を既読にする (ユーザー + テナントスコープ)
 }

--- a/src/features/notifications/actions/notification-actions.ts
+++ b/src/features/notifications/actions/notification-actions.ts
@@ -17,14 +17,18 @@ export async function markAllRead() {
   const session = await auth();
   // 未ログインなら拒否
   if (!session?.user?.id) throw new Error('Unauthorized');
+  // 所属テナント ID を取り出す (クロステナント既読化を防ぐためのスコープキー)
+  const tenantId = session.user.tenantId;
+  // テナント未確定のセッションは拒否 (スコープ無しでの既読化を防ぐ)
+  if (!tenantId) throw new Error('Unauthorized');
   // 60 秒あたり最大 10 回までに制限
   enforceRateLimit(`notifications-mark-read:${session.user.id}`, {
     limit: 10,
     windowMs: 60_000,
   });
 
-  // 本人の未読通知を全て既読に更新 (port 経由)
-  await repos.notifications.markAllRead(session.user.id);
+  // 本人 かつ 自テナントの未読通知だけを既読に更新 (port 経由、tenantId スコープ必須)
+  await repos.notifications.markAllRead(session.user.id, tenantId);
 
   // 通知一覧ページのキャッシュを無効化
   revalidatePath('/notifications');

--- a/tests/data/notification-repository.contract.prisma.test.ts
+++ b/tests/data/notification-repository.contract.prisma.test.ts
@@ -1,0 +1,98 @@
+// Vitest のテスト DSL (describe=グループ, beforeAll/afterAll=前後処理)
+import { describe, beforeAll, afterAll } from 'vitest';
+// Prisma クライアント本体 (生成物。DB へ実際に接続して操作する SDK)
+import { PrismaClient } from '@/generated/prisma';
+// 本番 Prisma 実装の repos 束を組み立てる関数
+import { buildPrismaRepos } from '@/data/adapters/prisma';
+// 共通契約テストとそのコンテキスト型 (memory 版と同じものを使い回す)
+import {
+  runNotificationRepositoryContract,
+  type NotificationContractContext,
+} from './notification-repository.contract';
+
+// テナント A の ID (契約テストの既定テナント)
+const TENANT_A = 'default-tenant';
+// クロステナント回帰テスト用のテナント B の ID
+const TENANT_B = 'tenant-b';
+
+// この DB 依存テストを実行してよいかどうかの明示フラグ (CI の専用ジョブだけが '1' を立てる)
+// DATABASE_URL の有無で判定すると、開発者の dev DB を誤って TRUNCATE しかねないため専用フラグにする
+const SHOULD_RUN = process.env.RUN_PRISMA_CONTRACT === '1';
+
+// Prisma 実装が NotificationRepository 契約を満たすか検証する (フラグが立っているときだけ走る)
+describe.runIf(SHOULD_RUN)('prisma adapter', () => {
+  // beforeAll で生成する PrismaClient を後続のヘルパーから参照するための変数
+  let prisma: PrismaClient;
+
+  // スイート開始時に 1 度だけ DB へ接続する
+  beforeAll(async () => {
+    // PrismaClient を生成 (接続先は環境変数 DATABASE_URL から読まれる)
+    prisma = new PrismaClient();
+    // 実際に DB へ接続を張る (失敗時はここで早期に分かる)
+    await prisma.$connect();
+  });
+
+  // スイート終了時に接続を確実に閉じる (接続リークを防ぐ)
+  afterAll(async () => {
+    // PrismaClient を破棄して接続を解放する
+    await prisma.$disconnect();
+  });
+
+  // 全テーブルを空にしてテスト間の状態を完全に独立させる
+  async function resetDatabase() {
+    // 子テーブル → 親テーブルの順序は CASCADE が吸収する。テーブル名はモデル名と同一 (PascalCase)
+    await prisma.$executeRawUnsafe(
+      'TRUNCATE TABLE "Attachment","TicketHistory","TicketComment","Notification","FaqCandidate","Ticket","Category","MagicLinkToken","User","Tenant" RESTART IDENTITY CASCADE',
+    );
+  }
+
+  // Prisma 実装向けに NotificationContractContext を組み立てる (契約の beforeEach から毎回呼ばれる)
+  async function makePrismaContext(): Promise<NotificationContractContext> {
+    // まず DB を空にして、このテスト専用のまっさらな状態を作る
+    await resetDatabase();
+
+    // 本番と同じ組み立て関数で repos 束を生成する
+    const repos = buildPrismaRepos(prisma);
+
+    // テナント A / B と、各テナントに 1 人ずつユーザーを用意するシード
+    const seedTwoTenants: NotificationContractContext['seedTwoTenants'] = async () => {
+      // テナント A / B を作成する (mode は lite で十分)
+      await prisma.tenant.create({ data: { id: TENANT_A, name: 'デフォルト組織', mode: 'lite' } });
+      await prisma.tenant.create({ data: { id: TENANT_B, name: '別組織', mode: 'lite' } });
+      // テナント A に属するユーザー ID
+      const userAId = 'u-a-1';
+      // テナント B に属するユーザー ID
+      const userBId = 'u-b-1';
+      // テナント A の依頼者ユーザーを作成する (passwordHash はテスト用ダミー)
+      await prisma.user.create({
+        data: {
+          id: userAId,
+          email: `${userAId}@example.com`,
+          name: userAId,
+          passwordHash: 'x',
+          role: 'requester',
+          tenantId: TENANT_A,
+        },
+      });
+      // テナント B の依頼者ユーザーを作成する
+      await prisma.user.create({
+        data: {
+          id: userBId,
+          email: `${userBId}@example.com`,
+          name: userBId,
+          passwordHash: 'x',
+          role: 'requester',
+          tenantId: TENANT_B,
+        },
+      });
+      // テスト本体が使うテナント ID / ユーザー ID を返す
+      return { tenantA: TENANT_A, tenantB: TENANT_B, userAId, userBId };
+    };
+
+    // 組み立てた repos とシード関数を契約コンテキストとして返す
+    return { repo: repos.notifications, seedTwoTenants };
+  }
+
+  // memory 版と同一の契約スイートを Prisma 実装に対して実行する
+  runNotificationRepositoryContract(makePrismaContext);
+});

--- a/tests/data/notification-repository.contract.test.ts
+++ b/tests/data/notification-repository.contract.test.ts
@@ -1,0 +1,73 @@
+// Vitest の describe (テストグループ) のみ使う
+import { describe } from 'vitest';
+// メモリ実装のリポジトリ束 + ストアを作成するファクトリ
+import { createMemoryContext } from '@/data/adapters/memory';
+// 共通契約テストとそのコンテキスト型
+import {
+  runNotificationRepositoryContract,
+  type NotificationContractContext,
+} from './notification-repository.contract';
+
+// テナント A の ID (マルチテナント化後はあらゆる行で必須)
+const TENANT_A = 'default-tenant';
+// クロステナント回帰テスト用のテナント B の ID
+const TENANT_B = 'tenant-b';
+
+// メモリ実装向けに NotificationContractContext を組み立てる
+function makeMemoryContext(): NotificationContractContext {
+  // 純粋メモリ実装の store / repos を生成する
+  const { store, repos } = createMemoryContext();
+
+  // テナント A / B と、各テナントに 1 人ずつユーザーを用意するシード
+  const seedTwoTenants: NotificationContractContext['seedTwoTenants'] = async () => {
+    // 現在時刻 (作成日時に使う)
+    const now = new Date();
+    // 投入する 2 テナントの定義 (id, name)
+    const tenantDefs: Array<[string, string]> = [
+      [TENANT_A, 'デフォルト組織'],
+      [TENANT_B, '別組織'],
+    ];
+    // 各テナントを store に直接書き込む (mode は lite で十分)
+    for (const [id, name] of tenantDefs) {
+      store.tenants.set(id, {
+        id,
+        name,
+        mode: 'lite',
+        industry: null,
+        createdAt: now,
+      });
+    }
+    // テナント A に属するユーザー ID
+    const userAId = 'u-a-1';
+    // テナント B に属するユーザー ID
+    const userBId = 'u-b-1';
+    // 投入するユーザーの定義 (id, 所属テナント ID)
+    const userDefs: Array<[string, string]> = [
+      [userAId, TENANT_A],
+      [userBId, TENANT_B],
+    ];
+    // 各ユーザーを store に直接書き込む (リポジトリは User の create を持たないため)
+    for (const [id, tenantId] of userDefs) {
+      store.users.set(id, {
+        id,
+        email: `${id}@example.com`,
+        name: id,
+        passwordHash: 'x',
+        role: 'requester',
+        tenantId, // 必ずテナントスコープを付与する
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+    // テスト本体が使うテナント ID / ユーザー ID を返す
+    return { tenantA: TENANT_A, tenantB: TENANT_B, userAId, userBId };
+  };
+
+  // 検証対象の通知リポジトリとシード関数を文脈として返す
+  return { repo: repos.notifications, seedTwoTenants };
+}
+
+// メモリアダプタが NotificationRepository 契約を満たしているかを実行する
+describe('memory adapter', () => {
+  runNotificationRepositoryContract(makeMemoryContext);
+});

--- a/tests/data/notification-repository.contract.ts
+++ b/tests/data/notification-repository.contract.ts
@@ -1,0 +1,117 @@
+/**
+ * Notification repository contract.
+ *
+ * Exported as a plain function (not a `*.test.ts` file) so it can be invoked
+ * against every adapter (memory / Prisma). See
+ * `notification-repository.contract.test.ts` for the in-memory run and
+ * `notification-repository.contract.prisma.test.ts` for the DB-backed run.
+ *
+ * 主眼: markAllRead が tenantId スコープを守り、他テナント由来の通知を既読化しないこと
+ * (userId 偽装によるクロステナント既読化ギャップを塞ぐ回帰テスト)。
+ */
+
+// Vitest のテスト DSL (describe=グループ, it=ケース, beforeEach=前処理, expect=検証)
+import { describe, expect, it, beforeEach } from 'vitest';
+// 検証対象である通知リポジトリの契約 (port) 型
+import type { NotificationRepository } from '@/data/ports/notification-repository';
+
+// 契約テストが利用する文脈 (アダプタ別に差し替え可能)
+export interface NotificationContractContext {
+  // 検証対象の通知リポジトリ実装
+  repo: NotificationRepository;
+  // テナント A / テナント B を用意し、各テナントに 1 人ずつユーザーを作るシード
+  // 戻り値はテスト本体が通知を作るのに使う tenantId / userId 一式
+  seedTwoTenants: () => Promise<{
+    tenantA: string; // テナント A の ID
+    tenantB: string; // テナント B の ID
+    userAId: string; // テナント A に属するユーザー ID
+    userBId: string; // テナント B に属するユーザー ID
+  }>;
+}
+
+// アダプタごとに渡される文脈で同一テストを実行する関数
+export function runNotificationRepositoryContract(
+  makeContext: () => NotificationContractContext | Promise<NotificationContractContext>,
+) {
+  describe('NotificationRepository contract', () => {
+    // テストごとに新しい文脈を保持する変数
+    let ctx: NotificationContractContext;
+
+    // 各テストの前に独立した状態のコンテキストを生成する
+    beforeEach(async () => {
+      ctx = await makeContext();
+    });
+
+    // create で作った未読通知が countUnread / list に正しく出ること (基本往復)
+    it('create surfaces an unread notification in countUnread and list (scoped to tenant)', async () => {
+      // テナント A / B とそれぞれのユーザーを用意する
+      const { tenantA, userAId } = await ctx.seedTwoTenants();
+      // テナント A のユーザー宛に通知を 1 件作成する
+      await ctx.repo.create({
+        userId: userAId,
+        type: 'assigned',
+        message: 'あなたにチケットが割り当てられました',
+        tenantId: tenantA,
+      });
+      // テナント A スコープで未読件数を数えると 1 件になる
+      expect(await ctx.repo.countUnread(userAId, tenantA)).toBe(1);
+      // 一覧にも 1 件出る
+      const listed = await ctx.repo.list(userAId, { limit: 50 }, tenantA);
+      expect(listed).toHaveLength(1);
+    });
+
+    // markAllRead が指定テナントの通知だけを既読化し、他テナントは未読のまま残すこと
+    it('markAllRead does not mark another tenant notifications as read', async () => {
+      // テナント A / B と各ユーザーを用意する
+      const { tenantA, tenantB, userAId, userBId } = await ctx.seedTwoTenants();
+
+      // テナント A のユーザー宛に未読通知を 1 件作成する
+      await ctx.repo.create({
+        userId: userAId,
+        type: 'assigned',
+        message: 'A 向け通知',
+        tenantId: tenantA,
+      });
+      // テナント B のユーザー宛にも未読通知を 1 件作成する
+      await ctx.repo.create({
+        userId: userBId,
+        type: 'assigned',
+        message: 'B 向け通知',
+        tenantId: tenantB,
+      });
+
+      // 前提確認: A も B もそれぞれ未読 1 件ずつある
+      expect(await ctx.repo.countUnread(userAId, tenantA)).toBe(1);
+      expect(await ctx.repo.countUnread(userBId, tenantB)).toBe(1);
+
+      // テナント A のユーザーとして markAllRead を実行する (A スコープで既読化)
+      await ctx.repo.markAllRead(userAId, tenantA);
+
+      // テナント A 側は既読化され、未読が 0 になる
+      expect(await ctx.repo.countUnread(userAId, tenantA)).toBe(0);
+      // テナント B 側は影響を受けず、未読 1 件のまま残る (クロステナント既読化を防げている)
+      expect(await ctx.repo.countUnread(userBId, tenantB)).toBe(1);
+    });
+
+    // 同じ userId が別テナントの tenantId で呼ばれても、対象テナントの通知しか既読化しないこと
+    // (userId を偽装してもスコープ外の通知へは波及しない、という防御の直接検証)
+    it('markAllRead with a mismatched tenant leaves the real tenant notifications unread', async () => {
+      // テナント A / B と各ユーザーを用意する
+      const { tenantA, tenantB, userAId } = await ctx.seedTwoTenants();
+
+      // テナント A のユーザー宛に未読通知を 1 件作成する
+      await ctx.repo.create({
+        userId: userAId,
+        type: 'assigned',
+        message: 'A 向け通知',
+        tenantId: tenantA,
+      });
+
+      // 攻撃想定: userA の通知をテナント B のスコープで既読化しようとする
+      await ctx.repo.markAllRead(userAId, tenantB);
+
+      // テナント B には userA の通知が存在しないので、A 側の通知は未読のまま残る
+      expect(await ctx.repo.countUnread(userAId, tenantA)).toBe(1);
+    });
+  });
+}


### PR DESCRIPTION
## 対応 Phase
`docs/smb-dx-pivot-plan.md` Phase 0（マルチテナント基盤の仕上げ）。`where.tenantId` 強制の「実体的な唯一の穴」を塞ぐセキュリティ修正です。

## 背景（課題）
`NotificationRepository.markAllRead(userId)` だけが tenantId を受け取らず、「User は単一テナント帰属だから不要」と正当化されていました。しかし userId をスコープキーに使う以上、**他テナント由来の通知まで一括既読化できる潜在的クロステナント漏洩面**でした。

## 変更
- **Port**: `markAllRead(userId, tenantId)` に変更（tenantId 必須）。
- **Prisma adapter**: `updateMany({ where: { userId, tenantId, read: false } })` で where に tenantId を必須化。
- **Memory adapter**: 既読化フィルタに `n.tenantId === tenantId` を追加。
- **Server Action**: `session.user.tenantId` を取り出し、未確定セッションは fail-closed で拒否してから呼び出し。
- **契約テスト追加**: memory/prisma 双方で走る共通契約に「別テナントの未読は既読化されない」ケースを追加。

## 検証
- `npm run lint` / `npm run typecheck` パス
- `npm run test` → 202 passed / 16 skipped（memory 契約テストの新規3件パス、Prisma 契約は `RUN_PRISMA_CONTRACT` 未設定で正しく skip）

## セキュリティ所見
全層（port/prisma/memory/action）で tenantId スコープが一貫し、tenantId 欠落セッションを fail-closed で拒否。多層防御として契約テストでクロステナント分離を恒常検証します。

https://claude.ai/code/session_01CGgSPdApk2CuwQWFtb8Duh

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGgSPdApk2CuwQWFtb8Duh)_