### PR TITLE
feat(inbound): メールのスレッド継続 (In-Reply-To で既存チケットへ追記)

### DIFF
--- a/prisma/migrations/20260620000000_add_email_thread_ref/migration.sql
+++ b/prisma/migrations/20260620000000_add_email_thread_ref/migration.sql
@@ -1,0 +1,35 @@
+-- Phase 2「スレッド継続 (In-Reply-To ヘッダで紐付け)」(docs/smb-dx-pivot-plan.md §4 / L130):
+-- 受信起票メール / 担当者の返信メールの Message-ID を、紐づくチケットと一緒に保管するテーブルを追加する。
+-- 後続の返信メールが In-Reply-To / References でこれらの Message-ID を参照してきたとき、
+-- 新規起票せず既存チケットへコメント追記する逆引き (Message-ID → ticket) に使う。
+-- @@unique([tenantId, messageId]) でテナント内一意にし、別テナントの Message-ID でスレッドを
+-- 乗っ取られないようにする (クロステナント漏洩防止)。
+
+CREATE TABLE "EmailThreadRef" (
+    "id" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "ticketId" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+
+    CONSTRAINT "EmailThreadRef_pkey" PRIMARY KEY ("id")
+);
+
+-- テナント内で Message-ID は一意 (スレッド乗っ取り・二重取り込み防止)
+CREATE UNIQUE INDEX "EmailThreadRef_tenantId_messageId_key" ON "EmailThreadRef"("tenantId", "messageId");
+
+-- チケット削除の連鎖や逆引きを高速化するインデックス
+CREATE INDEX "EmailThreadRef_ticketId_idx" ON "EmailThreadRef"("ticketId");
+
+-- テナントスコープ検索を高速化するインデックス
+CREATE INDEX "EmailThreadRef_tenantId_idx" ON "EmailThreadRef"("tenantId");
+
+-- 紐づくチケットへの外部キー (チケット削除で対応表も連鎖削除)
+ALTER TABLE "EmailThreadRef"
+    ADD CONSTRAINT "EmailThreadRef_ticketId_fkey"
+    FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- 所属テナントへの外部キー (テナント削除で対応表も連鎖削除)
+ALTER TABLE "EmailThreadRef"
+    ADD CONSTRAINT "EmailThreadRef_tenantId_fkey"
+    FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,6 +104,7 @@ model Tenant {
   notifications Notification[]
   attachments   Attachment[] // 添付ファイル (テナント境界の保持に必須)
   invitations   Invitation[] // メンバー招待リンク (発行〜受諾までのワンタイムトークン)
+  emailThreadRefs EmailThreadRef[] // メールスレッド継続用の Message-ID 対応表 (Phase 2)
 }
 
 // ─────────────────────────────────────────────
