### PR TITLE
feat: Phase 0 未実装項目（テナント作成 / 招待リンク発行画面・E2E 検証）

### DIFF
--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -109,8 +109,8 @@
 
 - [ ] `Tenant` モデル追加 + 全関連テーブルへの `tenantId` 付与 + マイグレーション
 - [ ] `auth.ts` の session 拡張（`tenantId` 載せる）と middleware でのスコープ強制
-- [ ] テナント作成 / 招待リンク発行画面（admin 用）
-- [ ] 既存 E2E / Vitest をテナント前提に修正
+- [x] テナント作成 / 招待リンク発行画面（admin 用）
+- [x] 既存 E2E / Vitest をテナント前提に修正
 
 ### Phase 1 — Lite モード MVP（4 週間）★ 最重要
 

--- a/e2e/invite.spec.ts
+++ b/e2e/invite.spec.ts
@@ -1,0 +1,107 @@
+// Playwright のテスト DSL と Page 型
+import { test, expect, Page } from '@playwright/test';
+// E2E 後始末で作成ユーザー/招待を消すため Prisma Client を使う
+import { PrismaClient } from '../src/generated/prisma';
+
+// DB 直接操作用 Prisma Client (後始末専用)
+const prisma = new PrismaClient();
+
+// 既存 seed の管理者 (招待を発行する側)
+const ADMIN_EMAIL = 'admin@example.com';
+// テスト実行ごとに一意な受諾者メール (リトライ間の衝突を避ける)
+const INVITEE_EMAIL = `e2e-invitee-${Date.now()}@example.com`;
+
+// 共通ログイン手順 (パスワードタブが既定)
+async function login(page: Page, email: string) {
+  await page.goto('/login');
+  await page.getByLabel(/メールアドレス|Email/i).fill(email);
+  await page.getByLabel(/パスワード|Password/i).fill('password123');
+  await page.getByRole('button', { name: /ログイン/i }).click();
+  await page.waitForURL(/\/dashboard|\/tickets/);
+}
+
+// テスト後に作成したユーザーを掃除する (招待は ON DELETE/掃除に任せる)
+test.afterAll(async () => {
+  // 受諾で作られたユーザーを削除する (存在しなくてもエラーにしない)
+  await prisma.user.deleteMany({ where: { email: INVITEE_EMAIL } });
+  // Prisma 接続を閉じる
+  await prisma.$disconnect();
+});
+
+test.describe('メンバー招待フロー', () => {
+  test('管理者が招待リンクを発行し、受諾するとログインできる', async ({ page, browser }) => {
+    // 管理者でログインする
+    await login(page, ADMIN_EMAIL);
+
+    // 設定画面へ移動する
+    await page.goto('/settings');
+    // 招待セクションが見えることを確認する
+    await expect(page.getByRole('heading', { name: 'メンバーを招待' })).toBeVisible();
+
+    // 「メンバー」権限を選択する (既定だが明示)
+    await page.getByRole('radio', { name: 'メンバー' }).check();
+    // 招待リンクを発行する
+    await page.getByRole('button', { name: '招待リンクを発行する' }).click();
+
+    // 発行された招待リンクが表示されるまで待つ
+    const linkInput = page.getByLabel('発行された招待リンク');
+    await expect(linkInput).toBeVisible();
+    // 招待 URL を読み取る
+    const inviteUrl = await linkInput.inputValue();
+    expect(inviteUrl).toContain('/invite/');
+
+    // 受諾は別コンテキスト (未ログインの新規ブラウザ) で行う
+    const inviteeContext = await browser.newContext();
+    const inviteePage = await inviteeContext.newPage();
+    // 招待リンクを開く
+    await inviteePage.goto(inviteUrl);
+    // 受諾フォームの見出しが見えることを確認する
+    await expect(inviteePage.getByRole('heading', { name: /招待/ })).toBeVisible();
+
+    // 氏名・メール・パスワードを入力する (リンクにメール無しなのでメール入力欄が出る)
+    await inviteePage.getByLabel('お名前').fill('E2E 招待メンバー');
+    await inviteePage.getByLabel('メールアドレス').fill(INVITEE_EMAIL);
+    await inviteePage.getByLabel(/パスワード/).fill('password123');
+    // 参加ボタンを押す
+    await inviteePage.getByRole('button', { name: /参加して利用を開始する/ }).click();
+
+    // メンバー (requester) なので問い合わせ一覧へ遷移する
+    await inviteePage.waitForURL(/\/tickets/);
+    // アプリのナビ (問い合わせ一覧) が見えることで、ログイン済みであることを確認する
+    await expect(inviteePage.getByRole('link', { name: '問い合わせ一覧' })).toBeVisible();
+
+    // 後始末
+    await inviteeContext.close();
+  });
+
+  test('使用済みの招待リンクは再度受諾できない', async ({ page, browser }) => {
+    // 管理者でログインして招待を 1 件発行する
+    await login(page, ADMIN_EMAIL);
+    await page.goto('/settings');
+    await page.getByRole('radio', { name: 'メンバー' }).check();
+    await page.getByRole('button', { name: '招待リンクを発行する' }).click();
+    const inviteUrl = await page.getByLabel('発行された招待リンク').inputValue();
+
+    // 1 回目の受諾 (一意メールで成功させる)
+    const firstEmail = `e2e-invitee-once-${Date.now()}@example.com`;
+    const ctx1 = await browser.newContext();
+    const p1 = await ctx1.newPage();
+    await p1.goto(inviteUrl);
+    await p1.getByLabel('お名前').fill('一回目');
+    await p1.getByLabel('メールアドレス').fill(firstEmail);
+    await p1.getByLabel(/パスワード/).fill('password123');
+    await p1.getByRole('button', { name: /参加して利用を開始する/ }).click();
+    await p1.waitForURL(/\/tickets/);
+    await ctx1.close();
+
+    // 2 回目に同じリンクを開くと「無効/使用済み」の案内が出る
+    const ctx2 = await browser.newContext();
+    const p2 = await ctx2.newPage();
+    await p2.goto(inviteUrl);
+    await expect(p2.getByRole('alert')).toContainText(/無効|期限|使用/);
+    await ctx2.close();
+
+    // 後始末 (1 回目で作ったユーザーを消す)
+    await prisma.user.deleteMany({ where: { email: firstEmail } });
+  });
+});

--- a/e2e/invite.spec.ts
+++ b/e2e/invite.spec.ts
@@ -94,11 +94,12 @@ test.describe('メンバー招待フロー', () => {
     await p1.waitForURL(/\/tickets/);
     await ctx1.close();
 
-    // 2 回目に同じリンクを開くと「無効/使用済み」の案内が出る
+    // 2 回目に同じリンクを開くと「無効/使用済み」の案内が出る。
+    // role=alert は Next.js のルートアナウンサーとも一致してしまうため、本文テキストで特定する
     const ctx2 = await browser.newContext();
     const p2 = await ctx2.newPage();
     await p2.goto(inviteUrl);
-    await expect(p2.getByRole('alert')).toContainText(/無効|期限|使用/);
+    await expect(p2.getByText(/この招待リンクは無効/)).toBeVisible();
     await ctx2.close();
 
     // 後始末 (1 回目で作ったユーザーを消す)

--- a/e2e/tenant-create.spec.ts
+++ b/e2e/tenant-create.spec.ts
@@ -1,0 +1,77 @@
+// Playwright のテスト DSL と Page 型
+import { test, expect, Page } from '@playwright/test';
+// E2E 後始末で作成テナント/ユーザーを消すため Prisma Client を使う
+import { PrismaClient } from '../src/generated/prisma';
+
+// DB 直接操作用 Prisma Client (後始末専用)
+const prisma = new PrismaClient();
+
+// 既存 seed の管理者 (テナントを作成する側)
+const ADMIN_EMAIL = 'admin@example.com';
+// テスト実行ごとに一意な新管理者メール (リトライ間の衝突を避ける)
+const NEW_ADMIN_EMAIL = `e2e-new-admin-${Date.now()}@example.com`;
+// 作成する組織名
+const NEW_TENANT_NAME = `E2E 新組織 ${Date.now()}`;
+
+// 共通ログイン手順 (パスワードタブが既定)
+async function login(page: Page, email: string) {
+  await page.goto('/login');
+  await page.getByLabel(/メールアドレス|Email/i).fill(email);
+  await page.getByLabel(/パスワード|Password/i).fill('password123');
+  await page.getByRole('button', { name: /ログイン/i }).click();
+  await page.waitForURL(/\/dashboard|\/tickets/);
+}
+
+// テスト後に作成したテナント (連鎖でユーザーも) を掃除する
+test.afterAll(async () => {
+  // 作成ユーザーを先に消す (念のため)
+  await prisma.user.deleteMany({ where: { email: NEW_ADMIN_EMAIL } });
+  // 組織名で作成テナントを消す (ON DELETE CASCADE で配下も消える)
+  await prisma.tenant.deleteMany({ where: { name: NEW_TENANT_NAME } });
+  // Prisma 接続を閉じる
+  await prisma.$disconnect();
+});
+
+test.describe('テナント作成フロー', () => {
+  test('管理者が新しい組織と初代管理者を作成し、新管理者でログインできる', async ({
+    page,
+    browser,
+  }) => {
+    // 既存管理者でログインする
+    await login(page, ADMIN_EMAIL);
+
+    // テナント作成ページへ移動する
+    await page.goto('/settings/tenants/new');
+    // 見出しが見えることを確認する
+    await expect(page.getByRole('heading', { name: '新しい組織を作成' })).toBeVisible();
+
+    // 組織名・初代管理者の情報を入力する
+    await page.getByLabel('組織名').fill(NEW_TENANT_NAME);
+    await page.getByLabel(/業種/).fill('製造業');
+    await page.getByLabel('お名前').fill('E2E 新管理者');
+    await page.getByLabel('メールアドレス').fill(NEW_ADMIN_EMAIL);
+    await page.getByLabel(/パスワード/).fill('password123');
+    // 作成ボタンを押す
+    await page.getByRole('button', { name: '組織を作成する' }).click();
+
+    // 成功メッセージが表示されることを確認する
+    await expect(page.getByRole('status')).toContainText('組織を作成しました');
+
+    // 新管理者で別コンテキストからログインできることを確認する
+    const newContext = await browser.newContext();
+    const newPage = await newContext.newPage();
+    await newPage.goto('/login');
+    await newPage.getByLabel(/メールアドレス|Email/i).fill(NEW_ADMIN_EMAIL);
+    await newPage.getByLabel(/パスワード|Password/i).fill('password123');
+    await newPage.getByRole('button', { name: /ログイン/i }).click();
+    // 管理者なのでダッシュボードへ遷移する
+    await newPage.waitForURL(/\/dashboard/);
+
+    // 新組織は空なので、既存組織のチケット (例: VPN に接続できない) は見えない
+    await newPage.goto('/tickets');
+    await expect(newPage.getByText('VPN に接続できない')).toHaveCount(0);
+
+    // 後始末
+    await newContext.close();
+  });
+});

--- a/prisma/migrations/20260519000000_add_invitation/migration.sql
+++ b/prisma/migrations/20260519000000_add_invitation/migration.sql
@@ -1,0 +1,33 @@
+-- Phase 0 / マルチテナント基盤 (docs/smb-dx-pivot-plan.md §4 Phase 0・§7.1):
+-- admin が発行する「メンバー招待リンク」のワンタイムトークン保管テーブルを追加する。
+-- MagicLinkToken と同じく生トークンは URL のみで運び、DB には SHA-256 ハッシュだけ保存する。
+-- MagicLinkToken と違い、発行時点で「どのテナントに・どの権限で参加させるか」が確定しているため
+-- tenantId / role を必ず持つ (受諾時にリクエスト入力からテナントを注入させない = クロステナント参加の防止)。
+
+CREATE TABLE "Invitation" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "email" TEXT,
+    "role" "Role" NOT NULL DEFAULT 'requester',
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "consumedAt" TIMESTAMP(3),
+    "invitedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "tenantId" TEXT NOT NULL,
+
+    CONSTRAINT "Invitation_pkey" PRIMARY KEY ("id")
+);
+
+-- tokenHash は一意制約 (同じハッシュが 2 件存在しない)
+CREATE UNIQUE INDEX "Invitation_tokenHash_key" ON "Invitation"("tokenHash");
+
+-- テナント単位の一覧・掃除を高速化するインデックス
+CREATE INDEX "Invitation_tenantId_idx" ON "Invitation"("tenantId");
+
+-- 期限切れ招待の一括削除を高速化するインデックス
+CREATE INDEX "Invitation_expiresAt_idx" ON "Invitation"("expiresAt");
+
+-- 参加先テナントへの外部キー (テナント削除で招待も連鎖削除)
+ALTER TABLE "Invitation"
+    ADD CONSTRAINT "Invitation_tenantId_fkey"
+    FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -98,6 +98,7 @@ model Tenant {
   faqCandidates FaqCandidate[]
   notifications Notification[]
   attachments   Attachment[] // 添付ファイル (テナント境界の保持に必須)
+  invitations   Invitation[] // メンバー招待リンク (発行〜受諾までのワンタイムトークン)
 }
 
 // ─────────────────────────────────────────────
@@ -146,6 +147,32 @@ model MagicLinkToken {
   createdAt   DateTime  @default(now()) // 作成日時
 
   @@index([email]) // メール単位の掃除・将来のレート制限カウントに使う
+  @@index([expiresAt]) // 期限切れ一括削除を高速化する
+}
+
+// ─────────────────────────────────────────────
+// Invitation (テナントへのメンバー招待リンクのワンタイムトークン)
+// ─────────────────────────────────────────────
+
+// admin が発行する招待リンクの正体。MagicLinkToken と同じく生トークンは URL のみで持ち、
+// DB には SHA-256 ハッシュだけを保存する。MagicLinkToken と違い「どのテナントに・どの権限で
+// 参加させるか」が発行時点で確定しているため tenantId / role を必ず持つ (受諾時に入力から
+// テナントを注入させない = クロステナント参加を防ぐための要)。
+model Invitation {
+  id          String    @id @default(cuid()) // 主キー (cuid)
+  tokenHash   String    @unique // 生トークンの SHA-256 ハッシュ (生は DB に保存しない)
+  email       String? // 宛先メール (任意。指定時はその人専用の案内メールも送る)
+  role        Role      @default(requester) // 参加後に付与する権限 (メンバー=requester / 担当者=agent)
+  expiresAt   DateTime // 失効時刻 (発行から 7 日後を想定。ログイン用より長め)
+  consumedAt  DateTime? // 受諾済み時刻。null なら未使用 (単回使用を強制)
+  invitedById String? // 発行した admin の User ID (監査用。ユーザー削除時は null 化される想定で任意)
+  createdAt   DateTime  @default(now()) // 作成日時
+
+  // 参加先テナント (招待リンクの本質。テナント削除で連鎖削除)
+  tenantId String
+  tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId]) // テナント単位の一覧・掃除用
   @@index([expiresAt]) // 期限切れ一括削除を高速化する
 }
 

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -2,10 +2,14 @@
 import { auth } from '@/lib/auth';
 // 現在ログイン中のテナントの動作モード (lite | pro) を取得するヘルパー
 import { getCurrentTenantMode } from '@/lib/tenant';
+// クライアント遷移付きリンク (テナント作成画面への導線)
+import Link from 'next/link';
 // モードの日本語ラベル (現在値の表示に使う)
 import { TENANT_MODE_LABELS } from '@/lib/constants';
 // Lite / Pro 切替フォーム (Client Component)
 import { TenantModeForm } from '@/features/settings/components/TenantModeForm';
