### PR TITLE
feat(dashboard): Lite モードの簡易ダッシュボード（自分の未対応 / 期限切れ）を追加

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -8,8 +8,14 @@ import { repos } from '@/data';
 import { isAgent as checkIsAgent } from '@/lib/role';
 // ステータスの日本語ラベル + Tailwind カラークラス
 import { STATUS_LABELS, STATUS_COLORS } from '@/lib/constants';
+// 現在ログイン中のテナントの動作モード (lite | pro) を取得するヘルパー
+import { getCurrentTenantMode } from '@/lib/tenant';
+// タブ ('mine' / 'overdue') の絞り込み条件を一元管理する純粋関数 (一覧ページと共有)
+import { applyTabFilter } from '@/features/tickets/tab-filter';
+// データ層が公開しているチケット一覧フィルタ型 (件数取得の引数)
+import type { TicketListFilter } from '@/data/ports/ticket-repository';
 
-// /dashboard : 集計ダッシュボード (役割で表示項目が変わる)
+// /dashboard : 集計ダッシュボード (テナント mode と役割で表示が変わる)
 export default async function DashboardPage() {
   // セッション取得
   const session = await auth();
@@ -20,9 +26,20 @@ export default async function DashboardPage() {
   const isAgent = checkIsAgent(session.user.role);
   // セッションから tenantId を取り出して以降の port 呼び出しに伝搬する
   const tenantId = session.user.tenantId;
-  // SLA 判定基準時刻 (現在時刻)
+  // SLA / 期限 判定基準時刻 (現在時刻)
   const now = new Date();
+  // テナントの動作モード (lite | pro) を取得し、表示内容を切り替える
+  const mode = await getCurrentTenantMode(tenantId);
 
+  // Lite モードのテナントは「自分の未対応 / 期限切れ」の 2 枚タイルだけの簡易版を表示する
+  // (Pivot plan §3.1 / §2 ギャップ表: 一人運用では SLA・担当者別の集計は意味が薄いため置換)
+  if (mode === 'lite') {
+    return (
+      <LiteDashboard isAgent={isAgent} userId={session.user.id} tenantId={tenantId} now={now} />
+    );
+  }
+
+  // 以降は Pro モードの従来ダッシュボード (情シス向けのフル集計)
   // ダッシュボード用 3 指標を 1 メソッドで取得 (内部は groupBy で 3 クエリに集約、tenantId スコープ)
   // - byStatus: 7 状態それぞれの件数 (依頼者なら自身のチケットに限定)
   // - slaOverdue / workload: 当該テナント内全件対象 (表示は呼び出し側で role 制御)
@@ -169,6 +186,78 @@ export default async function DashboardPage() {
           </div>
         </section>
       )}
+    </div>
+  );
+}
+
+// Lite モード用の簡易ダッシュボード (自分の未対応 / 期限切れ の 2 枚タイル)
+// Pivot plan §3.1 に対応。一覧タブと同じ条件 (applyTabFilter) で件数を数え、
+// タイルをタップすると該当タブの一覧 (/tickets?tab=...) へ遷移する。
+async function LiteDashboard({
+  isAgent,
+  userId,
+  tenantId,
+  now,
+}: {
+  isAgent: boolean; // 担当者 (agent/admin) かどうか。'mine' の絞り込み方が依頼者と変わる
+  userId: string; // ログインユーザー ID ('mine' で自分の担当/起票を絞る)
+  tenantId: string; // テナントスコープ (件数取得に必須)
+  now: Date; // 期限超過判定の基準時刻
+}) {
+  // 件数集計の共通土台。依頼者は自分のチケットのみ、担当者は全件 (creatorId 未指定)
+  const baseFilter: TicketListFilter = {
+    creatorId: isAgent ? undefined : userId,
+  };
+  // 一覧タブと同一の条件を再利用して「自分の未対応」「期限切れ」のフィルタを組み立てる
+  const mineFilter = applyTabFilter(baseFilter, 'mine', { isAgent, userId, now });
+  const overdueFilter = applyTabFilter(baseFilter, 'overdue', { isAgent, userId, now });
+
+  // 2 つの件数を並列に取得 (どちらも tenantId スコープ)
+  const [mineCount, overdueCount] = await Promise.all([
+    repos.tickets.count(mineFilter, tenantId),
+    repos.tickets.count(overdueFilter, tenantId),
+  ]);
+
+  return (
+    <div className="space-y-8">
+      {/* ページヘッダー: タイトル + やさしいサブテキスト (Lite はカタカナ/英語を避ける) */}
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">ホーム</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          いま対応が必要な問い合わせをまとめています。タイルを押すと一覧を開けます。
+        </p>
+      </div>
+
+      {/* 2 枚タイル (スマホでは縦 1 列、sm 以上で 2 列) */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {/* 自分の未対応 (Open / InProgress)。落ち着いたティールで主要導線として強調 */}
+        <Link
+          href="/tickets?tab=mine"
+          className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 transition duration-200 hover:-translate-y-0.5 hover:shadow-md hover:ring-teal-200"
+        >
+          <p className="text-sm font-medium text-slate-500">自分の未対応</p>
+          <p className="mt-2 text-4xl font-bold text-teal-700">{mineCount}</p>
+          <p className="mt-1 text-xs text-slate-400">未対応・対応中の問い合わせ</p>
+        </Link>
+
+        {/* 期限切れ。件数 0 はニュートラル、1 件以上はロゼで注意喚起 */}
+        <Link
+          href="/tickets?tab=overdue"
+          className={`rounded-2xl bg-white p-6 shadow-sm ring-1 transition duration-200 hover:-translate-y-0.5 hover:shadow-md ${
+            overdueCount > 0
+              ? 'ring-rose-200 hover:ring-rose-300'
+              : 'ring-slate-100 hover:ring-teal-200'
+          }`}
+        >
+          <p className="text-sm font-medium text-slate-500">期限切れ</p>
+          <p
+            className={`mt-2 text-4xl font-bold ${overdueCount > 0 ? 'text-rose-700' : 'text-slate-400'}`}
+          >
+            {overdueCount}
+          </p>
+          <p className="mt-1 text-xs text-slate-400">期限を過ぎた未完了の問い合わせ</p>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/tickets/page.tsx
+++ b/src/app/(app)/tickets/page.tsx
@@ -18,6 +18,8 @@ import { formatDateJP } from '@/lib/format-date';
 import { TicketFilters } from '@/features/tickets/components/TicketFilters';
 // 「自分の未対応 / 期限切れ / すべて」タブナビ (Client Component)
 import { TicketTabs, type TicketTabId } from '@/features/tickets/components/TicketTabs';
+// タブ ('mine' / 'overdue') の絞り込み条件を一元管理する純粋関数 (ダッシュボードと共有)
+import { applyTabFilter } from '@/features/tickets/tab-filter';
 // チケット状態・優先度の列挙型 (正準のドメイン型・URL クエリの型ガード用)
 import type { TicketStatus, Priority } from '@/domain/types';
 // データ層が公開しているチケット一覧フィルタ型 (port 経由クエリの引数)
@@ -78,8 +80,8 @@ export default async function TicketsPage({ searchParams }: Props) {
   // タブ ID を正規化 ('all' / 'mine' / 'overdue' のいずれか)
   const tab = parseTabParam(sp.tab);
 
-  // データ層に渡す TicketListFilter を組み立てる
-  const filter: TicketListFilter = {
+  // データ層に渡す TicketListFilter を組み立てる (検索/絞り込みの基本条件)
+  const baseFilter: TicketListFilter = {
     // RBAC: 依頼者は自分のチケットのみ (エージェントは creatorId 未指定 = 全件)
     creatorId: isAgent ? undefined : session.user.id,
     // フリーワード検索 (タイトル/本文の部分一致、大文字小文字無視)
@@ -94,20 +96,13 @@ export default async function TicketsPage({ searchParams }: Props) {
     assigneeId: normalizeAssigneeId(sp.assigneeId),
   };
 
-  // タブ別の追加フィルタを上書き適用する
-  // - mine: 「自分の未対応」= ステータスが Open または InProgress
-  //   - エージェントは「担当が自分」のもの
-  //   - 依頼者は creatorId 既定 (自分のチケット) で自動的に絞り込まれているため status だけ追加
-  // - overdue: 期限切れ + 未解決 (status=Resolved/Closed は除外)
-  if (tab === 'mine') {
-    filter.statusIn = ['Open', 'InProgress'];
-    if (isAgent) {
-      filter.assigneeId = session.user.id;
-    }
-  } else if (tab === 'overdue') {
-    // 現在時刻基準で期限超過判定を行う
-    filter.overdue = { now: new Date() };
-  }
+  // タブ別の追加条件 ('mine' / 'overdue') を共通ヘルパーで適用する
+  // (タブの意味はダッシュボードと共有する applyTabFilter に集約し、二重定義を避ける)
+  const filter = applyTabFilter(baseFilter, tab, {
+    isAgent,
+    userId: session.user.id,
+    now: new Date(),
+  });
 
   // セッションから tenantId を取り出して以降の port 呼び出しに伝搬する
   const tenantId = session.user.tenantId;

--- a/src/features/tickets/tab-filter.ts
+++ b/src/features/tickets/tab-filter.ts
@@ -1,0 +1,44 @@
+// 一覧タブ ('all' / 'mine' / 'overdue') の識別子型を再利用する (型のみ import なので client 境界の影響なし)
+import type { TicketTabId } from './components/TicketTabs';
+// データ層が公開しているチケット一覧フィルタ型 (タブ条件を差し込む対象)
+import type { TicketListFilter } from '@/data/ports/ticket-repository';
+
+// タブ条件を適用するときに必要な実行コンテキスト
+// - isAgent: 担当者 (agent/admin) なら true。'mine' タブの絞り込み方が依頼者と変わる
+// - userId : ログインユーザー ID。'mine' タブで「自分が担当」の判定に使う
+// - now    : 現在時刻。'overdue' タブの期限超過判定の基準
+interface TabFilterContext {
+  isAgent: boolean;
+  userId: string;
+  now: Date;
+}
+
+// 一覧タブの絞り込み条件を、共通の真実の源として 1 か所に集約する純粋関数。
+// 渡された base フィルタにタブ固有の条件を「追加」して返す (破壊的に書き換えず複製を返す)。
+// 一覧ページ (/tickets) と Lite ダッシュボードの両方から呼び、タブの意味を二重定義しない。
+// - 'all'    : 追加条件なし (base をそのまま使う)
+// - 'mine'   : 「自分の未対応」= ステータスが Open または InProgress。
+//              担当者は「担当が自分」のものに限定する (依頼者は base の creatorId で既に自分のチケットに絞られている)
+// - 'overdue': 「期限切れ」= 解決期限を過ぎた未解決チケット (now を基準に判定)
+export function applyTabFilter(
+  base: TicketListFilter,
+  tab: TicketTabId,
+  ctx: TabFilterContext,
+): TicketListFilter {
+  // base を直接書き換えないよう浅いコピーを作る (呼び出し側の filter を汚さない)
+  const filter: TicketListFilter = { ...base };
+  // 'mine' タブ: 未対応 (Open / InProgress) かつ担当者なら自分が担当のもの
+  if (tab === 'mine') {
+    // ステータスを未対応の 2 値に限定する
+    filter.statusIn = ['Open', 'InProgress'];
+    // 担当者ロールのときだけ「担当が自分」を追加 (依頼者は creatorId で既に絞られている)
+    if (ctx.isAgent) {
+      filter.assigneeId = ctx.userId;
+    }
+  } else if (tab === 'overdue') {
+    // 'overdue' タブ: 現在時刻基準で期限超過 + 未解決のみ
+    filter.overdue = { now: ctx.now };
+  }
+  // タブ条件を反映したフィルタを返す
+  return filter;
+}

--- a/tests/ticket-tab-filter.test.ts
+++ b/tests/ticket-tab-filter.test.ts
@@ -1,0 +1,75 @@
+// Vitest のテスト DSL
+import { describe, expect, it } from 'vitest';
+
+// 一覧タブの絞り込み条件を組み立てる純粋関数 (一覧ページ / Lite ダッシュボード共通)
+import { applyTabFilter } from '../src/features/tickets/tab-filter';
+// 件数/一覧フィルタ型 (テストの base フィルタ作成に使う)
+import type { TicketListFilter } from '../src/data/ports/ticket-repository';
+
+// テストで使う固定の現在時刻 (overdue 判定の基準が伝搬されることの確認用)
+const NOW = new Date('2026-06-16T00:00:00.000Z');
+
+// タブ別フィルタ生成のルール (= 一覧/ダッシュボードで共有する単一の真実) を守れているかのテスト
+describe('applyTabFilter', () => {
+  // 'all' タブは追加条件を付けず base をそのまま (複製で) 返すこと
+  it('returns base unchanged for the all tab', () => {
+    // 起票者で絞った base フィルタ
+    const base: TicketListFilter = { creatorId: 'u1' };
+    // 'all' タブを適用
+    const result = applyTabFilter(base, 'all', { isAgent: true, userId: 'u1', now: NOW });
+    // タブ固有条件が一切付いていないこと
+    expect(result.statusIn).toBeUndefined();
+    expect(result.overdue).toBeUndefined();
+    // base の条件は維持されていること
+    expect(result.creatorId).toBe('u1');
+  });
+
+  // 'mine' タブ (担当者): 未対応 2 値 + 自分が担当 の条件が付くこと
+  it('scopes mine tab to own assignments for agents', () => {
+    // 担当者は creatorId 未指定 (全件) の base
+    const base: TicketListFilter = { creatorId: undefined };
+    // 'mine' タブを担当者として適用
+    const result = applyTabFilter(base, 'mine', { isAgent: true, userId: 'agent1', now: NOW });
+    // 未対応 (Open / InProgress) に限定されること
+    expect(result.statusIn).toEqual(['Open', 'InProgress']);
+    // 担当者は「担当が自分」で絞られること
+    expect(result.assigneeId).toBe('agent1');
+  });
+
+  // 'mine' タブ (依頼者): 未対応 2 値のみで、担当者条件は付かないこと
+  it('scopes mine tab by status only for requesters', () => {
+    // 依頼者は creatorId = 自分 の base (呼び出し側で設定済みの想定)
+    const base: TicketListFilter = { creatorId: 'requester1' };
+    // 'mine' タブを依頼者として適用
+    const result = applyTabFilter(base, 'mine', { isAgent: false, userId: 'requester1', now: NOW });
+    // 未対応に限定されること
+    expect(result.statusIn).toEqual(['Open', 'InProgress']);
+    // 依頼者には担当者条件を付けない (creatorId で既に自分のチケットに絞られている)
+    expect(result.assigneeId).toBeUndefined();
+    // creatorId は維持されていること
+    expect(result.creatorId).toBe('requester1');
+  });
+
+  // 'overdue' タブ: 期限超過判定の基準時刻 now が伝搬されること
+  it('passes now to the overdue filter', () => {
+    // base は空 (担当者・全件想定)
+    const base: TicketListFilter = {};
+    // 'overdue' タブを適用
+    const result = applyTabFilter(base, 'overdue', { isAgent: true, userId: 'agent1', now: NOW });
+    // overdue.now に基準時刻が入ること
+    expect(result.overdue).toEqual({ now: NOW });
+    // 未対応条件 (statusIn) は付かないこと
+    expect(result.statusIn).toBeUndefined();
+  });
+
+  // 呼び出し元の base を破壊的に書き換えないこと (複製を返す)
+  it('does not mutate the base filter', () => {
+    // 元の base
+    const base: TicketListFilter = { creatorId: 'u1' };
+    // 'mine' タブを適用
+    applyTabFilter(base, 'mine', { isAgent: true, userId: 'u1', now: NOW });
+    // base 側にはタブ条件が漏れていないこと
+    expect(base.statusIn).toBeUndefined();
+    expect(base.assigneeId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Context / 方針対応

`docs/smb-dx-pivot-plan.md` **Phase 1（Lite モード MVP）の残タスク**に対応します。具体的には **§3.1 Lite モード「ダッシュボード: 『自分の未対応』『期限切れ・今日まで』の 2 枚タイル」** および **§2 ギャップ表「ダッシュボード → 一人運用だと意味が薄い → 簡易版に置換」** です。

Phase 1 の他項目（mode 切替設定 #131・mode-aware ラベル・Lite 遷移表・一覧タブ・簡易フォーム・スマホ最適化・添付 #110・マジックリンク認証 #106）は既に `main` に揃っていましたが、**ダッシュボードだけが mode を見ておらず**、Lite テナントでも Pro 用の「ステータス別 6 カード / SLA 超過 / 担当者別ワークロード」を Pro ラベル（`STATUS_LABELS`）で表示しており、Lite UI の用語簡素化方針と不整合でした。本 PR でこの最後の穴を塞ぎます。

Phase 順序は尊重し、後フェーズ機能（メール取り込み・課金等）は含みません。

## 変更内容

- **`src/app/(app)/dashboard/page.tsx`**: `getCurrentTenantMode(tenantId)` で mode を取得し、**Lite なら 2 枚タイルの簡易ダッシュボード**（「自分の未対応」= Open/InProgress、「期限切れ」= 期限超過の未解決）を表示。**Pro モードは従来表示のまま温存**（既存の集計・SLA・ワークロードに変更なし）。
- **`src/features/tickets/tab-filter.ts`（新規）**: タブ（`mine` / `overdue`）の絞り込み条件を純粋関数 `applyTabFilter` に集約。一覧ページと Lite ダッシュボードで**同一条件を共有**し、タブの意味を二重定義しない（DRY）。
- **`src/app/(app)/tickets/page.tsx`**: 既存のインラインなタブ条件を `applyTabFilter` に置換（**挙動不変のリファクタ**）。
- **`tests/ticket-tab-filter.test.ts`（新規）**: タブ条件生成のユニットテスト（all/mine[担当者・依頼者]/overdue/不変性の 5 ケース）。

## 設計判断

- 件数は**既存の `repos.tickets.count`（tenantId スコープ）を再利用**し、新しいクエリ経路を増やさない。
- タイルは `/tickets?tab=mine` / `?tab=overdue` へ遷移し、一覧のタブと**完全に同じ条件**で結果が表示される（タブ条件を `applyTabFilter` に一本化したため乖離しない）。
- RBAC: 依頼者は `creatorId = 自分` で自分のチケットのみ、担当者は全件（`mine` のみ「担当が自分」を追加）。一覧タブの既存挙動を踏襲。
- 「期限切れ」は件数 0 でニュートラル、1 件以上でロゼ表示の注意喚起。Lite の用語方針に合わせカタカナ/英語（SLA 等）を排除。

## 検証

- `npm run db:generate` → `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test` ✅ — **229 passed / 16 skipped**（新規 `ticket-tab-filter` 5 件含む。Prisma 契約テストは `RUN_PRISMA_CONTRACT` 未設定で正しく skip）
- `npm run build` ✅（`/dashboard` 含め本番ビルド成功）

DB / E2E 依存は CI で検証されます。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EChwmTv6LNXjd7FZZsEsVa

---
_Generated by [Claude Code](https://claude.ai/code/session_01EChwmTv6LNXjd7FZZsEsVa)_