@@ -241,6 +242,7 @@ model Ticket {
   faqCandidate  FaqCandidate? // 紐づく FAQ 候補 (1:1)
   notifications Notification[] // このチケットを参照する通知
   attachments   Attachment[] // 紐づく添付ファイル (画像)
+  emailThreadRefs EmailThreadRef[] // このチケットに紐づくメール Message-ID 群 (スレッド継続)
 
   // 検索性能向上のためのインデックス
   @@index([creatorId]) // 作成者で絞り込む一覧用
@@ -366,4 +368,29 @@ model Attachment {
   @@index([ticketId]) // チケット詳細での一覧取得用
   @@index([commentId]) // コメント単位での添付一覧用
   @@index([tenantId]) // テナントスコープ検索用 (クロステナント遮断テスト用)
+}
+
+// ─────────────────────────────────────────────
+// EmailThreadRef (メールスレッド継続用の Message-ID 対応表 / Phase 2)
+// ─────────────────────────────────────────────
+// docs/smb-dx-pivot-plan.md Phase 2「スレッド継続 (In-Reply-To ヘッダで紐付け)」(§4 / L130)。
+// 受信して起票したメールと、担当者が送信した返信メールの Message-ID を、紐づくチケットと一緒に
+// 記録する。後続の返信メールが In-Reply-To / References でこれらの Message-ID を参照してきたとき、
+// 新規起票せず既存チケットへコメント追記するための「Message-ID → ticket」逆引きに使う。
+// Message-ID は @@unique([tenantId, messageId]) でテナント内一意にし、別テナントの Message-ID を
+// 突き合わせてスレッドを乗っ取られない (クロステナント漏洩防止 §9) ようにする。
+model EmailThreadRef {
+  id        String   @id @default(cuid()) // 主キー
+  messageId String // メールの Message-ID (山括弧と前後空白を除いた正規化済みの値)
+  createdAt DateTime @default(now()) // 記録日時 (同一参照が複数あれば新しい紐付けを優先する)
+
+  ticketId String // 紐づくチケット ID
+  tenantId String // 所属テナント (突き合わせは必ずこのスコープ内で行う)
+
+  ticket Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade) // チケット削除で連鎖削除
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade) // テナント削除で連鎖削除
+
+  @@unique([tenantId, messageId]) // テナント内で Message-ID は一意 (スレッド乗っ取り・二重取り込み防止)
+  @@index([ticketId]) // チケット削除の連鎖や逆引き用
+  @@index([tenantId]) // テナントスコープ検索用
 }

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -227,6 +227,8 @@ export async function POST(req: Request) {
 
   // 冪等性: この受信メールの Message-ID を既に取り込み済みなら、二重起票/二重コメントを避ける。
   // Webhook は at-least-once 配送 (再送あり) なので、同じ Message-ID を見たら過去のチケットを返す。
+  // 注意: Message-ID が取れない (null) メールはこの重複判定が効かず、新規起票パスと同じ at-least-once
+  // 挙動 (再送で重複しうる) になる。実メールはほぼ必ず Message-ID を持つため通常は冪等に処理される。
   if (email.messageId) {
     const already = await repos.emailThreads.findTicketIdByMessageIds([email.messageId], tenant.id);
     if (already) {
@@ -249,6 +251,10 @@ export async function POST(req: Request) {
       const senderIsAgent = isAgent(sender.role);
       // 追記の権限: エージェント、または自分が起票したチケットのみ (第三者メンバーの混線/露出を防ぐ)。
       // 権限の無いメンバーは隔離扱い (202) にして無視する。
+      // セキュリティ注意 (§9 / §8 リスク表): 送信者の本人性はヘッダ From + 既知メンバー判定に依存し、
+      // DKIM/SPF 検証は未実装 (既存メール取り込みと同じ前提 = 将来課題)。エージェントの From を詐称した
+      // なりすまし POST は、共有シークレット (INBOUND_EMAIL_SECRET) と取り込みトークンの両方を要するため
+      // 信頼境界はプロバイダ側にあるが、本人性を強める SPF/DKIM 検証を後続で入れること。
       if (!senderIsAgent && ticket.creatorId !== sender.id) {
         console.warn(
           '[POST /api/inbound/email] quarantined: sender not allowed to append to thread',

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -18,12 +18,20 @@
 import { NextResponse } from 'next/server';
 // 共有シークレットの定数時間比較に使う (Node ランタイム前提のルート)
 import { timingSafeEqual } from 'node:crypto';
-// データ層 (テナント / ユーザー / チケットのリポジトリ束)
-import { repos } from '@/data';
+// ページキャッシュ無効化 (スレッド継続でコメント追記したチケット詳細を再描画させる)
+import { revalidatePath } from 'next/cache';
+// データ層 (テナント / ユーザー / チケットのリポジトリ束 + トランザクション境界)
+import { repos, uow } from '@/data';
 // 新規起票時の初期ステータスを mode から決める共通ルール (Web フォーム起票と単一の源を共有)
 import { initialStatusForMode } from '@/domain/ticket-status';
-// 受信メールの正規化ヘルパー (純粋関数)
-import { parseInboundEmail } from '@/lib/inbound-email';
+// コメント通知の宛先決定 (Web フォーム経由コメントと共有するヘルパー)
+import { resolveCommentRecipients } from '@/lib/comment-recipients';
+// 未読件数を SSE で即時配信するヘルパー (コメント追記時の通知扇形)
+import { broadcastUnreadCountToMany } from '@/features/notifications/notify';
+// 受信メールの正規化ヘルパー (純粋関数) と生ヘッダ読み取り
+import { parseInboundEmail, readRawHeader } from '@/lib/inbound-email';
+// エージェント権限判定 (スレッド追記の RBAC に使用)
+import { isAgent } from '@/lib/role';
 // 公開エンドポイントの流量制限 (§9: DoS / リソース枯渇防止)
 import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
 // 優先度から解決期限を計算する SLA ヘルパー (Web フォーム起票と同じ既定値に揃える)
@@ -60,14 +68,19 @@ function readProvidedSecret(req: Request, url: URL): string | null {
   return url.searchParams.get('secret');
 }
 
-// 受信メール 1 通分のフィールド (to / from / subject / text) を、JSON / multipart の
-// どちらのボディからでも取り出して共通形に揃える。
-async function readInboundFields(req: Request): Promise<{
-  to?: string | null;
-  from?: string | null;
-  subject?: string | null;
-  text?: string | null;
-}> {
+// 受信メール 1 通分のフィールドの共通形 (to / from / subject / text に加え、スレッド継続用ヘッダ)
+interface InboundFields {
+  to?: string | null; // 宛先 (ルーティング)
+  from?: string | null; // 送信者 (本人特定)
+  subject?: string | null; // 件名
+  text?: string | null; // テキスト本文
+  messageId?: string | null; // この受信メールの Message-ID
+  inReplyTo?: string | null; // In-Reply-To ヘッダ (直接の返信元)
+  references?: string | null; // References ヘッダ (スレッド上の Message-ID 列)
+}
+
+// 受信メール 1 通分のフィールドを、JSON / multipart のどちらのボディからでも取り出して共通形に揃える。
+async function readInboundFields(req: Request): Promise<InboundFields> {
   // Content-Type を小文字化して判定 (大文字小文字はメディアタイプ上区別しない)
   const contentType = (req.headers.get('content-type') ?? '').toLowerCase();
   // multipart/form-data (SendGrid Inbound Parse 等) は FormData として読む
@@ -97,6 +110,9 @@ async function readInboundFields(req: Request): Promise<{
     }
     // FormData の値を string | null に正規化する小ヘルパー
     const str = (v: FormDataEntryValue | null): string | null => (typeof v === 'string' ? v : null);
+    // SendGrid 等は個別の Message-ID / In-Reply-To フィールドを持たないことがあるため、
+    // 生ヘッダ (headers フィールド) からのフォールバック抽出も用意する (スレッド継続用)。
+    const rawHeaders = str(form.get('headers'));
     // 宛先 (ルーティング): envelope の RCPT を優先する (ヘッダ To より実配送先として確実)。
     // 送信者 (本人特定): ヘッダ From を優先する (人間が送った差出人。envelope from=MAIL FROM は
     // 戻り先で本人性が弱い)。いずれも DKIM/SPF 検証は将来課題で、現状は既知メンバー判定で守る。
@@ -105,6 +121,10 @@ async function readInboundFields(req: Request): Promise<{
       from: str(form.get('from')) ?? envFrom,
       subject: str(form.get('subject')),
       text: str(form.get('text')),
+      // Message-ID 系は個別フィールド優先、無ければ生ヘッダから読む
+      messageId: str(form.get('message-id')) ?? readRawHeader(rawHeaders, 'Message-ID'),
+      inReplyTo: str(form.get('in-reply-to')) ?? readRawHeader(rawHeaders, 'In-Reply-To'),
+      references: str(form.get('references')) ?? readRawHeader(rawHeaders, 'References'),
     };
   }
   // それ以外は JSON ボディとして読む (テスト・自前連携向け)
@@ -112,7 +132,16 @@ async function readInboundFields(req: Request): Promise<{
   // 文字列フィールドだけを取り出す小ヘルパー
   const pick = (k: string): string | null =>
     typeof body[k] === 'string' ? (body[k] as string) : null;
-  return { to: pick('to'), from: pick('from'), subject: pick('subject'), text: pick('text') };
+  return {
+    to: pick('to'),
+    from: pick('from'),
+    subject: pick('subject'),
+    text: pick('text'),
+    // camelCase / ヘッダ表記 (ハイフン) のどちらの JSON キーでも受ける
+    messageId: pick('messageId') ?? pick('message-id'),
+    inReplyTo: pick('inReplyTo') ?? pick('in-reply-to'),
+    references: pick('references'),
+  };
 }
 
 // POST /api/inbound/email : 受信メールを 1 件の問い合わせに変換する
@@ -143,12 +172,7 @@ export async function POST(req: Request) {
   }
 
   // 受信メールのフィールドを取り出す (JSON / multipart 両対応)
-  let fields: {
-    to?: string | null;
-    from?: string | null;
-    subject?: string | null;
-    text?: string | null;
-  };
+  let fields: InboundFields;
   try {
     fields = await readInboundFields(req);
   } catch (err) {
@@ -201,6 +225,86 @@ export async function POST(req: Request) {
     return NextResponse.json({ status: 'quarantined' }, { status: 202 });
   }
 
+  // 冪等性: この受信メールの Message-ID を既に取り込み済みなら、二重起票/二重コメントを避ける。
+  // Webhook は at-least-once 配送 (再送あり) なので、同じ Message-ID を見たら過去のチケットを返す。
+  if (email.messageId) {
+    const already = await repos.emailThreads.findTicketIdByMessageIds([email.messageId], tenant.id);
+    if (already) {
+      // 既に処理済み: 何もせず 200 を返す (プロバイダの再送ループを止める)
+      return NextResponse.json({ status: 'duplicate', ticketId: already }, { status: 200 });
+    }
+  }
+
+  // スレッド継続 (Phase 2 / L130): 参照 Message-ID (In-Reply-To / References) から既存チケットを
+  // 逆引きできれば、新規起票せず「そのチケットへのコメント追記」として取り込む。
+  const threadTicketId =
+    email.referenceIds.length > 0
+      ? await repos.emailThreads.findTicketIdByMessageIds(email.referenceIds, tenant.id)
+      : null;
+  if (threadTicketId) {
+    // 紐づくチケットを tenantId スコープで取得 (別テナント ID なら null)
+    const ticket = await repos.tickets.findById(threadTicketId, tenant.id);
+    if (ticket) {
+      // 送信者がエージェント/管理者か (通知扇形と RBAC の判定に使う)
+      const senderIsAgent = isAgent(sender.role);
+      // 追記の権限: エージェント、または自分が起票したチケットのみ (第三者メンバーの混線/露出を防ぐ)。
+      // 権限の無いメンバーは隔離扱い (202) にして無視する。
+      if (!senderIsAgent && ticket.creatorId !== sender.id) {
+        console.warn(
+          '[POST /api/inbound/email] quarantined: sender not allowed to append to thread',
+        );
+        return NextResponse.json({ status: 'quarantined' }, { status: 202 });
+      }
+      // コメント通知の送信先を決める (Web フォーム経由コメントと共通ロジック)
+      const recipientIds = await resolveCommentRecipients(
+        ticket,
+        sender.id,
+        senderIsAgent,
+        tenant.id,
+      );
+      // 通知メッセージ (Web フォーム経由コメントと同じ文言に揃える)
+      const message = `チケット「${ticket.title}」に新しいコメントが追加されました`;
+      // コメント追記 + Message-ID 登録 + 通知作成を 1 トランザクションで行う (中途半端な状態を残さない)
+      await uow.run(async (r) => {
+        // 受信メール本文を既存チケットへのコメントとして追記する
+        await r.comments.create({
+          ticketId: ticket.id, // 紐づく既存チケット
+          authorId: sender.id, // 追記者 = 送信者 (既知メンバー)
+          body: email.body, // メール本文
+          tenantId: tenant.id, // 親チケットのテナント一致を Adapter が検証する
+        });
+        // この受信メール自身の Message-ID も対応表へ登録する (返信の連鎖を辿れるように)
+        if (email.messageId) {
+          await r.emailThreads.register({
+            messageId: email.messageId,
+            ticketId: ticket.id,
+            tenantId: tenant.id,
+          });
+        }
+        // 通知対象へ「コメントが追加された」旨を一斉送付する
+        await Promise.all(
+          recipientIds.map((id) =>
+            r.notifications.create({
+              userId: id,
+              type: 'commented',
+              message,
+              ticketId: ticket.id,
+              tenantId: tenant.id,
+            }),
+          ),
+        );
+      });
+      // 通知対象が居れば未読件数を SSE で即時配信する
+      if (recipientIds.length > 0) await broadcastUnreadCountToMany(recipientIds, tenant.id);
+      // 追記したチケット詳細ページのキャッシュを無効化して再描画させる
+      revalidatePath(`/tickets/${ticket.id}`);
+      // スレッド追記として 200 を返す (新規起票ではないことを threaded フラグで示す)
+      return NextResponse.json({ ticketId: ticket.id, threaded: true }, { status: 200 });
+    }
+    // 参照先チケットが見つからない (削除済み等) 場合は、下の新規起票へフォールスルーする
+    console.warn('[POST /api/inbound/email] referenced ticket not found; creating a new one');
+  }
+
   // 起票時刻 (SLA 期限の計算基準)
   const now = new Date();
   // 初期ステータスは Web フォーム起票と同じ共通ルールで決める (Lite='Open' / Pro=DB既定 New)
@@ -219,6 +323,20 @@ export async function POST(req: Request) {
     status: initialStatus, // Lite は 'Open'、Pro は undefined (既定 New)
     resolutionDueAt, // 解決期限 (優先度ベース)
   });
+
+  // この受信メールの Message-ID を対応表へ登録する (後続の返信をこのチケットへ紐付けるため)。
+  // ベストエフォート: 登録失敗で 500 を返すと再送 → 二重起票になりかねないので、握ってログに残す。
+  if (email.messageId) {
+    try {
+      await repos.emailThreads.register({
+        messageId: email.messageId,
+        ticketId: ticket.id,
+        tenantId: tenant.id,
+      });
+    } catch (err) {
+      console.warn('[POST /api/inbound/email] failed to register inbound message id', err);
+    }
+  }
 
   // 作成された問い合わせ ID を 201 で返す (プロバイダは本文を使わないが疎通確認に役立つ)
   return NextResponse.json({ ticketId: ticket.id }, { status: 201 });

--- a/src/app/api/tickets/[id]/comments/route.ts
+++ b/src/app/api/tickets/[id]/comments/route.ts
@@ -18,8 +18,12 @@ import { getEmailSender } from '@/lib/email';
 import { resolveAppBaseUrl } from '@/lib/app-url';
 // 依頼者宛「返信が届きました」メールの URL 構築 / 本文組み立て (純粋ヘルパー)
 import { buildTicketUrl, renderTicketReplyEmail } from '@/lib/ticket-email';
+// 返信メールに付与する決定的 Message-ID の生成 (スレッド継続の起点)
+import { buildReplyMessageId, resolveMessageIdDomain } from '@/lib/email-message-id';
 // エージェント権限判定 (agent または admin のとき true)
 import { isAgent } from '@/lib/role';
+// コメント通知の宛先決定 (メール取り込みのスレッド継続と共有するヘルパー)
+import { resolveCommentRecipients } from '@/lib/comment-recipients';
 // レート制限ヘルパー (超過時は RateLimitError を throw)
 import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
 // コメント本文の Zod スキーマ
@@ -200,6 +204,7 @@ export async function POST(req: Request, { params }: Params) {
       authorName: session.user.name ?? '担当者',
       commentBody: trimmedBody,
       ticketId,
+      tenantId,
     });
   }
 
@@ -219,8 +224,9 @@ async function sendReplyEmailToRequester(args: {
   authorName: string;
   commentBody: string;
   ticketId: string;
+  tenantId: string;
 }): Promise<void> {
-  const { ticket, authorId, authorName, commentBody, ticketId } = args;
+  const { ticket, authorId, authorName, commentBody, ticketId, tenantId } = args;
   // 自分が起票したチケットに自分で返信した場合は自分宛メールを送らない
   if (ticket.creatorId === authorId) return;
 
@@ -241,34 +247,26 @@ async function sendReplyEmailToRequester(args: {
       commentBody,
       agentName: authorName,
     });
-    // 設定された EmailSender (console / smtp) 経由で送信
-    await getEmailSender().send({ to: creator.email, subject, text, html });
+    // Phase 2 スレッド継続: 返信メールに決定的 Message-ID を付与する。依頼者がこのメールに
+    // 返信すると In-Reply-To にこの値が載るので、受信 Webhook 側で元チケットへ紐付けられる。
+    const replyMessageId = buildReplyMessageId(ticketId, resolveMessageIdDomain());
+    // Message-ID → チケットの対応を先に登録する (送信前でも害は無く、登録漏れを避けられる)。
+    // register は冪等なので再送・重複でも安全。
+    await repos.emailThreads.register({
+      messageId: replyMessageId.normalized, // 山括弧なしの正規化値 (受信側の表記と一致)
+      ticketId, // この返信が属するチケット
+      tenantId, // 所属テナント (突き合わせスコープ)
+    });
+    // 設定された EmailSender (console / smtp) 経由で送信 (Message-ID ヘッダ付き)
+    await getEmailSender().send({
+      to: creator.email,
+      subject,
+      text,
+      html,
+      messageId: replyMessageId.header,
+    });
   } catch (err) {
     // 送信失敗はサーバログに残すだけ (依頼者への通知はアプリ内にも残っている)
     console.error('[POST /api/tickets/[id]/comments] 依頼者宛メール送信に失敗しました', err);
   }
-}
-
-// コメント通知の送信先を決定する内部ヘルパー (既存 addComment と同じロジック)
-async function resolveCommentRecipients(
-  ticket: { creatorId: string; assigneeId: string | null },
-  authorId: string,
-  authorIsAgent: boolean,
-  tenantId: string,
-): Promise<string[]> {
-  // 宛先候補を集める配列
-  const candidates: string[] = [];
-  // エージェントがコメントした場合: 依頼者 (+ 担当者が居れば担当者)
-  if (authorIsAgent) {
-    candidates.push(ticket.creatorId);
-    if (ticket.assigneeId) candidates.push(ticket.assigneeId);
-  } else if (ticket.assigneeId) {
-    // 依頼者がコメントし担当者が決まっている場合は担当者のみ
-    candidates.push(ticket.assigneeId);
-  } else {
-    // 依頼者がコメントし担当者未定なら全エージェントに通知 (テナント内のみ)
-    candidates.push(...(await repos.users.listAgentIds(tenantId)));
-  }
-  // 重複排除し、コメント投稿者自身は除外して返す
-  return Array.from(new Set(candidates)).filter((id) => id !== authorId);
 }

--- a/src/data/adapters/memory/email-thread-repository.memory.ts
+++ b/src/data/adapters/memory/email-thread-repository.memory.ts
@@ -1,0 +1,45 @@
+// メールスレッド対応表リポジトリの契約 (port) と、メモリストア/ID 生成ヘルパーをインポート
+import type { EmailThreadRepository } from '@/data/ports/email-thread-repository';
+import { nextId, type EmailThreadRefRow, type Store } from './store';
+
+// メモリストアを使った EmailThreadRef リポジトリを生成する関数
+export function makeEmailThreadRepo(store: Store): EmailThreadRepository {
+  return {
+    // 参照 Message-ID 群から、紐づく既存チケット ID を 1 件返す (tenantId スコープ)
+    async findTicketIdByMessageIds(messageIds, tenantId) {
+      // 参照が無ければ突き合わせ不要
+      if (messageIds.length === 0) return null;
+      // 高速に判定するため参照 ID を Set 化する
+      const wanted = new Set(messageIds);
+      // tenantId 一致かつ messageId が参照集合に含まれる行を集める (クロステナント遮断 §9)
+      const matches = Array.from(store.emailThreadRefs.values()).filter(
+        (row) => row.tenantId === tenantId && wanted.has(row.messageId),
+      );
+      // 1 件も無ければ null
+      if (matches.length === 0) return null;
+      // 最も新しく記録された対応を優先する (Prisma 実装の orderBy createdAt desc に揃える)
+      matches.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      // 先頭 (最新) の ticketId を返す
+      return matches[0].ticketId;
+    },
+
+    // Message-ID とチケットの対応を 1 件登録する (冪等)
+    async register(input) {
+      // 既に同じ (tenantId, messageId) があれば何もしない (Webhook 再送でも二重登録しない)
+      const duplicated = Array.from(store.emailThreadRefs.values()).some(
+        (row) => row.tenantId === input.tenantId && row.messageId === input.messageId,
+      );
+      if (duplicated) return;
+      // 新規行を組み立てる (ID と記録日時はここで決定)
+      const row: EmailThreadRefRow = {
+        id: nextId(store, 'etr'), // 'etr_...' 形式の一意 ID
+        messageId: input.messageId, // 正規化済み Message-ID
+        ticketId: input.ticketId, // 紐づくチケット
+        tenantId: input.tenantId, // 所属テナント
+        createdAt: new Date(), // 現在時刻
+      };
+      // ストアに登録
+      store.emailThreadRefs.set(row.id, row);
+    },
+  };
+}

--- a/src/data/adapters/memory/email-thread-repository.memory.ts
+++ b/src/data/adapters/memory/email-thread-repository.memory.ts
@@ -17,8 +17,12 @@ export function makeEmailThreadRepo(store: Store): EmailThreadRepository {
       );
       // 1 件も無ければ null
       if (matches.length === 0) return null;
-      // 最も新しく記録された対応を優先する (Prisma 実装の orderBy createdAt desc に揃える)
-      matches.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      // 最も新しく記録された対応を優先する (Prisma 実装の orderBy createdAt desc に揃える)。
+      // createdAt 同値のときは id を副キーにして並びを決定的にする (Prisma の orderBy と同じ規則)。
+      matches.sort((a, b) => {
+        const byTime = b.createdAt.getTime() - a.createdAt.getTime();
+        return byTime !== 0 ? byTime : a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
+      });
       // 先頭 (最新) の ticketId を返す
       return matches[0].ticketId;
     },

--- a/src/data/adapters/memory/index.ts
+++ b/src/data/adapters/memory/index.ts
@@ -3,6 +3,7 @@ import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
 // 各エンティティ用のメモリリポジトリ生成関数を取り込む
 import { makeAttachmentRepo } from './attachment-repository.memory';
 import { makeCategoryRepo } from './category-repository.memory';
+import { makeEmailThreadRepo } from './email-thread-repository.memory';
 import { makeFaqRepo } from './faq-repository.memory';
 import { makeInvitationRepo } from './invitation-repository.memory';
 import { makeMagicLinkRepo } from './magic-link-repository.memory';
@@ -33,6 +34,7 @@ export function buildMemoryRepos(store: Store): Repos {
     magicLinks: makeMagicLinkRepo(store),
     invitations: makeInvitationRepo(store),
     attachments: makeAttachmentRepo(store),
+    emailThreads: makeEmailThreadRepo(store),
   };
 }
 

--- a/src/data/adapters/memory/store.ts
+++ b/src/data/adapters/memory/store.ts
@@ -21,6 +21,15 @@ export interface CategoryRow {
   tenantId: string; // 所属テナント ID (マルチテナント化のキー)
 }
 
+// メモリ内で保持するメールスレッド対応表の 1 行 (Message-ID → ticket / Phase 2)
+export interface EmailThreadRefRow {
+  id: string; // 行 ID
+  messageId: string; // 正規化済み Message-ID
+  ticketId: string; // 紐づくチケット ID
+  tenantId: string; // 所属テナント ID (突き合わせスコープのキー)
+  createdAt: Date; // 記録日時 (新しい紐付けを優先するため)
+}
+
 // テスト用アダプタが使うインメモリストア。
 // `idSeq` カウンタはストアごとに独立しているので、テストコンテキスト間で状態が混ざらず
 // 連番 ID も安定して再現できる。
@@ -37,6 +46,7 @@ export interface Store {
   magicLinks: Map<string, MagicLinkToken>; // マジックリンクトークン (パスワードレス認証)
   invitations: Map<string, Invitation>; // 招待リンクトークン (メンバー招待)
   attachments: Map<string, Attachment>; // 添付ファイルのメタ情報 (画像)
+  emailThreadRefs: Map<string, EmailThreadRefRow>; // メール Message-ID → チケット 対応表 (Phase 2)
   idSeq: { value: number }; // 連番生成用のカウンタ (オブジェクトに包んで参照共有)
 }
 
@@ -55,6 +65,7 @@ export function createEmptyStore(): Store {
     magicLinks: new Map(),
     invitations: new Map(),
     attachments: new Map(),
+    emailThreadRefs: new Map(),
     idSeq: { value: 0 },
   };
 }
@@ -74,6 +85,7 @@ export function cloneStore(src: Store): Store {
     magicLinks: new Map(src.magicLinks),
     invitations: new Map(src.invitations),
     attachments: new Map(src.attachments),
+    emailThreadRefs: new Map(src.emailThreadRefs),
     idSeq: { value: src.idSeq.value },
   };
 }
