### PR TITLE
fix(tickets): 自己更新時の無駄なSSE配信を防止

### DIFF
--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -63,9 +63,10 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
   // 10 秒あたり 10 回までに制限 (チケット単位)
   enforceRateLimit(`ticket-status:${session.user.id}:${ticketId}`, { limit: 10, windowMs: 10_000 });
 
-  // uow.run の外で起票者 ID を保持して、コミット後の broadcastUnreadCount に使う
+  // コミット後の broadcastUnreadCount に渡す「通知を実際に書き込んだ起票者 ID」を保持する
   // (ticket は uow.run 内で取得するため、クロージャ変数として外側に宣言しておく必要がある)
-  let ticketCreatorId: string | null = null;
+  // 自己更新 (起票者=操作者) では通知を作らないため null のままにし、無駄な SSE 配信を避ける
+  let notifiedCreatorId: string | null = null;
 
   // 1 トランザクションでチケット更新と履歴記録を実行
   await uow.run(async (r) => {
@@ -125,8 +126,6 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
       oldValue: ticket.status,
       newValue: newStatus,
     });
-    // 起票者 ID を外側変数に渡す (コミット後の SSE 配信に使う)
-    ticketCreatorId = ticket.creatorId;
     // 自分以外の起票者にのみ通知を送る (エージェント本人が起票したチケットを更新する場合は自己通知しない)
     if (ticket.creatorId !== session.user.id) {
       // 起票者にステータス変更通知を DB に書き込む
@@ -138,11 +137,14 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
         ticketId, // 関連チケット ID
         tenantId: ticket.tenantId, // テナントスコープ (クロステナント漏洩防止)
       });
+      // 通知を書き込んだ起票者 ID を外側変数に渡す (コミット後の SSE 配信に使う)
+      notifiedCreatorId = ticket.creatorId;
     }
   });
 
-  // 起票者の未読件数を SSE でリアルタイム配信 (トランザクションコミット後に呼ぶ)
-  if (ticketCreatorId) await broadcastUnreadCount(ticketCreatorId, tenantId);
+  // 通知を実際に書き込んだ場合のみ、起票者の未読件数を SSE でリアルタイム配信する
+  // (トランザクションコミット後に呼ぶ。自己更新時は notifiedCreatorId が null なので配信しない)
+  if (notifiedCreatorId) await broadcastUnreadCount(notifiedCreatorId, tenantId);
 
   // チケット詳細ページのキャッシュを無効化して再描画
   revalidatePath(`/tickets/${ticketId}`);


### PR DESCRIPTION
## 概要

`updateTicketStatus`（`src/features/tickets/actions/update-ticket.ts`）で、起票者＝操作者（自己更新）の場合にも `broadcastUnreadCount` が呼ばれていた不具合を修正します。

### 背景・問題
- 従来は外側変数 `ticketCreatorId` を「通知を送るかどうかの判定（`ticket.creatorId !== session.user.id`）の外」で無条件に代入していたため、自己更新で通知 DB 書き込みが**発生しない**ケースでもコミット後に SSE 配信（`broadcastUnreadCount`）が走っていました。
- 通知 DB 書き込み条件と SSE 配信条件が一致しておらず、不要なリアルタイム配信が発生していました（§D 通知パイプラインの意図に反する）。

### 修正内容
- 変数を `notifiedCreatorId`（「通知を実際に書き込んだ起票者 ID」）にリネームし、代入を `if (ticket.creatorId !== session.user.id)` ブロック内（通知書き込み直後）へ移動。
- 自己更新時は `notifiedCreatorId` が `null` のままとなり、SSE 配信をスキップ。これにより通知書き込み条件と SSE 配信条件が一致します。
- 既存の `tenantId` スコープ（クロステナント漏洩防止）は維持。

### 検証
- `npm run db:generate`: OK
- `npm run typecheck`: OK
- `npm run lint`: OK
- `npm run test`: OK（Vitest ユニットテスト緑）
- DB 依存の契約テスト / E2E は本環境に PostgreSQL・ブラウザがないため未実行（CI で検証）。

### 方針整合
- `docs/smb-dx-pivot-plan.md` の方針に反しない軽微なバグ修正。Phase をまたぐ機能追加ではありません。
- §5 コメント規約・§6 最小スコープ・§12 1コミット=1論理変更に準拠。

---
_Generated by [Claude Code](https://claude.ai/code/session_0144ghPSRnts12a5At5w2zuj)_