### PR TITLE
セキュリティレビュー対応: 認証ハードニング + クロステナント分離強化 (#119, #121, #123)

### DIFF
--- a/src/app/api/tickets/[id]/comments/route.ts
+++ b/src/app/api/tickets/[id]/comments/route.ts
@@ -120,6 +120,7 @@ export async function POST(req: Request, { params }: Params) {
         ticketId,
         authorId,
         body: trimmedBody,
+        tenantId, // 親チケットのテナント一致を Adapter 側でも検証する (issue #123)
       });
 
       // 添付ファイルがあれば 1 件ずつ「ストレージ書き込み → メタ INSERT」の順に処理する

--- a/src/data/adapters/memory/ticket-comment-repository.memory.ts
+++ b/src/data/adapters/memory/ticket-comment-repository.memory.ts
@@ -8,6 +8,13 @@ export function makeTicketCommentRepo(store: Store): TicketCommentRepository {
   return {
     // コメントを 1 件作成してストアに登録する
     async create(input) {
+      // 親チケットが指定テナントに属することを検証する (issue #123)。
+      // Prisma 実装と同じく、他テナントのチケットへのコメント付けを fail-closed で防ぐ。
+      const parent = store.tickets.get(input.ticketId);
+      // 親チケットが無い、または別テナントなら作成を拒否する
+      if (!parent || parent.tenantId !== input.tenantId) {
+        throw new Error('チケットが見つかりません');
+      }
       // 作成用オブジェクトを組み立てる (ID と作成日時をここで決定)
       const row: TicketComment = {
         id: nextId(store, 'cmt'), // 'cmt_...' 形式の一意 ID

--- a/src/data/adapters/prisma/ticket-comment-repository.prisma.ts
+++ b/src/data/adapters/prisma/ticket-comment-repository.prisma.ts
@@ -8,6 +8,17 @@ export function makeTicketCommentRepo(db: PrismaLike): TicketCommentRepository {
   return {
     // コメントを 1 件作成して、ドメイン型で返す
     async create(input) {
+      // 親チケットが指定テナントに属することを検証する (issue #123)。
+      // 呼び出し側が tenant スコープの取得を忘れても、他テナントのチケットへは
+      // コメントを付けられないよう Adapter 側で fail-closed にする。
+      const parent = await db.ticket.findFirst({
+        where: { id: input.ticketId, tenantId: input.tenantId }, // チケット ID + テナントの AND 一致
+        select: { id: true }, // 存在確認だけなので id のみ取得
+      });
+      // 親チケットが無い (= 別テナント or 不在) なら作成を拒否する
+      if (!parent) {
+        throw new Error('チケットが見つかりません');
+      }
       const row = await db.ticketComment.create({
         data: {
           ticketId: input.ticketId, // 対象チケット

--- a/src/data/ports/ticket-comment-repository.ts
+++ b/src/data/ports/ticket-comment-repository.ts
@@ -6,6 +6,7 @@ export interface CreateCommentInput {
   ticketId: string; // 対象チケット ID
   authorId: string; // 書き込みユーザー ID
   body: string; // コメント本文
+  tenantId: string; // 所属テナント ID。親チケットがこのテナントに属することを Adapter が検証する
 }
 
 // コメント書き込み用リポジトリの契約 (port)

--- a/src/data/ports/ticket-comment-repository.ts
+++ b/src/data/ports/ticket-comment-repository.ts
@@ -2,11 +2,16 @@
 import type { TicketComment } from '@/domain/types';
 
 // コメント作成時に渡す入力値
+//
+// セキュリティ不変条件 (issue #123): `tenantId` は **必ず認証済みセッション
+// (`session.user.tenantId`) から取得**すること。リクエストボディ・クエリ・フォーム値など
+// 攻撃者が制御できる入力から渡してはならない。Adapter は「親チケットが渡された tenantId に
+// 属するか」しか検証しないため、tenantId 自体がスプーフィングされるとガードを回避できる。
 export interface CreateCommentInput {
   ticketId: string; // 対象チケット ID
   authorId: string; // 書き込みユーザー ID
   body: string; // コメント本文
-  tenantId: string; // 所属テナント ID。親チケットがこのテナントに属することを Adapter が検証する
+  tenantId: string; // 所属テナント ID (セッション由来必須)。親チケットがこのテナントに属することを Adapter が検証する
 }
 
 // コメント書き込み用リポジトリの契約 (port)

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,14 +2,60 @@
 import NextAuth from 'next-auth';
 // 認証方式としてメール+パスワードを扱う Credentials プロバイダ
 import Credentials from 'next-auth/providers/credentials';
-// bcryptjs のパスワード照合関数 (ハッシュと平文を安全に比較)
-import { compare } from 'bcryptjs';
+// bcryptjs のパスワード照合 (compare) と、タイミング撹乱用ダミーハッシュ生成 (hashSync)
+import { compare, hashSync } from 'bcryptjs';
 // データ層の Composition Root 経由でユーザー取得 (Prisma 直叩きを避ける)
 import { repos } from '@/data';
 // マジックリンクのトークンハッシュ計算 (生トークン -> DB 検索キー)
 import { hashMagicLinkToken } from '@/lib/magic-link';
+// ログイン失敗のスロットル (ブルートフォース / クレデンシャルスタッフィング対策)
+import {
+  clearLoginFailures,
+  isLoginBlocked,
+  loginEmailKey,
+  loginIpKey,
+  recordLoginFailure,
+} from '@/lib/login-throttle';
 // ロール (権限) 型
 import type { Role } from '@/domain/types';
+
+// ユーザー不在時に compare へ渡すダミー bcrypt ハッシュ。実ユーザーと同じコスト 12 で
+// 計算するため、「ユーザー有無」で bcrypt の実行有無が変わらず、応答時間の差から在不在を
+// 推測されるタイミングオラクルを緩和する (issue #119)。
+// 遅延生成: middleware は edge ランタイムでこのモジュールを読み込むため、モジュール読込時に
+// hashSync を走らせるとコールドスタートが重くなる。authorize は node ランタイムの API
+// ルートでのみ実行されるので、初回ログイン試行時に 1 度だけ計算してキャッシュする。
+let dummyPasswordHash: string | null = null;
+// キャッシュ済みのダミーハッシュを返す (未計算なら 1 度だけ生成する)
+function getDummyPasswordHash(): string {
+  // まだ生成していなければここで bcrypt ハッシュを 1 度だけ計算する
+  if (dummyPasswordHash === null) {
+    dummyPasswordHash = hashSync('timing-decoy-not-a-real-password', 12);
+  }
+  // 生成済みのハッシュを返す
+  return dummyPasswordHash;
+}
+
+// Request の転送ヘッダからクライアント IP を取り出す (best-effort)。
+// 信頼できるプロキシ設定が無い環境では X-Forwarded-For は偽装可能なので、
+// IP ベースのスロットルは補助。主たる防御はメール単位のロックアウト。
+function clientIpFromRequest(request: Request | undefined): string | null {
+  // request が無ければ IP 不明
+  if (!request) return null;
+  // X-Forwarded-For (プロキシ経由の元 IP, カンマ区切りで複数) を優先的に読む
+  const forwarded = request.headers.get('x-forwarded-for');
+  // 値があれば先頭 (最も手前のクライアント) を採用する
+  if (forwarded) {
+    // カンマで分割し、先頭要素の空白を除去して返す
+    const first = forwarded.split(',')[0]?.trim();
+    // 空でなければそれを IP として使う
+    if (first) return first;
+  }
+  // 予備として X-Real-IP ヘッダも見る
+  const realIp = request.headers.get('x-real-ip');
+  // あれば採用、無ければ null
+  return realIp?.trim() || null;
+}
 
 // 本番環境で使ってはいけない「弱い/既定値」のシークレット一覧
 const WEAK_NEXTAUTH_SECRETS = new Set([
@@ -21,15 +67,29 @@ const WEAK_NEXTAUTH_SECRETS = new Set([
 
 // 環境変数から NextAuth のシークレットを取得
 const secret = process.env.NEXTAUTH_SECRET;
-// シークレットが未設定なら警告 (サーバー再起動でセッションが失効する危険)
-if (!secret) {
+// 本番実行かどうか (NODE_ENV=production)
+const isProduction = process.env.NODE_ENV === 'production';
+// `next build` はこのモジュールを NODE_ENV=production で import するが、ビルド時点では
+// 実行用シークレットが未設定でも正常。ビルドフェーズでは fail-fast せず実行時のみ止める。
+const isBuildPhase = process.env.NEXT_PHASE === 'phase-production-build';
+// シークレットが未設定、または既知の弱い/プレースホルダ値かどうかを判定
+const secretIsWeak = !secret || WEAK_NEXTAUTH_SECRETS.has(secret);
+// 弱い場合: 本番実行時は致命的に扱い、それ以外は警告に留める (issue #121)
+if (secretIsWeak) {
+  // 状況に応じた説明メッセージを組み立てる
+  const detail = !secret
+    ? 'NEXTAUTH_SECRET is not set'
+    : 'NEXTAUTH_SECRET is set to a known placeholder/weak value';
+  // 本番実行 (ビルドフェーズを除く) では、セッション偽造を防ぐため起動を止める (fail-fast)
+  if (isProduction && !isBuildPhase) {
+    // magic-link の NEXTAUTH_URL fail-fast と同方針で、運用に強制的に気づかせる
+    throw new Error(
+      `[auth] ${detail}. Generate a strong secret (e.g. \`openssl rand -base64 32\`) and set NEXTAUTH_SECRET before deploying.`,
+    );
+  }
+  // 開発・ビルド時は警告のみ (起動は継続)
   console.warn(
-    '[auth] NEXTAUTH_SECRET is not set — sessions will not be verifiable across restarts.',
-  );
-  // シークレットが既知の弱い値なら、本番投入前に強固な値に差し替えるよう警告
-} else if (WEAK_NEXTAUTH_SECRETS.has(secret)) {
-  console.warn(
-    '[auth] NEXTAUTH_SECRET is set to a known placeholder value. Generate a strong secret (e.g. `openssl rand -base64 32`) before deploying.',
+    `[auth] ${detail}. Generate a strong secret (e.g. \`openssl rand -base64 32\`) before deploying to production.`,
   );
 }
 
@@ -45,20 +105,58 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         password: { label: 'Password', type: 'password' },
       },
       // 実際の認証ロジック。成功ならユーザーオブジェクト、失敗なら null を返す
-      async authorize(credentials) {
+      // 第 2 引数 request からクライアント IP を取り出してスロットルに使う
+      async authorize(credentials, request) {
         // 入力不足ならすぐ失敗
         if (!credentials?.email || !credentials?.password) return null;
 
-        // email で User を検索 (port 経由)
-        const user = await repos.users.findByEmail(credentials.email as string);
+        // email を小文字化して、失敗カウントのキーを大文字小文字で割れないようにする
+        const email = (credentials.email as string).trim().toLowerCase();
+        // メール単位の失敗カウントキー (偽装不可の主防御)
+        const emailKey = loginEmailKey(email);
+        // リクエストからクライアント IP を取得 (best-effort)
+        const ip = clientIpFromRequest(request as Request | undefined);
+        // IP 単位の失敗カウントキー (取得できた場合のみ)
+        const ipKey = ip ? loginIpKey(ip) : null;
 
-        // ユーザー未存在、またはパスワード未設定なら失敗
-        if (!user || !user.passwordHash) return null;
+        // メールまたは IP が窓内の失敗上限に達していれば、bcrypt を実行せず即拒否する
+        // (ブルートフォース / クレデンシャルスタッフィングのロックアウト)
+        if (isLoginBlocked(emailKey) || (ipKey !== null && isLoginBlocked(ipKey))) {
+          return null;
+        }
+
+        // email で User を検索 (port 経由)
+        const user = await repos.users.findByEmail(email);
+
+        // ユーザー未存在、またはパスワード未設定の場合
+        if (!user || !user.passwordHash) {
+          // ダミーハッシュと比較して bcrypt の処理時間を実在ユーザーと揃える
+          // (在/不在を応答時間から推測されるのを防ぐ)。結果は捨てる。
+          await compare(credentials.password as string, getDummyPasswordHash());
+          // 失敗としてカウントする (スプレー攻撃のロックアウトに反映)
+          recordLoginFailure(emailKey);
+          // IP が分かっていれば IP 側にも失敗を記録する
+          if (ipKey !== null) recordLoginFailure(ipKey);
+          // 認証失敗
+          return null;
+        }
 
         // 入力パスワードを DB のハッシュと比較 (bcrypt)
         const isValid = await compare(credentials.password as string, user.passwordHash);
-        // 一致しなければ失敗
-        if (!isValid) return null;
+        // 一致しなければ失敗としてカウントしてから拒否する
+        if (!isValid) {
+          // メール単位の失敗を記録する
+          recordLoginFailure(emailKey);
+          // IP が分かっていれば IP 側にも記録する
+          if (ipKey !== null) recordLoginFailure(ipKey);
+          // 認証失敗
+          return null;
+        }
+
+        // 認証成功: このメール / IP の失敗カウントをリセットする
+        clearLoginFailures(emailKey);
+        // IP が分かっていれば IP 側の失敗カウントもリセットする
+        if (ipKey !== null) clearLoginFailures(ipKey);
 
         // 認証成功: セッションに乗せるユーザー情報を返す
         return {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,60 +2,14 @@
 import NextAuth from 'next-auth';
 // 認証方式としてメール+パスワードを扱う Credentials プロバイダ
 import Credentials from 'next-auth/providers/credentials';
-// bcryptjs のパスワード照合 (compare) と、タイミング撹乱用ダミーハッシュ生成 (hashSync)
-import { compare, hashSync } from 'bcryptjs';
 // データ層の Composition Root 経由でユーザー取得 (Prisma 直叩きを避ける)
 import { repos } from '@/data';
 // マジックリンクのトークンハッシュ計算 (生トークン -> DB 検索キー)
 import { hashMagicLinkToken } from '@/lib/magic-link';
-// ログイン失敗のスロットル (ブルートフォース / クレデンシャルスタッフィング対策)
-import {
-  clearLoginFailures,
-  isLoginBlocked,
-  loginEmailKey,
-  loginIpKey,
-  recordLoginFailure,
-} from '@/lib/login-throttle';
+// パスワード認証ロジック (スロットル + ダミー bcrypt 比較込み)。単体テスト可能なよう分離 (issue #119)
+import { passwordAuthorize } from '@/lib/password-authorize';
 // ロール (権限) 型
 import type { Role } from '@/domain/types';
-
-// ユーザー不在時に compare へ渡すダミー bcrypt ハッシュ。実ユーザーと同じコスト 12 で
-// 計算するため、「ユーザー有無」で bcrypt の実行有無が変わらず、応答時間の差から在不在を
-// 推測されるタイミングオラクルを緩和する (issue #119)。
-// 遅延生成: middleware は edge ランタイムでこのモジュールを読み込むため、モジュール読込時に
-// hashSync を走らせるとコールドスタートが重くなる。authorize は node ランタイムの API
-// ルートでのみ実行されるので、初回ログイン試行時に 1 度だけ計算してキャッシュする。
-let dummyPasswordHash: string | null = null;
-// キャッシュ済みのダミーハッシュを返す (未計算なら 1 度だけ生成する)
-function getDummyPasswordHash(): string {
-  // まだ生成していなければここで bcrypt ハッシュを 1 度だけ計算する
-  if (dummyPasswordHash === null) {
-    dummyPasswordHash = hashSync('timing-decoy-not-a-real-password', 12);
-  }
-  // 生成済みのハッシュを返す
-  return dummyPasswordHash;
-}
-
-// Request の転送ヘッダからクライアント IP を取り出す (best-effort)。
-// 信頼できるプロキシ設定が無い環境では X-Forwarded-For は偽装可能なので、
-// IP ベースのスロットルは補助。主たる防御はメール単位のロックアウト。
-function clientIpFromRequest(request: Request | undefined): string | null {
-  // request が無ければ IP 不明
-  if (!request) return null;
-  // X-Forwarded-For (プロキシ経由の元 IP, カンマ区切りで複数) を優先的に読む
-  const forwarded = request.headers.get('x-forwarded-for');
-  // 値があれば先頭 (最も手前のクライアント) を採用する
-  if (forwarded) {
-    // カンマで分割し、先頭要素の空白を除去して返す
-    const first = forwarded.split(',')[0]?.trim();
-    // 空でなければそれを IP として使う
-    if (first) return first;
-  }
-  // 予備として X-Real-IP ヘッダも見る
-  const realIp = request.headers.get('x-real-ip');
-  // あれば採用、無ければ null
-  return realIp?.trim() || null;
-}
 
 // 本番環境で使ってはいけない「弱い/既定値」のシークレット一覧
 const WEAK_NEXTAUTH_SECRETS = new Set([
@@ -104,69 +58,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         email: { label: 'Email', type: 'email' },
         password: { label: 'Password', type: 'password' },
       },
-      // 実際の認証ロジック。成功ならユーザーオブジェクト、失敗なら null を返す
-      // 第 2 引数 request からクライアント IP を取り出してスロットルに使う
-      async authorize(credentials, request) {
-        // 入力不足ならすぐ失敗
-        if (!credentials?.email || !credentials?.password) return null;
-
-        // email を小文字化して、失敗カウントのキーを大文字小文字で割れないようにする
-        const email = (credentials.email as string).trim().toLowerCase();
-        // メール単位の失敗カウントキー (偽装不可の主防御)
-        const emailKey = loginEmailKey(email);
-        // リクエストからクライアント IP を取得 (best-effort)
-        const ip = clientIpFromRequest(request as Request | undefined);
-        // IP 単位の失敗カウントキー (取得できた場合のみ)
-        const ipKey = ip ? loginIpKey(ip) : null;
-
-        // メールまたは IP が窓内の失敗上限に達していれば、bcrypt を実行せず即拒否する
-        // (ブルートフォース / クレデンシャルスタッフィングのロックアウト)
-        if (isLoginBlocked(emailKey) || (ipKey !== null && isLoginBlocked(ipKey))) {
-          return null;
-        }
-
-        // email で User を検索 (port 経由)
-        const user = await repos.users.findByEmail(email);
-
-        // ユーザー未存在、またはパスワード未設定の場合
-        if (!user || !user.passwordHash) {
-          // ダミーハッシュと比較して bcrypt の処理時間を実在ユーザーと揃える
-          // (在/不在を応答時間から推測されるのを防ぐ)。結果は捨てる。
-          await compare(credentials.password as string, getDummyPasswordHash());
-          // 失敗としてカウントする (スプレー攻撃のロックアウトに反映)
-          recordLoginFailure(emailKey);
-          // IP が分かっていれば IP 側にも失敗を記録する
-          if (ipKey !== null) recordLoginFailure(ipKey);
-          // 認証失敗
-          return null;
-        }
-
-        // 入力パスワードを DB のハッシュと比較 (bcrypt)
-        const isValid = await compare(credentials.password as string, user.passwordHash);
-        // 一致しなければ失敗としてカウントしてから拒否する
-        if (!isValid) {
-          // メール単位の失敗を記録する
-          recordLoginFailure(emailKey);
-          // IP が分かっていれば IP 側にも記録する
-          if (ipKey !== null) recordLoginFailure(ipKey);
-          // 認証失敗
-          return null;
-        }
-
-        // 認証成功: このメール / IP の失敗カウントをリセットする
-        clearLoginFailures(emailKey);
-        // IP が分かっていれば IP 側の失敗カウントもリセットする
-        if (ipKey !== null) clearLoginFailures(ipKey);
-
-        // 認証成功: セッションに乗せるユーザー情報を返す
-        return {
-          id: user.id, // ユーザー ID
-          email: user.email, // メール
-          name: user.name, // 氏名
-          role: user.role, // 権限
-          tenantId: user.tenantId, // 所属テナント ID (マルチテナント化のキー)
-        };
-      },
+      // 実際の認証ロジックは password-authorize.ts に分離 (スロットル + ダミー比較込み)。
+      // 単体テストから直接 passwordAuthorize を検証できるようにするため。
+      authorize: passwordAuthorize,
     }),
     // マジックリンク (メール内ワンタイム URL) を受け付ける 2 つめの Credentials プロバイダ。
     // /api/auth/magic-link/callback ルートが署名済みトークンを携えて signIn('magic-link', ...) を呼ぶ

--- a/src/lib/login-throttle.ts
+++ b/src/lib/login-throttle.ts
@@ -1,0 +1,91 @@
+/**
+ * In-process failed-login throttle (issue #119).
+ *
+ * Sliding-window lockout for the Credentials password provider, which the
+ * generic `enforceRateLimit` (mutation actions) does not cover. Only FAILED
+ * attempts are counted; a successful login clears that key, so legitimate
+ * users are not penalised for occasional typos.
+ *
+ * Keys:
+ *  - by email (primary): NOT attacker-spoofable — it is the login target, so
+ *    an account is protected from credential-stuffing regardless of source IP.
+ *  - by client IP (best-effort): X-Forwarded-For can be forged without a
+ *    trusted proxy, so this is a supplementary throttle for broad spraying,
+ *    never the sole control.
+ *
+ * Same single-instance caveat as `rate-limit.ts` / `sse-subscribers.ts`: the
+ * registry is an in-process Map and assumes one Next.js instance. Horizontal
+ * scaling requires moving this to Redis / a shared store.
+ */
+
+// 窓内で許容する連続失敗回数 (これ以上はロックアウト)
+export const LOGIN_MAX_FAILURES = 5;
+// 失敗回数を数える時間窓 (15 分)
+export const LOGIN_FAILURE_WINDOW_MS = 15 * 60_000;
+
+// キー (email:... / ip:...) ごとの「失敗時刻」一覧を持つレジストリ
+const failures = new Map<string, number[]>();
+
+// cutoff より古い失敗時刻を捨てて、窓内に残る分だけ返すヘルパー
+function prune(timestamps: number[], cutoff: number): number[] {
+  // 配列は時系列順なので、先頭から cutoff 未満を数えれば境界がわかる
+  let i = 0;
+  // cutoff より古い要素数をカウントする
+  while (i < timestamps.length && timestamps[i] < cutoff) i += 1;
+  // 古いものが無ければそのまま、あればその分だけ切り落として返す
+  return i === 0 ? timestamps : timestamps.slice(i);
+}
+
+// 指定キーが現在ロックアウト中か (窓内の失敗回数が上限以上か) を判定する
+export function isLoginBlocked(key: string, now: number = Date.now()): boolean {
+  // 窓の開始時刻を求める
+  const cutoff = now - LOGIN_FAILURE_WINDOW_MS;
+  // 窓内に残る失敗時刻だけに絞り込む
+  const live = prune(failures.get(key) ?? [], cutoff);
+  // 失敗履歴が空ならエントリを削除して未ブロックを返す (メモリ肥大防止)
+  if (live.length === 0) {
+    failures.delete(key);
+    return false;
+  }
+  // 絞り込んだ履歴を書き戻す
+  failures.set(key, live);
+  // 窓内の失敗回数が上限以上ならブロック中
+  return live.length >= LOGIN_MAX_FAILURES;
+}
+
+// 指定キーに対する「ログイン失敗」を 1 件記録する
+export function recordLoginFailure(key: string, now: number = Date.now()): void {
+  // 窓の開始時刻を求める
+  const cutoff = now - LOGIN_FAILURE_WINDOW_MS;
+  // 窓内に残る履歴に絞ってから今回の失敗を追記する
+  const live = prune(failures.get(key) ?? [], cutoff);
+  // 今回の失敗時刻を末尾に追加する
+  live.push(now);
+  // レジストリを更新する
+  failures.set(key, live);
+}
+
+// 指定キーの失敗履歴を消去する (ログイン成功時に呼ぶ)
+export function clearLoginFailures(key: string): void {
+  // 該当キーのエントリを丸ごと削除する
+  failures.delete(key);
+}
+
+// email から失敗カウント用のキーを作る (大文字小文字を無視するため小文字化)
+export function loginEmailKey(email: string): string {
+  // "email:" 接頭辞でIPキーと衝突しないようにする
+  return `email:${email.trim().toLowerCase()}`;
+}
+
+// クライアント IP から失敗カウント用のキーを作る
+export function loginIpKey(ip: string): string {
+  // "ip:" 接頭辞で email キーと衝突しないようにする
+  return `ip:${ip}`;
+}
+
+/** Testing helper: clear all failure buckets between test cases. */
+// テスト間で状態を初期化するためのヘルパー (本番コードからは呼ばない)
+export function __resetLoginThrottle(): void {
+  // 全エントリを空にする
+  failures.clear();
+}

--- a/src/lib/login-throttle.ts
+++ b/src/lib/login-throttle.ts
@@ -16,6 +16,15 @@
  * Same single-instance caveat as `rate-limit.ts` / `sse-subscribers.ts`: the
  * registry is an in-process Map and assumes one Next.js instance. Horizontal
  * scaling requires moving this to Redis / a shared store.
+ *
+ * Availability tradeoff: a hard email lockout means someone who knows a
+ * victim's email can keep that account locked by sending failed passwords.
+ * This is inherent to failed-attempt lockout and is accepted here because it is
+ * (a) bounded by the 15-minute rolling window (auto-recovers) and (b) escapable
+ * via the magic-link login provider, which is intentionally NOT throttled — a
+ * locked-out user can always sign in through the emailed one-time link. Do not
+ * add throttling to the magic-link path without providing another recovery
+ * route.
  */
 
 // 窓内で許容する連続失敗回数 (これ以上はロックアウト)

--- a/src/lib/password-authorize.ts
+++ b/src/lib/password-authorize.ts
@@ -1,0 +1,137 @@
+/**
+ * Password Credentials `authorize` logic, extracted from `auth.ts` so it can be
+ * unit-tested in isolation (the NextAuth() init + module-level secret fail-fast
+ * in auth.ts make that module awkward to import in tests). issue #119.
+ *
+ * Brute-force / credential-stuffing defense:
+ *  - Failed attempts are throttled per **email** (primary, not attacker-spoofable)
+ *    and per **client IP** (best-effort, X-Forwarded-For is forgeable without a
+ *    trusted proxy). See `login-throttle.ts`.
+ *  - When a key is locked out we reject BEFORE the DB lookup + bcrypt.
+ *  - On the user-not-found path we still run a dummy bcrypt compare so the
+ *    response time does not reveal account existence.
+ *
+ * Availability tradeoff (documented, accepted): a hard email lockout means an
+ * attacker who knows a victim's email can keep that account locked by sending
+ * failed passwords. This is the inherent cost of failed-attempt lockout. It is
+ * bounded by the 15-minute rolling window (auto-recovers) and, crucially, the
+ * **magic-link login provider is intentionally NOT throttled** — a locked-out
+ * user can always sign in via the emailed one-time link. Keep that recovery
+ * path unthrottled.
+ */
+// bcryptjs のパスワード照合 (compare) と、タイミング撹乱用ダミーハッシュ生成 (hashSync)
+import { compare, hashSync } from 'bcryptjs';
+// next-auth の User 型 (role / tenantId は src/types/next-auth.d.ts で必須化済み)
+import type { User } from 'next-auth';
+// データ層の Composition Root 経由でユーザー取得 (Prisma 直叩きを避ける)
+import { repos } from '@/data';
+// ログイン失敗のスロットル (ブルートフォース / クレデンシャルスタッフィング対策)
+import {
+  clearLoginFailures,
+  isLoginBlocked,
+  loginEmailKey,
+  loginIpKey,
+  recordLoginFailure,
+} from '@/lib/login-throttle';
+
+// ユーザー不在時に compare へ渡すダミー bcrypt ハッシュ。実ユーザーと同じコスト 12 で
+// 計算するため、「ユーザー有無」で bcrypt の実行有無が変わらず、応答時間の差から在不在を
+// 推測されるタイミングオラクルを緩和する。遅延生成でモジュール読込コストを避ける。
+let dummyPasswordHash: string | null = null;
+// キャッシュ済みのダミーハッシュを返す (未計算なら 1 度だけ生成する)
+function getDummyPasswordHash(): string {
+  // まだ生成していなければここで bcrypt ハッシュを 1 度だけ計算する
+  if (dummyPasswordHash === null) {
+    dummyPasswordHash = hashSync('timing-decoy-not-a-real-password', 12);
+  }
+  // 生成済みのハッシュを返す
+  return dummyPasswordHash;
+}
+
+// Request の転送ヘッダからクライアント IP を取り出す (best-effort)。
+// 信頼できるプロキシ設定が無い環境では X-Forwarded-For は偽装可能なので、
+// IP ベースのスロットルは補助。主たる防御はメール単位のロックアウト。
+export function clientIpFromRequest(request: Request | undefined): string | null {
+  // request が無ければ IP 不明
+  if (!request) return null;
+  // X-Forwarded-For (プロキシ経由の元 IP, カンマ区切りで複数) を優先的に読む
+  const forwarded = request.headers.get('x-forwarded-for');
+  // 値があれば先頭 (最も手前のクライアント) を採用する
+  if (forwarded) {
+    // カンマで分割し、先頭要素の空白を除去して返す
+    const first = forwarded.split(',')[0]?.trim();
+    // 空でなければそれを IP として使う
+    if (first) return first;
+  }
+  // 予備として X-Real-IP ヘッダも見る
+  const realIp = request.headers.get('x-real-ip');
+  // あれば採用、無ければ null
+  return realIp?.trim() || null;
+}
+
+// パスワード認証ロジック本体。成功ならユーザーオブジェクト、失敗なら null を返す。
+// 第 2 引数 request からクライアント IP を取り出してスロットルに使う。
+export async function passwordAuthorize(
+  credentials: Partial<Record<string, unknown>> | undefined,
+  request: Request | undefined,
+): Promise<User | null> {
+  // 入力不足ならすぐ失敗
+  if (!credentials?.email || !credentials?.password) return null;
+
+  // email を小文字化して、失敗カウントのキーを大文字小文字で割れないようにする
+  const email = (credentials.email as string).trim().toLowerCase();
+  // メール単位の失敗カウントキー (偽装不可の主防御)
+  const emailKey = loginEmailKey(email);
+  // リクエストからクライアント IP を取得 (best-effort)
+  const ip = clientIpFromRequest(request);
+  // IP 単位の失敗カウントキー (取得できた場合のみ)
+  const ipKey = ip ? loginIpKey(ip) : null;
+
+  // メールまたは IP が窓内の失敗上限に達していれば、bcrypt を実行せず即拒否する
+  // (ブルートフォース / クレデンシャルスタッフィングのロックアウト)
+  if (isLoginBlocked(emailKey) || (ipKey !== null && isLoginBlocked(ipKey))) {
+    return null;
+  }
+
+  // email で User を検索 (port 経由)
+  const user = await repos.users.findByEmail(email);
+
+  // ユーザー未存在、またはパスワード未設定の場合
+  if (!user || !user.passwordHash) {
+    // ダミーハッシュと比較して bcrypt の処理時間を実在ユーザーと揃える
+    // (在/不在を応答時間から推測されるのを防ぐ)。結果は捨てる。
+    await compare(credentials.password as string, getDummyPasswordHash());
+    // 失敗としてカウントする (スプレー攻撃のロックアウトに反映)
+    recordLoginFailure(emailKey);
+    // IP が分かっていれば IP 側にも失敗を記録する
+    if (ipKey !== null) recordLoginFailure(ipKey);
+    // 認証失敗
+    return null;
+  }
+
+  // 入力パスワードを DB のハッシュと比較 (bcrypt)
+  const isValid = await compare(credentials.password as string, user.passwordHash);
+  // 一致しなければ失敗としてカウントしてから拒否する
+  if (!isValid) {
+    // メール単位の失敗を記録する
+    recordLoginFailure(emailKey);
+    // IP が分かっていれば IP 側にも記録する
+    if (ipKey !== null) recordLoginFailure(ipKey);
+    // 認証失敗
+    return null;
+  }
+
+  // 認証成功: このメール / IP の失敗カウントをリセットする
+  clearLoginFailures(emailKey);
+  // IP が分かっていれば IP 側の失敗カウントもリセットする
+  if (ipKey !== null) clearLoginFailures(ipKey);
+
+  // 認証成功: セッションに乗せるユーザー情報を返す
+  return {
+    id: user.id, // ユーザー ID
+    email: user.email, // メール
+    name: user.name, // 氏名
+    role: user.role, // 権限
+    tenantId: user.tenantId, // 所属テナント ID (マルチテナント化のキー)
+  };
+}

--- a/tests/data/cross-tenant-create.test.ts
+++ b/tests/data/cross-tenant-create.test.ts
@@ -1,0 +1,106 @@
+// クロステナント作成拒否の単体テスト (issue #123)。
+// コメント / 添付の create Adapter が「親チケットのテナント一致」を fail-closed で
+// 検証することを確認する。呼び出し側の tenant チェック漏れに対する多層防御の最終段。
+
+// Vitest の DSL とフック
+import { beforeEach, describe, expect, it } from 'vitest';
+// メモリ context (store/repos)
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// 型のみ
+import type { Repos } from '@/data/ports/unit-of-work';
+
+// テスト用テナント / ユーザー識別子
+const TENANT_A = 'tenant-a';
+const TENANT_B = 'tenant-b';
+const USER_A = 'u-a';
+
+// テストごとに作り直す依存
+let store: Store;
+let repos: Repos;
+
+// テナント A・B と、テナント A のチケットを 1 件投入する共通シード
+async function seed() {
+  // 現在時刻 (createdAt 用)
+  const now = new Date();
+  // テナント A・B を投入 (Lite モード)
+  for (const t of [TENANT_A, TENANT_B]) {
+    store.tenants.set(t, { id: t, name: t, mode: 'lite', industry: null, createdAt: now });
+  }
+  // テナント A のユーザーを 1 人投入する
+  store.users.set(USER_A, {
+    id: USER_A,
+    email: 'a@example.com',
+    name: 'A',
+    passwordHash: 'x',
+    role: 'requester',
+    tenantId: TENANT_A,
+    createdAt: now,
+    updatedAt: now,
+  });
+  // テナント A のチケットを 1 件作成し、その ID を返す
+  const ticket = await repos.tickets.create({
+    title: 'A',
+    body: 'a',
+    priority: 'Medium',
+    creatorId: USER_A,
+    categoryId: null,
+    tenantId: TENANT_A,
+  });
+  // 後続テストで参照するチケット ID を返す
+  return ticket.id;
+}
+
+// クロステナント作成拒否の仕様確認テスト群
+describe('cross-tenant create guards (#123)', () => {
+  // 各テストの前にメモリ context を作り直す
+  beforeEach(() => {
+    const ctx = createMemoryContext();
+    store = ctx.store;
+    repos = ctx.repos;
+  });
+
+  // 同テナントならコメントを作成できる
+  it('allows commenting on a ticket in the same tenant', async () => {
+    // テナント A のチケットを用意する
+    const ticketId = await seed();
+    // 同じテナント A 指定でコメント作成 → 成功する
+    const comment = await repos.comments.create({
+      ticketId,
+      authorId: USER_A,
+      body: 'こんにちは',
+      tenantId: TENANT_A,
+    });
+    // 作成されたコメントが対象チケットに紐づくこと
+    expect(comment.ticketId).toBe(ticketId);
+  });
+
+  // 別テナント指定のコメント作成は拒否される
+  it('rejects commenting with a mismatched tenant', async () => {
+    // テナント A のチケットを用意する
+    const ticketId = await seed();
+    // テナント B を名乗ってテナント A のチケットへコメント → 拒否される
+    await expect(
+      repos.comments.create({
+        ticketId,
+        authorId: USER_A,
+        body: '侵入',
+        tenantId: TENANT_B,
+      }),
+    ).rejects.toThrow(/チケットが見つかりません/);
+  });
+
+  // 存在しないチケット ID へのコメント作成も拒否される
+  it('rejects commenting on a non-existent ticket', async () => {
+    // テナント A を用意する (チケットは存在しない ID を指定)
+    await seed();
+    // 実在しないチケット ID へコメント → 拒否される
+    await expect(
+      repos.comments.create({
+        ticketId: 'no-such-ticket',
+        authorId: USER_A,
+        body: '宛先なし',
+        tenantId: TENANT_A,
+      }),
+    ).rejects.toThrow(/チケットが見つかりません/);
+  });
+});

--- a/tests/login-throttle.test.ts
+++ b/tests/login-throttle.test.ts
@@ -1,0 +1,103 @@
+// Vitest のテスト DSL (フック/グルーピング/期待値/個別テスト)
+import { beforeEach, describe, expect, it } from 'vitest';
+
+// ログイン失敗スロットルの本体と、テスト用に内部状態をリセットする関数
+import {
+  __resetLoginThrottle,
+  clearLoginFailures,
+  isLoginBlocked,
+  LOGIN_FAILURE_WINDOW_MS,
+  LOGIN_MAX_FAILURES,
+  loginEmailKey,
+  loginIpKey,
+  recordLoginFailure,
+} from '../src/lib/login-throttle';
+
+// ログイン失敗スロットル (issue #119) の仕様確認テスト群
+describe('login-throttle', () => {
+  // 各テストの前に失敗履歴をクリアしてテスト間の独立を保つ
+  beforeEach(() => {
+    __resetLoginThrottle();
+  });
+
+  // 失敗が無いキーはブロックされない
+  it('does not block a key with no recorded failures', () => {
+    // 何も記録していないキーは未ブロック
+    expect(isLoginBlocked('email:foo@example.com')).toBe(false);
+  });
+
+  // 上限未満の失敗ではブロックされない
+  it('does not block while failures stay below the limit', () => {
+    // 基準時刻 (固定値で再現性確保)
+    const now = 1_000_000;
+    // 上限 - 1 回だけ失敗を記録する
+    for (let i = 0; i < LOGIN_MAX_FAILURES - 1; i += 1) {
+      recordLoginFailure('email:foo@example.com', now + i);
+    }
+    // まだ上限に達していないのでブロックされない
+    expect(isLoginBlocked('email:foo@example.com', now + LOGIN_MAX_FAILURES)).toBe(false);
+  });
+
+  // 上限に達した失敗でブロックされる
+  it('blocks once failures reach the limit within the window', () => {
+    // 基準時刻
+    const now = 1_000_000;
+    // 上限ちょうどまで失敗を記録する
+    for (let i = 0; i < LOGIN_MAX_FAILURES; i += 1) {
+      recordLoginFailure('email:foo@example.com', now + i);
+    }
+    // 上限に達したのでブロックされる
+    expect(isLoginBlocked('email:foo@example.com', now + LOGIN_MAX_FAILURES)).toBe(true);
+  });
+
+  // 窓から古い失敗が抜ければ再びブロックが解ける
+  it('unblocks once old failures age out of the window', () => {
+    // 基準時刻
+    const t0 = 1_000_000;
+    // 上限まで失敗を記録してブロック状態にする
+    for (let i = 0; i < LOGIN_MAX_FAILURES; i += 1) {
+      recordLoginFailure('email:foo@example.com', t0 + i);
+    }
+    // 直後はブロックされている
+    expect(isLoginBlocked('email:foo@example.com', t0 + LOGIN_MAX_FAILURES)).toBe(true);
+    // 窓を 1ms 超えて時間を進めると、全ての失敗が窓外になる
+    const later = t0 + LOGIN_FAILURE_WINDOW_MS + 1;
+    // 古い失敗が抜けたのでブロックは解除される
+    expect(isLoginBlocked('email:foo@example.com', later)).toBe(false);
+  });
+
+  // 成功時クリアでブロックが即解除される
+  it('clears failures so a key is no longer blocked', () => {
+    // 基準時刻
+    const now = 1_000_000;
+    // 上限まで失敗を記録してブロックする
+    for (let i = 0; i < LOGIN_MAX_FAILURES; i += 1) {
+      recordLoginFailure('email:foo@example.com', now + i);
+    }
+    // ログイン成功を模して失敗履歴をクリアする
+    clearLoginFailures('email:foo@example.com');
+    // クリア後はブロックされない
+    expect(isLoginBlocked('email:foo@example.com', now + LOGIN_MAX_FAILURES)).toBe(false);
+  });
+
+  // email キーと IP キーは独立して数えられる
+  it('counts email and IP keys independently', () => {
+    // 基準時刻
+    const now = 1_000_000;
+    // email キー側だけを上限まで失敗させる
+    const emailKey = loginEmailKey('foo@example.com');
+    for (let i = 0; i < LOGIN_MAX_FAILURES; i += 1) {
+      recordLoginFailure(emailKey, now + i);
+    }
+    // email キーはブロックされる
+    expect(isLoginBlocked(emailKey, now + LOGIN_MAX_FAILURES)).toBe(true);
+    // IP キーは一度も失敗していないのでブロックされない
+    expect(isLoginBlocked(loginIpKey('1.2.3.4'), now + LOGIN_MAX_FAILURES)).toBe(false);
+  });
+
+  // email キーは大文字小文字を区別しない (同一アカウント扱い)
+  it('treats email keys case-insensitively', () => {
+    // 大文字混じりと小文字で同じキーになることを確認する
+    expect(loginEmailKey('Foo@Example.com')).toBe(loginEmailKey('foo@example.com'));
+  });
+});

--- a/tests/password-authorize.test.ts
+++ b/tests/password-authorize.test.ts
@@ -1,0 +1,190 @@
+// Vitest の DSL とモック機能
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// vi.mock のファクトリはファイル先頭へ巻き上げられるため、参照する mock 関数は
+// vi.hoisted で同様に巻き上げて「初期化前参照」エラーを避ける。
+const { findByEmail } = vi.hoisted(() => ({ findByEmail: vi.fn() }));
+
+// データ層をモック: passwordAuthorize が使うのは repos.users.findByEmail のみ
+vi.mock('@/data', () => ({
+  repos: { users: { findByEmail } },
+}));
+
+// bcryptjs をモック: compare は「正しいパスワード」のときだけ true を返す。
+// hashSync はダミーハッシュ生成用に固定文字列を返す (実際の計算はしない)。
+vi.mock('bcryptjs', () => ({
+  compare: vi.fn(async (pw: string) => pw === 'correct-password'),
+  hashSync: vi.fn(() => '$2a$12$dummy.decoy.hash.value.placeholder.0123456789abc'),
+}));
+
+// テスト対象 (モック設定後に import する)
+import { passwordAuthorize } from '@/lib/password-authorize';
+// 失敗カウントをテスト間でリセットするためのヘルパー
+import { __resetLoginThrottle } from '@/lib/login-throttle';
+// 呼び出し回数を検証するためモック化済みの compare を取得
+import { compare } from 'bcryptjs';
+
+// テストで使う既存ユーザー (passwordHash 付き)
+const USER = {
+  id: 'u1',
+  email: 'user@example.com',
+  name: 'User One',
+  role: 'agent' as const,
+  tenantId: 't1',
+  passwordHash: '$2a$12$realhashplaceholderplaceholderplaceholderplace',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+// passwordAuthorize (ログイン認証本体 + スロットル配線) の振る舞いを検証する
+describe('passwordAuthorize (#119)', () => {
+  // 各テストの前に失敗カウントとモックの呼び出し履歴を初期化する
+  beforeEach(() => {
+    // スロットルの内部状態をクリア (テスト間の独立性を保つ)
+    __resetLoginThrottle();
+    // findByEmail の実装と履歴を消す (各テストで個別に mockResolvedValue する)
+    findByEmail.mockReset();
+    // compare は実装を保持したまま呼び出し履歴だけクリアする
+    vi.mocked(compare).mockClear();
+  });
+
+  // 正しいパスワードなら user を返し、失敗カウントをクリアする
+  it('returns the user object on a correct password', async () => {
+    // ユーザーが見つかる状態にする
+    findByEmail.mockResolvedValue(USER);
+    // 正しいパスワードで認証する
+    const res = await passwordAuthorize(
+      { email: 'user@example.com', password: 'correct-password' },
+      undefined,
+    );
+    // role / tenantId 込みのユーザー情報が返ること
+    expect(res).toMatchObject({ id: 'u1', role: 'agent', tenantId: 't1' });
+  });
+
+  // 入力欠如 (email/password 無し) は即 null
+  it('returns null when email or password is missing', async () => {
+    // password が無いケース
+    const res = await passwordAuthorize({ email: 'user@example.com' }, undefined);
+    // 認証は失敗し、DB も引かない
+    expect(res).toBeNull();
+    expect(findByEmail).not.toHaveBeenCalled();
+  });
+
+  // 誤ったパスワードは null を返す
+  it('returns null on a wrong password', async () => {
+    // ユーザーは存在する
+    findByEmail.mockResolvedValue(USER);
+    // 誤ったパスワードで認証する
+    const res = await passwordAuthorize(
+      { email: 'user@example.com', password: 'wrong' },
+      undefined,
+    );
+    // 認証失敗
+    expect(res).toBeNull();
+  });
+
+  // ユーザー不在経路でもダミー bcrypt compare を実行する (在不在のタイミングオラクル緩和)
+  it('runs a dummy bcrypt compare when the user does not exist', async () => {
+    // ユーザーが見つからない状態にする
+    findByEmail.mockResolvedValue(null);
+    // 存在しないメールで認証する
+    const res = await passwordAuthorize(
+      { email: 'ghost@example.com', password: 'whatever' },
+      undefined,
+    );
+    // 認証は失敗する
+    expect(res).toBeNull();
+    // それでも compare は 1 回呼ばれている (ダミーハッシュとの比較で処理時間を揃える)
+    expect(vi.mocked(compare)).toHaveBeenCalledTimes(1);
+  });
+
+  // 5 回失敗するとロックアウトし、6 回目は DB を引く前に短絡する
+  it('locks out after 5 failures and short-circuits before the DB lookup', async () => {
+    // ユーザーは存在する (= 失敗はパスワード不一致による)
+    findByEmail.mockResolvedValue(USER);
+    // 5 回連続で誤ったパスワードを送る
+    for (let i = 0; i < 5; i += 1) {
+      await passwordAuthorize({ email: 'user@example.com', password: 'wrong' }, undefined);
+    }
+    // ここまでで findByEmail は 5 回呼ばれている
+    const callsAfterFive = findByEmail.mock.calls.length;
+    // 6 回目は「正しいパスワード」でもロックアウト中なので拒否される
+    const res = await passwordAuthorize(
+      { email: 'user@example.com', password: 'correct-password' },
+      undefined,
+    );
+    // 認証は拒否される
+    expect(res).toBeNull();
+    // かつ DB lookup は増えていない (bcrypt 前に短絡したことの証明)
+    expect(findByEmail.mock.calls.length).toBe(callsAfterFive);
+  });
+
+  // ログイン成功は失敗カウントをリセットする
+  it('resets the failure counter after a successful login', async () => {
+    // ユーザーは存在する
+    findByEmail.mockResolvedValue(USER);
+    // 上限未満の 4 回失敗させる
+    for (let i = 0; i < 4; i += 1) {
+      await passwordAuthorize({ email: 'user@example.com', password: 'wrong' }, undefined);
+    }
+    // 正しいパスワードで成功させる (この時点で失敗カウントがクリアされる)
+    expect(
+      await passwordAuthorize(
+        { email: 'user@example.com', password: 'correct-password' },
+        undefined,
+      ),
+    ).not.toBeNull();
+    // リセット後、再び 4 回失敗させる (まだロックされないはず)
+    for (let i = 0; i < 4; i += 1) {
+      await passwordAuthorize({ email: 'user@example.com', password: 'wrong' }, undefined);
+    }
+    // 5 回目の失敗の直前の呼び出し回数を控える
+    const before = findByEmail.mock.calls.length;
+    // 5 回目の失敗はまだロックされておらず DB に到達する (= リセットが効いている証明)
+    await passwordAuthorize({ email: 'user@example.com', password: 'wrong' }, undefined);
+    // findByEmail が 1 回増えている (短絡していない)
+    expect(findByEmail.mock.calls.length).toBe(before + 1);
+  });
+
+  // ロックアウトはメール単位で、大文字小文字を区別しない
+  it('keys lockout by email case-insensitively', async () => {
+    // ユーザーは存在する
+    findByEmail.mockResolvedValue(USER);
+    // 大文字混じりのメールで 5 回失敗させる
+    for (let i = 0; i < 5; i += 1) {
+      await passwordAuthorize({ email: 'User@Example.com', password: 'wrong' }, undefined);
+    }
+    // ここまでの DB 呼び出し回数を控える
+    const calls = findByEmail.mock.calls.length;
+    // 小文字の同一メールは同じバケット → ロック中で DB を引かない
+    await passwordAuthorize(
+      { email: 'user@example.com', password: 'correct-password' },
+      undefined,
+    );
+    // DB 呼び出しは増えていない (同一メール扱いでロックされている)
+    expect(findByEmail.mock.calls.length).toBe(calls);
+  });
+
+  // IP 単位でもロックアウトする (X-Forwarded-For ヘッダ由来)
+  it('also locks out by client IP from x-forwarded-for', async () => {
+    // ユーザーは存在する
+    findByEmail.mockResolvedValue(USER);
+    // 同一 IP・異なるメールで 5 回失敗させる (メールキーは分散、IP キーが累積)
+    for (let i = 0; i < 5; i += 1) {
+      // 攻撃者が毎回違うメールを試すが送信元 IP は同じという想定
+      const req = new Request('http://localhost/api/auth', {
+        headers: { 'x-forwarded-for': '203.0.113.7' },
+      });
+      await passwordAuthorize({ email: `spray${i}@example.com`, password: 'wrong' }, req);
+    }
+    // 同一 IP からの 6 回目は IP ロックで短絡する
+    const calls = findByEmail.mock.calls.length;
+    const req = new Request('http://localhost/api/auth', {
+      headers: { 'x-forwarded-for': '203.0.113.7' },
+    });
+    // 別メールでも同一 IP なのでロックされ、DB を引かない
+    await passwordAuthorize({ email: 'spray-final@example.com', password: 'wrong' }, req);
+    // DB 呼び出しが増えていない (IP キーで短絡)
+    expect(findByEmail.mock.calls.length).toBe(calls);
+  });
+});


### PR DESCRIPTION
## 概要

セキュリティレビュー指摘の helpdesk-hub 分。Phase 0（マルチテナント基盤）のクロステナント分離強化と認証フローのハードニング（`docs/smb-dx-pivot-plan.md` §5.1）。**多角的な PR レビュー（セキュリティ / 型・lint / テスト回帰の 3 観点）を実施し、指摘を反映済み。**

> 注: 当初含めていた **#120（`markAllRead` の tenantId スコープ化）は、`main` に先行マージされた #124 が同一の修正を実装済み**のため、本ブランチからは該当コミットを除外し `origin/main` にリベースしました（重複・コンフリクト解消）。

## 対応した issue

### #119 ログインのブルートフォース / クレデンシャルスタッフィング対策 〔feat/refactor(auth)〕
- `src/lib/login-throttle.ts`: 失敗ベースのスライディングウィンドウ・ロックアウト（15分窓 / 5回）。**メール単位**（偽装不可の主防御）+ **IP 単位**（X-Forwarded-For ベースの best-effort）。成功時にカウントをクリア。
- 認証ロジックを `src/lib/password-authorize.ts` に分離（`authorize` 冒頭で bcrypt 前にロックアウト判定、ユーザー不在時のダミー bcrypt 比較でタイミングオラクル緩和）。
- **レビュー反映**: 配線（5回失敗で短絡 / ダミー比較 / 成功時リセット / メール・IP キー）を `tests/password-authorize.test.ts` で統合テスト。メールロックアウトの可用性トレードオフ（標的型 DoS）と、**magic-link が非スロットルの回復経路**である旨をコードに明文化。

### #121 弱い / 未設定 NEXTAUTH_SECRET の本番 fail-fast 〔feat(auth)〕
- 本番実行時に起動停止。`next build` を壊さないようビルドフェーズ（`NEXT_PHASE`）は警告のみ（Next が build 時に必ず設定するため安全）。

### #123 コメント作成のクロステナント多層防御 〔fix(infra)〕
- `CreateCommentInput` に `tenantId` を追加し、コメント create アダプタ（Prisma / メモリ）で**親チケットのテナント一致を fail-closed 検証**（不一致・不在は「チケットが見つかりません」で拒否）。
- **レビュー反映**: `tenantId` は必ずセッション由来とする不変条件を port に doc 化（リクエスト入力からの注入禁止）。
- 添付 create は既に `tenantId` を持ち route 側で検証済みのため現状維持（既存の添付リポジトリ単体テスト設計を尊重）。
- クロステナント / 不在チケットのコメント拒否を `tests/data/cross-tenant-create.test.ts` で担保。

## レビューで「現状維持」と判断した残課題（フォローアップ）
- **Prisma コメントガードの契約テスト**: メモリ adapter は単体テスト済み。Prisma 側は同一ロジック（`findFirst({id, tenantId})`）だが契約テスト未追加。`*.contract.prisma.test.ts` への追加を後続フォローアップとする。
- **IP スロットルの XFF 信頼**: 信頼プロキシ設定が無い環境では best-effort（コード明記済み）。主防御はメールキー。

## 対応を見送った issue
### #122 magic-link GET callback の login CSRF / prefetch 消費 — **deferred を尊重し `not planned` でクローズ済み**
コード内に「現行 SMB Lite ターゲットでは受容」と文書化された製品判断があり、GET→POST 確認ページ化は認証フロー・e2e・UX を変える大規模変更のため、CLAUDE.md の方針に従い見送り（ユーザー確認済み）。

## 検証
- 本環境は `node_modules` 未導入のため `lint`/`typecheck`/`test` は CI で確認。`auth.ts` のリファクタは import 整合・型互換（`authorize` への代入は反変的に安全）を静的に確認済み。
- 追加テスト: `tests/login-throttle.test.ts`、`tests/password-authorize.test.ts`、`tests/data/cross-tenant-create.test.ts`。

## 補足
- Codex 自動レビューは usage 上限のため起動不可（bot が上限通知を返答）。本 PR は別途 3 体のレビューエージェントで多角検証済み。

https://claude.ai/code/session_01DLhtJpxTFKmJ2aMNRzQ86r