@@ -92,6 +104,7 @@ export function overwriteStore(dst: Store, src: Store): void {
   dst.magicLinks = new Map(src.magicLinks);
   dst.invitations = new Map(src.invitations);
   dst.attachments = new Map(src.attachments);
+  dst.emailThreadRefs = new Map(src.emailThreadRefs);
   // 連番も元に戻す
   dst.idSeq.value = src.idSeq.value;
 }

--- a/src/data/adapters/prisma/email-thread-repository.prisma.ts
+++ b/src/data/adapters/prisma/email-thread-repository.prisma.ts
@@ -13,7 +13,9 @@ export function makeEmailThreadRepo(db: PrismaLike): EmailThreadRepository {
       const row = await db.emailThreadRef.findFirst({
         where: { tenantId, messageId: { in: messageIds } }, // 必ず tenantId でスコープ (クロステナント遮断 §9)
         select: { ticketId: true }, // 逆引きに必要なのは ticketId のみ
-        orderBy: { createdAt: 'desc' }, // 直近に紐づけた対応を優先
+        // 直近に紐づけた対応を優先。createdAt 同値 (同一リクエスト内の複数登録など) でも結果が
+        // ブレないよう id を副キーにして並びを決定的にする (メモリ実装と挙動を揃える)
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
       });
       // 見つかれば ticketId、無ければ null
       return row?.ticketId ?? null;

--- a/src/data/adapters/prisma/email-thread-repository.prisma.ts
+++ b/src/data/adapters/prisma/email-thread-repository.prisma.ts
@@ -1,0 +1,38 @@
+// メールスレッド対応表リポジトリの契約 (port) と Prisma 共通型をインポート
+import type { EmailThreadRepository } from '@/data/ports/email-thread-repository';
+import type { PrismaLike } from './types';
+
+// Prisma クライアントを使った EmailThreadRef リポジトリを生成する関数
+export function makeEmailThreadRepo(db: PrismaLike): EmailThreadRepository {
+  return {
+    // 参照 Message-ID 群から、紐づく既存チケット ID を 1 件返す (tenantId スコープ)
+    async findTicketIdByMessageIds(messageIds, tenantId) {
+      // 参照が無ければ突き合わせ不要 (新規起票へ倒す)
+      if (messageIds.length === 0) return null;
+      // tenantId + messageId IN (...) で対応表を引く。複数ヒット時は新しい登録を優先する
+      const row = await db.emailThreadRef.findFirst({
+        where: { tenantId, messageId: { in: messageIds } }, // 必ず tenantId でスコープ (クロステナント遮断 §9)
+        select: { ticketId: true }, // 逆引きに必要なのは ticketId のみ
+        orderBy: { createdAt: 'desc' }, // 直近に紐づけた対応を優先
+      });
+      // 見つかれば ticketId、無ければ null
+      return row?.ticketId ?? null;
+    },
+
+    // Message-ID とチケットの対応を 1 件登録する (冪等)
+    async register(input) {
+      // createMany + skipDuplicates で「既に同じ (tenantId, messageId) があれば無視」する。
+      // Webhook の再送 (at-least-once) でも二重登録にならず、例外も投げない。
+      await db.emailThreadRef.createMany({
+        data: [
+          {
+            messageId: input.messageId, // 正規化済み Message-ID
+            ticketId: input.ticketId, // 紐づくチケット
+            tenantId: input.tenantId, // 所属テナント (where スコープのキー)
+          },
+        ],
+        skipDuplicates: true, // (tenantId, messageId) のユニーク衝突は無視する
+      });
+    },
+  };
+}

--- a/src/data/adapters/prisma/index.ts
+++ b/src/data/adapters/prisma/index.ts
@@ -4,6 +4,7 @@ import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
 // 各エンティティ用の Prisma リポジトリ生成関数を取り込む
 import { makeAttachmentRepo } from './attachment-repository.prisma';
 import { makeCategoryRepo } from './category-repository.prisma';
+import { makeEmailThreadRepo } from './email-thread-repository.prisma';
 import { makeFaqRepo } from './faq-repository.prisma';
 import { makeInvitationRepo } from './invitation-repository.prisma';
 import { makeMagicLinkRepo } from './magic-link-repository.prisma';
@@ -34,6 +35,7 @@ export function buildPrismaRepos(db: PrismaLike): Repos {
     magicLinks: makeMagicLinkRepo(db),
     invitations: makeInvitationRepo(db),
     attachments: makeAttachmentRepo(db),
+    emailThreads: makeEmailThreadRepo(db),
   };
 }
 