+// メンバー招待リンク発行フォーム (Client Component)
+import { InviteForm } from '@/features/settings/components/InviteForm';
 
 // /settings : テナント設定ページ (現状は Lite/Pro モードの切替のみ。管理者専用)
 export default async function SettingsPage() {
@@ -50,6 +54,39 @@ export default async function SettingsPage() {
         </div>
         {/* 切替フォーム本体 (現在値を初期選択として渡す) */}
         <TenantModeForm current={mode} />
+      </section>
+
+      {/* メンバー招待カード */}
+      <section className="space-y-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+        <div>
+          {/* セクション見出し */}
+          <h2 className="text-base font-semibold text-slate-900">メンバーを招待</h2>
+          {/* 説明: リンクを発行して共有する運用を伝える */}
+          <p className="mt-1 text-sm text-slate-500">
+            招待リンクを発行して共有すると、相手は組織のメンバーとして参加できます。
+          </p>
+        </div>
+        {/* 招待リンク発行フォーム本体 */}
+        <InviteForm />
+      </section>
+
+      {/* テナント (組織) 作成カード */}
+      <section className="space-y-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+        <div>
+          {/* セクション見出し */}
+          <h2 className="text-base font-semibold text-slate-900">新しい組織を作成</h2>
+          {/* 説明: 運用者が別組織を立ち上げる導線 */}
+          <p className="mt-1 text-sm text-slate-500">
+            別の組織（テナント）を新規に作成し、その初代管理者を登録します。
+          </p>
+        </div>
+        {/* テナント作成フォームへの導線 (別ページ) */}
+        <Link
+          href="/settings/tenants/new"
+          className="inline-block rounded-lg border border-teal-300 bg-white px-4 py-2 text-sm font-semibold text-teal-800 transition hover:bg-teal-50"
+        >
+          組織を作成する
+        </Link>
       </section>
     </div>
   );

--- a/src/app/(app)/settings/tenants/new/page.tsx
+++ b/src/app/(app)/settings/tenants/new/page.tsx
@@ -1,0 +1,46 @@
+// 現在のセッション (ログイン情報) を取得
+import { auth } from '@/lib/auth';
+// 設定トップへ戻る導線
+import Link from 'next/link';
+// テナント作成フォーム (Client Component)
+import { CreateTenantForm } from '@/features/settings/components/CreateTenantForm';
+
+// /settings/tenants/new : 新しい組織 (テナント) と初代管理者を作成するページ (管理者専用)
+export default async function NewTenantPage() {
+  // セッション取得 (middleware で未ログインは弾かれている前提)
+  const session = await auth();
+  // 未ログイン or tenantId 不在なら何も描画しない (middleware が先に弾く想定の保険)
+  if (!session?.user?.id || !session.user.tenantId) return null;
+
+  // テナント作成は組織管理にあたるため管理者専用。admin 以外には権限なし表示を返す
+  // (middleware は認証のみを担当するため、RBAC はページ側で明示的に強制する)
+  if (session.user.role !== 'admin') {
+    return (
+      <div className="rounded-2xl bg-white py-20 text-center text-slate-400 ring-1 ring-slate-200">
+        <p className="text-sm">この画面は管理者のみ利用できます。</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      {/* パンくず兼戻る導線 */}
+      <Link href="/settings" className="text-sm text-teal-700 hover:underline">
+        ← 設定に戻る
+      </Link>
+
+      {/* ヘッダー: タイトル + 説明文 */}
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">新しい組織を作成</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          別の組織（テナント）を作成し、その初代管理者を登録します。作成した組織は独立して動作します。
+        </p>
+      </div>
+
+      {/* 作成フォーム本体 */}
+      <section className="space-y-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+        <CreateTenantForm />
+      </section>
+    </div>
+  );
+}

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,0 +1,67 @@
+// 招待受諾フォーム (Client Component)
+import { AcceptInviteForm } from '@/features/auth/components/AcceptInviteForm';
+// トークンの有効性を読み取り専用で判定する (消費はしない)
+import { isInvitationAcceptable } from '@/features/auth/actions/accept-invitation';
+// 共通ブランドマーク (シンボル + ワードマーク)
+import { Logo } from '@/components/brand/Logo';
+
+// /invite/[token] : 招待受諾ページ (公開・未認証で開ける)。
+// トークンの有効性を表示時点で判定し、有効なときだけ受諾フォームを出す。
+export default async function InvitePage({
+  params,
+}: {
+  // Next.js 15 では params が Promise として渡される
+  params: Promise<{ token: string }>;
+}) {
+  // URL パスから生トークンを取り出す
+  const { token } = await params;
+  // トークンが「今この瞬間」有効か、メール入力が必要かを判定する (消費はしない)
+  const { acceptable, needsEmail } = await isInvitationAcceptable(token);
+
+  return (
+    // 画面全体: ログイン画面と揃えた柔らかなティールグラデ + 中央寄せ
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-br from-teal-50 via-white to-emerald-50 px-4 py-12">
+      {/* 装飾用の薄いブラー円 (右上) */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -top-24 -right-24 h-72 w-72 rounded-full bg-teal-200/40 blur-3xl"
+      />
+      {/* 装飾用の薄いブラー円 (左下) */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -bottom-24 -left-24 h-72 w-72 rounded-full bg-emerald-200/40 blur-3xl"
+      />
+
+      {/* 受諾カード本体 (前面に出すため z-10) */}
+      <div className="relative z-10 w-full max-w-md rounded-2xl bg-white/95 p-10 shadow-xl ring-1 ring-slate-100 backdrop-blur">
+        {/* 上部: ブランドマーク + 見出し */}
+        <div className="mb-8 flex flex-col items-center text-center">
+          {/* シンボルのみ表示し、画面名は下の h1 に任せる */}
+          <Logo showWordmark={false} size={44} />
+          {/* ページの主見出し */}
+          <h1 className="mt-4 text-2xl font-bold tracking-tight text-slate-900">
+            HelpDesk Hub への招待
+          </h1>
+          {/* 補足コピー */}
+          <p className="mt-3 text-sm text-slate-500">
+            お名前とパスワードを設定すると利用を開始できます
+          </p>
+        </div>
+
+        {acceptable ? (
+          // 有効なトークン: 受諾フォームを表示
+          <AcceptInviteForm token={token} needsEmail={needsEmail} />
+        ) : (
+          // 無効 / 失効 / 使用済み: 受諾できない旨を案内する (詮索余地を減らすため一括メッセージ)
+          <p
+            role="alert"
+            className="rounded-lg bg-rose-50 px-4 py-3 text-sm text-rose-700 ring-1 ring-rose-200"
+          >
+            この招待リンクは無効か、有効期限が切れているか、既に使用されています。
+            お手数ですが、管理者に新しい招待リンクの発行を依頼してください。
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,13 +8,8 @@ import { NotificationBell } from './NotificationBell';
 import { MobileNavToggle } from './MobileNavToggle';
 // ログアウト用サーバーアクション
 import { logout } from '@/features/auth/actions/logout';
-
-// ロール表示用の日本語ラベル (技術名を画面に出さないため)
-const ROLE_LABELS: Record<string, string> = {
-  admin: '管理者',
-  agent: '担当者',
-  requester: '依頼者',
-};
+// ロール表示用の日本語ラベル (一元管理された単一参照元。技術名を画面に出さないため)
+import { ROLE_LABELS } from '@/lib/constants';
 
 // 名前から最大 2 文字のイニシャル (アバター用) を作る
 // 日本語名は先頭 1 文字、英語名は単語頭を 2 文字に

--- a/src/data/adapters/memory/index.ts
+++ b/src/data/adapters/memory/index.ts
@@ -4,6 +4,7 @@ import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
 import { makeAttachmentRepo } from './attachment-repository.memory';
 import { makeCategoryRepo } from './category-repository.memory';
 import { makeFaqRepo } from './faq-repository.memory';
+import { makeInvitationRepo } from './invitation-repository.memory';
 import { makeMagicLinkRepo } from './magic-link-repository.memory';
 import { makeNotificationRepo } from './notification-repository.memory';
 import { cloneStore, createEmptyStore, overwriteStore, type Store } from './store';
@@ -30,6 +31,7 @@ export function buildMemoryRepos(store: Store): Repos {
     categories: makeCategoryRepo(store),
     tenants: makeTenantRepo(store),
     magicLinks: makeMagicLinkRepo(store),
+    invitations: makeInvitationRepo(store),
     attachments: makeAttachmentRepo(store),
   };
 }

--- a/src/data/adapters/memory/invitation-repository.memory.ts
+++ b/src/data/adapters/memory/invitation-repository.memory.ts
@@ -1,0 +1,105 @@
+// InvitationRepository の契約 (port) をインポート
+import type { InvitationRepository } from '@/data/ports/invitation-repository';
+// ドメイン型
+import type { Invitation } from '@/domain/types';
+// メモリストア型と ID 生成関数
+import { nextId, type Store } from './store';
+
+// メモリストアを使った Invitation リポジトリを生成する関数 (テスト用)
+export function makeInvitationRepo(store: Store): InvitationRepository {
+  return {
+    // 新規招待を 1 件作成してストアに登録
+    async create(input) {
+      // 新しい招待行を組み立てる
+      const invitation: Invitation = {
+        id: nextId(store, 'inv'), // 'inv_...' 形式の一意 ID
+        tokenHash: input.tokenHash,
+        email: input.email ?? null,
+        role: input.role,
+        expiresAt: input.expiresAt,
+        consumedAt: null, // 作成直後は未消費
+        invitedById: input.invitedById ?? null,
+        tenantId: input.tenantId,
+        createdAt: new Date(),
+      };
+      // ストアの Map に登録
+      store.invitations.set(invitation.id, invitation);
+      // 防御的コピーを返す (外から書き換えできないように)
+      return { ...invitation };
+    },
+
+    // tokenHash で 1 件取得 (見つからなければ null)
+    async findByTokenHash(tokenHash) {
+      // 全招待を走査し、tokenHash 一致のものを探す
+      for (const inv of store.invitations.values()) {
+        if (inv.tokenHash === tokenHash) {
+          // 防御的コピーを返す
+          return { ...inv };
+        }
+      }
+      // 見つからなければ null
+      return null;
+    },
+
+    // tokenHash で「未消費かつ失効前」の招待を原子的に消費する。
+    // JS は単一スレッドのため、check + update の間に他の callback は割り込めない。
+    // 関数本体で await を一切挟まないことで、見た目上の同時呼び出しでも片方しか成功しないことを保証する。
+    async consumeValidToken({ tokenHash, now }) {
+      // 全招待を走査して tokenHash 一致のエントリを探す
+      let targetId: string | null = null;
+      for (const [id, inv] of store.invitations) {
+        if (inv.tokenHash === tokenHash) {
+          targetId = id;
+          break;
+        }
+      }
+      // 該当なし
+      if (targetId === null) return null;
+      // 対象行を取得
+      const row = store.invitations.get(targetId)!;
+      // 既に消費済み
+      if (row.consumedAt !== null) return null;
+      // 失効済み
+      if (row.expiresAt < now) return null;
+      // 消費印を打って Map を上書き (await を挟まないので race にならない)
+      const updated = { ...row, consumedAt: now };
+      store.invitations.set(targetId, updated);
+      // 呼び出し側へ防御的コピーを返す
+      return { ...updated };
+    },
+
+    // 指定 ID を 1 件物理削除する (rollback 用)。存在しなければ何もしない
+    async deleteById(id) {
+      store.invitations.delete(id);
+    },
+
+    // expiresAt が now より前の招待を一括削除して件数を返す
+    async deleteExpired(now) {
+      let count = 0; // 削除件数カウンタ
+      // 全招待を走査
+      for (const [id, inv] of store.invitations) {
+        // 失効済みのものだけ削除
+        if (inv.expiresAt < now) {
+          store.invitations.delete(id);
+          count += 1;
+        }
+      }
+      // 削除件数を返す
+      return count;
+    },
+
+    // 指定テナント宛に since 以降に発行された招待件数を数える
+    async countRecentByTenant(tenantId, since) {
+      let count = 0; // カウンタ
+      // 全招待を走査
+      for (const inv of store.invitations.values()) {
+        // tenantId 一致 + createdAt >= since の条件で数える
+        if (inv.tenantId === tenantId && inv.createdAt >= since) {
+          count += 1;
+        }
+      }
+      // 件数を返す
+      return count;
+    },
+  };
+}

--- a/src/data/adapters/memory/store.ts
+++ b/src/data/adapters/memory/store.ts
@@ -1,6 +1,7 @@
 // ドメイン型をインポート (メモリストア内に保持するデータ型)
 import type {
   FaqCandidate,
+  Invitation,
   MagicLinkToken,
   Notification,
   Tenant,
@@ -34,6 +35,7 @@ export interface Store {
   faq: Map<string, FaqCandidate>; // FAQ 候補
   notifications: Map<string, Notification>; // 通知
   magicLinks: Map<string, MagicLinkToken>; // マジックリンクトークン (パスワードレス認証)
+  invitations: Map<string, Invitation>; // 招待リンクトークン (メンバー招待)
   attachments: Map<string, Attachment>; // 添付ファイルのメタ情報 (画像)
   idSeq: { value: number }; // 連番生成用のカウンタ (オブジェクトに包んで参照共有)
 }
@@ -51,6 +53,7 @@ export function createEmptyStore(): Store {
     faq: new Map(),
     notifications: new Map(),
     magicLinks: new Map(),
+    invitations: new Map(),
     attachments: new Map(),
     idSeq: { value: 0 },
   };
@@ -69,6 +72,7 @@ export function cloneStore(src: Store): Store {
     faq: new Map(src.faq),
     notifications: new Map(src.notifications),
     magicLinks: new Map(src.magicLinks),
+    invitations: new Map(src.invitations),
     attachments: new Map(src.attachments),
     idSeq: { value: src.idSeq.value },
   };
@@ -86,6 +90,7 @@ export function overwriteStore(dst: Store, src: Store): void {
   dst.faq = new Map(src.faq);
   dst.notifications = new Map(src.notifications);
   dst.magicLinks = new Map(src.magicLinks);
+  dst.invitations = new Map(src.invitations);
   dst.attachments = new Map(src.attachments);
   // 連番も元に戻す
   dst.idSeq.value = src.idSeq.value;

--- a/src/data/adapters/memory/tenant-repository.memory.ts
+++ b/src/data/adapters/memory/tenant-repository.memory.ts
@@ -1,7 +1,9 @@
 // Tenant リポジトリの契約 (port)
 import type { TenantRepository } from '@/data/ports/tenant-repository';
-// メモリストア型
-import type { Store } from './store';
+// ドメイン型
+import type { Tenant } from '@/domain/types';
+// メモリストア型と ID 生成関数
+import { nextId, type Store } from './store';
 
 // メモリストアを使った Tenant リポジトリを生成する関数 (テスト用)
 export function makeTenantRepo(store: Store): TenantRepository {
@@ -16,6 +18,22 @@ export function makeTenantRepo(store: Store): TenantRepository {
     async findDefault() {
       const t = store.tenants.get('default-tenant');
       return t ? { ...t } : null;
+    },
+
+    // 新規テナント (組織) を 1 件作成する (テナント作成フォーム用)
+    async create(input) {
+      // 新しいテナント行を組み立てる (mode 未指定なら lite)
+      const tenant: Tenant = {
+        id: nextId(store, 'tnt'), // 'tnt_...' 形式の一意 ID
+        name: input.name,
+        mode: input.mode ?? 'lite',
+        industry: input.industry ?? null,
+        createdAt: new Date(),
+      };
+      // ストアの Map に登録
+      store.tenants.set(tenant.id, tenant);
+      // 防御的コピーを返す
+      return { ...tenant };
     },
 
     // テナントの動作モード (lite | pro) を更新し、更新後の Tenant を返す

--- a/src/data/adapters/memory/user-repository.memory.ts
+++ b/src/data/adapters/memory/user-repository.memory.ts
@@ -1,7 +1,7 @@
 // ユーザーリポジトリの契約 (port) と、ドメイン型/ストア型をインポート
 import type { UserRepository } from '@/data/ports/user-repository';
-import type { UserSummary } from '@/domain/types';
-import type { Store } from './store';
+import type { User, UserSummary } from '@/domain/types';
+import { nextId, type Store } from './store';
 
 // メモリストアを使ったユーザーリポジトリを生成する関数
 export function makeUserRepo(store: Store): UserRepository {
@@ -21,6 +21,34 @@ export function makeUserRepo(store: Store): UserRepository {
       }
       // 見つからなければ null
       return null;
+    },
+
+    // 新規ユーザーを 1 件作成する (招待受諾・初代管理者登録用)
+    async create(input) {
+      // email の @unique 制約を擬似的に再現する: 既存メールと重複したら例外で弾く
+      for (const u of store.users.values()) {
+        if (u.email === input.email) {
+          // Prisma の P2002 (unique 制約違反) 相当のエラーを投げて呼び出し側に重複を伝える
+          throw new Error('このメールアドレスは既に登録されています');
+        }
+      }
+      // 現在時刻 (作成・更新日時に使う)
+      const now = new Date();
+      // 新しいユーザー行を組み立てる
+      const user: User = {
+        id: nextId(store, 'usr'), // 'usr_...' 形式の一意 ID
+        email: input.email,
+        name: input.name,
+        passwordHash: input.passwordHash,
+        role: input.role,
+        tenantId: input.tenantId,
+        createdAt: now,
+        updatedAt: now,
+      };
+      // ストアの Map に登録
+      store.users.set(user.id, user);
+      // 防御的コピーを返す
+      return { ...user };
     },
 
     // 当該テナント内の agent または admin を名前順で一覧取得

--- a/src/data/adapters/prisma/index.ts
+++ b/src/data/adapters/prisma/index.ts
@@ -5,6 +5,7 @@ import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
 import { makeAttachmentRepo } from './attachment-repository.prisma';
 import { makeCategoryRepo } from './category-repository.prisma';
 import { makeFaqRepo } from './faq-repository.prisma';
+import { makeInvitationRepo } from './invitation-repository.prisma';
 import { makeMagicLinkRepo } from './magic-link-repository.prisma';
 import { makeNotificationRepo } from './notification-repository.prisma';
 import { makeTenantRepo } from './tenant-repository.prisma';
@@ -31,6 +32,7 @@ export function buildPrismaRepos(db: PrismaLike): Repos {
     categories: makeCategoryRepo(db),
     tenants: makeTenantRepo(db),
     magicLinks: makeMagicLinkRepo(db),
+    invitations: makeInvitationRepo(db),
     attachments: makeAttachmentRepo(db),
   };
 }

--- a/src/data/adapters/prisma/invitation-repository.prisma.ts
+++ b/src/data/adapters/prisma/invitation-repository.prisma.ts
@@ -1,0 +1,80 @@
+// InvitationRepository の契約 (port) をインポート
+import type { InvitationRepository } from '@/data/ports/invitation-repository';
+// Prisma 行 → ドメイン型のマッパー
+import { toInvitation } from './mappers';
+// Prisma クライアント/トランザクション共通型
+import type { PrismaLike } from './types';
+
+// Prisma クライアントを使った Invitation リポジトリを生成する関数
+export function makeInvitationRepo(db: PrismaLike): InvitationRepository {
+  return {
+    // 新規招待を 1 件作成して保存する
+    async create(input) {
+      // Prisma 経由で行を作成
+      const row = await db.invitation.create({
+        data: {
+          tokenHash: input.tokenHash, // 生トークンの SHA-256 ハッシュ
+          tenantId: input.tenantId, // 参加先テナント
+          role: input.role, // 付与する権限
+          expiresAt: input.expiresAt, // 失効時刻
+          email: input.email ?? null, // 宛先メール (任意)
+          invitedById: input.invitedById ?? null, // 発行者 (任意)
+        },
+      });
+      // 作成行をドメイン型に変換して返す
+      return toInvitation(row);
+    },
+
+    // tokenHash で 1 件取得 (見つからなければ null)
+    async findByTokenHash(tokenHash) {
+      // tokenHash は @unique なので findUnique で確実に 1 件取れる
+      const row = await db.invitation.findUnique({ where: { tokenHash } });
+      // 見つかればドメイン型に変換、見つからなければ null
+      return row ? toInvitation(row) : null;
+    },
+
+    // tokenHash で「未消費かつ失効前」の招待を原子的に消費する。
+    // Prisma の updateMany は単一 SQL (UPDATE ... WHERE ...) として評価され、
+    // PostgreSQL の行ロックで並行クリックでも成功は 1 件に限られる。
+    async consumeValidToken({ tokenHash, now }) {
+      // 1 単一 UPDATE: 「未消費 (consumedAt IS NULL) かつ 失効前 (expiresAt >= now)」の行に消費印を立てる
+      const result = await db.invitation.updateMany({
+        where: {
+          tokenHash, // 検索キー (@unique なので最大 1 件)
+          consumedAt: null, // まだ使われていない
+          expiresAt: { gte: now }, // 失効していない
+        },
+        data: { consumedAt: now }, // 消費時刻を打刻
+      });
+      // 0 件 = 既に消費済み / 失効 / 不在 のいずれか
+      if (result.count !== 1) return null;
+      // 消費直後の行を取り直して tenantId / role 等を呼び出し側へ返す
+      const row = await db.invitation.findUnique({ where: { tokenHash } });
+      return row ? toInvitation(row) : null;
+    },
+
+    // 指定 ID を 1 件物理削除する (rollback 用)。存在しない ID でも例外で落とさない
+    async deleteById(id) {
+      // 既に消えている場合に Prisma の P2025 (record not found) を投げさせないよう deleteMany を使う
+      await db.invitation.deleteMany({ where: { id } });
+    },
+
+    // expiresAt が now より前の招待を一括削除して件数を返す
+    async deleteExpired(now) {
+      // 期限切れのものを deleteMany で物理削除
+      const result = await db.invitation.deleteMany({
+        where: { expiresAt: { lt: now } },
+      });
+      // 削除件数 (Prisma の戻り値 .count) を返す
+      return result.count;
+    },
+
+    // 指定テナント宛に since 以降に発行された招待件数を数える (レート制限用)
+    async countRecentByTenant(tenantId, since) {
+      // tenantId + createdAt >= since で件数取得
+      return db.invitation.count({
+        where: { tenantId, createdAt: { gte: since } },
+      });
+    },
+  };
+}

--- a/src/data/adapters/prisma/mappers.ts
+++ b/src/data/adapters/prisma/mappers.ts
@@ -2,6 +2,7 @@
 import type { Prisma } from '@/generated/prisma';
 // ドメイン型 (アダプタが返すべき型) をインポート
 import type {
+  Invitation,
   MagicLinkToken,
   Notification,
   FaqCandidate,
@@ -37,6 +38,8 @@ type HistoryRow = Prisma.TicketHistoryGetPayload<Record<string, never>>;
 type FaqRow = Prisma.FaqCandidateGetPayload<Record<string, never>>;
 // MagicLinkToken テーブルの型エイリアス
 type MagicLinkRow = Prisma.MagicLinkTokenGetPayload<Record<string, never>>;
+// Invitation テーブルの型エイリアス
+type InvitationRow = Prisma.InvitationGetPayload<Record<string, never>>;
 // Attachment テーブルの型エイリアス
 type AttachmentRow = Prisma.AttachmentGetPayload<Record<string, never>>;
 
@@ -144,6 +147,22 @@ export function toMagicLinkToken(row: MagicLinkRow): MagicLinkToken {
     expiresAt: row.expiresAt,
     consumedAt: row.consumedAt,
     requestedIp: row.requestedIp,
+    createdAt: row.createdAt,
+  };
+}
+
+// Prisma の Invitation 行をドメイン型 Invitation に変換する関数
+export function toInvitation(row: InvitationRow): Invitation {
+  // 必要なフィールドだけを詰め替えて返す (生トークンは元から保存していないので無い)
+  return {
+    id: row.id,
+    tokenHash: row.tokenHash,
+    email: row.email,
+    role: row.role,
+    expiresAt: row.expiresAt,
+    consumedAt: row.consumedAt,
+    invitedById: row.invitedById,
+    tenantId: row.tenantId, // 参加先テナント (受諾時の信頼の起点)
     createdAt: row.createdAt,
   };
 }

--- a/src/data/adapters/prisma/tenant-repository.prisma.ts
+++ b/src/data/adapters/prisma/tenant-repository.prisma.ts
@@ -37,6 +37,20 @@ export function makeTenantRepo(db: PrismaLike): TenantRepository {
       return row ? toTenant(row) : null;
     },
 
+    // 新規テナント (組織) を 1 件作成する (運用者向けのテナント作成フォーム用)
+    async create(input) {
+      // Prisma 経由で行を作成。mode 未指定なら SMB 既定の lite で作る
+      const row = await db.tenant.create({
+        data: {
+          name: input.name, // 組織名
+          industry: input.industry ?? null, // 業種テンプレ識別子 (任意)
+          mode: input.mode ?? 'lite', // 動作モード (既定 lite)
+        },
+      });
+      // 作成行をドメイン型に変換して返す
+      return toTenant(row);
+    },
+
     // テナントの動作モード (lite | pro) を更新し、更新後の行をドメイン型で返す
     async updateMode(id, mode) {
       // 主キー (tenantId) で対象テナントを特定し mode 列のみ更新する

--- a/src/data/adapters/prisma/user-repository.prisma.ts
+++ b/src/data/adapters/prisma/user-repository.prisma.ts
@@ -18,6 +18,22 @@ export function makeUserRepo(db: PrismaLike): UserRepository {
       return row ? toUser(row) : null;
     },
 
+    // 新規ユーザーを 1 件作成する (招待受諾・初代管理者登録用)
+    async create(input) {
+      // Prisma 経由で行を作成 (email の @unique 制約に反すると P2002 が投げられる)
+      const row = await db.user.create({
+        data: {
+          email: input.email, // ログイン用メール (正規化済み)
+          name: input.name, // 表示名
+          passwordHash: input.passwordHash, // bcrypt 済みハッシュ
+          role: input.role, // 付与する権限
+          tenantId: input.tenantId, // 所属テナント
+        },
+      });
+      // 作成行をドメイン型に変換して返す
+      return toUser(row);
+    },
+
     // 当該テナント内の agent または admin を名前順で取得 (担当者候補)
     async listAgents(tenantId) {
       const rows = await db.user.findMany({

--- a/src/data/ports/invitation-repository.ts
+++ b/src/data/ports/invitation-repository.ts
@@ -1,0 +1,40 @@
+// 招待リンクのドメイン型を参照
+import type { Invitation } from '@/domain/types';
+// 付与権限の型 (requester=メンバー / agent=担当者)
+import type { Role } from '@/domain/types';
+
+// テナントへのメンバー招待リンク (ワンタイムトークン) 保管リポジトリの契約 (port)。
+// MagicLinkRepository と構造はほぼ同じだが、発行時点で参加先 (tenantId) と付与権限 (role) が
+// 確定している点が異なる。受諾時はこのテーブルの tenantId を信頼の起点にし、リクエスト入力から
+// テナントを注入させない (クロステナント参加の防止)。
+export interface InvitationRepository {
+  // 新しい招待を 1 件作成して保存する。tokenHash は呼び出し側で SHA-256 済みの値を渡す
+  create(input: {
+    tokenHash: string; // 生トークンの SHA-256 ハッシュ
+    tenantId: string; // 参加先テナント ID (発行者のセッション由来のみを渡す契約)
+    role: Role; // 参加後に付与する権限
+    expiresAt: Date; // 失効時刻
+    email?: string | null; // 宛先メール (任意)
+    invitedById?: string | null; // 発行した admin の User ID (監査用、任意)
+  }): Promise<Invitation>;
+
+  // tokenHash で 1 件取得 (見つからなければ null)。読み取り専用の検査用途
+  findByTokenHash(tokenHash: string): Promise<Invitation | null>;
+
+  // tokenHash で「未消費 かつ 失効前」の招待を **原子的に** 消費する。
+  // 検索 + 検証 + 消費印を 1 操作で行うことで、同一リンクの並行クリックでも高々 1 件しか
+  // 成功させない (ワンタイム性を DB 層で担保。MagicLinkRepository と同じ思想)。
+  // 戻り値:
+  //   - 該当行が見つかり消費に成功 → 消費後のドメイン型 (tenantId / role を呼び出し側で利用)
+  //   - 既に消費済み / 失効済み / 存在しない → null
+  consumeValidToken(input: { tokenHash: string; now: Date }): Promise<Invitation | null>;
+
+  // 指定 ID の招待を 1 件物理削除する (メール送信失敗時の rollback 用)
+  deleteById(id: string): Promise<void>;
+
+  // expiresAt が now より前の招待を一括削除 (掃除用)。削除件数を返す
+  deleteExpired(now: Date): Promise<number>;
+
+  // 指定テナント宛に since 以降に発行された招待件数を返す (発行レート制限用)
+  countRecentByTenant(tenantId: string, since: Date): Promise<number>;
+}

--- a/src/data/ports/tenant-repository.ts
+++ b/src/data/ports/tenant-repository.ts
@@ -5,6 +5,9 @@ import type { Tenant, TenantMode } from '@/domain/types';
 export interface TenantRepository {
   findById(id: string): Promise<Tenant | null>; // 主キー検索
   findDefault(): Promise<Tenant | null>; // ピボット途中で使う 'default-tenant' を取得する便利メソッド
+  // 新規テナント (組織) を 1 件作成する (運用者向けのテナント作成フォームで使う)。
+  // mode 未指定なら SMB 既定の lite で作る。
+  create(input: { name: string; industry?: string | null; mode?: TenantMode }): Promise<Tenant>;
   // テナントの動作モード (lite | pro) を更新し、更新後の Tenant を返す
   // id はセッション由来の tenantId のみを渡す契約 (リクエスト入力から注入しないこと = クロステナント防止)
   updateMode(id: string, mode: TenantMode): Promise<Tenant>;

--- a/src/data/ports/unit-of-work.ts
+++ b/src/data/ports/unit-of-work.ts
@@ -2,6 +2,7 @@
 import type { AttachmentRepository } from './attachment-repository';
 import type { CategoryRepository } from './category-repository';
 import type { FaqRepository } from './faq-repository';
+import type { InvitationRepository } from './invitation-repository';
 import type { MagicLinkRepository } from './magic-link-repository';
 import type { NotificationRepository } from './notification-repository';
 import type { TenantRepository } from './tenant-repository';
@@ -21,6 +22,7 @@ export interface Repos {
   categories: CategoryRepository; // カテゴリ操作
   tenants: TenantRepository; // テナント操作 (マルチテナント化)
   magicLinks: MagicLinkRepository; // マジックリンクトークン操作 (パスワードレス認証)
+  invitations: InvitationRepository; // 招待リンクトークン操作 (メンバー招待)
   attachments: AttachmentRepository; // 添付ファイル (画像) のメタ情報操作
 }
 

--- a/src/data/ports/user-repository.ts
+++ b/src/data/ports/user-repository.ts
@@ -1,5 +1,5 @@
 // ドメイン層のユーザー型をインポート
-import type { User, UserSummary } from '@/domain/types';
+import type { Role, User, UserSummary } from '@/domain/types';
 
 // ユーザー取得系リポジトリの契約 (port)
 // 認証フローで使う findById / findByEmail は **tenantId スコープなし** (どのテナントに
@@ -8,6 +8,16 @@ import type { User, UserSummary } from '@/domain/types';
 export interface UserRepository {
   findById(id: string): Promise<User | null>; // ID 指定で 1 件取得 (認証用、テナント横断)
   findByEmail(email: string): Promise<User | null>; // メール指定で 1 件取得 (ログイン用、テナント横断)
+  // 新規ユーザーを 1 件作成する (招待受諾・テナント作成時の初代管理者登録で使う)。
+  // tenantId は招待行 / 作成テナント由来のみを渡す契約 (リクエスト入力から注入しないこと)。
+  // email は @unique 制約のため、重複時はアダプタが例外を投げる (呼び出し側で握って案内する)。
+  create(input: {
+    email: string; // ログイン用メール (小文字正規化済みであること)
+    name: string; // 表示名
+    passwordHash: string; // bcrypt 済みパスワードハッシュ (平文は渡さない)
+    role: Role; // 付与する権限
+    tenantId: string; // 所属テナント ID
+  }): Promise<User>;
   /** Agents and admins in the given tenant. */
   listAgents(tenantId: string): Promise<UserSummary[]>; // 当該テナント内の agent/admin 一覧
   listAgentIds(tenantId: string): Promise<string[]>; // 当該テナント内の agent/admin の ID だけ

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -134,6 +134,21 @@ export interface MagicLinkToken {
   createdAt: Date; // 作成日時
 }
 
+// テナントへのメンバー招待リンク 1 件分
+// 生トークンは URL のみで保持し、DB には SHA-256 ハッシュ (tokenHash) を保存する。
+// 発行時点で参加先 (tenantId) と付与権限 (role) が確定しているのが MagicLinkToken との違い。
+export interface Invitation {
+  id: string; // 招待 ID (主キー)
+  tokenHash: string; // 生トークンの SHA-256 ハッシュ
+  email: string | null; // 宛先メール (任意。未指定ならリンク手渡し想定)
+  role: Role; // 参加後に付与する権限 (requester=メンバー / agent=担当者)
+  expiresAt: Date; // 失効時刻 (発行 7 日後)
+  consumedAt: Date | null; // 受諾済み時刻。null なら未使用 (単回使用を強制)
+  invitedById: string | null; // 発行した admin の User ID (監査用)
+  tenantId: string; // 参加先テナント ID (受諾時はこの値でユーザーを作る = 入力から注入しない)
+  createdAt: Date; // 作成日時
+}
+
 // ユーザー向け通知 1 件分
 export interface Notification {
   id: string; // 通知 ID

--- a/src/features/auth/actions/accept-invitation.ts
+++ b/src/features/auth/actions/accept-invitation.ts
@@ -21,8 +21,8 @@ import { hash } from 'bcryptjs';
 import { repos, uow } from '@/data';
 // 招待トークンのハッシュ化 (生トークン → DB 保存値と同じ SHA-256 へ)
 import { hashInviteToken } from '@/lib/invite';
-// 受諾フォームの入力検証スキーマと、宛先メール任意入力の正規化用スキーマ
-import { acceptInvitationSchema } from '@/lib/validations/invite';
+// 受諾フォームの入力検証スキーマと、ユーザー入力メールの検証・正規化スキーマ
+import { acceptInvitationSchema, emailSchema } from '@/lib/validations/invite';
 
 // accept の戻り値型。作成に使ったメールを返し、クライアントがそのままログインに使う
 export interface AcceptInvitationResult {
@@ -47,12 +47,22 @@ export async function acceptInvitation(
   // 検証済みの氏名・パスワード
   const { name, password } = parsed.data;
 
-  // 招待行に email が無い場合に使う「招待される人が自分で入力したメール」を取り出して正規化する
+  // 招待行に email が無い場合に使う「招待される人が自分で入力したメール」を取り出す。
+  // 空文字/空白だけなら未入力扱い (null)、入力があれば共通スキーマでメール形式・長さを検証する。
+  // (trim/lowercase だけだと不正形式や過大長がそのまま User.email に入り、Prisma 500 になり得る)
   const rawInputEmail = formData.get('email');
-  const inputEmail =
-    typeof rawInputEmail === 'string' && rawInputEmail.trim() !== ''
-      ? rawInputEmail.trim().toLowerCase()
-      : null;
+  let inputEmail: string | null = null;
+  // 文字列かつ空白除去後に中身がある場合のみ検証へ回す
+  if (typeof rawInputEmail === 'string' && rawInputEmail.trim() !== '') {
+    // メール形式・最大長を検証し、小文字へ正規化する
+    const emailParsed = emailSchema.safeParse(rawInputEmail);
+    // 形式不正・過大長ならユーザー向け日本語メッセージで throw (消費前に弾く)
+    if (!emailParsed.success) {
+      throw new Error(emailParsed.error.issues[0]?.message ?? '正しいメールアドレスを入力してください');
+    }
+    // 検証済みの正規化メール
+    inputEmail = emailParsed.data;
+  }
 
   // 生トークンを DB 保存値と同じ SHA-256 ハッシュへ変換する
   const tokenHash = await hashInviteToken(rawToken);

--- a/src/features/auth/actions/accept-invitation.ts
+++ b/src/features/auth/actions/accept-invitation.ts
@@ -1,0 +1,119 @@
+'use server';
+
+/**
+ * 招待受諾サーバーアクション (公開)。
+ *
+ * 招待リンクのトークンと、招待された人が入力した氏名・パスワードを受け取り、
+ * 招待行が指すテナント・権限でユーザーを 1 件作成する。トークンが「秘密」であることが
+ * 認可の根拠なので auth() は不要 (公開アクション)。
+ *
+ * セキュリティ要点:
+ *  - tenantId / role は **招待行 (consumeValidToken の戻り) からのみ** 取り出す。
+ *    リクエスト入力には tenantId を一切含めない (クロステナント参加の防止 / §5.6)。
+ *  - 消費 (単回使用ガード) とユーザー作成を 1 トランザクションで行い、作成失敗時は
+ *    消費もロールバックして招待を無駄に焼かない。
+ *  - パスワードは bcrypt でハッシュ化して保存する (平文は保存しない / §9)。
+ */
+
+// bcrypt によるパスワードハッシュ化 (seed と同じ cost 12)
+import { hash } from 'bcryptjs';
+// データ層の Composition Root (リポジトリ束とトランザクション境界)
+import { repos, uow } from '@/data';
+// 招待トークンのハッシュ化 (生トークン → DB 保存値と同じ SHA-256 へ)
+import { hashInviteToken } from '@/lib/invite';
+// 受諾フォームの入力検証スキーマと、宛先メール任意入力の正規化用スキーマ
+import { acceptInvitationSchema } from '@/lib/validations/invite';
+
+// accept の戻り値型。作成に使ったメールを返し、クライアントがそのままログインに使う
+export interface AcceptInvitationResult {
+  email: string; // 作成したユーザーのログイン用メール
+}
+
+// 招待を受諾してユーザーを作成するサーバーアクション。
+// rawToken は受諾ページの URL から、name/password/email はフォームから渡る。
+export async function acceptInvitation(
+  rawToken: string,
+  formData: FormData,
+): Promise<AcceptInvitationResult> {
+  // フォーム入力 (氏名・パスワード) を Zod で検証する
+  const parsed = acceptInvitationSchema.safeParse({
+    name: formData.get('name'),
+    password: formData.get('password'),
+  });
+  // 検証失敗ならユーザー向け日本語メッセージで throw
+  if (!parsed.success) {
+    throw new Error(parsed.error.issues[0]?.message ?? '入力が正しくありません');
+  }
+  // 検証済みの氏名・パスワード
+  const { name, password } = parsed.data;
+
+  // 招待行に email が無い場合に使う「招待される人が自分で入力したメール」を取り出して正規化する
+  const rawInputEmail = formData.get('email');
+  const inputEmail =
+    typeof rawInputEmail === 'string' && rawInputEmail.trim() !== ''
+      ? rawInputEmail.trim().toLowerCase()
+      : null;
+
+  // 生トークンを DB 保存値と同じ SHA-256 ハッシュへ変換する
+  const tokenHash = await hashInviteToken(rawToken);
+  // 消費判定の基準時刻
+  const now = new Date();
+
+  // 消費 (単回使用ガード) → ユーザー作成を 1 トランザクションで行う。
+  // 途中で例外が出れば消費もロールバックされ、招待リンクは再利用可能なまま残る。
+  const result = await uow.run(async (tx) => {
+    // 招待を原子的に消費する。未消費かつ失効前のときだけ成功して招待行を返す
+    const invitation = await tx.invitations.consumeValidToken({ tokenHash, now });
+    // 無効 / 失効 / 既使用ならここで中断 (どれも同じ案内にして詮索余地を減らす)
+    if (!invitation) {
+      throw new Error('この招待リンクは無効か、既に使用されています。');
+    }
+
+    // 作成に使うメールを決める: 招待にメールがあればそれを優先 (なりすまし防止)、無ければ入力値
+    const finalEmail = invitation.email ?? inputEmail;
+    // どちらも無ければメール必須エラー
+    if (!finalEmail) {
+      throw new Error('メールアドレスは必須です');
+    }
+
+    // 既存ユーザーとの重複を事前チェック (@unique 制約より親切な日本語エラーを返すため)
+    const existing = await tx.users.findByEmail(finalEmail);
+    if (existing) {
+      throw new Error('このメールアドレスは既に登録されています。ログインしてください。');
+    }
+
+    // パスワードを bcrypt でハッシュ化 (cost 12。seed と同条件)
+    const passwordHash = await hash(password, 12);
+    // 招待行が指すテナント・権限でユーザーを作成する (tenantId は入力ではなく invitation 由来)
+    await tx.users.create({
+      email: finalEmail,
+      name,
+      passwordHash,
+      role: invitation.role,
+      tenantId: invitation.tenantId,
+    });
+
+    // クライアントがログインに使うメールを返す
+    return { email: finalEmail };
+  });
+
+  // トランザクションの結果 (作成に使ったメール) を返す
+  return result;
+}
+
+// 受諾ページが「このトークンが今この瞬間に有効か」を表示判定するための読み取り専用ヘルパー。
+// 消費はしない (ページ表示で焼かないため)。期限切れ / 使用済み / 不在なら false を返す。
+export async function isInvitationAcceptable(
+  rawToken: string,
+): Promise<{ acceptable: boolean; needsEmail: boolean }> {
+  // 生トークンを DB 保存値と同じ SHA-256 ハッシュへ変換する
+  const tokenHash = await hashInviteToken(rawToken);
+  // tokenHash で招待を引く (読み取りのみ)
+  const invitation = await repos.invitations.findByTokenHash(tokenHash);
+  // 不在 / 使用済み / 失効はいずれも受諾不可
+  if (!invitation || invitation.consumedAt !== null || invitation.expiresAt < new Date()) {
+    return { acceptable: false, needsEmail: false };
+  }
+  // 招待にメールが無い場合は、受諾フォームでメール入力を求める必要がある
+  return { acceptable: true, needsEmail: invitation.email === null };
+}

--- a/src/features/auth/actions/request-magic-link.ts
+++ b/src/features/auth/actions/request-magic-link.ts
@@ -82,7 +82,7 @@ export async function requestMagicLink(
   const email = parsed.data.email;
 
   // ── 列挙対策マスクの外で設定不備を先に表面化させる ──
-  // getEmailSender() / resolveMagicLinkBaseUrl() は環境変数の妥当性チェックを兼ねるため、
+  // getEmailSender() / resolveAppBaseUrl() は環境変数の妥当性チェックを兼ねるため、
   // ここで投げた例外は呼び出し側 (= 操作した運用者) にそのまま 500 として返したい。
   // ループ内の delivery 例外 (DB / SMTP 一時障害) とは扱いを分ける (Codex P1 指摘)。
   // 未登録メールでも同じく throw されるので列挙耐性は壊れない

--- a/src/features/auth/actions/request-magic-link.ts
+++ b/src/features/auth/actions/request-magic-link.ts
@@ -32,6 +32,8 @@
  */
 // データ層の Composition Root (Prisma 直叩きを避けるための入口)
 import { repos } from '@/data';
+// メール内リンクのベース URL を解決する共通ヘルパー (招待リンクと共有)
+import { resolveAppBaseUrl } from '@/lib/app-url';
 // 環境変数で切り替わる EmailSender 実装を取得するファクトリ
 import { getEmailSender, type EmailSender } from '@/lib/email';
 // マジックリンク用の純粋ヘルパー (トークン生成・ハッシュ・URL 構築・メール本文 + 各種定数)
@@ -65,46 +67,6 @@ async function atLeast<T>(promise: Promise<T>, ms: number): Promise<T> {
   return value;
 }
 
-// マジックリンク URL を組み立てるためのベース URL を解決する。
-// production で NEXTAUTH_URL が未設定だと、メールに http://localhost:3000 のリンクが
-// 入ってユーザーが開けない事故になる (Codex P1 指摘)。fail-fast で運用に伝える。
-// 加えて、空白だけ / scheme なし / ホスト欠落のような壊れた値も WHATWG URL でパースし、
-// 失敗時は明示エラーにする (truthy 判定だけだと不正値が黙って出ていく Codex P2 指摘)
-function resolveMagicLinkBaseUrl(): string {
-  // 前後空白を除去してから空判定する (".env で NEXTAUTH_URL=' ' " などを未指定扱い)
-  const raw = process.env.NEXTAUTH_URL?.trim();
-  // 未設定または空白だけの場合: 本番は即エラー、dev/test は localhost フォールバック
-  if (!raw) {
-    if (process.env.NODE_ENV === 'production') {
-      throw new Error(
-        'NEXTAUTH_URL is required in production to issue working magic-link URLs',
-      );
-    }
-    return 'http://localhost:3000';
-  }
-  // URL として解釈できることを WHATWG URL パーサで検証する
-  let parsed: URL;
-  try {
-    parsed = new URL(raw);
-  } catch {
-    throw new Error(
-      `NEXTAUTH_URL の形式が不正です ("${raw}"): http(s):// で始まる完全な URL を指定してください`,
-    );
-  }
-  // scheme が http/https 以外 (例: file://) や、host が空の URL は弾く
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    throw new Error(
-      `NEXTAUTH_URL の scheme は http または https である必要があります (実際: ${parsed.protocol})`,
-    );
-  }
-  if (!parsed.host) {
-    throw new Error('NEXTAUTH_URL に host が含まれていません');
-  }
-  // バリデーション済みの URL 文字列を返す (raw に含まれていた末尾スラッシュ等の差異は
-  // buildMagicLinkUrl 側で吸収される)
-  return raw;
-}
-
 // 公開する Server Action。フォームから直接呼べる形にする (FormData 経由でも JSON でも可)
 export async function requestMagicLink(
   input: { email: string },
@@ -124,7 +86,7 @@ export async function requestMagicLink(
   // ここで投げた例外は呼び出し側 (= 操作した運用者) にそのまま 500 として返したい。
   // ループ内の delivery 例外 (DB / SMTP 一時障害) とは扱いを分ける (Codex P1 指摘)。
   // 未登録メールでも同じく throw されるので列挙耐性は壊れない
-  const baseUrl = resolveMagicLinkBaseUrl();
+  const baseUrl = resolveAppBaseUrl();
   const sender = getEmailSender();
 
   // 最低限の遅延を確保しつつ本処理を実行する。

--- a/src/features/auth/components/AcceptInviteForm.tsx
+++ b/src/features/auth/components/AcceptInviteForm.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+// クライアント側のサインイン関数とセッション再取得関数 (作成直後の自動ログイン用)
+import { signIn, getSession } from 'next-auth/react';
+// ログイン後のページ遷移に使う
+import { useRouter } from 'next/navigation';
+// 入力状態 (エラー/ローディング) を持つための React フック
+import { useState } from 'react';
+// 招待受諾サーバーアクション
+import { acceptInvitation } from '@/features/auth/actions/accept-invitation';
+// エージェント権限判定 (ログイン後の遷移先決定で利用)
+import { isAgent } from '@/lib/role';
+
+// 受け取る props (受諾対象トークンと、メール入力が必要か)
+interface Props {
+  token: string; // 受諾ページの URL から渡る生トークン
+  needsEmail: boolean; // 招待にメールが無い場合は true (フォームでメールを尋ねる)
+}
+
+// 招待受諾フォーム。氏名・パスワード (必要ならメール) を設定してユーザーを作成し、自動ログインする
+export function AcceptInviteForm({ token, needsEmail }: Props) {
+  // クライアント側のページ遷移用ルーター
+  const router = useRouter();
+  // エラー文言 (受諾失敗時に表示)
+  const [error, setError] = useState('');
+  // 送信中フラグ (連打防止 + ボタン文言切替)
+  const [loading, setLoading] = useState(false);
+
+  // フォーム送信時のハンドラ (受諾 → 自動ログイン)
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    // ブラウザ既定のページ遷移を抑止
+    e.preventDefault();
+    // 直前のエラー表示を消す
+    setError('');
+    // ローディング表示開始
+    setLoading(true);
+
+    // フォーム要素を取得
+    const form = e.currentTarget;
+    // 送信する FormData を組み立てる (name / password / email)
+    const formData = new FormData(form);
+    // 入力したパスワードは自動ログインで再利用するため控えておく
+    const password = (form.elements.namedItem('password') as HTMLInputElement).value;
+
+    try {
+      // 招待を受諾してユーザーを作成する (失敗時は throw される)
+      const { email } = await acceptInvitation(token, formData);
+      // 作成したメール + 設定したパスワードでそのままログインする (redirect はせず結果を見る)
+      const result = await signIn('credentials', { email, password, redirect: false });
+      // ローディング解除
+      setLoading(false);
+      if (result?.error) {
+        // 作成はできたがログインに失敗した稀なケース: ログイン画面へ案内する
+        setError('アカウントを作成しましたが、自動ログインに失敗しました。ログイン画面からお試しください。');
+        return;
+      }
+      // 成功時: 最新セッションを取得し、権限に応じた既定ページへ遷移
+      const session = await getSession();
+      router.push(isAgent(session?.user?.role) ? '/dashboard' : '/tickets');
+    } catch (err) {
+      // ローディング解除
+      setLoading(false);
+      // サーバーアクションの日本語エラーメッセージを表示
+      setError(err instanceof Error ? err.message : '招待の受諾に失敗しました');
+    }
+  }
+
+  return (
+    // フォーム本体
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {/* 氏名入力 */}
+      <div>
+        <label htmlFor="name" className="mb-1.5 block text-sm font-medium text-slate-700">
+          お名前
+        </label>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          required
+          autoComplete="name"
+          className="block w-full rounded-lg border border-slate-200 bg-slate-50/60 px-4 py-2.5 text-sm text-slate-900 transition placeholder:text-slate-400 focus:border-teal-500 focus:bg-white focus:ring-2 focus:ring-teal-500/30 focus:outline-none"
+          placeholder="山田 太郎"
+        />
+      </div>
+
+      {/* メール入力 (招待にメールが無い場合のみ表示) */}
+      {needsEmail && (
+        <div>
+          <label htmlFor="email" className="mb-1.5 block text-sm font-medium text-slate-700">
+            メールアドレス
+          </label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            required
+            autoComplete="email"
+            className="block w-full rounded-lg border border-slate-200 bg-slate-50/60 px-4 py-2.5 text-sm text-slate-900 transition placeholder:text-slate-400 focus:border-teal-500 focus:bg-white focus:ring-2 focus:ring-teal-500/30 focus:outline-none"
+            placeholder="name@example.com"
+          />
+        </div>
+      )}
+
+      {/* パスワード入力 */}
+      <div>
+        <label htmlFor="password" className="mb-1.5 block text-sm font-medium text-slate-700">
+          パスワード（8文字以上）
+        </label>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          required
+          minLength={8}
+          autoComplete="new-password"
+          className="block w-full rounded-lg border border-slate-200 bg-slate-50/60 px-4 py-2.5 text-sm text-slate-900 transition placeholder:text-slate-400 focus:border-teal-500 focus:bg-white focus:ring-2 focus:ring-teal-500/30 focus:outline-none"
+          placeholder="••••••••"
+        />
+      </div>
+
+      {/* エラー文言 (ある場合のみ表示) */}
+      {error && (
+        <p
+          role="alert"
+          className="rounded-lg bg-rose-50 px-3 py-2.5 text-sm text-rose-700 ring-1 ring-rose-200"
+        >
+          {error}
+        </p>
+      )}
+
+      {/* 送信ボタン (ローディング中は無効化) */}
+      <button
+        type="submit"
+        disabled={loading}
+        aria-busy={loading}
+        className="w-full rounded-lg bg-teal-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-teal-800 active:bg-teal-900 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {loading ? '設定中...' : '参加して利用を開始する'}
+      </button>
+    </form>
+  );
+}

--- a/src/features/auth/components/AcceptInviteForm.tsx
+++ b/src/features/auth/components/AcceptInviteForm.tsx
@@ -10,6 +10,8 @@ import { useState } from 'react';
 import { acceptInvitation } from '@/features/auth/actions/accept-invitation';
 // エージェント権限判定 (ログイン後の遷移先決定で利用)
 import { isAgent } from '@/lib/role';
+// パスワード最小長の単一参照元 (サーバー検証スキーマと共有)
+import { PASSWORD_MIN_LENGTH } from '@/lib/validations/invite';
 
 // 受け取る props (受諾対象トークンと、メール入力が必要か)
 interface Props {
@@ -105,14 +107,14 @@ export function AcceptInviteForm({ token, needsEmail }: Props) {
       {/* パスワード入力 */}
       <div>
         <label htmlFor="password" className="mb-1.5 block text-sm font-medium text-slate-700">
-          パスワード（8文字以上）
+          パスワード（{PASSWORD_MIN_LENGTH}文字以上）
         </label>
         <input
           id="password"
           name="password"
           type="password"
           required
-          minLength={8}
+          minLength={PASSWORD_MIN_LENGTH}
           autoComplete="new-password"
           className="block w-full rounded-lg border border-slate-200 bg-slate-50/60 px-4 py-2.5 text-sm text-slate-900 transition placeholder:text-slate-400 focus:border-teal-500 focus:bg-white focus:ring-2 focus:ring-teal-500/30 focus:outline-none"
           placeholder="••••••••"

--- a/src/features/settings/actions/create-invitation.ts
+++ b/src/features/settings/actions/create-invitation.ts
@@ -1,0 +1,118 @@
+'use server';
+
+/**
+ * 招待リンク発行サーバーアクション (管理者専用)。
+ *
+ * admin が自テナントへのメンバー招待リンクを 1 件発行する。生トークンは戻り値の URL で
+ * のみ返し、DB には SHA-256 ハッシュだけを保存する (マジックリンクと同方式)。
+ * email を指定した場合は案内メールも送るが、失敗してもリンク自体は返す (admin が手渡しできる)。
+ *
+ * セキュリティ要点:
+ *  - tenantId / invitedById はセッション由来のみを使い、リクエスト入力から注入させない
+ *    (クロステナント招待の防止 / docs/smb-dx-pivot-plan.md §5.6)。
+ *  - 発行は admin のみ (assertAdminSession)。
+ *  - テナント単位の発行レート制限で招待スパム・誤連打を抑止する。
+ */
+
+// データ層の Composition Root (Prisma 直叩きを避けるための入口)
+import { repos } from '@/data';
+// 現在のセッション (ログイン中ユーザー) を取得
+import { auth } from '@/lib/auth';
+// メール内リンクのベース URL を解決する共通ヘルパー
+import { resolveAppBaseUrl } from '@/lib/app-url';
+// 環境変数で切り替わる EmailSender 実装を取得するファクトリ
+import { getEmailSender } from '@/lib/email';
+// 招待固有のトークン生成・ハッシュ・URL/メール構築・各種定数
+import {
+  buildInviteUrl,
+  generateInviteToken,
+  hashInviteToken,
+  INVITE_RATE_LIMIT_MAX,
+  INVITE_RATE_LIMIT_WINDOW_MS,
+  INVITE_TTL_MS,
+  renderInviteEmail,
+} from '@/lib/invite';
+// 管理者権限を強制する共通アサーション
+import { assertAdminSession } from '@/lib/role';
+// 招待発行フォームの入力検証スキーマ
+import { createInvitationSchema } from '@/lib/validations/invite';
+
+// createInvitation の戻り値型 (発行した招待リンクの URL を返す)
+export interface CreateInvitationResult {
+  url: string; // 受諾ページの URL (admin がコピーして共有する / メールにも入る)
+}
+
+// 招待リンクを 1 件発行するサーバーアクション。フォーム (FormData) から呼ぶ
+export async function createInvitation(formData: FormData): Promise<CreateInvitationResult> {
+  // セッション取得
+  const session = await auth();
+  // 管理者権限を要求 (失敗時は日本語エラーを throw)
+  assertAdminSession(session);
+  // 参加先テナントはログイン中テナントのみ (クロステナント招待の防止)
+  const tenantId = session.user.tenantId;
+
+  // フォーム入力 (role / email) を Zod で検証する
+  const parsed = createInvitationSchema.safeParse({
+    role: formData.get('role'),
+    email: formData.get('email'),
+  });
+  // 検証失敗ならユーザー向け日本語メッセージで throw
+  if (!parsed.success) {
+    throw new Error(parsed.error.issues[0]?.message ?? '入力が正しくありません');
+  }
+  // 検証済みの権限と宛先メール (未指定なら undefined)
+  const { role, email } = parsed.data;
+
+  // 期限切れ招待をベストエフォートで掃除 (専用 cron はフォローアップ課題)
+  await repos.invitations.deleteExpired(new Date());
+
+  // テナント単位の発行レート制限 (招待スパム・誤連打を抑止)。
+  // マジックリンク同様 DB カウントで判定し、再起動をまたいでも効くようにする。
+  const since = new Date(Date.now() - INVITE_RATE_LIMIT_WINDOW_MS);
+  const recent = await repos.invitations.countRecentByTenant(tenantId, since);
+  // 上限超過なら admin にエラーを見せて中断する (マジックリンクと違い列挙耐性は不要)
+  if (recent >= INVITE_RATE_LIMIT_MAX) {
+    throw new Error('招待の発行が多すぎます。しばらく待ってから再度お試しください。');
+  }
+
+  // 256-bit のランダムトークンを生成し、SHA-256 ハッシュを DB に保存する (生は URL のみ)
+  const rawToken = generateInviteToken();
+  const tokenHash = await hashInviteToken(rawToken);
+  // 失効時刻 (現在時刻 + TTL)
+  const expiresAt = new Date(Date.now() + INVITE_TTL_MS);
+  // DB に招待行を作成 (tenantId / invitedById はセッション由来のみ)
+  const created = await repos.invitations.create({
+    tokenHash,
+    tenantId,
+    role,
+    expiresAt,
+    email: email ?? null,
+    invitedById: session.user.id,
+  });
+
+  // 受諾ページの URL を組み立てる (NEXTAUTH_URL ベース)
+  const url = buildInviteUrl(resolveAppBaseUrl(), rawToken);
+
+  // email を指定した場合のみ案内メールを送る。送信失敗してもリンクは返す (admin が手渡し可能)
+  if (email) {
+    try {
+      // 参加先の組織名を取得して件名/本文に使う
+      const tenant = await repos.tenants.findById(tenantId);
+      // 件名 + 本文 (Text / HTML) を構築
+      const { subject, text, html } = renderInviteEmail({
+        url,
+        tenantName: tenant?.name ?? 'HelpDesk Hub',
+        expiresInDays: Math.floor(INVITE_TTL_MS / (24 * 60 * 60 * 1000)),
+      });
+      // EmailSender 経由で送信
+      await getEmailSender().send({ to: email, subject, text, html });
+    } catch (err) {
+      // 送信失敗はログに残すが、招待自体は有効なので URL は返す。
+      // 行を消すとリンクが無効になるため、ここでは created を削除しない
+      console.error('[invite] email delivery failed (link still issued):', created.id, err);
+    }
+  }
+
+  // 発行した招待リンクの URL を返す (画面でコピー表示する)
+  return { url };
+}

--- a/src/features/settings/actions/create-invitation.ts
+++ b/src/features/settings/actions/create-invitation.ts
@@ -54,7 +54,8 @@ export async function createInvitation(formData: FormData): Promise<CreateInvita
   // フォーム入力 (role / email) を Zod で検証する
   const parsed = createInvitationSchema.safeParse({
     role: formData.get('role'),
-    email: formData.get('email'),
+    // 任意フィールドはフォーム未送信時に null になるため空文字へ正規化する (スキーマは '' を許容)
+    email: formData.get('email') ?? '',
   });
   // 検証失敗ならユーザー向け日本語メッセージで throw
   if (!parsed.success) {

--- a/src/features/settings/actions/create-invitation.ts
+++ b/src/features/settings/actions/create-invitation.ts
@@ -54,8 +54,9 @@ export async function createInvitation(formData: FormData): Promise<CreateInvita
   // フォーム入力 (role / email) を Zod で検証する
   const parsed = createInvitationSchema.safeParse({
     role: formData.get('role'),
-    // 任意フィールドはフォーム未送信時に null になるため空文字へ正規化する (スキーマは '' を許容)
-    email: formData.get('email') ?? '',
+    // 任意フィールドは未送信時 null・空白のみの入力も「未指定」扱いにしたいので trim して渡す
+    // (スキーマは '' を未指定として undefined に正規化する)
+    email: (formData.get('email') ?? '').toString().trim(),
   });
   // 検証失敗ならユーザー向け日本語メッセージで throw
   if (!parsed.success) {
@@ -76,6 +77,11 @@ export async function createInvitation(formData: FormData): Promise<CreateInvita
     throw new Error('招待の発行が多すぎます。しばらく待ってから再度お試しください。');
   }
 
+  // 受諾ページ URL のベースを「行を作る前」に解決して fail-fast する。
+  // production で NEXTAUTH_URL 未設定だと resolveAppBaseUrl が throw するが、行作成後に
+  // 呼ぶと招待行だけが孤児として DB に残り URL も admin に渡らない。先に解決して防ぐ。
+  const baseUrl = resolveAppBaseUrl();
+
   // 256-bit のランダムトークンを生成し、SHA-256 ハッシュを DB に保存する (生は URL のみ)
   const rawToken = generateInviteToken();
   const tokenHash = await hashInviteToken(rawToken);
@@ -91,8 +97,8 @@ export async function createInvitation(formData: FormData): Promise<CreateInvita
     invitedById: session.user.id,
   });
 
-  // 受諾ページの URL を組み立てる (NEXTAUTH_URL ベース)
-  const url = buildInviteUrl(resolveAppBaseUrl(), rawToken);
+  // 受諾ページの URL を組み立てる (先に解決済みの baseUrl を使う)
+  const url = buildInviteUrl(baseUrl, rawToken);
 
   // email を指定した場合のみ案内メールを送る。送信失敗してもリンクは返す (admin が手渡し可能)
   if (email) {

--- a/src/features/settings/actions/create-tenant.ts
+++ b/src/features/settings/actions/create-tenant.ts
@@ -1,0 +1,88 @@
+'use server';
+
+/**
+ * テナント作成サーバーアクション (運用者向け・管理者専用)。
+ *
+ * 新しい組織 (テナント) と、その初代管理者 (admin) ユーザーを 1 件ずつ作成する。
+ * セルフサーブ・サインアップやオンボーディングウィザード (業種テンプレ自動投入等) は
+ * Phase 3 の領域なので、ここでは「組織 + 初代管理者を作るだけ」の最小フォームに留める。
+ *
+ * セキュリティ要点:
+ *  - 実行は admin のみ (assertAdminSession)。作成テナントは呼び出し元テナントと独立。
+ *  - テナント作成とユーザー作成を 1 トランザクションで行い、ユーザー作成失敗時 (メール重複等) は
+ *    テナント作成もロールバックして孤児テナントを残さない。
+ *  - パスワードは bcrypt でハッシュ化して保存する (平文は保存しない / §9)。
+ */
+
+// bcrypt によるパスワードハッシュ化 (seed と同じ cost 12)
+import { hash } from 'bcryptjs';
+// データ層の Composition Root (リポジトリ束とトランザクション境界)
+import { uow } from '@/data';
+// 現在のセッション (ログイン中ユーザー) を取得
+import { auth } from '@/lib/auth';
+// 連打防止のための共通レート制限ヘルパー
+import { enforceRateLimit } from '@/lib/rate-limit';
+// 管理者権限を強制する共通アサーション
+import { assertAdminSession } from '@/lib/role';
+// テナント作成フォームの入力検証スキーマ
+import { createTenantSchema } from '@/lib/validations/invite';
+
+// createTenant の戻り値型 (作成したテナント ID と初代管理者メールを返す)
+export interface CreateTenantResult {
+  tenantId: string; // 作成したテナントの ID
+  adminEmail: string; // 初代管理者のログイン用メール
+}
+
+// 新しいテナント + 初代管理者を作成するサーバーアクション。フォーム (FormData) から呼ぶ
+export async function createTenant(formData: FormData): Promise<CreateTenantResult> {
+  // セッション取得
+  const session = await auth();
+  // 管理者権限を要求 (失敗時は日本語エラーを throw)
+  assertAdminSession(session);
+  // テナント作成の連打を抑制 (60 秒あたり 5 回まで、ユーザー単位)
+  enforceRateLimit(`tenant-create:${session.user.id}`, { limit: 5, windowMs: 60_000 });
+
+  // フォーム入力を Zod で検証する
+  const parsed = createTenantSchema.safeParse({
+    tenantName: formData.get('tenantName'),
+    // 任意フィールドはフォーム未送信時に null になるため空文字へ正規化する (スキーマは '' を許容)
+    industry: formData.get('industry') ?? '',
+    adminName: formData.get('adminName'),
+    adminEmail: formData.get('adminEmail'),
+    adminPassword: formData.get('adminPassword'),
+  });
+  // 検証失敗ならユーザー向け日本語メッセージで throw
+  if (!parsed.success) {
+    throw new Error(parsed.error.issues[0]?.message ?? '入力が正しくありません');
+  }
+  // 検証済みの入力値 (industry は未指定なら undefined)
+  const { tenantName, industry, adminName, adminEmail, adminPassword } = parsed.data;
+
+  // テナント作成 → 初代管理者作成を 1 トランザクションで行う。
+  // ユーザー作成 (メール重複等) で失敗したらテナント作成もロールバックして孤児を残さない。
+  const result = await uow.run(async (tx) => {
+    // 先にメール重複を確認 (テナントを作る前に弾けるならその方が無駄がない)
+    const existing = await tx.users.findByEmail(adminEmail);
+    if (existing) {
+      throw new Error('このメールアドレスは既に登録されています。別のメールを指定してください。');
+    }
+
+    // 新しいテナント (組織) を作成する。mode 未指定で SMB 既定の lite になる
+    const tenant = await tx.tenants.create({ name: tenantName, industry: industry ?? null });
+    // パスワードを bcrypt でハッシュ化する (cost 12)
+    const passwordHash = await hash(adminPassword, 12);
+    // 初代管理者 (admin) を作成テナントに所属させて作る
+    await tx.users.create({
+      email: adminEmail,
+      name: adminName,
+      passwordHash,
+      role: 'admin',
+      tenantId: tenant.id,
+    });
+    // 作成結果を返す
+    return { tenantId: tenant.id, adminEmail };
+  });
+
+  // 作成したテナント ID と管理者メールを返す
+  return result;
+}

--- a/src/features/settings/actions/update-tenant-mode.ts
+++ b/src/features/settings/actions/update-tenant-mode.ts
@@ -8,23 +8,10 @@ import { auth } from '@/lib/auth';
 import { repos } from '@/data';
 // 連打防止のための共通レート制限ヘルパー
 import { enforceRateLimit } from '@/lib/rate-limit';
+// 管理者権限を強制する共通アサーション (組織設定系で共有)
+import { assertAdminSession } from '@/lib/role';
 // テナントモード入力 (lite | pro) の Zod 検証スキーマ
 import { tenantModeSchema } from '@/lib/validations/tenant';
-// next-auth のセッション型
-import type { Session } from 'next-auth';
-
-// セッションが管理者 (admin) 権限を持つことを保証するアサーション関数
-// テナント全体の動作モード変更は組織設定にあたるため、agent ではなく admin のみ許可する
-function assertAdminSession(session: Session | null): asserts session is Session {
-  // 未ログイン (ユーザー ID 無し) は拒否
-  if (!session?.user?.id) throw new Error('ログインが必要です');
-  // tenantId 不在は middleware で弾く想定だが、Server Action でも防御的にチェック
-  if (!session.user.tenantId) throw new Error('ログインが必要です');
-  // admin 以外 (agent / requester) は拒否 (テナント設定は管理者専用)
-  if (session.user.role !== 'admin') {
-    throw new Error('この操作は管理者のみ実行できます');
-  }
-}
 
 // テナントの動作モード (lite | pro) を切り替えるサーバーアクション
 export async function updateTenantMode(formData: FormData): Promise<void> {

--- a/src/features/settings/components/CreateTenantForm.tsx
+++ b/src/features/settings/components/CreateTenantForm.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+// 状態管理・非ブロッキング送信のためのフック
+import { useState, useTransition } from 'react';
+// テナント作成のサーバーアクション
+import { createTenant } from '@/features/settings/actions/create-tenant';
+
+// 新しい組織 (テナント) と初代管理者を作成するフォーム
+export function CreateTenantForm() {
+  // 送信中フラグ + トランジション (二重送信防止・ボタン無効化に使う)
+  const [isPending, startTransition] = useTransition();
+  // 作成成功時に表示する初代管理者メール (未作成なら null)
+  const [createdEmail, setCreatedEmail] = useState<string | null>(null);
+  // エラーメッセージ (サーバーアクションが throw した日本語メッセージ)
+  const [error, setError] = useState<string | null>(null);
+
+  // フォーム送信ハンドラ (既定の遷移を止めてアクションを呼ぶ)
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    // ブラウザ既定の送信 (フルリロード) を抑止する
+    e.preventDefault();
+    // 直近のメッセージをリセット
+    setError(null);
+    setCreatedEmail(null);
+    // フォーム内容を FormData にまとめる
+    const formData = new FormData(e.currentTarget);
+    // 送信成功後にフォームをクリアできるよう、要素参照を控える
+    const form = e.currentTarget;
+    // トランジション内でサーバーアクションを実行
+    startTransition(async () => {
+      try {
+        // テナント + 初代管理者を作成する (失敗時は throw される)
+        const result = await createTenant(formData);
+        // 成功表示を出し、入力をクリアする
+        setCreatedEmail(result.adminEmail);
+        form.reset();
+      } catch (err) {
+        // サーバーアクションの日本語エラーメッセージを表示
+        setError(err instanceof Error ? err.message : '組織の作成に失敗しました');
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {/* 組織名 */}
+      <div className="space-y-1">
+        <label htmlFor="tenantName" className="block text-sm font-medium text-slate-700">
+          組織名
+        </label>
+        <input
+          id="tenantName"
+          name="tenantName"
+          type="text"
+          required
+          className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-teal-400 focus:outline-none focus:ring-1 focus:ring-teal-200"
+          placeholder="株式会社サンプル"
+        />
+      </div>
+
+      {/* 業種 (任意) */}
+      <div className="space-y-1">
+        <label htmlFor="industry" className="block text-sm font-medium text-slate-700">
+          業種（任意）
+        </label>
+        <input
+          id="industry"
+          name="industry"
+          type="text"
+          className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-teal-400 focus:outline-none focus:ring-1 focus:ring-teal-200"
+          placeholder="製造業 / 飲食 / 介護 など"
+        />
+      </div>
+
+      {/* 区切り見出し: 初代管理者 */}
+      <fieldset className="space-y-4 border-t border-slate-100 pt-4">
+        <legend className="text-sm font-semibold text-slate-800">初代管理者</legend>
+
+        {/* 管理者氏名 */}
+        <div className="space-y-1">
+          <label htmlFor="adminName" className="block text-sm font-medium text-slate-700">
+            お名前
+          </label>
+          <input
+            id="adminName"
+            name="adminName"
+            type="text"
+            required
+            autoComplete="name"
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-teal-400 focus:outline-none focus:ring-1 focus:ring-teal-200"
+            placeholder="山田 太郎"
+          />
+        </div>
+
+        {/* 管理者メール */}
+        <div className="space-y-1">
+          <label htmlFor="adminEmail" className="block text-sm font-medium text-slate-700">
+            メールアドレス
+          </label>
+          <input
+            id="adminEmail"
+            name="adminEmail"
+            type="email"
+            required
+            autoComplete="email"
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-teal-400 focus:outline-none focus:ring-1 focus:ring-teal-200"
+            placeholder="admin@example.com"
+          />
+        </div>
+
+        {/* 管理者パスワード */}
+        <div className="space-y-1">
+          <label htmlFor="adminPassword" className="block text-sm font-medium text-slate-700">
+            パスワード（8文字以上）
+          </label>
+          <input
+            id="adminPassword"
+            name="adminPassword"
+            type="password"
+            required
+            minLength={8}
+            autoComplete="new-password"
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-teal-400 focus:outline-none focus:ring-1 focus:ring-teal-200"
+            placeholder="••••••••"
+          />
+        </div>
+      </fieldset>
+
+      {/* 成功メッセージ (aria-live でスクリーンリーダーに通知) */}
+      {createdEmail && (
+        <p className="text-sm text-teal-700" role="status" aria-live="polite">
+          組織を作成しました。初代管理者（{createdEmail}）でログインできます。
+        </p>
+      )}
+      {/* エラーメッセージ (色だけでなくテキストでも状態を伝える) */}
+      {error && (
+        <p className="text-sm text-rose-700" role="alert">
+          {error}
+        </p>
+      )}
+
+      {/* 作成ボタン */}
+      <button
+        type="submit"
+        disabled={isPending}
+        className="rounded-lg bg-teal-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-teal-800 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isPending ? '作成中…' : '組織を作成する'}
+      </button>
+    </form>
+  );
+}

--- a/src/features/settings/components/CreateTenantForm.tsx
+++ b/src/features/settings/components/CreateTenantForm.tsx
@@ -4,6 +4,8 @@
 import { useState, useTransition } from 'react';
 // テナント作成のサーバーアクション
 import { createTenant } from '@/features/settings/actions/create-tenant';
+// パスワード最小長の単一参照元 (サーバー検証スキーマと共有)
+import { PASSWORD_MIN_LENGTH } from '@/lib/validations/invite';
 
 // 新しい組織 (テナント) と初代管理者を作成するフォーム
 export function CreateTenantForm() {
@@ -110,14 +112,14 @@ export function CreateTenantForm() {
         {/* 管理者パスワード */}
         <div className="space-y-1">
           <label htmlFor="adminPassword" className="block text-sm font-medium text-slate-700">
-            パスワード（8文字以上）
+            パスワード（{PASSWORD_MIN_LENGTH}文字以上）
           </label>
           <input
             id="adminPassword"
             name="adminPassword"
             type="password"
             required
-            minLength={8}
+            minLength={PASSWORD_MIN_LENGTH}
             autoComplete="new-password"
             className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-teal-400 focus:outline-none focus:ring-1 focus:ring-teal-200"
             placeholder="••••••••"

--- a/src/features/settings/components/InviteForm.tsx
+++ b/src/features/settings/components/InviteForm.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+// 状態管理・非ブロッキング送信のためのフック
+import { useState, useTransition } from 'react';
+// 招待リンク発行のサーバーアクション
+import { createInvitation } from '@/features/settings/actions/create-invitation';
+// 招待可能な権限の一覧と、その日本語ラベル (一元管理された定数)
+import { INVITABLE_ROLES, ROLE_LABELS } from '@/lib/constants';
+// 権限型 (requester | agent | admin)
+import type { Role } from '@/domain/types';
+
+// メンバー招待リンクを発行するフォーム (権限選択 + 任意メール + リンク表示)
+export function InviteForm() {
+  // 送信中フラグ + トランジション (二重送信防止・ボタン無効化に使う)
+  const [isPending, startTransition] = useTransition();
+  // 選択中の権限 (初期値はメンバー = requester)
+  const [role, setRole] = useState<Role>('requester');
+  // 宛先メール (任意。空ならリンク手渡し)
+  const [email, setEmail] = useState('');
+  // 発行に成功した招待リンクの URL (未発行なら null)
+  const [issuedUrl, setIssuedUrl] = useState<string | null>(null);
+  // 「コピーしました」表示のフラグ
+  const [copied, setCopied] = useState(false);
+  // エラーメッセージ (サーバーアクションが throw した日本語メッセージ)
+  const [error, setError] = useState<string | null>(null);
+
+  // フォーム送信ハンドラ (既定の遷移を止めてアクションを呼ぶ)
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    // ブラウザ既定の送信 (フルリロード) を抑止する
+    e.preventDefault();
+    // 直近のメッセージをリセット
+    setError(null);
+    setCopied(false);
+    // 送信する FormData を組み立てる (role / email)
+    const formData = new FormData();
+    formData.set('role', role);
+    formData.set('email', email);
+    // トランジション内でサーバーアクションを実行
+    startTransition(async () => {
+      try {
+        // 招待リンクを発行 (失敗時は throw されるので catch で拾う)
+        const result = await createInvitation(formData);
+        // 発行された URL を保持して画面に表示する
+        setIssuedUrl(result.url);
+      } catch (err) {
+        // サーバーアクションの日本語エラーメッセージを表示
+        setError(err instanceof Error ? err.message : '招待リンクの発行に失敗しました');
+      }
+    });
+  }
+
+  // 発行された URL をクリップボードにコピーするハンドラ
+  async function handleCopy() {
+    // 発行済み URL が無ければ何もしない
+    if (!issuedUrl) return;
+    try {
+      // Clipboard API でコピー (HTTPS / localhost で利用可能)
+      await navigator.clipboard.writeText(issuedUrl);
+      // コピー成功表示を出す
+      setCopied(true);
+    } catch {
+      // コピーに失敗してもエラーにはしない (URL はテキストとして選択可能なため)
+      setCopied(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {/* 権限選択 (メンバー / 担当者) */}
+      <fieldset className="space-y-2">
+        {/* スクリーンリーダー向けにグループの目的を伝える凡例 */}
+        <legend className="text-sm font-medium text-slate-700">招待する人の権限</legend>
+        <div className="flex flex-wrap gap-3">
+          {INVITABLE_ROLES.map((r) => {
+            // この選択肢が現在選択中か
+            const isChecked = role === r;
+            return (
+              <label
+                key={r}
+                // 選択中はティールで強調する
+                className={`flex cursor-pointer items-center gap-2 rounded-lg border px-4 py-2 text-sm transition ${
+                  isChecked
+                    ? 'border-teal-400 bg-teal-50/60 ring-1 ring-teal-200'
+                    : 'border-slate-200 bg-white hover:border-teal-200'
+                }`}
+              >
+                {/* ラジオボタン本体 (name を揃えて単一選択にする) */}
+                <input
+                  type="radio"
+                  name="role"
+                  value={r}
+                  checked={isChecked}
+                  onChange={() => setRole(r)}
+                  className="h-4 w-4 accent-teal-600"
+                />
+                {/* 権限ラベル (メンバー / 担当者) */}
+                <span className="font-medium text-slate-800">{ROLE_LABELS[r]}</span>
+              </label>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      {/* 宛先メール (任意) */}
+      <div className="space-y-1">
+        {/* 入力に対応するラベル (a11y) */}
+        <label htmlFor="invite-email" className="block text-sm font-medium text-slate-700">
+          宛先メール（任意）
+        </label>
+        {/* 任意入力。指定すると案内メールも届く */}
+        <input
+          id="invite-email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="member@example.com"
+          className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-teal-400 focus:outline-none focus:ring-1 focus:ring-teal-200"
+        />
+        {/* 補足: メール未指定でもリンクは発行できる */}
+        <p className="text-xs text-slate-500">
+          メールを入力すると案内メールも送ります。空欄の場合は発行されたリンクを手渡しできます。
+        </p>
+      </div>
+
+      {/* エラーメッセージ (色だけでなくテキストでも状態を伝える) */}
+      {error && (
+        <p className="text-sm text-rose-700" role="alert">
+          {error}
+        </p>
+      )}
+
+      {/* 発行ボタン */}
+      <button
+        type="submit"
+        disabled={isPending}
+        className="rounded-lg bg-teal-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-teal-800 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isPending ? '発行中…' : '招待リンクを発行する'}
+      </button>
+
+      {/* 発行された招待リンクの表示 (コピー可能) */}
+      {issuedUrl && (
+        // aria-live で発行結果をスクリーンリーダーに通知する
+        <div className="space-y-2 rounded-xl border border-teal-200 bg-teal-50/60 p-4" aria-live="polite">
+          {/* 見出し */}
+          <p className="text-sm font-semibold text-teal-800">招待リンクを発行しました</p>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            {/* 発行 URL (読み取り専用。選択してコピーもできる) */}
+            <input
+              type="text"
+              readOnly
+              value={issuedUrl}
+              aria-label="発行された招待リンク"
+              className="w-full flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 font-mono text-xs text-slate-700"
+              onFocus={(e) => e.currentTarget.select()}
+            />
+            {/* コピーボタン */}
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="shrink-0 rounded-lg border border-teal-300 bg-white px-3 py-2 text-sm font-medium text-teal-800 transition hover:bg-teal-50"
+            >
+              {copied ? 'コピーしました' : 'リンクをコピー'}
+            </button>
+          </div>
+          {/* 補足: このリンクを共有すると相手が参加できる */}
+          <p className="text-xs text-slate-500">
+            このリンクを共有すると、相手はお名前とパスワードを設定して利用を開始できます。
+          </p>
+        </div>
+      )}
+    </form>
+  );
+}

--- a/src/lib/app-url.ts
+++ b/src/lib/app-url.ts
@@ -14,7 +14,7 @@ export function resolveAppBaseUrl(): string {
   // 未設定または空白だけの場合: 本番は即エラー、dev/test は localhost フォールバック
   if (!raw) {
     if (process.env.NODE_ENV === 'production') {
-      throw new Error('NEXTAUTH_URL is required in production to issue working magic-link URLs');
+      throw new Error('NEXTAUTH_URL is required in production to issue working email links');
     }
     return 'http://localhost:3000';
   }

--- a/src/lib/app-url.ts
+++ b/src/lib/app-url.ts
@@ -1,0 +1,41 @@
+/**
+ * Application base-URL resolver (shared by magic-link & invitation links).
+ *
+ * メールに埋め込むリンクのベース URL を NEXTAUTH_URL から解決する純粋ヘルパー。
+ * production で未設定だと「メールに http://localhost:3000 のリンクが入って開けない」
+ * 事故になるため fail-fast する。マジックリンクと招待リンクの両方が使うため 1 か所に集約した。
+ */
+
+// production で NEXTAUTH_URL が未設定 / 空白だけ / 壊れた形式のときに投げるエラーメッセージ群。
+// メッセージは既存のマジックリンク実装と同一にし、挙動・テスト互換性を保つ。
+export function resolveAppBaseUrl(): string {
+  // 前後空白を除去してから空判定する (".env で NEXTAUTH_URL=' ' " などを未指定扱い)
+  const raw = process.env.NEXTAUTH_URL?.trim();
+  // 未設定または空白だけの場合: 本番は即エラー、dev/test は localhost フォールバック
+  if (!raw) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('NEXTAUTH_URL is required in production to issue working magic-link URLs');
+    }
+    return 'http://localhost:3000';
+  }
+  // URL として解釈できることを WHATWG URL パーサで検証する
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(
+      `NEXTAUTH_URL の形式が不正です ("${raw}"): http(s):// で始まる完全な URL を指定してください`,
+    );
+  }
+  // scheme が http/https 以外 (例: file://) や、host が空の URL は弾く
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(
+      `NEXTAUTH_URL の scheme は http または https である必要があります (実際: ${parsed.protocol})`,
+    );
+  }
+  if (!parsed.host) {
+    throw new Error('NEXTAUTH_URL に host が含まれていません');
+  }
+  // バリデーション済みの URL 文字列を返す (末尾スラッシュ等の差異は呼び出し側 URL 構築で吸収)
+  return raw;
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,5 @@
-// チケット状態型とテナントモード型 (lite | pro) を正準のドメイン型から 1 本でインポート
-import type { TicketStatus, TenantMode } from '@/domain/types';
+// チケット状態型・テナントモード型 (lite | pro)・権限型を正準のドメイン型から 1 本でインポート
+import type { TicketStatus, TenantMode, Role } from '@/domain/types';
 // Lite モードの 3 値型と型ガード関数を取り込み、mode-aware ラベル関数で使う
 import { isLiteStatus, type LiteStatus } from '@/domain/ticket-status';
 
@@ -57,6 +57,18 @@ export const TENANT_MODE_DESCRIPTIONS: Record<TenantMode, string> = {
   // Pro: 7 ステータス・SLA・エスカレーション・FAQ 候補などフル機能を有効化
   pro: '7つのステータス・SLA期限・エスカレーション・FAQ候補など、情シス向けのすべての機能を有効にします。',
 };
+
+// 権限 (Role) の日本語表示ラベル (Pivot plan §3.1 の用語表に基づく)。
+// admin も組織管理者は「対応する人」なので担当者扱いの語彙に寄せる (UI ではロール 2 種に簡素化)。
+export const ROLE_LABELS: Record<Role, string> = {
+  requester: 'メンバー', // 問い合わせを出す人 (依頼者)
+  agent: '担当者', // 問い合わせに対応する人
+  admin: '管理者', // 組織の管理者 (担当者 + 設定権限)
+};
+
+// 招待リンクで付与できる権限の一覧 (招待画面の選択肢に使う)。
+// admin は招待リンク経由では付与しない (管理者は別途テナント作成フォームで登録する想定)。
+export const INVITABLE_ROLES: readonly Role[] = ['requester', 'agent'];
 
 // 優先度キーに対応する日本語表示ラベル
 export const PRIORITY_LABELS: Record<string, string> = {

--- a/src/lib/invite.ts
+++ b/src/lib/invite.ts
@@ -1,0 +1,73 @@
+/**
+ * Invitation-link helpers (pure URL building / email rendering / constants).
+ *
+ * 招待リンクの「生トークン → URL」「招待メール本文」を 1 か所にまとめた純粋ヘルパー。
+ * トークン生成と SHA-256 ハッシュはマジックリンクと同一方式のため `@/lib/magic-link` の
+ * 関数を再利用する (DRY)。招待固有なのは URL パスとメール文面、TTL/レート制限の定数のみ。
+ */
+
+// 生トークンの生成・ハッシュ化はマジックリンクと共通 (Web Crypto 実装)
+export { generateMagicLinkToken as generateInviteToken } from '@/lib/magic-link';
+export { hashMagicLinkToken as hashInviteToken } from '@/lib/magic-link';
+
+// 招待リンクの既定 TTL (7 日)。ログイン用マジックリンク (15 分) より長めにする。
+// 招待は「あとで受け取って登録する」運用が前提のため、即時性は不要で猶予を持たせる。
+export const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+// 同一テナントからの発行レート制限 (招待スパム・誤連打対策)。1 時間に 30 件までを上限とする。
+export const INVITE_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+// 上記の窓内で許容される発行回数の上限。
+export const INVITE_RATE_LIMIT_MAX = 30;
+
+// 指定した baseUrl と生トークンから、招待される人が踏む受諾ページの URL を組み立てる
+// 例: buildInviteUrl('http://localhost:3000', 'xxx') -> 'http://localhost:3000/invite/xxx'
+export function buildInviteUrl(baseUrl: string, rawToken: string): string {
+  // 末尾のスラッシュをトリムして二重スラッシュを防ぐ
+  const trimmed = baseUrl.replace(/\/$/, '');
+  // トークンは base64url なので URL パスにそのまま入れられるが、念のため encode する
+  return `${trimmed}/invite/${encodeURIComponent(rawToken)}`;
+}
+
+// 招待メール本文 (Text / HTML) を構築する純粋関数。email 指定で招待した場合のみ送信する
+export function renderInviteEmail(input: {
+  url: string; // 受諾ページの URL
+  tenantName: string; // 参加先の組織名 (誰からの招待かを伝える)
+  expiresInDays: number; // 有効期限 (日数)
+}): { subject: string; text: string; html: string } {
+  // 件名 (SMB ユーザー向けに専門用語を避ける)
+  const subject = `${input.tenantName} への招待が届いています`;
+  // テキスト本文 (HTML 非対応クライアント向けフォールバック)
+  const text = [
+    `${input.tenantName} のヘルプデスクに招待されました。`,
+    '',
+    '下のリンクを開いて、お名前とパスワードを設定すると利用を開始できます。',
+    '',
+    `${input.url}`,
+    '',
+    `このリンクの有効期限は約 ${input.expiresInDays} 日です。`,
+    '心当たりがない場合はこのメールを破棄してください。',
+  ].join('\n');
+  // HTML 本文 (URL は href / 表示テキストの両方に入れる)
+  const escapedUrl = escapeHtml(input.url);
+  const escapedTenant = escapeHtml(input.tenantName);
+  const html = `
+    <p>${escapedTenant} のヘルプデスクに招待されました。</p>
+    <p>下のボタンから、お名前とパスワードを設定すると利用を開始できます。</p>
+    <p><a href="${escapedUrl}" style="display:inline-block;padding:10px 16px;background:#0f766e;color:#ffffff;border-radius:6px;text-decoration:none;font-weight:600;">参加する</a></p>
+    <p style="font-size:13px;color:#475569;">うまく開けない場合はこちらの URL をブラウザに貼り付けてください:<br><span style="word-break:break-all;">${escapedUrl}</span></p>
+    <p style="font-size:13px;color:#64748b;">このリンクの有効期限は約 ${input.expiresInDays} 日です。<br>心当たりがない場合はこのメールを破棄してください。</p>
+  `.trim();
+  // 3 点セットを返す
+  return { subject, text, html };
+}
+
+// HTML に挿入する文字列を最低限エスケープする (差出側自前 URL / 組織名でも念のため)
+function escapeHtml(s: string): string {
+  // 危険な 5 文字だけを実体参照に変換
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/src/lib/role.ts
+++ b/src/lib/role.ts
@@ -1,9 +1,26 @@
 // ロール (権限) 型を正準のドメイン型 (@/domain/types) からインポート
 import type { Role } from '@/domain/types';
+// セッション型 (型のみ。middleware の Edge バンドルには実体を持ち込まない)
+import type { Session } from 'next-auth';
 
 // 渡されたロールが「担当者権限を持っている」と判定できるかを返す関数
 // agent または admin ならエージェント扱い (admin 限定チェックではないことに注意)
 export function isAgent(role: Role | string | null | undefined): boolean {
   // 'agent' か 'admin' のいずれかに一致すれば true を返す
   return role === 'agent' || role === 'admin';
+}
+
+// セッションが管理者 (admin) 権限かつ tenantId を持つことを保証するアサーション関数。
+// 組織設定 (モード切替・招待発行・テナント作成) は管理者専用のため、各 Server Action の
+// 冒頭で呼んで RBAC をサーバー側で強制する (UI 非表示には頼らない)。
+// 通過後は session が非 null に narrow され、session.user.tenantId / role を安全に使える。
+export function assertAdminSession(session: Session | null): asserts session is Session {
+  // 未ログイン (ユーザー ID 無し) は拒否
+  if (!session?.user?.id) throw new Error('ログインが必要です');
+  // tenantId 不在は middleware で弾く想定だが、Server Action でも防御的にチェック
+  if (!session.user.tenantId) throw new Error('ログインが必要です');
+  // admin 以外 (agent / requester) は拒否 (組織設定は管理者専用)
+  if (session.user.role !== 'admin') {
+    throw new Error('この操作は管理者のみ実行できます');
+  }
 }

--- a/src/lib/validations/invite.ts
+++ b/src/lib/validations/invite.ts
@@ -1,0 +1,92 @@
+// Zod (スキーマ検証ライブラリ) をインポート
+import { z } from 'zod';
+
+// 招待リンクで付与できる権限は「メンバー (requester)」か「担当者 (agent)」のみ。
+// admin はリンク経由で付与しない (テナント作成フォームで初代管理者を作る運用)。
+export const invitableRoleSchema = z.enum(['requester', 'agent'], {
+  message: '権限の指定が正しくありません',
+});
+
+// 招待リンク発行フォームの入力検証スキーマ
+// - role: 必須 (メンバー / 担当者)
+// - email: 任意 (リンク手渡しもあるため)。指定時はメール形式 + 小文字正規化
+export const createInvitationSchema = z.object({
+  // 付与する権限
+  role: invitableRoleSchema,
+  // 宛先メール (任意)。空文字は「未指定」として扱い null に正規化する
+  email: z
+    .string()
+    .trim()
+    .max(320, 'メールアドレスが長すぎます')
+    .email('正しいメールアドレスを入力してください')
+    .transform((v) => v.toLowerCase())
+    .optional()
+    .or(z.literal('').transform(() => undefined)),
+});
+
+// パスワードの最小長 (招待受諾・テナント作成で共通利用するため定数化)
+export const PASSWORD_MIN_LENGTH = 8;
+// パスワードの最大長 (bcrypt は 72 byte までしか見ないため、過大入力を弾く)
+export const PASSWORD_MAX_LENGTH = 72;
+// 表示名の最大長 (DB は無制限だが現実的な上限を設ける)
+export const NAME_MAX_LENGTH = 100;
+
+// パスワード入力の共通スキーマ (受諾・テナント作成で再利用)
+const passwordSchema = z
+  .string()
+  .min(PASSWORD_MIN_LENGTH, `パスワードは${PASSWORD_MIN_LENGTH}文字以上で入力してください`)
+  .max(PASSWORD_MAX_LENGTH, `パスワードは${PASSWORD_MAX_LENGTH}文字以下で入力してください`);
+
+// 表示名入力の共通スキーマ
+const nameSchema = z
+  .string()
+  .trim()
+  .min(1, 'お名前は必須です')
+  .max(NAME_MAX_LENGTH, 'お名前が長すぎます');
+
+// メール入力の共通スキーマ (必須・正規化)
+const emailSchema = z
+  .string()
+  .trim()
+  .min(1, 'メールアドレスは必須です')
+  .max(320, 'メールアドレスが長すぎます')
+  .email('正しいメールアドレスを入力してください')
+  .transform((v) => v.toLowerCase());
+
+// 招待受諾フォームの入力検証スキーマ (氏名 + パスワード設定)。
+// tenantId / role は招待行から取り出すため入力に含めない (クロステナント参加の防止)。
+export const acceptInvitationSchema = z.object({
+  // 表示名
+  name: nameSchema,
+  // 設定するパスワード
+  password: passwordSchema,
+});
+
+// テナント作成フォーム (運用者向け最小) の入力検証スキーマ。
+// 組織名 + 業種 (任意) + 初代管理者の氏名 / メール / パスワード。
+export const createTenantSchema = z.object({
+  // 組織名
+  tenantName: z
+    .string()
+    .trim()
+    .min(1, '組織名は必須です')
+    .max(NAME_MAX_LENGTH, '組織名が長すぎます'),
+  // 業種テンプレ識別子 (任意。Phase 3 のカテゴリ初期投入で利用予定)
+  industry: z
+    .string()
+    .trim()
+    .max(NAME_MAX_LENGTH, '業種が長すぎます')
+    .optional()
+    .or(z.literal('').transform(() => undefined)),
+  // 初代管理者の氏名
+  adminName: nameSchema,
+  // 初代管理者のメール
+  adminEmail: emailSchema,
+  // 初代管理者のパスワード
+  adminPassword: passwordSchema,
+});
+
+// スキーマから TypeScript 型を生成
+export type CreateInvitationInput = z.infer<typeof createInvitationSchema>;
+export type AcceptInvitationInput = z.infer<typeof acceptInvitationSchema>;
+export type CreateTenantInput = z.infer<typeof createTenantSchema>;

--- a/src/lib/validations/invite.ts
+++ b/src/lib/validations/invite.ts
@@ -44,8 +44,8 @@ const nameSchema = z
   .min(1, 'お名前は必須です')
   .max(NAME_MAX_LENGTH, 'お名前が長すぎます');
 
-// メール入力の共通スキーマ (必須・正規化)
-const emailSchema = z
+// メール入力の共通スキーマ (必須・正規化)。招待受諾でユーザー入力メールの検証にも使うため export する
+export const emailSchema = z
   .string()
   .trim()
   .min(1, 'メールアドレスは必須です')

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,6 +8,9 @@ import { isAgent } from '@/lib/role';
 export default auth((req) => {
   const isLoggedIn = !!req.auth;
   const isAuthPage = req.nextUrl.pathname.startsWith('/login');
+  // 招待受諾ページは未認証で開ける公開ページ (トークン自体が認可の根拠)。
+  // /login と同様にログインガードの対象外にする。
+  const isInvitePage = req.nextUrl.pathname.startsWith('/invite');
   const isApiAuth = req.nextUrl.pathname.startsWith('/api/auth');
   const isApiRoute = req.nextUrl.pathname.startsWith('/api/');
 
@@ -25,13 +28,14 @@ export default auth((req) => {
     return NextResponse.next();
   }
 
-  if (!isLoggedIn && !isAuthPage) {
+  if (!isLoggedIn && !isAuthPage && !isInvitePage) {
     return NextResponse.redirect(new URL('/login', req.url));
   }
 
   // 認証済み HTML 遷移でも tenantId 不在なら /login に戻す (旧 JWT 互換性のセーフティネット)
-  // 通常は auth.ts の jwt callback が補完するが、補完失敗時の最後の砦としてここでも判定する
-  if (isLoggedIn && !isAuthPage && !req.auth?.user?.tenantId) {
+  // 通常は auth.ts の jwt callback が補完するが、補完失敗時の最後の砦としてここでも判定する。
+  // 招待受諾ページは公開のため対象外 (ログイン済みでも閲覧を許す)
+  if (isLoggedIn && !isAuthPage && !isInvitePage && !req.auth?.user?.tenantId) {
     return NextResponse.redirect(new URL('/login', req.url));
   }
 

--- a/tests/data/invitation-repository.contract.prisma.test.ts
+++ b/tests/data/invitation-repository.contract.prisma.test.ts
@@ -1,0 +1,72 @@
+// Vitest のテスト DSL (describe=グループ, beforeAll/afterAll=前後処理)
+import { describe, beforeAll, afterAll } from 'vitest';
+// Prisma クライアント本体 (生成物。DB へ実際に接続して操作する SDK)
+import { PrismaClient } from '@/generated/prisma';
+// 本番 Prisma 実装の repos 束を組み立てる関数
+import { buildPrismaRepos } from '@/data/adapters/prisma';
+// 共通契約テストとそのコンテキスト型 (memory 版と同じものを使い回す)
+import {
+  runInvitationRepositoryContract,
+  type InvitationContractContext,
+} from './invitation-repository.contract';
+
+// テナント A の ID (契約テストの既定テナント)
+const TENANT_A = 'default-tenant';
+// クロステナント回帰テスト用のテナント B の ID
+const TENANT_B = 'tenant-b';
+
+// この DB 依存テストを実行してよいかどうかの明示フラグ (CI の専用ジョブだけが '1' を立てる)
+// DATABASE_URL の有無で判定すると、開発者の dev DB を誤って TRUNCATE しかねないため専用フラグにする
+const SHOULD_RUN = process.env.RUN_PRISMA_CONTRACT === '1';
+
+// Prisma 実装が InvitationRepository 契約を満たすか検証する (フラグが立っているときだけ走る)
+describe.runIf(SHOULD_RUN)('prisma adapter', () => {
+  // beforeAll で生成する PrismaClient を後続のヘルパーから参照するための変数
+  let prisma: PrismaClient;
+
+  // スイート開始時に 1 度だけ DB へ接続する
+  beforeAll(async () => {
+    // PrismaClient を生成 (接続先は環境変数 DATABASE_URL から読まれる)
+    prisma = new PrismaClient();
+    // 実際に DB へ接続を張る (失敗時はここで早期に分かる)
+    await prisma.$connect();
+  });
+
+  // スイート終了時に接続を確実に閉じる (接続リークを防ぐ)
+  afterAll(async () => {
+    // PrismaClient を破棄して接続を解放する
+    await prisma.$disconnect();
+  });
+
+  // 全テーブルを空にしてテスト間の状態を完全に独立させる
+  async function resetDatabase() {
+    // 子テーブル → 親テーブルの順序は CASCADE が吸収する。テーブル名はモデル名と同一 (PascalCase)
+    await prisma.$executeRawUnsafe(
+      'TRUNCATE TABLE "Attachment","TicketHistory","TicketComment","Notification","FaqCandidate","Ticket","Category","Invitation","MagicLinkToken","User","Tenant" RESTART IDENTITY CASCADE',
+    );
+  }
+
+  // Prisma 実装向けに InvitationContractContext を組み立てる (契約の beforeEach から毎回呼ばれる)
+  async function makePrismaContext(): Promise<InvitationContractContext> {
+    // まず DB を空にして、このテスト専用のまっさらな状態を作る
+    await resetDatabase();
+
+    // 本番と同じ組み立て関数で repos 束を生成する
+    const repos = buildPrismaRepos(prisma);
+
+    // テナント A / B を用意するシード
+    const seedTwoTenants: InvitationContractContext['seedTwoTenants'] = async () => {
+      // テナント A / B を作成する (mode は lite で十分)
+      await prisma.tenant.create({ data: { id: TENANT_A, name: 'デフォルト組織', mode: 'lite' } });
+      await prisma.tenant.create({ data: { id: TENANT_B, name: '別組織', mode: 'lite' } });
+      // テスト本体が使うテナント ID を返す
+      return { tenantA: TENANT_A, tenantB: TENANT_B };
+    };
+
+    // 組み立てた repos とシード関数を契約コンテキストとして返す
+    return { repo: repos.invitations, seedTwoTenants };
+  }
+
+  // memory 版と同一の契約スイートを Prisma 実装に対して実行する
+  runInvitationRepositoryContract(makePrismaContext);
+});

--- a/tests/data/invitation-repository.contract.test.ts
+++ b/tests/data/invitation-repository.contract.test.ts
@@ -1,0 +1,45 @@
+// Vitest の describe (テストグループ) のみ使う
+import { describe } from 'vitest';
+// メモリ実装のリポジトリ束 + ストアを作成するファクトリ
+import { createMemoryContext } from '@/data/adapters/memory';
+// 共通契約テストとそのコンテキスト型
+import {
+  runInvitationRepositoryContract,
+  type InvitationContractContext,
+} from './invitation-repository.contract';
+
+// テナント A の ID (マルチテナント化後はあらゆる行で必須)
+const TENANT_A = 'default-tenant';
+// クロステナント回帰テスト用のテナント B の ID
+const TENANT_B = 'tenant-b';
+
+// メモリ実装向けに InvitationContractContext を組み立てる
+function makeMemoryContext(): InvitationContractContext {
+  // 純粋メモリ実装の store / repos を生成する
+  const { store, repos } = createMemoryContext();
+
+  // テナント A / B を用意するシード
+  const seedTwoTenants: InvitationContractContext['seedTwoTenants'] = async () => {
+    // 現在時刻 (作成日時に使う)
+    const now = new Date();
+    // 投入する 2 テナントの定義 (id, name)
+    const tenantDefs: Array<[string, string]> = [
+      [TENANT_A, 'デフォルト組織'],
+      [TENANT_B, '別組織'],
+    ];
+    // 各テナントを store に直接書き込む (mode は lite で十分)
+    for (const [id, name] of tenantDefs) {
+      store.tenants.set(id, { id, name, mode: 'lite', industry: null, createdAt: now });
+    }
+    // テスト本体が使うテナント ID を返す
+    return { tenantA: TENANT_A, tenantB: TENANT_B };
+  };
+
+  // 検証対象の招待リポジトリとシード関数を文脈として返す
+  return { repo: repos.invitations, seedTwoTenants };
+}
+
+// メモリアダプタが InvitationRepository 契約を満たしているかを実行する
+describe('memory adapter', () => {
+  runInvitationRepositoryContract(makeMemoryContext);
+});

--- a/tests/data/invitation-repository.contract.ts
+++ b/tests/data/invitation-repository.contract.ts
@@ -1,0 +1,176 @@
+/**
+ * Invitation repository contract.
+ *
+ * Exported as a plain function (not a `*.test.ts` file) so it can be invoked
+ * against every adapter (memory / Prisma). See
+ * `invitation-repository.contract.test.ts` for the in-memory run and
+ * `invitation-repository.contract.prisma.test.ts` for the DB-backed run.
+ *
+ * 主眼:
+ *  - consumeValidToken がワンタイム性 (単回消費) と失効を守ること。
+ *  - 消費後の招待が参加先 tenantId / role を正しく運ぶこと (受諾フローの信頼の起点)。
+ *  - countRecentByTenant が tenantId スコープを守り、他テナントの発行を数えないこと。
+ */
+
+// Vitest のテスト DSL (describe=グループ, it=ケース, beforeEach=前処理, expect=検証)
+import { describe, expect, it, beforeEach } from 'vitest';
+// 検証対象である招待リポジトリの契約 (port) 型
+import type { InvitationRepository } from '@/data/ports/invitation-repository';
+
+// 契約テストが利用する文脈 (アダプタ別に差し替え可能)
+export interface InvitationContractContext {
+  // 検証対象の招待リポジトリ実装
+  repo: InvitationRepository;
+  // テナント A / テナント B を用意するシード (招待は tenantId を必須とするため)
+  seedTwoTenants: () => Promise<{
+    tenantA: string; // テナント A の ID
+    tenantB: string; // テナント B の ID
+  }>;
+}
+
+// アダプタごとに渡される文脈で同一テストを実行する関数
+export function runInvitationRepositoryContract(
+  makeContext: () => InvitationContractContext | Promise<InvitationContractContext>,
+) {
+  describe('InvitationRepository contract', () => {
+    // テストごとに新しい文脈を保持する変数
+    let ctx: InvitationContractContext;
+
+    // 各テストの前に独立した状態のコンテキストを生成する
+    beforeEach(async () => {
+      ctx = await makeContext();
+    });
+
+    // create で作った招待が findByTokenHash で引け、tenantId / role を保持していること (基本往復)
+    it('create surfaces an invitation via findByTokenHash with tenant and role', async () => {
+      // テナント A / B を用意する
+      const { tenantA } = await ctx.seedTwoTenants();
+      // テナント A 宛・担当者 (agent) 権限の招待を 1 件作成する
+      const expiresAt = new Date(Date.now() + 60_000); // 1 分後に失効
+      await ctx.repo.create({
+        tokenHash: 'hash-1',
+        tenantId: tenantA,
+        role: 'agent',
+        expiresAt,
+      });
+      // tokenHash で引き直すと作成した招待が取れる
+      const found = await ctx.repo.findByTokenHash('hash-1');
+      // 参加先テナントと付与権限が保存されている
+      expect(found?.tenantId).toBe(tenantA);
+      expect(found?.role).toBe('agent');
+      // 作成直後は未消費 (consumedAt が null)
+      expect(found?.consumedAt).toBeNull();
+    });
+
+    // consumeValidToken は未消費・失効前の招待を消費し、参加先 tenantId を返すこと
+    it('consumeValidToken consumes a valid invitation and returns its tenant', async () => {
+      // テナント A / B を用意する
+      const { tenantA } = await ctx.seedTwoTenants();
+      // 有効な招待を 1 件作成する
+      await ctx.repo.create({
+        tokenHash: 'hash-2',
+        tenantId: tenantA,
+        role: 'requester',
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      // 現在時刻で消費する
+      const consumed = await ctx.repo.consumeValidToken({ tokenHash: 'hash-2', now: new Date() });
+      // 消費に成功し、参加先テナントを運んで返す
+      expect(consumed?.tenantId).toBe(tenantA);
+      // 消費印 (consumedAt) が立っている
+      expect(consumed?.consumedAt).not.toBeNull();
+    });
+
+    // 同じ招待リンクは 2 回消費できないこと (ワンタイム性)
+    it('consumeValidToken rejects a second consume (single-use)', async () => {
+      // テナント A / B を用意する
+      const { tenantA } = await ctx.seedTwoTenants();
+      // 有効な招待を 1 件作成する
+      await ctx.repo.create({
+        tokenHash: 'hash-3',
+        tenantId: tenantA,
+        role: 'requester',
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      // 1 回目は成功する
+      const first = await ctx.repo.consumeValidToken({ tokenHash: 'hash-3', now: new Date() });
+      expect(first).not.toBeNull();
+      // 2 回目は既に消費済みなので null になる (二重登録を防ぐ)
+      const second = await ctx.repo.consumeValidToken({ tokenHash: 'hash-3', now: new Date() });
+      expect(second).toBeNull();
+    });
+
+    // 失効済みの招待は消費できないこと
+    it('consumeValidToken rejects an expired invitation', async () => {
+      // テナント A / B を用意する
+      const { tenantA } = await ctx.seedTwoTenants();
+      // 既に失効している招待を作る (expiresAt が過去)
+      await ctx.repo.create({
+        tokenHash: 'hash-4',
+        tenantId: tenantA,
+        role: 'requester',
+        expiresAt: new Date(Date.now() - 1_000), // 1 秒前に失効
+      });
+      // 現在時刻で消費を試みると失効済みのため null
+      const consumed = await ctx.repo.consumeValidToken({ tokenHash: 'hash-4', now: new Date() });
+      expect(consumed).toBeNull();
+    });
+
+    // deleteExpired は失効済みだけを削除し、有効な招待は残すこと
+    it('deleteExpired removes only expired invitations', async () => {
+      // テナント A / B を用意する
+      const { tenantA } = await ctx.seedTwoTenants();
+      // 失効済みと有効をそれぞれ 1 件ずつ作る
+      await ctx.repo.create({
+        tokenHash: 'expired',
+        tenantId: tenantA,
+        role: 'requester',
+        expiresAt: new Date(Date.now() - 1_000),
+      });
+      await ctx.repo.create({
+        tokenHash: 'valid',
+        tenantId: tenantA,
+        role: 'requester',
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      // 現在時刻で掃除すると失効済み 1 件だけ消える
+      const removed = await ctx.repo.deleteExpired(new Date());
+      expect(removed).toBe(1);
+      // 有効な招待は残っている
+      expect(await ctx.repo.findByTokenHash('valid')).not.toBeNull();
+      // 失効済みは消えている
+      expect(await ctx.repo.findByTokenHash('expired')).toBeNull();
+    });
+
+    // countRecentByTenant がテナントスコープを守り、他テナントの発行を数えないこと
+    it('countRecentByTenant is scoped to the tenant', async () => {
+      // テナント A / B を用意する
+      const { tenantA, tenantB } = await ctx.seedTwoTenants();
+      // 直近の基準時刻 (これ以降の発行を数える)
+      const since = new Date(Date.now() - 60_000);
+      // テナント A に 2 件、テナント B に 1 件の招待を作る
+      await ctx.repo.create({
+        tokenHash: 'a-1',
+        tenantId: tenantA,
+        role: 'requester',
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      await ctx.repo.create({
+        tokenHash: 'a-2',
+        tenantId: tenantA,
+        role: 'requester',
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      await ctx.repo.create({
+        tokenHash: 'b-1',
+        tenantId: tenantB,
+        role: 'requester',
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      // テナント A のカウントは 2 件 (B の 1 件は含まない)
+      expect(await ctx.repo.countRecentByTenant(tenantA, since)).toBe(2);
+      // テナント B のカウントは 1 件
+      expect(await ctx.repo.countRecentByTenant(tenantB, since)).toBe(1);
+    });
+  });
+}

--- a/tests/features/accept-invitation.test.ts
+++ b/tests/features/accept-invitation.test.ts
@@ -1,0 +1,171 @@
+// Vitest のテスト DSL とモック機能
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// メモリ実装の context (store/repos/uow)
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// リポジトリ束 / UnitOfWork の型
+import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
+// 招待トークンのハッシュ化 (DB 保存値と同じ SHA-256 を作るために使う)
+import { hashInviteToken } from '@/lib/invite';
+
+// 各テスト前に書き換える依存。Action import 前に getter で参照させる
+let store: Store;
+let repos: Repos;
+let uow: UnitOfWork;
+
+// @/data を差し替え。getter で参照することで、テスト中の上書きが反映される
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+  get uow() {
+    return uow;
+  },
+}));
+
+// 動的 import: 上のモック設定が反映された後で対象を読み込む
+async function loadAction() {
+  const mod = await import('@/features/auth/actions/accept-invitation');
+  return mod.acceptInvitation;
+}
+
+// テナント A / B の ID。受諾は B 側の招待で行い、A に漏れないことを確認する
+const TENANT_A = 'tenant-a';
+const TENANT_B = 'tenant-b';
+
+// テストごとにクリーンな状態 + テナント 2 つを用意する
+beforeEach(() => {
+  const ctx = createMemoryContext();
+  store = ctx.store;
+  repos = ctx.repos;
+  uow = ctx.uow;
+  // 現在時刻 (テナント作成日時に使う)
+  const now = new Date();
+  // テナント A / B を投入する (User の FK 先として必要)
+  for (const [id, name] of [
+    [TENANT_A, 'A 組織'],
+    [TENANT_B, 'B 組織'],
+  ] as const) {
+    store.tenants.set(id, { id, name, mode: 'lite', industry: null, createdAt: now });
+  }
+});
+
+// 招待を 1 件作成して生トークンを返すヘルパー
+async function seedInvitation(overrides: {
+  tenantId: string;
+  role: 'requester' | 'agent';
+  email?: string | null;
+  expiresAt?: Date;
+}): Promise<string> {
+  // 生トークン (テスト内では固定文字列で十分。ハッシュ化して保存する)
+  const rawToken = `raw-${overrides.tenantId}-${overrides.role}-${Math.random()}`;
+  // DB 保存値と同じ SHA-256 ハッシュへ変換する
+  const tokenHash = await hashInviteToken(rawToken);
+  // 招待行を作成する
+  await repos.invitations.create({
+    tokenHash,
+    tenantId: overrides.tenantId,
+    role: overrides.role,
+    email: overrides.email ?? null,
+    expiresAt: overrides.expiresAt ?? new Date(Date.now() + 60_000),
+  });
+  // 受諾アクションに渡す生トークンを返す
+  return rawToken;
+}
+
+// FormData を組み立てるヘルパー
+function makeForm(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.set(k, v);
+  return fd;
+}
+
+describe('acceptInvitation', () => {
+  // 招待行のテナント・権限でユーザーが作られること (tenantId は入力ではなく招待由来)
+  it('招待が指すテナント・権限でユーザーを作成する (クロステナント注入なし)', async () => {
+    // テナント B・担当者(agent)・メール付きの招待を用意する
+    const rawToken = await seedInvitation({
+      tenantId: TENANT_B,
+      role: 'agent',
+      email: 'invitee@example.com',
+    });
+    // 受諾アクションを実行 (氏名 + パスワードのみ。tenantId は一切渡さない)
+    const acceptInvitation = await loadAction();
+    const result = await acceptInvitation(rawToken, makeForm({ name: '招待 太郎', password: 'password123' }));
+
+    // 戻り値のメールは招待行のメール
+    expect(result.email).toBe('invitee@example.com');
+    // 作成されたユーザーを store から探す
+    const created = [...store.users.values()].find((u) => u.email === 'invitee@example.com');
+    // テナントは招待行 (B) のもの。A には作られない
+    expect(created?.tenantId).toBe(TENANT_B);
+    // 権限は招待行の agent
+    expect(created?.role).toBe('agent');
+  });
+
+  // 招待にメールが無い場合は、入力されたメールでユーザーを作ること
+  it('メール無し招待では入力メールでユーザーを作る', async () => {
+    // メール無しの招待を用意する
+    const rawToken = await seedInvitation({ tenantId: TENANT_B, role: 'requester', email: null });
+    // 受諾アクションを実行 (フォームでメールを入力)
+    const acceptInvitation = await loadAction();
+    const result = await acceptInvitation(
+      rawToken,
+      makeForm({ name: '自前 花子', password: 'password123', email: 'self@example.com' }),
+    );
+    // 入力メールでユーザーが作られる
+    expect(result.email).toBe('self@example.com');
+    expect([...store.users.values()].some((u) => u.email === 'self@example.com')).toBe(true);
+  });
+
+  // 同じ招待リンクは 2 回使えないこと (単回使用)
+  it('同じ招待リンクは 2 回受諾できない', async () => {
+    // 有効な招待を用意する
+    const rawToken = await seedInvitation({ tenantId: TENANT_B, role: 'requester', email: 'once@example.com' });
+    const acceptInvitation = await loadAction();
+    // 1 回目は成功
+    await acceptInvitation(rawToken, makeForm({ name: '一回目', password: 'password123' }));
+    // 2 回目は消費済みのため拒否される
+    await expect(
+      acceptInvitation(rawToken, makeForm({ name: '二回目', password: 'password123' })),
+    ).rejects.toThrow(/無効|使用/);
+  });
+
+  // 失効済みの招待は受諾できないこと
+  it('失効した招待は受諾できない', async () => {
+    // 既に失効した招待を用意する
+    const rawToken = await seedInvitation({
+      tenantId: TENANT_B,
+      role: 'requester',
+      email: 'expired@example.com',
+      expiresAt: new Date(Date.now() - 1_000),
+    });
+    const acceptInvitation = await loadAction();
+    // 失効済みのため拒否される
+    await expect(
+      acceptInvitation(rawToken, makeForm({ name: '遅刻', password: 'password123' })),
+    ).rejects.toThrow(/無効|使用/);
+  });
+
+  // メール重複時はエラーになり、招待が消費されない (トランザクションでロールバック) こと
+  it('メール重複時は招待を消費せずエラーにする (ロールバック)', async () => {
+    // 既存ユーザーを先に登録しておく (同じメール)
+    await repos.users.create({
+      email: 'dup@example.com',
+      name: '既存',
+      passwordHash: 'x',
+      role: 'requester',
+      tenantId: TENANT_A,
+    });
+    // 同じメール宛の招待を用意する
+    const rawToken = await seedInvitation({ tenantId: TENANT_B, role: 'requester', email: 'dup@example.com' });
+    const tokenHash = await hashInviteToken(rawToken);
+    const acceptInvitation = await loadAction();
+    // 重複のため拒否される
+    await expect(
+      acceptInvitation(rawToken, makeForm({ name: '重複', password: 'password123' })),
+    ).rejects.toThrow(/既に登録/);
+    // 招待はロールバックで未消費のまま残っている (再利用可能)
+    const invitation = await repos.invitations.findByTokenHash(tokenHash);
+    expect(invitation?.consumedAt).toBeNull();
+  });
+});

--- a/tests/features/accept-invitation.test.ts
+++ b/tests/features/accept-invitation.test.ts
@@ -117,6 +117,24 @@ describe('acceptInvitation', () => {
     expect([...store.users.values()].some((u) => u.email === 'self@example.com')).toBe(true);
   });
 
+  // メール無し招待で不正な形式のメールを入力した場合は拒否されること (消費されない)
+  it('メール無し招待で不正なメール形式は拒否される', async () => {
+    // メール無しの招待を用意する
+    const rawToken = await seedInvitation({ tenantId: TENANT_B, role: 'requester', email: null });
+    const tokenHash = await hashInviteToken(rawToken);
+    const acceptInvitation = await loadAction();
+    // 不正な形式のメールを入力すると拒否される
+    await expect(
+      acceptInvitation(
+        rawToken,
+        makeForm({ name: '不正', password: 'password123', email: 'not-an-email' }),
+      ),
+    ).rejects.toThrow(/メールアドレス/);
+    // 招待は未消費のまま (消費前に弾いている)
+    const invitation = await repos.invitations.findByTokenHash(tokenHash);
+    expect(invitation?.consumedAt).toBeNull();
+  });
+
   // 同じ招待リンクは 2 回使えないこと (単回使用)
   it('同じ招待リンクは 2 回受諾できない', async () => {
     // 有効な招待を用意する

--- a/tests/features/create-tenant.test.ts
+++ b/tests/features/create-tenant.test.ts
@@ -1,0 +1,140 @@
+// Vitest のテスト DSL とモック機能
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// メモリ実装の context (store/repos/uow)
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// リポジトリ束 / UnitOfWork の型
+import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
+// レート制限の履歴をテスト間でクリアする内部用関数
+import { __resetRateLimits } from '@/lib/rate-limit';
+
+// 各テスト前に書き換える依存。Action import 前に getter で参照させる
+let store: Store;
+let repos: Repos;
+let uow: UnitOfWork;
+// セッションの権限 (テスト中に書き換えてシナリオを変える)
+let sessionRole: 'requester' | 'agent' | 'admin' = 'admin';
+
+// 呼び出し元テナント (作成される新テナントとは別物であることを確認する)
+const CALLER_TENANT = 'caller-tenant';
+
+// @/data を差し替え。getter で参照することで、テスト中の上書きが反映される
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+  get uow() {
+    return uow;
+  },
+}));
+
+// 認証は固定セッションを返すモックに置換 (権限は sessionRole で切替)
+vi.mock('@/lib/auth', () => ({
+  auth: async () => ({
+    user: { id: 'admin-1', role: sessionRole, tenantId: CALLER_TENANT },
+  }),
+}));
+
+// 動的 import: 上のモック設定が反映された後で対象を読み込む
+async function loadAction() {
+  const mod = await import('@/features/settings/actions/create-tenant');
+  return mod.createTenant;
+}
+
+// FormData を組み立てるヘルパー
+function makeForm(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.set(k, v);
+  return fd;
+}
+
+// テストごとにクリーンな状態にする
+beforeEach(() => {
+  const ctx = createMemoryContext();
+  store = ctx.store;
+  repos = ctx.repos;
+  uow = ctx.uow;
+  sessionRole = 'admin';
+  // レート制限履歴をクリア (テスト間の干渉を防ぐ)
+  __resetRateLimits();
+  // 呼び出し元テナントを 1 つ用意しておく
+  store.tenants.set(CALLER_TENANT, {
+    id: CALLER_TENANT,
+    name: '呼び出し元組織',
+    mode: 'lite',
+    industry: null,
+    createdAt: new Date(),
+  });
+});
+
+describe('createTenant', () => {
+  // 新しいテナントと初代管理者 (admin) が作成されること
+  it('新しい組織と初代管理者を作成する', async () => {
+    const createTenant = await loadAction();
+    // テナント + 初代管理者を作成する
+    const result = await createTenant(
+      makeForm({
+        tenantName: '新組織',
+        industry: '製造業',
+        adminName: '管理 太郎',
+        adminEmail: 'newadmin@example.com',
+        adminPassword: 'password123',
+      }),
+    );
+    // 作成テナントは呼び出し元テナントとは別 ID
+    expect(result.tenantId).not.toBe(CALLER_TENANT);
+    // 作成テナントが store に存在し、業種も保存されている
+    const tenant = store.tenants.get(result.tenantId);
+    expect(tenant?.name).toBe('新組織');
+    expect(tenant?.industry).toBe('製造業');
+    // 初代管理者が作成テナントに admin として作られている
+    const admin = [...store.users.values()].find((u) => u.email === 'newadmin@example.com');
+    expect(admin?.role).toBe('admin');
+    expect(admin?.tenantId).toBe(result.tenantId);
+  });
+
+  // admin 以外は拒否されること (RBAC)
+  it('admin 以外は拒否される', async () => {
+    // 権限を agent に下げる
+    sessionRole = 'agent';
+    const createTenant = await loadAction();
+    // 管理者専用のため拒否される
+    await expect(
+      createTenant(
+        makeForm({
+          tenantName: 'x',
+          adminName: 'y',
+          adminEmail: 'z@example.com',
+          adminPassword: 'password123',
+        }),
+      ),
+    ).rejects.toThrow(/管理者/);
+  });
+
+  // メール重複時はテナント作成もロールバックされること (孤児テナントを残さない)
+  it('メール重複時はテナント作成もロールバックする', async () => {
+    // 既存ユーザーを先に登録しておく (同じメール)
+    await repos.users.create({
+      email: 'dup@example.com',
+      name: '既存',
+      passwordHash: 'x',
+      role: 'requester',
+      tenantId: CALLER_TENANT,
+    });
+    // 作成前のテナント数を控える
+    const before = store.tenants.size;
+    const createTenant = await loadAction();
+    // 重複のため拒否される
+    await expect(
+      createTenant(
+        makeForm({
+          tenantName: '失敗組織',
+          adminName: '重複',
+          adminEmail: 'dup@example.com',
+          adminPassword: 'password123',
+        }),
+      ),
+    ).rejects.toThrow(/既に登録/);
+    // テナント数は増えていない (ロールバックされている)
+    expect(store.tenants.size).toBe(before);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -15,9 +19,23 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## 概要

`docs/smb-dx-pivot-plan.md` §4 **Phase 0（基盤整備）** の未実装チェックリスト 2 件を実装します。

- [x] テナント作成 / 招待リンク発行画面（admin 用）
- [x] 既存 E2E / Vitest をテナント前提に検証

Phase 0 の既存実装（Tenant モデル・全テーブル `tenantId`・session/JWT 拡張・middleware スコープ・クロステナント契約テスト・`multitenant.spec.ts`）の上に、招待リンクとテナント作成の 2 画面、および新フローのテストを追加します。後フェーズ機能（メール/LINE 取り込み・マジックリンク招待・業種テンプレ自動投入等）は混ぜていません。

## 実装方針（事前確認済み）

- **テナント作成**: 運用者（admin）向けの最小フォーム（組織＋初代管理者）。セルフサーブ・サインアップ／オンボーディングウィザードは Phase 3 に委譲。
- **招待受諾の認証**: パスワード設定（既存 Credentials Provider + bcryptjs を流用）。

## 変更点

### データ層（Ports & Adapters）
- `Invitation` モデル＋マイグレーション（`20260519000000_add_invitation`）。`MagicLinkToken` 同型のワンタイムトークンに `tenantId` / `role` を持たせ、受諾時の参加先・権限を発行時点で固定。
- `InvitationRepository` を新設、`UserRepository` / `TenantRepository` に `create` を追加（prisma / memory 両実装＋契約テスト）。

### 招待リンク
- `create-invitation`（admin 専用）: 自テナントの招待リンクを発行。`tenantId`/`invitedById` はセッション由来のみ・テナント単位の発行レート制限。
- `accept-invitation`（公開）: トークン＋氏名＋パスワードでユーザー作成。`tenantId`/`role` は招待行由来のみ。消費とユーザー作成を uow トランザクションで実行し、失敗時はロールバック。
- UI: 設定画面の招待セクション（`InviteForm`）、公開ページ `/invite/[token]`（`AcceptInviteForm`、自動ログインまで）。`middleware` で `/invite` を公開。

### テナント作成
- `create-tenant`（admin 専用）: 組織＋初代管理者を uow トランザクションで作成。メール重複時はテナント作成もロールバック。
- UI: `/settings/tenants/new`（`CreateTenantForm`）。

### 共通化・定数
- `app-url.ts` に baseURL 解決を集約し `request-magic-link` をリファクタ（DRY）。
- `assertAdminSession` を `lib/role.ts` に集約。
- `ROLE_LABELS`（メンバー/担当者）・`INVITABLE_ROLES` を `constants.ts` に一元追加。

## セキュリティ
- トークンは SHA-256 ハッシュのみ保存（生は URL のみ）・単回消費を DB 層で原子的に担保・期限（招待 7 日）。
- `tenantId` はセッション/招待行由来のみで入力から注入させない（クロステナント参加の防止 / §5.6）。
- admin RBAC はサーバー側で強制・パスワードは bcrypt ハッシュ・受諾後リダイレクトは内部パスのみ。

## 検証

ローカルで実 PostgreSQL + 実アプリを立てて確認済み。

- `npm run typecheck` / `npm run lint`: パス
- `npm run test`: **245 passed / 24 skipped**（招待・受諾・テナント作成の単体＋契約テストを追加）
- `RUN_PRISMA_CONTRACT=1 npm run test:contract`: **24 passed**（新 Invitation 契約含む。マイグレーション SQL の実 DB 適用も確認）
- `npm run test:e2e`: **27 passed**（既存 24 + 新規 3。既存 E2E はテナント前提のまま無変更で全通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W28K2WpGbXfJdMZ3vs6Tiw)_