### PR TITLE
fix(api): POST /api/tickets の tenantId 欠落ガードを他入口と統一

### DIFF
--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -39,8 +39,10 @@ function validationError(message: string, path: (string | number)[]) {
 export async function POST(req: Request) {
   // セッション取得
   const session = await auth();
-  // 未ログインなら 401 を返す
-  if (!session?.user?.id) {
+  // 未ログイン、または tenantId が取得できない場合は 401。
+  // tenantId が null だと以降の where 句注入(テナント分離)が効かず、NOT NULL 列への
+  // 書き込みも 500 になるため、他の認証付き入口(コメント投稿等)と同じく早期に弾く。
+  if (!session?.user?.id || !session.user.tenantId) {
     return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
   }
 


### PR DESCRIPTION
## Context
コードレビューで見つかったマルチテナント周りの多層防御の穴を塞ぎます（`docs/smb-dx-pivot-plan.md` §5.1 マルチテナント化 / CLAUDE.md「新規入口は冒頭で tenantId を取り出して where に差し込む」方針の補強）。

## 問題
`POST /api/tickets` の認証ガードは `session?.user?.id` のみを確認していました。一方、他のすべての認証付き入口（`POST .../comments`、`GET .../stream`、`markAllRead`、`update-ticket`、`faq-actions`）は `!session.user.tenantId` も併せて 401 で弾きます。本ルートだけガードが非対称で弱く、`tenantId` が万一 null のセッションでは where 句注入（テナント分離）が機能せず、`tenantId` NOT NULL 列への書き込みが 500 になります（クロステナント漏洩ではないが多層防御の欠落）。

## 修正
他入口と同じく `!session?.user?.id || !session.user.tenantId` で 401 を返すよう統一。

## レビュー指摘のうち見送った項目（理由付き）
同レビューで「`requestMagicLink` に IP 単位のレート制限が無い」も挙がりましたが、**見送り**ました。`src/lib/login-throttle.ts` の設計コメントに「マジックリンク経路はパスワードロックアウト時の復旧経路として*意図的に*スロットルしない。別の復旧経路を用意せずにスロットルを追加するな」と明記されており、IP レート制限の追加はこの文書化された設計判断に反します（CLAUDE.md「正本に反する変更をしない／逸脱時は先に計画書を更新」）。volumetric な負荷はメール単位の上限（5件/15分）で部分的に緩和されています。対処するなら被害者の復旧を妨げない粗粒度の制御が必要で、設計変更として別途検討すべきです。

## 検証
`npm run typecheck` / `npm run lint` / `npm run test` いずれも緑（220 passed / 16 skipped）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6R38LYjthAQu1ZsnCGfuM)_