--- a/src/data/ports/email-thread-repository.ts
+++ b/src/data/ports/email-thread-repository.ts
@@ -1,0 +1,31 @@
+// メールスレッド継続用の Message-ID 対応表リポジトリの契約 (port)。
+//
+// docs/smb-dx-pivot-plan.md Phase 2「スレッド継続 (In-Reply-To ヘッダで紐付け)」(§4 / L130)。
+// 受信して起票したメール / 担当者が送信した返信メールの Message-ID を「どのチケットに属するか」と
+// 一緒に記録し、後続の返信メール (In-Reply-To / References) からチケットを逆引きするために使う。
+//
+// セキュリティ不変条件 (§9): 突き合わせ・登録は必ず認証済み文脈で得た `tenantId` でスコープすること。
+// 別テナントの Message-ID を参照させると、攻撃者が他テナントのチケットへコメントを差し込めてしまう
+// (クロステナント漏洩) ため、Adapter 側でも tenantId を必ず where に含める。
+
+// 対応表へ 1 件登録するときの入力値
+export interface RegisterEmailThreadRefInput {
+  messageId: string; // メールの Message-ID (山括弧と前後空白を除いた正規化済みの値)
+  ticketId: string; // 紐づくチケット ID
+  tenantId: string; // 所属テナント ID (セッション/宛先テナント由来必須)
+}
+
+// メールスレッド対応表リポジトリの契約 (port)
+export interface EmailThreadRepository {
+  /**
+   * 受信メールの参照 Message-ID 群から、紐づく既存チケット ID を 1 件返す (tenantId スコープ)。
+   * 複数ヒットした場合は最も新しく記録された対応を優先する。見つからなければ null。
+   */
+  findTicketIdByMessageIds(messageIds: string[], tenantId: string): Promise<string | null>;
+
+  /**
+   * Message-ID とチケットの対応を 1 件登録する (tenantId スコープ)。
+   * 同一 (tenantId, messageId) が既にあれば何もしない (冪等: Webhook 再送でも安全)。
+   */
+  register(input: RegisterEmailThreadRefInput): Promise<void>;
+}

--- a/src/data/ports/unit-of-work.ts
+++ b/src/data/ports/unit-of-work.ts
@@ -1,6 +1,7 @@
 // 各リポジトリの契約 (port) を束ねて 1 セットとして扱うための型定義
 import type { AttachmentRepository } from './attachment-repository';
 import type { CategoryRepository } from './category-repository';
+import type { EmailThreadRepository } from './email-thread-repository';
 import type { FaqRepository } from './faq-repository';
 import type { InvitationRepository } from './invitation-repository';
 import type { MagicLinkRepository } from './magic-link-repository';
@@ -24,6 +25,7 @@ export interface Repos {
   magicLinks: MagicLinkRepository; // マジックリンクトークン操作 (パスワードレス認証)
   invitations: InvitationRepository; // 招待リンクトークン操作 (メンバー招待)
   attachments: AttachmentRepository; // 添付ファイル (画像) のメタ情報操作
+  emailThreads: EmailThreadRepository; // メール Message-ID → チケット 対応表 (スレッド継続 / Phase 2)
 }
 
 // トランザクション境界を表す契約 (Unit of Work パターン)

--- a/src/lib/comment-recipients.ts
+++ b/src/lib/comment-recipients.ts
@@ -1,0 +1,40 @@
+/**
+ * Comment notification fan-out target resolution (shared helper).
+ *
+ * 「コメント (返信) が付いたとき、誰にアプリ内通知を送るか」を 1 か所に集約した純粋寄りのヘルパー。
+ * Web フォーム経由のコメント投稿 (POST /api/tickets/[id]/comments) と、メール取り込みの
+ * スレッド継続 (POST /api/inbound/email でのコメント追記 / Phase 2) の両方から再利用する (DRY)。
+ *
+ * 宛先の方針:
+ *  - 担当者/エージェントがコメント → 依頼者 (起票者) + 担当者が居れば担当者。
+ *  - 依頼者がコメントし担当者が決まっている → その担当者のみ。
+ *  - 依頼者がコメントし担当者未定 → テナント内の全エージェント。
+ * いずれもコメント投稿者自身は除外し、テナント内のユーザーだけを対象にする (クロステナント遮断 §9)。
+ */
+
+// リポジトリ束 (テナント内エージェント ID の取得に使用)
+import { repos } from '@/data';
+
+// コメント通知の送信先ユーザー ID 群を決定する (テナントスコープ)
+export async function resolveCommentRecipients(
+  ticket: { creatorId: string; assigneeId: string | null }, // 対象チケットの起票者/担当者
+  authorId: string, // コメントを書いたユーザー
+  authorIsAgent: boolean, // 書き手がエージェント/管理者か
+  tenantId: string, // 当該テナント (全エージェント取得のスコープ)
+): Promise<string[]> {
+  // 宛先候補を集める配列
+  const candidates: string[] = [];
+  // エージェントがコメントした場合: 依頼者 (+ 担当者が居れば担当者)
+  if (authorIsAgent) {
+    candidates.push(ticket.creatorId);
+    if (ticket.assigneeId) candidates.push(ticket.assigneeId);
+  } else if (ticket.assigneeId) {
+    // 依頼者がコメントし担当者が決まっている場合は担当者のみ
+    candidates.push(ticket.assigneeId);
+  } else {
+    // 依頼者がコメントし担当者未定なら全エージェントに通知 (テナント内のみ)
+    candidates.push(...(await repos.users.listAgentIds(tenantId)));
+  }
+  // 重複排除し、コメント投稿者自身は除外して返す
+  return Array.from(new Set(candidates)).filter((id) => id !== authorId);
+}

