### PR TITLE
fix: §5コメント追加・rollbackエラーログ改善

### DIFF
--- a/src/app/api/tickets/[id]/comments/route.ts
+++ b/src/app/api/tickets/[id]/comments/route.ts
@@ -28,6 +28,7 @@ type Params = { params: Promise<{ id: string }> };
 
 // 422 (バリデーションエラー) を共通フォーマットで返すヘルパー
 function validationError(message: string, path: (string | number)[]) {
+  // Zod 互換の issues 形状で 422 レスポンスを返す (フォーム側が読みやすいよう整形)
   return NextResponse.json(
     {
       error: '入力値が正しくありません',

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -61,8 +61,10 @@ export async function POST(req: Request) {
     // multipart/form-data を FormData として読み出す
     let form: FormData;
     try {
-      form = await req.formData();
-    } catch {
+      form = await req.formData(); // ブラウザが送った multipart ボディを FormData オブジェクトに変換する
+    } catch (formErr) {
+      // FormData の読み出し失敗はサーバログにエラーとして記録する (握りつぶさない)
+      console.error('[POST /api/tickets] failed to parse FormData', formErr);
       // 不正な FormData は 400 で弾く
       return NextResponse.json(
         { error: 'リクエストの形式が正しくありません' },
@@ -84,8 +86,10 @@ export async function POST(req: Request) {
   } else {
     // 従来どおり JSON ボディとして読み出す
     try {
-      rawInput = (await req.json()) as Record<string, unknown>;
-    } catch {
+      rawInput = (await req.json()) as Record<string, unknown>; // JSON を JS オブジェクトに変換する
+    } catch (jsonErr) {
+      // JSON の解析失敗はサーバログにエラーとして記録する (握りつぶさない)
+      console.error('[POST /api/tickets] failed to parse JSON body', jsonErr);
       return NextResponse.json(
         { error: 'リクエストの形式が正しくありません' },
         { status: 400 },
@@ -210,8 +214,9 @@ export async function POST(req: Request) {
     await Promise.all(
       writtenKeys.map((key) =>
         storage.delete(key).catch((cleanupErr) => {
-          // 削除失敗はログだけ残して握りつぶす (リトライ用 GC は将来の課題)
-          console.warn('[POST /api/tickets] failed to clean up storage', { key, cleanupErr });
+          // ストレージ削除失敗はエラーとしてログに残す (リトライ用 GC は将来の課題)
+          // warn ではなく error: ロールバック失敗は警告ではなく本物のエラー
+          console.error('[POST /api/tickets] failed to clean up storage', { key, cleanupErr });
         }),
       ),
     );


### PR DESCRIPTION
## Summary
- `faq-actions.ts`: §5コメント規約に従いすべての実行行に日本語コメントを追加（変更前から既に対応済みのため今回の差分には含まれない）
- `route.ts`: rollbackエラーの `console.warn` を `console.error` に変更（ロールバック失敗は警告ではなく本物のエラー）
- `route.ts`: FormData/JSON 解析の空 catch ブロックにエラー変数捕捉と `console.error` ログを追加（エラーを握りつぶさない）
- `route.ts`: 各 catch ブロックの実行行に §5 日本語コメントを追加

## Test plan
- [ ] `npm run typecheck` グリーン
- [ ] `npm run lint` グリーン
- [ ] `npm run test` グリーン

https://claude.ai/code/session_01CbBifMRmWtkcCAJAqPhKL3

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbBifMRmWtkcCAJAqPhKL3)_