### PR TITLE
fix(tickets): 一覧ページで tenantId を明示ガードしクロステナント漏洩を多層防御

### DIFF
--- a/src/app/(app)/tickets/page.tsx
+++ b/src/app/(app)/tickets/page.tsx
@@ -69,8 +69,10 @@ export default async function TicketsPage({ searchParams }: Props) {
   const sp = await searchParams;
   // セッション取得
   const session = await auth();
-  // 未ログインなら描画しない
-  if (!session?.user?.id) return null;
+  // 未ログイン、または tenantId 欠落（テナント未確定）なら描画しない。
+  // 他の入口（api/tickets・comments・faq-actions・stream）と同じく tenantId を明示ガードし、
+  // クロステナント漏洩を多層防御で防ぐ（CLAUDE.md §3 マルチテナント / §9）。
+  if (!session?.user?.id || !session.user.tenantId) return null;
 
   // ロール判定
   const isAgent = checkIsAgent(session.user.role);


### PR DESCRIPTION
## Context
`docs/smb-dx-pivot-plan.md` §5.1（マルチテナント基盤）の「全入口で `tenantId` スコープを強制する」方針に対し、`src/app/(app)/tickets/page.tsx` だけが `session.user.id` のみをガードし `tenantId` 欠落を弾いていなかった。他の入口（`api/tickets/route.ts`・`comments/route.ts`・`faq-actions.ts`・`notifications/stream/route.ts`）は `session.user.tenantId` を明示ガードしており、本ページのみ非対称だった。

`auth.ts` の `jwt` callback が `tenantId` を補完する（欠落時はセッション無効化）ため現時点で実害はないが、多層防御（defense-in-depth）と一貫性のための修正。

## 変更点
- 未ログインガードを `if (!session?.user?.id || !session.user.tenantId) return null;` に変更（コメントで意図を明記）

## 検証
- 変更は型の絞り込みガード追加のみ。CI（typecheck / lint / test / E2E / Prisma 契約）で検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHZwQo98Rbx1VBJ6DPk7gt)_