--- a/src/lib/email-message-id.ts
+++ b/src/lib/email-message-id.ts
@@ -10,7 +10,7 @@
  * 山括弧なしの値で、受信側の normalizeMessageId が返す表記に一致させる。
  */
 
-// 衝突しない一意サフィックスを作るための UUID 生成 (Node の Web Crypto)
+// 衝突しない一意サフィックスを作るための UUID 生成 (Node 標準の crypto)
 import { randomUUID } from 'node:crypto';
 
 // Message-ID のドメイン部が未設定のときに使う既定ドメイン (取り込みドメインと揃える想定)

--- a/src/lib/email-message-id.ts
+++ b/src/lib/email-message-id.ts
@@ -1,0 +1,38 @@
+/**
+ * Outbound email Message-ID helpers (Phase 2 スレッド継続).
+ *
+ * docs/smb-dx-pivot-plan.md Phase 2「スレッド継続 (In-Reply-To ヘッダで紐付け)」(§4 / L130)。
+ * 担当者の返信を依頼者へメールで送るとき、決定的な Message-ID を付与する。依頼者がそのメールに
+ * 返信すると In-Reply-To にこの Message-ID が載るので、受信 Webhook 側で「どのチケットへの返信か」を
+ * 逆引きできる (EmailThreadRef に登録した正規化値と突き合わせる)。
+ *
+ * `header` はメールヘッダにそのまま入れる "<...>" 形式、`normalized` は対応表に登録/突き合わせる
+ * 山括弧なしの値で、受信側の normalizeMessageId が返す表記に一致させる。
+ */
+
+// 衝突しない一意サフィックスを作るための UUID 生成 (Node の Web Crypto)
+import { randomUUID } from 'node:crypto';
+
+// Message-ID のドメイン部が未設定のときに使う既定ドメイン (取り込みドメインと揃える想定)
+const DEFAULT_MESSAGE_ID_DOMAIN = 'helpdesk-hub.app';
+
+// Message-ID のドメイン部を解決する。取り込みドメイン (INBOUND_EMAIL_DOMAIN) があれば流用し、
+// 無ければ既定ドメインにフォールバックする (送受信で同じ前提に揃えるため一元化)。
+export function resolveMessageIdDomain(): string {
+  // 環境変数の前後空白を除く
+  const configured = process.env.INBOUND_EMAIL_DOMAIN?.trim();
+  // 値があればそれを、無ければ既定ドメインを使う
+  return configured && configured.length > 0 ? configured : DEFAULT_MESSAGE_ID_DOMAIN;
+}
+
+// チケット返信メール用の Message-ID を組み立てる。
+// header: ヘッダにそのまま入れる "<...>" 形式 / normalized: 対応表へ登録・突き合わせる正規化値。
+export function buildReplyMessageId(
+  ticketId: string,
+  domain: string,
+): { header: string; normalized: string } {
+  // ticketId は cuid (英数字) なのでそのまま埋め込める。UUID を足して同一チケットでも一意にする
+  const bare = `reply-${ticketId}-${randomUUID()}@${domain}`;
+  // ヘッダ用は山括弧で囲む。登録用は山括弧なし (受信側 normalizeMessageId の戻り値と一致させる)
+  return { header: `<${bare}>`, normalized: bare };
+}

--- a/src/lib/email/email-sender.ts
+++ b/src/lib/email/email-sender.ts
@@ -13,6 +13,10 @@ export interface EmailMessage {
   subject: string; // 件名 (日本語想定)
   html: string; // HTML 本文 (リッチ表示用)
   text: string; // テキスト本文 (HTML 非対応クライアント用フォールバック)
+  // 任意: このメールに付与する Message-ID (山括弧込み "<...>")。
+  // Phase 2 スレッド継続で、依頼者がこのメールに返信したとき In-Reply-To で元チケットへ
+  // 紐付けられるよう、呼び出し側が決定的な Message-ID を指定して送る。未指定なら送信側に委ねる。
+  messageId?: string;
 }
 
 // 任意のトランスポート (Console / Nodemailer SMTP / 将来の SES など) を抽象化する契約

--- a/src/lib/email/nodemailer-email-sender.ts
+++ b/src/lib/email/nodemailer-email-sender.ts
@@ -33,7 +33,8 @@ export function createNodemailerEmailSender(config: NodemailerEmailSenderConfig)
   const secure = config.port === 465;
 
   // 認証情報が両方揃っているときだけ auth ブロックを渡す (匿名 SMTP 対応)
-  const auth = config.user && config.password ? { user: config.user, pass: config.password } : undefined;
+  const auth =
+    config.user && config.password ? { user: config.user, pass: config.password } : undefined;
 
   // Nodemailer トランスポートを 1 度だけ生成して使い回す
   const transporter: Transporter = nodemailer.createTransport({
@@ -53,6 +54,8 @@ export function createNodemailerEmailSender(config: NodemailerEmailSenderConfig)
         subject: message.subject,
         text: message.text,
         html: message.html,
+        // 指定があれば Message-ID を明示する (スレッド継続の紐付けに使う)。未指定なら nodemailer が自動採番
+        messageId: message.messageId,
       });
     },
   };

--- a/src/lib/inbound-email.ts
+++ b/src/lib/inbound-email.ts
@@ -143,6 +143,9 @@ export function normalizeMessageId(raw: string | null | undefined): string | nul
   if (value.length === 0 || value.length > INBOUND_MESSAGE_ID_MAX) return null;
   // Message-ID は addr-spec 形なので、空白を含まず "@" を 1 つ以上持つことを最低条件にする
   if (/\s/.test(value) || !value.includes('@')) return null;
+  // 外側 1 組の山括弧を外した後に山括弧が残るのは不正 (例: "<a@b><c@d>" のような複数 ID)。
+  // ここで弾かないと送受信で表記が食い違い、スレッドの突き合わせが静かに外れるため null にする。
+  if (value.includes('<') || value.includes('>')) return null;
   // 正規化済みの値を返す
   return value;
 }

--- a/src/lib/inbound-email.ts
+++ b/src/lib/inbound-email.ts
@@ -19,6 +19,12 @@ export const INBOUND_BODY_MAX = 100_000;
 export const INBOUND_ADDRESS_MAX = 254;
 // 件名が空のときに使う既定タイトル (Lite 用語に合わせ専門用語を避ける)
 export const INBOUND_DEFAULT_SUBJECT = '(件名なし)';
+// Message-ID 1 件の最大長 (文字数)。RFC 5322 の行長上限 (998) に合わせ、異常に長い値を弾く
+export const INBOUND_MESSAGE_ID_MAX = 998;
+// 1 通から取り込む参照 Message-ID の最大数。References が肥大化したメールでの走査コスト/DoS を抑える (§9)
+export const INBOUND_MAX_REFERENCE_IDS = 50;
+// 生ヘッダ文字列を走査する際の最大長 (文字数)。巨大ヘッダの全走査によるコスト/DoS を抑える上限 (§9)
+const INBOUND_RAW_HEADER_MAX = 64_000;
 // 自動生成する取り込みトークンの長さ (英小文字 + 数字)。十分長く取り衝突を実質ゼロにする
 const INBOUND_TOKEN_LENGTH = 16;
 // 取り込みトークンに使う文字集合。メールのローカルパートに安全な英小文字 + 数字のみに限定する
@@ -31,6 +37,8 @@ export interface ParsedInboundEmail {
   senderName: string; // 送信者の表示名 (取れなければアドレスを流用)
   subject: string; // 件名 (空なら既定タイトル / 上限まで切り詰め済み)
   body: string; // 本文テキスト (上限まで切り詰め済み)
+  messageId: string | null; // この受信メール自身の Message-ID (正規化済み / 取れなければ null)
+  referenceIds: string[]; // In-Reply-To + References から得た参照 Message-ID 群 (重複排除済み / スレッド継続用)
 }
 
 // "表示名 <addr@example.com>" や "addr@example.com" から純粋なメールアドレスを取り出す。
@@ -120,6 +128,86 @@ export function generateInboundToken(): string {
   return token;
 }
 
+// "<id@host>" 形式から山括弧と前後空白を除いた正規化済み Message-ID を返す。
+// 妥当な形 (空白を含まず "@" を持つ addr-spec 風) でなければ null を返す (fail-closed)。
+// 受信メールのヘッダと送信メールの生成側を同じ関数で正規化し、突き合わせの表記揺れを無くす。
+export function normalizeMessageId(raw: string | null | undefined): string | null {
+  // 空入力は Message-ID 無しとして扱う
+  if (!raw) return null;
+  // 前後の空白を除去する
+  let value = raw.trim();
+  // 先頭・末尾を 1 組だけ囲む山括弧があれば中身を取り出す ("<id@host>" → "id@host")
+  const wrapped = value.match(/^<([^>]*)>$/);
+  if (wrapped) value = wrapped[1].trim();
+  // 長さ上限を超える / 空 のものは弾く
+  if (value.length === 0 || value.length > INBOUND_MESSAGE_ID_MAX) return null;
+  // Message-ID は addr-spec 形なので、空白を含まず "@" を 1 つ以上持つことを最低条件にする
+  if (/\s/.test(value) || !value.includes('@')) return null;
+  // 正規化済みの値を返す
+  return value;
+}
+
+// In-Reply-To / References ヘッダ値から複数の Message-ID を取り出す (空白区切りの "<id>" 列)。
+// 取り込み数は上限でクランプし、各値を normalizeMessageId で検証する (重複は呼び出し側で排除)。
+export function extractMessageIds(raw: string | null | undefined): string[] {
+  // 空入力は参照無し
+  if (!raw) return [];
+  // 走査コストを抑えるため、入力長を上限でクランプしてから解析する (§9 DoS 対策)
+  const capLen = INBOUND_MESSAGE_ID_MAX * INBOUND_MAX_REFERENCE_IDS;
+  const capped = raw.length > capLen ? raw.slice(0, capLen) : raw;
+  // まず "<...>" の塊を拾う ([^>]+ は単純なので線形時間 / ReDoS なし)。無ければ空白区切りで分解する
+  const tokens = capped.match(/<[^>]+>/g) ?? capped.trim().split(/\s+/);
+  // 検証を通った Message-ID を上限までためる
+  const out: string[] = [];
+  for (const token of tokens) {
+    // 上限に達したら打ち切る (これ以上の参照は無視)
+    if (out.length >= INBOUND_MAX_REFERENCE_IDS) break;
+    // 1 件を正規化・検証する
+    const id = normalizeMessageId(token);
+    // 妥当なものだけ採用する
+    if (id) out.push(id);
+  }
+  // Message-ID の配列を返す
+  return out;
+}
+
+// 生ヘッダ文字列 (例: SendGrid Inbound Parse の "headers" フィールド) から、指定ヘッダの値を 1 件取り出す。
+// ヘッダ名は大文字小文字を区別せず、折り返された継続行 (先頭が空白の行) は 1 行に連結する。
+// 見つからなければ null。プロバイダが個別フィールドを提供しない場合のフォールバックに使う。
+export function readRawHeader(rawHeaders: string | null | undefined, name: string): string | null {
+  // 空入力はヘッダ無し
+  if (!rawHeaders) return null;
+  // 走査コストを抑えるため入力長を上限でクランプする (§9)
+  const capped =
+    rawHeaders.length > INBOUND_RAW_HEADER_MAX
+      ? rawHeaders.slice(0, INBOUND_RAW_HEADER_MAX)
+      : rawHeaders;
+  // 探したいヘッダ名を小文字化して比較に使う
+  const target = name.toLowerCase();
+  // CRLF / LF どちらの改行でも行に分割する
+  const lines = capped.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    // 現在行
+    const line = lines[i];
+    // "名前: 値" の区切りコロンの位置を探す
+    const colon = line.indexOf(':');
+    // コロンが無い / 先頭にある行はヘッダ行ではないのでスキップ
+    if (colon <= 0) continue;
+    // ヘッダ名が一致しなければスキップ (大文字小文字無視)
+    if (line.slice(0, colon).trim().toLowerCase() !== target) continue;
+    // 値部分を取り出す
+    let value = line.slice(colon + 1).trim();
+    // 後続の継続行 (先頭が空白) を 1 行に連結する (References は折り返されやすい)
+    for (let j = i + 1; j < lines.length && /^[ \t]/.test(lines[j]); j++) {
+      value += ' ' + lines[j].trim();
+    }
+    // 最初に一致したヘッダの値を返す
+    return value;
+  }
+  // 見つからなければ null
+  return null;
+}
+
 // 文字列を指定長で安全に切り詰める内部ヘルパー (上限超過時のみ切る)
 function clamp(value: string, max: number): string {
   // 上限以内ならそのまま、超えていれば先頭 max 文字に切り詰める
@@ -134,6 +222,9 @@ export function parseInboundEmail(
     from?: string | null; // 送信者 (ヘッダ or envelope 由来)
     subject?: string | null; // 件名
     text?: string | null; // テキスト本文
+    messageId?: string | null; // この受信メールの Message-ID ヘッダ (スレッド継続用)
+    inReplyTo?: string | null; // In-Reply-To ヘッダ (直接の返信元 Message-ID)
+    references?: string | null; // References ヘッダ (スレッド上の Message-ID 列)
   },
   options?: { expectedDomain?: string | null }, // 宛先ドメイン検証 (任意)
 ): { ok: true; email: ParsedInboundEmail } | { ok: false; reason: string } {
@@ -167,6 +258,12 @@ export function parseInboundEmail(
   );
   // 本文は上限まで切り詰める (空でも許容: 件名だけのメールもあり得る)
   const body = clamp((fields.text ?? '').trim(), INBOUND_BODY_MAX);
+  // この受信メール自身の Message-ID を正規化する (後続の返信を紐付けるための記録用)
+  const messageId = normalizeMessageId(fields.messageId);
+  // In-Reply-To と References から参照 Message-ID を集め、重複を排除する (スレッド継続の突き合わせキー)
+  const referenceIds = Array.from(
+    new Set([...extractMessageIds(fields.inReplyTo), ...extractMessageIds(fields.references)]),
+  );
   // 正規化済みの受信メールを返す
   return {
     ok: true,
@@ -176,6 +273,8 @@ export function parseInboundEmail(
       senderName: clamp(senderName, INBOUND_ADDRESS_MAX),
       subject,
       body,
+      messageId,
+      referenceIds,
     },
   };
 }

--- a/tests/data/email-thread-repository.contract.prisma.test.ts
+++ b/tests/data/email-thread-repository.contract.prisma.test.ts
@@ -1,0 +1,129 @@
+// メールスレッド対応表リポジトリ (本番 Prisma 実装) の契約テスト。
+// Message-ID → チケットの逆引き・冪等登録・クロステナント分離 (§9) を実 DB で検証する。
+// RUN_PRISMA_CONTRACT=1 のときだけ走り、beforeEach で全テーブルを TRUNCATE するため
+// **開発 DB を指さないこと** (CLAUDE.md §テスト)。専用 DB で実行する。
+
+// Vitest の DSL とフック
+import { describe, beforeAll, afterAll, beforeEach, expect, it } from 'vitest';
+// Prisma クライアント本体 (生成物)
+import { PrismaClient } from '@/generated/prisma';
+// 本番 Prisma 実装の repos 束を組み立てる関数
+import { buildPrismaRepos } from '@/data/adapters/prisma';
+
+// テナント A / B の ID
+const TENANT_A = 'default-tenant';
+const TENANT_B = 'tenant-b';
+
+// DB 依存テストを実行してよいかの明示フラグ (CI の専用ジョブだけが '1' を立てる)
+const SHOULD_RUN = process.env.RUN_PRISMA_CONTRACT === '1';
+
+describe.runIf(SHOULD_RUN)('EmailThreadRef prisma adapter', () => {
+  // スイート全体で共有する PrismaClient
+  let prisma: PrismaClient;
+
+  // スイート開始時に 1 度だけ接続する
+  beforeAll(async () => {
+    prisma = new PrismaClient();
+    await prisma.$connect();
+  });
+
+  // スイート終了時に接続を閉じる (接続リーク防止)
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  // 各テスト前に全テーブルを空にし、テナント A/B とそれぞれのチケットをシードする。
+  // EmailThreadRef は Tenant/Ticket への CASCADE FK があるため、Tenant TRUNCATE で連鎖的に消える。
+  beforeEach(async () => {
+    await prisma.$executeRawUnsafe(
+      'TRUNCATE TABLE "EmailThreadRef","Attachment","TicketHistory","TicketComment","Notification","FaqCandidate","Ticket","Category","Invitation","MagicLinkToken","User","Tenant" RESTART IDENTITY CASCADE',
+    );
+    // テナント A / B を作成する
+    await prisma.tenant.create({ data: { id: TENANT_A, name: 'デフォルト組織', mode: 'lite' } });
+    await prisma.tenant.create({ data: { id: TENANT_B, name: '別組織', mode: 'lite' } });
+    // 各テナントに 1 人ユーザーと 1 件チケットを用意する (EmailThreadRef の FK 先)
+    for (const [tenantId, suffix] of [
+      [TENANT_A, 'a'],
+      [TENANT_B, 'b'],
+    ] as const) {
+      await prisma.user.create({
+        data: {
+          id: `u-${suffix}`,
+          email: `user-${suffix}@example.com`,
+          name: `ユーザー${suffix}`,
+          passwordHash: 'x',
+          role: 'requester',
+          tenantId,
+        },
+      });
+      await prisma.ticket.create({
+        data: {
+          id: `t-${suffix}`,
+          title: '件名',
+          body: '本文',
+          creatorId: `u-${suffix}`,
+          tenantId,
+        },
+      });
+    }
+  });
+
+  // 登録した Message-ID から ticketId を逆引きできる
+  it('登録した Message-ID からチケットを逆引きできる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await repos.emailThreads.register({
+      messageId: 'm1@x.com',
+      ticketId: 't-a',
+      tenantId: TENANT_A,
+    });
+    expect(await repos.emailThreads.findTicketIdByMessageIds(['m1@x.com'], TENANT_A)).toBe('t-a');
+  });
+
+  // 同一 (tenant, messageId) の二重登録は冪等 (createMany skipDuplicates)
+  it('同一 Message-ID の二重登録は冪等', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await repos.emailThreads.register({
+      messageId: 'm1@x.com',
+      ticketId: 't-a',
+      tenantId: TENANT_A,
+    });
+    // 2 回目も例外を投げず、件数は 1 のまま
+    await repos.emailThreads.register({
+      messageId: 'm1@x.com',
+      ticketId: 't-a',
+      tenantId: TENANT_A,
+    });
+    expect(await prisma.emailThreadRef.count()).toBe(1);
+  });
+
+  // 別テナントの Message-ID は突き合わせ対象にしない (クロステナント遮断)
+  it('別テナントの Message-ID は逆引きできない', async () => {
+    const repos = buildPrismaRepos(prisma);
+    // テナント B に登録した Message-ID は…
+    await repos.emailThreads.register({
+      messageId: 'm1@x.com',
+      ticketId: 't-b',
+      tenantId: TENANT_B,
+    });
+    // テナント A のスコープでは見つからない
+    expect(await repos.emailThreads.findTicketIdByMessageIds(['m1@x.com'], TENANT_A)).toBeNull();
+    // 自テナント (B) では引ける
+    expect(await repos.emailThreads.findTicketIdByMessageIds(['m1@x.com'], TENANT_B)).toBe('t-b');
+  });
+
+  // 別テナントが同じ Message-ID を使っても衝突しない ((tenantId, messageId) 複合一意のため)
+  it('テナントが違えば同一 Message-ID を別々に登録できる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await repos.emailThreads.register({
+      messageId: 'same@x.com',
+      ticketId: 't-a',
+      tenantId: TENANT_A,
+    });
+    await repos.emailThreads.register({
+      messageId: 'same@x.com',
+      ticketId: 't-b',
+      tenantId: TENANT_B,
+    });
+    expect(await prisma.emailThreadRef.count()).toBe(2);
+  });
+});

--- a/tests/data/email-thread-repository.memory.test.ts
+++ b/tests/data/email-thread-repository.memory.test.ts
@@ -1,0 +1,98 @@
+// メールスレッド対応表リポジトリ (メモリアダプタ) の単体テスト。
+// Message-ID → チケットの逆引き・冪等登録・クロステナント分離を検証する (DB を持ち込まない)。
+
+// Vitest の DSL とフック
+import { beforeEach, describe, expect, it } from 'vitest';
+// メモリ context (store/repos)
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// 型のみ
+import type { Repos } from '@/data/ports/unit-of-work';
+
+// テスト用テナント識別子
+const TENANT_A = 'tenant-a';
+const TENANT_B = 'tenant-b';
+
+// テストごとに作り直す依存
+let store: Store;
+let repos: Repos;
+
+// 各テストでメモリ context を作り直す
+beforeEach(() => {
+  const ctx = createMemoryContext();
+  store = ctx.store;
+  repos = ctx.repos;
+});
+
+describe('emailThreads (memory adapter)', () => {
+  // 登録した Message-ID から、その後正しく ticketId を逆引きできる
+  it('登録した Message-ID からチケットを逆引きできる', async () => {
+    await repos.emailThreads.register({
+      messageId: 'm1@x.com',
+      ticketId: 't1',
+      tenantId: TENANT_A,
+    });
+    // 参照に m1 を含めれば t1 が返る
+    const found = await repos.emailThreads.findTicketIdByMessageIds(['m1@x.com'], TENANT_A);
+    expect(found).toBe('t1');
+  });
+
+  // 参照が空 / 未登録なら null
+  it('未登録・空参照なら null を返す', async () => {
+    expect(await repos.emailThreads.findTicketIdByMessageIds([], TENANT_A)).toBeNull();
+    expect(
+      await repos.emailThreads.findTicketIdByMessageIds(['unknown@x.com'], TENANT_A),
+    ).toBeNull();
+  });
+
+  // 同じ (tenant, messageId) を二重登録しても 1 件のまま (冪等)
+  it('同一 Message-ID の二重登録は冪等', async () => {
+    await repos.emailThreads.register({
+      messageId: 'm1@x.com',
+      ticketId: 't1',
+      tenantId: TENANT_A,
+    });
+    await repos.emailThreads.register({
+      messageId: 'm1@x.com',
+      ticketId: 't1',
+      tenantId: TENANT_A,
+    });
+    // ストア上は 1 件だけ
+    expect(store.emailThreadRefs.size).toBe(1);
+  });
+
+  // 別テナントの Message-ID は突き合わせ対象にしない (クロステナント遮断)
+  it('別テナントの Message-ID は逆引きできない', async () => {
+    // テナント B に登録した Message-ID を…
+    await repos.emailThreads.register({
+      messageId: 'm1@x.com',
+      ticketId: 't-b',
+      tenantId: TENANT_B,
+    });
+    // テナント A のスコープで引いても見つからない
+    expect(await repos.emailThreads.findTicketIdByMessageIds(['m1@x.com'], TENANT_A)).toBeNull();
+    // 同じ Message-ID でも自テナント (B) では引ける
+    expect(await repos.emailThreads.findTicketIdByMessageIds(['m1@x.com'], TENANT_B)).toBe('t-b');
+  });
+
+  // 実運用ではスレッド上の複数 Message-ID (元メール + 過去返信) は同じチケットを指す。
+  // どの参照を渡しても、また複数まとめて渡しても、そのチケットが返ることを保証する。
+  it('同一チケットの複数 Message-ID はどの参照でも同じチケットを返す', async () => {
+    // 1 つのチケット t1 に、元メールと返信メールの 2 つの Message-ID を紐づける
+    await repos.emailThreads.register({
+      messageId: 'orig@x.com',
+      ticketId: 't1',
+      tenantId: TENANT_A,
+    });
+    await repos.emailThreads.register({
+      messageId: 'reply@x.com',
+      ticketId: 't1',
+      tenantId: TENANT_A,
+    });
+    // 個別に引いても、まとめて引いても t1 が返る
+    expect(await repos.emailThreads.findTicketIdByMessageIds(['orig@x.com'], TENANT_A)).toBe('t1');
+    expect(await repos.emailThreads.findTicketIdByMessageIds(['reply@x.com'], TENANT_A)).toBe('t1');
+    expect(
+      await repos.emailThreads.findTicketIdByMessageIds(['orig@x.com', 'reply@x.com'], TENANT_A),
+    ).toBe('t1');
+  });
+});

--- a/tests/features/inbound-email-route.test.ts
+++ b/tests/features/inbound-email-route.test.ts
@@ -16,15 +16,33 @@ const TOKEN = 'abc123';
 const MEMBER_EMAIL = 'ichiro@example.com';
 const MEMBER_ID = 'u-member-1';
 
+// UnitOfWork 型 (スレッド継続のコメント追記でトランザクションを使う)
+import type { UnitOfWork } from '@/data/ports/unit-of-work';
+
 // 各テストで差し替える可変な依存 (Route import 前に値を入れる)
 let store: Store;
 let repos: Repos;
+let uow: UnitOfWork;
 
 // @/data を差し替え (getter で beforeEach の上書きを反映)
 vi.mock('@/data', () => ({
   get repos() {
     return repos;
   },
+  get uow() {
+    return uow;
+  },
+}));
+
+// next/cache の副作用 (revalidatePath) はテストでは不要
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}));
+
+// SSE ブロードキャスト経路もテストでは不要 (購読者がいないだけだが明示的に無効化)
+vi.mock('@/lib/sse-subscribers', () => ({
+  broadcast: vi.fn(),
 }));
 
 // テナント (Lite) + 既知メンバー 1 人をシードする
@@ -80,6 +98,7 @@ describe('POST /api/inbound/email', () => {
     const ctx = createMemoryContext();
     store = ctx.store;
     repos = ctx.repos;
+    uow = ctx.uow;
     seed();
     vi.stubEnv('INBOUND_EMAIL_SECRET', SECRET);
   });
@@ -224,5 +243,81 @@ describe('POST /api/inbound/email', () => {
     const res = await POST(req);
     expect(res.status).toBe(413);
     expect(store.tickets.size).toBe(0);
+  });
+
+  // スレッド継続: 参照 Message-ID が既存チケットに紐づくなら、新規起票せずコメント追記する
+  it('In-Reply-To が既知 Message-ID に一致すると既存チケットへコメント追記する', async () => {
+    const { POST } = await import('@/app/api/inbound/email/route');
+    // まず通常の受信メール (Message-ID 付き) で 1 件起票する
+    const res1 = await POST(makeRequest({ ...VALID_EMAIL, messageId: '<orig-1@example.com>' }));
+    expect(res1.status).toBe(201);
+    const { ticketId } = (await res1.json()) as { ticketId: string };
+    // 起票直後はコメント 0 件
+    expect(store.comments.size).toBe(0);
+
+    // 同じ送信者が、その起票メールに返信する (In-Reply-To で元 Message-ID を参照)
+    const res2 = await POST(
+      makeRequest({
+        ...VALID_EMAIL,
+        subject: 'Re: プリンターが動きません',
+        text: 'まだ直りません',
+        messageId: '<reply-1@example.com>',
+        inReplyTo: '<orig-1@example.com>',
+      }),
+    );
+    // 200 + threaded フラグで「追記」されたことを示す
+    expect(res2.status).toBe(200);
+    const body2 = (await res2.json()) as { ticketId: string; threaded?: boolean };
+    expect(body2.threaded).toBe(true);
+    expect(body2.ticketId).toBe(ticketId);
+    // 新規チケットは増えず (1 件のまま)、コメントが 1 件追記される
+    expect(store.tickets.size).toBe(1);
+    expect(store.comments.size).toBe(1);
+    // 追記コメントは送信者本人 (既知メンバー) が作者で、本文が載る
+    const comment = Array.from(store.comments.values())[0];
+    expect(comment.ticketId).toBe(ticketId);
+    expect(comment.authorId).toBe(MEMBER_ID);
+    expect(comment.body).toBe('まだ直りません');
+  });
+
+  // スレッド継続: 同じ Message-ID の再送 (Webhook リトライ) は冪等で二重取り込みしない
+  it('同一 Message-ID の再送は冪等に処理する (duplicate)', async () => {
+    const { POST } = await import('@/app/api/inbound/email/route');
+    const req = () => makeRequest({ ...VALID_EMAIL, messageId: '<dup-1@example.com>' });
+    // 1 回目は通常起票
+    const res1 = await POST(req());
+    expect(res1.status).toBe(201);
+    const { ticketId } = (await res1.json()) as { ticketId: string };
+    // 2 回目 (再送) は新規起票せず duplicate として 200 + 同じ ticketId を返す
+    const res2 = await POST(req());
+    expect(res2.status).toBe(200);
+    const body2 = (await res2.json()) as { ticketId: string; status?: string };
+    expect(body2.status).toBe('duplicate');
+    expect(body2.ticketId).toBe(ticketId);
+    // チケットは 1 件のまま
+    expect(store.tickets.size).toBe(1);
+  });
+
+  // スレッド継続: 参照先が別テナントの Message-ID なら一致せず、新規起票にフォールバックする
+  it('別テナントの Message-ID には紐付かず新規起票する', async () => {
+    // 別テナントに Message-ID を直接登録しておく (別テナントのスレッド)
+    await repos.emailThreads.register({
+      messageId: 'foreign@example.com',
+      ticketId: 't-foreign',
+      tenantId: 'other',
+    });
+    const { POST } = await import('@/app/api/inbound/email/route');
+    // default-tenant 宛メールが、別テナントの Message-ID を In-Reply-To で参照しても紐付かない
+    const res = await POST(
+      makeRequest({
+        ...VALID_EMAIL,
+        messageId: '<new-1@example.com>',
+        inReplyTo: '<foreign@example.com>',
+      }),
+    );
+    // 新規起票 (201) になり、コメント追記ではない
+    expect(res.status).toBe(201);
+    expect(store.comments.size).toBe(0);
+    expect(store.tickets.size).toBe(1);
   });
 });

--- a/tests/inbound-email.test.ts
+++ b/tests/inbound-email.test.ts
@@ -7,13 +7,18 @@ import { describe, expect, it } from 'vitest';
 import {
   INBOUND_BODY_MAX,
   INBOUND_DEFAULT_SUBJECT,
+  INBOUND_MAX_REFERENCE_IDS,
+  INBOUND_MESSAGE_ID_MAX,
   INBOUND_SUBJECT_MAX,
   buildInboundAddress,
   extractEmailAddress,
   extractInboundToken,
+  extractMessageIds,
   generateInboundToken,
   localPartOf,
+  normalizeMessageId,
   parseInboundEmail,
+  readRawHeader,
 } from '@/lib/inbound-email';
 
 describe('extractEmailAddress', () => {
@@ -170,5 +175,107 @@ describe('parseInboundEmail', () => {
       { expectedDomain: 'inbox.helpdesk-hub.app' },
     );
     expect(result.ok).toBe(false);
+  });
+
+  // スレッド継続: Message-ID / In-Reply-To / References を正規化して取り込む
+  it('Message-ID と参照 ID を正規化して email に載せる', () => {
+    const result = parseInboundEmail({
+      to: 'abc123@inbox.helpdesk-hub.app',
+      from: 'ichiro@example.com',
+      subject: 'Re: プリンター',
+      text: '直りました',
+      messageId: '  <reply-1@inbox.helpdesk-hub.app>  ',
+      inReplyTo: '<orig-1@example.com>',
+      references: '<root@example.com> <orig-1@example.com>',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // 山括弧と前後空白を除いた値になる
+    expect(result.email.messageId).toBe('reply-1@inbox.helpdesk-hub.app');
+    // In-Reply-To + References を統合し重複排除する (orig-1 は 1 件に)
+    expect(result.email.referenceIds).toEqual(['orig-1@example.com', 'root@example.com']);
+  });
+
+  // スレッド継続: ヘッダが無いメールは messageId=null / referenceIds=[] になる
+  it('スレッドヘッダが無ければ messageId は null・参照は空配列', () => {
+    const result = parseInboundEmail({
+      to: 'abc123@inbox.helpdesk-hub.app',
+      from: 'ichiro@example.com',
+      subject: '新規',
+      text: '本文',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.email.messageId).toBeNull();
+    expect(result.email.referenceIds).toEqual([]);
+  });
+});
+
+describe('normalizeMessageId', () => {
+  // 山括弧と前後空白を外す
+  it('"<id@host>" から山括弧を外して返す', () => {
+    expect(normalizeMessageId('  <abc@example.com>  ')).toBe('abc@example.com');
+  });
+
+  // 山括弧なしでも妥当ならそのまま
+  it('山括弧なしの妥当な値はそのまま返す', () => {
+    expect(normalizeMessageId('abc@example.com')).toBe('abc@example.com');
+  });
+
+  // 空・null・"@" 無し・空白入り・長すぎは null (fail-closed)
+  it('不正な値は null を返す', () => {
+    expect(normalizeMessageId(null)).toBeNull();
+    expect(normalizeMessageId('')).toBeNull();
+    expect(normalizeMessageId('no-at-sign')).toBeNull();
+    expect(normalizeMessageId('<a b@example.com>')).toBeNull();
+    expect(normalizeMessageId('x@' + 'a'.repeat(INBOUND_MESSAGE_ID_MAX))).toBeNull();
+  });
+});
+
+describe('extractMessageIds', () => {
+  // 空白区切りの "<id>" 列を分解して正規化する
+  it('References の "<id> <id>" 列を分解する', () => {
+    expect(extractMessageIds('<a@x.com>\n <b@y.com>')).toEqual(['a@x.com', 'b@y.com']);
+  });
+
+  // 山括弧が無い単一トークンも受ける
+  it('山括弧なしの単一トークンも受ける', () => {
+    expect(extractMessageIds('a@x.com')).toEqual(['a@x.com']);
+  });
+
+  // 取り込み件数は上限でクランプする (DoS 防止)
+  it('参照 ID は上限件数までに切り詰める', () => {
+    // 上限 + 10 件の "<id>" を並べる
+    const many = Array.from(
+      { length: INBOUND_MAX_REFERENCE_IDS + 10 },
+      (_, i) => `<id${i}@x.com>`,
+    ).join(' ');
+    expect(extractMessageIds(many).length).toBe(INBOUND_MAX_REFERENCE_IDS);
+  });
+
+  // 空・null は空配列
+  it('空・null は空配列', () => {
+    expect(extractMessageIds(null)).toEqual([]);
+    expect(extractMessageIds('')).toEqual([]);
+  });
+});
+
+describe('readRawHeader', () => {
+  // 生ヘッダ文字列から大文字小文字を無視して値を取り出す
+  it('ヘッダ名を大文字小文字無視で取り出す', () => {
+    const raw = 'From: a@x.com\r\nMessage-ID: <m1@x.com>\r\nSubject: hi';
+    expect(readRawHeader(raw, 'message-id')).toBe('<m1@x.com>');
+  });
+
+  // 折り返された継続行 (先頭が空白) を 1 行に連結する
+  it('折り返し継続行を連結する', () => {
+    const raw = 'References: <a@x.com>\r\n <b@x.com>\r\nSubject: hi';
+    expect(readRawHeader(raw, 'References')).toBe('<a@x.com> <b@x.com>');
+  });
+
+  // 見つからない / 空入力は null
+  it('見つからなければ null', () => {
+    expect(readRawHeader('Subject: hi', 'Message-ID')).toBeNull();
+    expect(readRawHeader(null, 'Message-ID')).toBeNull();
   });
 });

--- a/tests/inbound-email.test.ts
+++ b/tests/inbound-email.test.ts
@@ -229,6 +229,8 @@ describe('normalizeMessageId', () => {
     expect(normalizeMessageId('no-at-sign')).toBeNull();
     expect(normalizeMessageId('<a b@example.com>')).toBeNull();
     expect(normalizeMessageId('x@' + 'a'.repeat(INBOUND_MESSAGE_ID_MAX))).toBeNull();
+    // 外側 1 組を外しても山括弧が残る (複数 ID 連結) のは不正
+    expect(normalizeMessageId('<a@b><c@d>')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## 概要

`docs/smb-dx-pivot-plan.md` **Phase 2「スレッド継続（In-Reply-To ヘッダで紐付け）」(§4 / L130)** を実装します。

これまで受信メールは毎回**新規チケット**になっていましたが、依頼者が「担当者の返信メール」や「自分の元メール」に返信すると、**新規起票せず既存チケットへコメント追記**するようにしました。田中さん（§1.1）の「あの件どうなった？」を 1 チケットで追えるようにするのが狙いです。

## 仕組み

1. 受信して起票したメール／担当者が送信した返信メールの **`Message-ID`** を、紐づくチケットと一緒に `EmailThreadRef` テーブルへ記録。
2. 後続の返信メールの **`In-Reply-To` / `References`** をこの対応表で逆引きし、ヒットしたら既存チケットへコメント追記（通知・SSE も発火）。
3. ヒットしなければ従来どおり新規起票し、その `Message-ID` を登録。

## 主な変更

- **prisma**: `EmailThreadRef` モデル＋マイグレーション。`@@unique([tenantId, messageId])` でテナント内一意にし、別テナントの Message-ID でスレッドを乗っ取られないように（§9 クロステナント遮断）。
- **ports & adapters**: `EmailThreadRepository` を Port → Prisma/Memory で実装し `repos` に配線。`register` は `skipDuplicates` で冪等。
- **inbound-email.ts**（純粋関数）: `normalizeMessageId` / `extractMessageIds` / `readRawHeader` を追加。入力長・件数を上限クランプ（§9 DoS 対策、ReDoS なし）。
- **route**: ① `Message-ID` 既取込なら `duplicate` 返却（Webhook 再送の冪等化）、② 参照逆引き→コメント追記分岐（追記権限は「起票者 or エージェント」に限定、第三者メンバーは隔離）。
- **送信側**: 返信メールに決定的 `Message-ID` を付与し対応表へ登録（依頼者の返信が元チケットへ戻るように）。`EmailMessage.messageId` を追加。
- **comment-recipients.ts**: 通知宛先決定を共有ヘルパーへ抽出し、コメントルートと DRY 化。

## 検証

- `npm run lint` ✅ / `npm run typecheck` ✅
- `npm run test` ✅（304 passed / 28 skipped＝DB 必須の契約テスト）
- 追加テスト: 純粋パーサ、メモリ＆Prisma 契約（クロステナント分離・冪等）、ルート（追記・冪等・別テナント非一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dmhQ4iJMCMb1DvdfoGnXi

---
_Generated by [Claude Code](https://claude.ai/code/session_013dmhQ4iJMCMb1DvdfoGnXi)_