### PR TITLE
feat(tickets,settings): Phase2メール通知テンプレート拡充・Phase3業種テンプレ・CSVインポート

### DIFF
--- a/e2e/tenant-create.spec.ts
+++ b/e2e/tenant-create.spec.ts
@@ -47,7 +47,8 @@ test.describe('テナント作成フロー', () => {
 
     // 組織名・初代管理者の情報を入力する
     await page.getByLabel('組織名').fill(NEW_TENANT_NAME);
-    await page.getByLabel(/業種/).fill('製造業');
+    // 業種は <select> 要素なので selectOption で選択する (fill は input/textarea 専用)
+    await page.getByLabel(/業種/).selectOption({ label: '製造業' });
     await page.getByLabel('お名前').fill('E2E 新管理者');
     await page.getByLabel('メールアドレス').fill(NEW_ADMIN_EMAIL);
     await page.getByLabel(/パスワード/).fill('password123');

--- a/src/app/(app)/tickets/import/page.tsx
+++ b/src/app/(app)/tickets/import/page.tsx
@@ -1,0 +1,61 @@
+// CSV インポートページ (Phase 3 CSVインポート)
+// エージェント / 管理者のみがアクセス可能なチケット一括取り込み画面
+
+// セッション取得 (認可チェック用)
+import { auth } from '@/lib/auth';
+// リポジトリ束 (カテゴリ取得用)
+import { repos } from '@/data';
+// エージェント権限判定 (agent または admin のとき true)
+import { isAgent } from '@/lib/role';
+// CSV インポートフォーム (Client Component)
+import { CsvImportForm } from '@/features/tickets/components/CsvImportForm';
+// クライアント遷移付きリンク (一覧ページへ戻るボタン用)
+import Link from 'next/link';
+// 未ログイン / 権限不足時のリダイレクト
+import { redirect } from 'next/navigation';
+
+// チケット CSV インポートページ (Server Component)
+export default async function TicketImportPage() {
+  // セッション取得してログイン済みかを確認する
+  const session = await auth();
+  // 未ログイン、または tenantId 欠落の場合はログインページへリダイレクトする
+  if (!session?.user?.id || !session.user.tenantId) {
+    redirect('/login');
+  }
+  // エージェント / 管理者以外は一覧ページへリダイレクトする (依頼者はアクセス不可)
+  if (!isAgent(session.user.role)) {
+    redirect('/tickets');
+  }
+
+  // tenantId を使ってカテゴリ一覧を取得する (将来の列マッピング UI に備えた先行取得)
+  const tenantId = session.user.tenantId;
+  // カテゴリをリポジトリ経由で取得する (tenantId スコープ)
+  const categories = await repos.categories.list(tenantId);
+
+  return (
+    <div className="space-y-6">
+      {/* ページヘッダー: パンくずリスト + タイトル */}
+      <div>
+        {/* パンくずリスト: チケット一覧ページへ戻る */}
+        <Link
+          href="/tickets"
+          className="text-sm text-teal-700 transition hover:underline"
+        >
+          ← チケット一覧
+        </Link>
+        {/* ページタイトル */}
+        <h1 className="mt-2 text-2xl font-bold text-slate-900">CSV インポート</h1>
+        {/* ページの説明文 */}
+        <p className="mt-1 text-sm text-slate-500">
+          CSV ファイルからチケットを一括で取り込みます。
+        </p>
+      </div>
+
+      {/* CSV インポートフォーム (Client Component) */}
+      <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+        {/* カテゴリ一覧を Props で渡す (将来の列マッピング UI 向け) */}
+        <CsvImportForm categories={categories} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/tickets/page.tsx
+++ b/src/app/(app)/tickets/page.tsx
@@ -139,12 +139,24 @@ export default async function TicketsPage({ searchParams }: Props) {
             社内からの問い合わせを一元管理し、対応状況を追跡します。
           </p>
         </div>
-        <Link
-          href="/tickets/new"
-          className="rounded-lg bg-teal-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-teal-800"
-        >
-          ＋ 新規登録
-        </Link>
+        {/* ボタングループ: 新規登録 + CSV インポート (エージェント以上のみ CSV インポートを表示) */}
+        <div className="flex items-center gap-2">
+          <Link
+            href="/tickets/new"
+            className="rounded-lg bg-teal-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-teal-800"
+          >
+            ＋ 新規登録
+          </Link>
+          {/* エージェント / 管理者にのみ CSV インポートリンクを表示する */}
+          {isAgent && (
+            <Link
+              href="/tickets/import"
+              className="rounded-lg border border-teal-600 px-4 py-2 text-sm font-semibold text-teal-700 shadow-sm transition hover:bg-teal-50"
+            >
+              CSV インポート
+            </Link>
+          )}
+        </div>
       </div>
 
       {/* タブナビ (自分の未対応 / 期限切れ / すべて)。Lite/Pro どちらでも常に表示する */}

--- a/src/data/adapters/memory/category-repository.memory.ts
+++ b/src/data/adapters/memory/category-repository.memory.ts
@@ -1,6 +1,6 @@
 // カテゴリリポジトリの契約 (port) と、テスト用メモリストア型をインポート
 import type { CategoryRepository } from '@/data/ports/category-repository';
-import type { Store } from './store';
+import { nextId, type Store } from './store';
 
 // メモリストアを使ったカテゴリリポジトリを生成するファクトリ関数
 export function makeCategoryRepo(store: Store): CategoryRepository {
@@ -18,6 +18,22 @@ export function makeCategoryRepo(store: Store): CategoryRepository {
       // 存在 & テナント一致のときだけ要約を返す
       if (!c || c.tenantId !== tenantId) return null;
       return { id: c.id, name: c.name };
+    },
+    // カテゴリを 1 件新規作成してストアに登録する (Phase 3 業種テンプレ初期投入用)
+    async create(input) {
+      // ストアのカウンタを使って一意 ID を生成する ('cat' プレフィックス)
+      const id = nextId(store, 'cat');
+      // 新しいカテゴリ行をインメモリストアの CategoryRow 型に合わせて組み立てる
+      const row = {
+        id, // 生成した ID
+        name: input.name, // カテゴリ名
+        tenantId: input.tenantId, // 所属テナント ID
+        createdAt: new Date(), // 作成日時 (現在時刻)
+      };
+      // ストアの Map に登録する
+      store.categories.set(id, row);
+      // port 契約の CategorySummary 型 (id / name のみ) で返す
+      return { id: row.id, name: row.name };
     },
   };
 }

--- a/src/data/adapters/prisma/category-repository.prisma.ts
+++ b/src/data/adapters/prisma/category-repository.prisma.ts
@@ -25,5 +25,16 @@ export function makeCategoryRepo(db: PrismaLike): CategoryRepository {
         select: { id: true, name: true },
       });
     },
+    // カテゴリを 1 件新規作成して返す (Phase 3 業種テンプレ初期投入用)
+    // tenantId は input に含まれているため、クロステナント作成は呼び出し側の責任で防ぐ
+    async create(input) {
+      // Prisma の create で name + tenantId を INSERT し、id と name だけ SELECT して返す
+      const row = await db.category.create({
+        data: { name: input.name, tenantId: input.tenantId }, // 作成データを渡す
+        select: { id: true, name: true }, // port 契約の CategorySummary 型に合わせた最小選択
+      });
+      // 作成した行 (id / name) を返す
+      return row;
+    },
   };
 }

--- a/src/data/ports/category-repository.ts
+++ b/src/data/ports/category-repository.ts
@@ -11,4 +11,6 @@ export interface CategoryRepository {
   list(tenantId: string): Promise<CategorySummary[]>;
   // ID 指定で 1 件取得 (他テナントの ID なら null を返す)
   findById(id: string, tenantId: string): Promise<CategorySummary | null>;
+  // カテゴリを 1 件新規作成して返す (Phase 3 業種テンプレ初期投入用)
+  create(input: { name: string; tenantId: string }): Promise<CategorySummary>;
 }

--- a/src/features/settings/actions/create-tenant.ts
+++ b/src/features/settings/actions/create-tenant.ts
@@ -94,14 +94,15 @@ export async function createTenant(formData: FormData): Promise<CreateTenantResu
     if (industry) {
       // 指定 ID のテンプレートを取得する (存在しなければ undefined)
       const template = findIndustryTemplate(industry);
-      // テンプレートが見つかった場合のみカテゴリを一括作成する
+      // テンプレートが見つかった場合のみカテゴリを順次作成する
       if (template) {
-        // カテゴリ名のリストを並列 create に変換して実行する (順序不問なので Promise.all で並列化)
-        await Promise.all(
-          template.categories.map((name) =>
-            tx.categories.create({ name, tenantId: tenant.id })
-          )
-        );
+        // Prisma のインタラクティブトランザクション内では 1 つの接続を直列に使うため
+        // Promise.all で並列クエリを投げると "Transaction already closed" になる場合がある。
+        // for...of + await で直列実行して安全性を保つ (カテゴリは数件なので性能上問題なし)
+        for (const name of template.categories) {
+          // カテゴリを 1 件ずつトランザクション内で作成する
+          await tx.categories.create({ name, tenantId: tenant.id });
+        }
       }
     }
     // 作成結果を返す

--- a/src/features/settings/actions/create-tenant.ts
+++ b/src/features/settings/actions/create-tenant.ts
@@ -28,6 +28,8 @@ import { assertAdminSession } from '@/lib/role';
 import { createTenantSchema } from '@/lib/validations/invite';
 // メール取り込み用の転送アドレストークンを払い出すヘルパー (Phase 2)
 import { generateInboundToken } from '@/lib/inbound-email';
+// 業種テンプレートの検索関数 (Phase 3 業種テンプレ自動投入)
+import { findIndustryTemplate } from '@/lib/industry-templates';
 
 // createTenant の戻り値型 (作成したテナント ID と初代管理者メールを返す)
 export interface CreateTenantResult {
@@ -87,6 +89,21 @@ export async function createTenant(formData: FormData): Promise<CreateTenantResu
       role: 'admin',
       tenantId: tenant.id,
     });
+    // 業種テンプレートが指定されている場合はカテゴリを初期投入する
+    // (Phase 3 業種テンプレ: 選択した業種に紐づくカテゴリを 1 件ずつ作成する)
+    if (industry) {
+      // 指定 ID のテンプレートを取得する (存在しなければ undefined)
+      const template = findIndustryTemplate(industry);
+      // テンプレートが見つかった場合のみカテゴリを一括作成する
+      if (template) {
+        // カテゴリ名のリストを並列 create に変換して実行する (順序不問なので Promise.all で並列化)
+        await Promise.all(
+          template.categories.map((name) =>
+            tx.categories.create({ name, tenantId: tenant.id })
+          )
+        );
+      }
+    }
     // 作成結果を返す
     return { tenantId: tenant.id, adminEmail };
   });

--- a/src/features/settings/components/CreateTenantForm.tsx
+++ b/src/features/settings/components/CreateTenantForm.tsx
@@ -6,6 +6,8 @@ import { useState, useTransition } from 'react';
 import { createTenant } from '@/features/settings/actions/create-tenant';
 // パスワード最小長の単一参照元 (サーバー検証スキーマと共有)
 import { PASSWORD_MIN_LENGTH } from '@/lib/validations/invite';
+// 業種テンプレート一覧 (ドロップダウンの選択肢として使う / 純粋データなので Client Component でも安全にインポートできる)
+import { INDUSTRY_TEMPLATES } from '@/lib/industry-templates';
 
 // 新しい組織 (テナント) と初代管理者を作成するフォーム
 export function CreateTenantForm() {
@@ -59,18 +61,27 @@ export function CreateTenantForm() {
         />
       </div>
 
-      {/* 業種 (任意) */}
+      {/* 業種 (任意): ドロップダウン選択肢は INDUSTRY_TEMPLATES から生成する (一元管理) */}
       <div className="space-y-1">
         <label htmlFor="industry" className="block text-sm font-medium text-slate-700">
           業種（任意）
         </label>
-        <input
+        {/* select 要素にすることで選択肢を限定し、自由入力による意図しない値を防ぐ */}
+        <select
           id="industry"
           name="industry"
-          type="text"
           className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-teal-400 focus:outline-none focus:ring-1 focus:ring-teal-200"
-          placeholder="製造業 / 飲食 / 介護 など"
-        />
+        >
+          {/* 未選択を表す既定オプション (空文字を送信するとサーバー側で undefined 扱い) */}
+          <option value="">（なし）</option>
+          {/* INDUSTRY_TEMPLATES を展開して各業種を選択肢として列挙する */}
+          {INDUSTRY_TEMPLATES.map((t) => (
+            <option key={t.id} value={t.id}>
+              {/* 画面に見せる日本語ラベルを表示する */}
+              {t.label}
+            </option>
+          ))}
+        </select>
       </div>
 
       {/* 区切り見出し: 初代管理者 */}

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -27,6 +27,74 @@ const PRIORITY_MAP: Record<string, Priority> = {
   低: 'Low', // 「低」→ Low
 };
 
+// RFC 4180 準拠の CSV 行パーサ (引用符を含むフィールドでもカンマを正しく扱う)
+// 例: `"PCトラブル, ネットワーク",高` → ['PCトラブル, ネットワーク', '高']
+function parseCsvLine(line: string): string[] {
+  // 解析結果を格納する配列
+  const fields: string[] = [];
+  // 現在のフィールド文字列を蓄積するバッファ
+  let current = '';
+  // フィールドが引用符で囲まれているかのフラグ
+  let inQuotes = false;
+  // 1 文字ずつ走査する
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]; // 現在の文字
+    if (inQuotes) {
+      if (ch === '"') {
+        // 次の文字も '"' なら RFC 4180 のエスケープ ('' → ") として扱う
+        if (line[i + 1] === '"') {
+          current += '"'; // エスケープされた引用符をバッファに追加
+          i += 1; // 次の '"' をスキップする
+        } else {
+          // 引用符の終了 → 引用モードを抜ける
+          inQuotes = false;
+        }
+      } else {
+        // 引用符内の通常文字はそのままバッファに追加する
+        current += ch;
+      }
+    } else {
+      if (ch === '"') {
+        // フィールド開始直後の引用符 → 引用モードへ入る
+        inQuotes = true;
+      } else if (ch === ',') {
+        // カンマ → フィールド終端。前後の空白を除いてリストに追加する
+        fields.push(current.trim());
+        // バッファをリセットして次のフィールドへ
+        current = '';
+      } else {
+        // 通常文字をバッファに追加する
+        current += ch;
+      }
+    }
+  }
+  // 最後のフィールドを追加する (末尾のカンマがなくても確実に取り込む)
+  fields.push(current.trim());
+  // 解析済みフィールド配列を返す
+  return fields;
+}
+
+// YYYY-MM-DD 形式の日付文字列をローカル時刻の Date に変換する純粋関数
+// `new Date('YYYY-MM-DD')` は UTC 0 時として解釈されるため JST 環境では前日になる問題を回避する
+function parseDateLocal(dateStr: string): Date | null {
+  // ハイフンで分割して年・月・日を取り出す
+  const parts = dateStr.split('-');
+  // 3 要素 (年・月・日) がなければ不正フォーマット
+  if (parts.length !== 3) return null;
+  // 各部分を整数に変換する
+  const year = parseInt(parts[0] ?? '', 10);
+  const month = parseInt(parts[1] ?? '', 10); // 1 始まり (後で 0 始まりに調整)
+  const day = parseInt(parts[2] ?? '', 10);
+  // いずれかが NaN なら不正フォーマット
+  if (isNaN(year) || isNaN(month) || isNaN(day)) return null;
+  // `new Date(year, month-1, day)` はローカル時刻の午前 0 時を生成する (UTC ではない)
+  const d = new Date(year, month - 1, day);
+  // 実際に有効な日付かを確認する (例: 2 月 30 日は 3 月に繰り越されるため不正と判断)
+  if (d.getFullYear() !== year || d.getMonth() + 1 !== month || d.getDate() !== day) return null;
+  // 有効な Date を返す
+  return d;
+}
+
 // importTickets の戻り値型
 export interface ImportTicketsResult {
   imported: number; // 正常に取り込めた件数
@@ -71,8 +139,8 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
 
   // 1 行目をヘッダとして取り出す
   const headerLine = nonEmptyLines[0];
-  // カンマで分割してヘッダ列名の配列を得る (前後の空白と引用符を除去)
-  const headers = headerLine.split(',').map((h) => h.trim().replace(/^"|"$/g, ''));
+  // RFC 4180 パーサでヘッダ列名の配列を得る (引用符内のカンマにも対応)
+  const headers = parseCsvLine(headerLine ?? '');
 
   // 「件名」列が必須。見つからなければ即エラー
   const titleIndex = headers.indexOf('件名');
@@ -103,8 +171,8 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     // 現在の行を取り出す
     const line = dataLines[i];
 
-    // カンマで分割して各セルを取り出す (前後の空白・引用符を除去)
-    const cells = line.split(',').map((c) => c.trim().replace(/^"|"$/g, ''));
+    // RFC 4180 パーサで各セルを取り出す (引用符内のカンマにも対応)
+    const cells = parseCsvLine(line ?? '');
 
     // 件名セルを取り出す
     const title = cells[titleIndex] ?? '';
@@ -124,9 +192,10 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
       // 期限日セルの値を取り出す
       const dueDateRaw = cells[dueDateIndex] ?? '';
       if (dueDateRaw) {
-        // YYYY-MM-DD 形式を Date オブジェクトに変換する
-        const parsed = new Date(dueDateRaw);
-        if (isNaN(parsed.getTime())) {
+        // YYYY-MM-DD 形式をローカル時刻の Date に変換する
+        // (`new Date('YYYY-MM-DD')` は UTC 午前 0 時なので JST 環境で前日になるバグを回避)
+        const parsed = parseDateLocal(dueDateRaw);
+        if (parsed === null) {
           // 変換に失敗した (不正な形式) 場合はエラーとして記録してこの行をスキップ
           errors.push({ row: rowNum, message: `期限日の形式が正しくありません: "${dueDateRaw}"（YYYY-MM-DD 形式で入力してください）` });
           // 次の行へ進む (部分成功なので continue)

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -1,0 +1,164 @@
+'use server';
+
+// CSV テキストからチケットを一括作成するサーバーアクション (Phase 3 CSVインポート)
+// docs/smb-dx-pivot-plan.md §4 Phase 3「CSV インポート」に対応
+
+// セッション取得
+import { auth } from '@/lib/auth';
+// リポジトリ束 (チケット作成用)
+import { repos } from '@/data';
+// エージェント権限判定 (agent または admin のとき true)
+import { isAgent } from '@/lib/role';
+// 連打防止のための共通レート制限ヘルパー (超過時は RateLimitError を throw)
+import { enforceRateLimit } from '@/lib/rate-limit';
+// テナントの動作モード (lite | pro) を取得するヘルパー
+import { getCurrentTenantMode } from '@/lib/tenant';
+// 優先度・ステータスのドメイン型
+import type { Priority, TicketStatus } from '@/domain/types';
+
+// 1 インポートあたりの最大行数 (これを超えたらエラー)
+const MAX_ROWS = 200;
+
+// CSV の優先度文字列 (日本語) を Priority 型にマップする対応表
+// 一元管理することで「高」「中」「低」の定義が 1 か所に集まる
+const PRIORITY_MAP: Record<string, Priority> = {
+  高: 'High', // 「高」→ High
+  中: 'Medium', // 「中」→ Medium
+  低: 'Low', // 「低」→ Low
+};
+
+// importTickets の戻り値型
+export interface ImportTicketsResult {
+  imported: number; // 正常に取り込めた件数
+  errors: Array<{ row: number; message: string }>; // 失敗した行の番号とエラーメッセージ
+}
+
+// CSV テキストを受け取ってチケットを一括作成するサーバーアクション
+export async function importTickets(csvText: string): Promise<ImportTicketsResult> {
+  // セッション取得 (ログイン状態を確認)
+  const session = await auth();
+  // 未ログインまたは tenantId 欠落は拒否する (後段の where 句で tenantId が必須なため)
+  if (!session?.user?.id || !session.user.tenantId) {
+    throw new Error('認証が必要です');
+  }
+  // エージェント / 管理者のみ実行可能 (依頼者はアクセス不可)
+  if (!isAgent(session.user.role)) {
+    throw new Error('この操作はエージェントまたは管理者のみ実行できます');
+  }
+  // セッションから tenantId と起票者 ID を取り出す
+  const tenantId = session.user.tenantId;
+  const creatorId = session.user.id;
+
+  // 60 秒あたり 5 回までに制限 (大量インポートの連打を防ぐ)
+  enforceRateLimit(`csv-import:${session.user.id}`, { limit: 5, windowMs: 60_000 });
+
+  // テナントの動作モードを取得する (初期ステータスを Lite/Pro で切り替えるために必要)
+  const mode = await getCurrentTenantMode(tenantId);
+
+  // Lite モードの初期ステータスは「Open」(未対応)、Pro モードは「New」(新規)
+  const initialStatus: TicketStatus = mode === 'lite' ? 'Open' : 'New';
+
+  // --- CSV パース開始 ---
+  // 改行コード (CRLF / LF どちらにも対応) で行に分割する
+  const allLines = csvText.split(/\r?\n/);
+  // 空行を除外した行の配列を作る
+  const nonEmptyLines = allLines.filter((line) => line.trim() !== '');
+
+  // 1 行もない場合はエラー
+  if (nonEmptyLines.length === 0) {
+    throw new Error('CSV が空です');
+  }
+
+  // 1 行目をヘッダとして取り出す
+  const headerLine = nonEmptyLines[0];
+  // カンマで分割してヘッダ列名の配列を得る (前後の空白と引用符を除去)
+  const headers = headerLine.split(',').map((h) => h.trim().replace(/^"|"$/g, ''));
+
+  // 「件名」列が必須。見つからなければ即エラー
+  const titleIndex = headers.indexOf('件名');
+  if (titleIndex === -1) {
+    throw new Error('CSV のヘッダに「件名」列が必要です');
+  }
+  // 任意列のインデックスを取得する (見つからなければ -1)
+  const bodyIndex = headers.indexOf('内容'); // チケット本文
+  const dueDateIndex = headers.indexOf('期限日'); // 解決期限 (YYYY-MM-DD 形式)
+  const priorityIndex = headers.indexOf('優先度'); // 高 / 中 / 低
+
+  // データ行 (2 行目以降) を取り出す
+  const dataLines = nonEmptyLines.slice(1);
+
+  // 最大行数チェック (DoS / リソース枯渇防止)
+  if (dataLines.length > MAX_ROWS) {
+    throw new Error(`1 回のインポートは最大 ${MAX_ROWS} 行です（${dataLines.length} 行ありました）`);
+  }
+
+  // 集計用カウンタとエラーリストを初期化する
+  let imported = 0;
+  const errors: Array<{ row: number; message: string }> = [];
+
+  // データ行を 1 件ずつ処理する (部分成功を許可するため、1 件エラーでも他を続ける)
+  for (let i = 0; i < dataLines.length; i += 1) {
+    // CSV の行番号は 1-indexed のヘッダを含めて数えるため +2 する (エラー表示用)
+    const rowNum = i + 2;
+    // 現在の行を取り出す
+    const line = dataLines[i];
+
+    // カンマで分割して各セルを取り出す (前後の空白・引用符を除去)
+    const cells = line.split(',').map((c) => c.trim().replace(/^"|"$/g, ''));
+
+    // 件名セルを取り出す
+    const title = cells[titleIndex] ?? '';
+    // 件名が空の行はスキップする (ヘッダ後の空行などを無視する)
+    if (!title) continue;
+
+    // 本文セルを取り出す (未指定なら空文字)
+    const body = bodyIndex !== -1 ? (cells[bodyIndex] ?? '') : '';
+
+    // 優先度セルを日本語から Priority 型へ変換する (未指定または未知値は Medium にフォールバック)
+    const priorityRaw = priorityIndex !== -1 ? (cells[priorityIndex] ?? '') : '';
+    const priority: Priority = PRIORITY_MAP[priorityRaw] ?? 'Medium';
+
+    // 期限日セルを Date に変換する (形式が不正なら null として解決期限なしにする)
+    let resolutionDueAt: Date | null = null;
+    if (dueDateIndex !== -1) {
+      // 期限日セルの値を取り出す
+      const dueDateRaw = cells[dueDateIndex] ?? '';
+      if (dueDateRaw) {
+        // YYYY-MM-DD 形式を Date オブジェクトに変換する
+        const parsed = new Date(dueDateRaw);
+        if (isNaN(parsed.getTime())) {
+          // 変換に失敗した (不正な形式) 場合はエラーとして記録してこの行をスキップ
+          errors.push({ row: rowNum, message: `期限日の形式が正しくありません: "${dueDateRaw}"（YYYY-MM-DD 形式で入力してください）` });
+          // 次の行へ進む (部分成功なので continue)
+          continue;
+        }
+        // 変換できた値を解決期限として使う
+        resolutionDueAt = parsed;
+      }
+    }
+
+    // チケットを 1 件作成する (失敗してもループを続けて部分成功を許可する)
+    try {
+      // リポジトリ経由でチケットを DB に保存する
+      await repos.tickets.create({
+        title, // 件名
+        body, // 本文 (空文字も許容)
+        priority, // 優先度
+        categoryId: null, // CSV インポートではカテゴリ未指定 (後から設定できる)
+        creatorId, // セッションのユーザーが起票者になる
+        tenantId, // テナントスコープを必ず付与する (クロステナント防止)
+        status: initialStatus, // Lite: Open / Pro: New
+        resolutionDueAt, // 期限日 (未指定なら null)
+      });
+      // 成功カウンタをインクリメント
+      imported += 1;
+    } catch (err) {
+      // チケット作成エラーを行番号と共に記録する (他の行は継続)
+      const message = err instanceof Error ? err.message : 'チケットの作成に失敗しました';
+      errors.push({ row: rowNum, message });
+    }
+  }
+
+  // 成功件数とエラー一覧を返す
+  return { imported, errors };
+}

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -18,6 +18,13 @@ import type { Priority, TicketStatus } from '@/domain/types';
 
 // 1 インポートあたりの最大行数 (これを超えたらエラー)
 const MAX_ROWS = 200;
+// CSV テキスト全体の最大バイト数 (200行 × 平均 500 文字 を余裕を持って設定)
+// Next.js Server Action のデフォルト上限 (1MB) より小さく設定して早期エラーにする
+const MAX_CSV_BYTES = 512 * 1024; // 512KB
+// チケット件名の最大文字数 (createTicketSchema と合わせる)
+const TITLE_MAX_LENGTH = 200;
+// チケット本文の最大文字数 (createTicketSchema と合わせる)
+const BODY_MAX_LENGTH = 10_000;
 
 // CSV の優先度文字列 (日本語) を Priority 型にマップする対応表
 // 一元管理することで「高」「中」「低」の定義が 1 か所に集まる
@@ -117,6 +124,12 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
   const tenantId = session.user.tenantId;
   const creatorId = session.user.id;
 
+  // CSV テキスト全体のサイズをチェックする (DoS / 過大ペイロードの防止)
+  // Buffer.byteLength で実際のバイト数を計測する (日本語は UTF-8 で 3 bytes / 文字)
+  if (Buffer.byteLength(csvText, 'utf8') > MAX_CSV_BYTES) {
+    throw new Error(`CSV ファイルのサイズが大きすぎます（上限 ${MAX_CSV_BYTES / 1024}KB）`);
+  }
+
   // 60 秒あたり 5 回までに制限 (大量インポートの連打を防ぐ)
   enforceRateLimit(`csv-import:${session.user.id}`, { limit: 5, windowMs: 60_000 });
 
@@ -174,13 +187,29 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     // RFC 4180 パーサで各セルを取り出す (引用符内のカンマにも対応)
     const cells = parseCsvLine(line ?? '');
 
-    // 件名セルを取り出す
-    const title = cells[titleIndex] ?? '';
+    // 件名セルを取り出す (TITLE_MAX_LENGTH を超える分はエラーにして行をスキップ)
+    const titleRaw = cells[titleIndex] ?? '';
     // 件名が空の行はスキップする (ヘッダ後の空行などを無視する)
-    if (!title) continue;
+    if (!titleRaw) continue;
+    // 件名が長すぎる場合はエラーとして記録してこの行をスキップ (DB の制約前に弾く)
+    if (titleRaw.length > TITLE_MAX_LENGTH) {
+      errors.push({ row: rowNum, message: `件名が長すぎます（${TITLE_MAX_LENGTH}文字以内にしてください）` });
+      // 次の行へ進む (部分成功なので continue)
+      continue;
+    }
+    // 検証済みの件名を確定する
+    const title = titleRaw;
 
     // 本文セルを取り出す (未指定なら空文字)
-    const body = bodyIndex !== -1 ? (cells[bodyIndex] ?? '') : '';
+    const bodyRaw = bodyIndex !== -1 ? (cells[bodyIndex] ?? '') : '';
+    // 本文が長すぎる場合はエラーとして記録してこの行をスキップ
+    if (bodyRaw.length > BODY_MAX_LENGTH) {
+      errors.push({ row: rowNum, message: `内容が長すぎます（${BODY_MAX_LENGTH}文字以内にしてください）` });
+      // 次の行へ進む (部分成功なので continue)
+      continue;
+    }
+    // 検証済みの本文を確定する
+    const body = bodyRaw;
 
     // 優先度セルを日本語から Priority 型へ変換する (未指定または未知値は Medium にフォールバック)
     const priorityRaw = priorityIndex !== -1 ? (cells[priorityIndex] ?? '') : '';
@@ -222,9 +251,10 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
       // 成功カウンタをインクリメント
       imported += 1;
     } catch (err) {
-      // チケット作成エラーを行番号と共に記録する (他の行は継続)
-      const message = err instanceof Error ? err.message : 'チケットの作成に失敗しました';
-      errors.push({ row: rowNum, message });
+      // 内部エラー (Prisma 例外等) をサーバーログに記録する (スキーマ情報の漏洩防止のため UI には返さない)
+      console.error(`[importTickets] 行 ${rowNum} のチケット作成に失敗:`, err);
+      // ユーザーには汎用メッセージのみ返す (Prisma のエラー詳細をフロントに漏らさない)
+      errors.push({ row: rowNum, message: 'チケットの作成に失敗しました。内容を確認してください。' });
     }
   }
 

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -30,6 +30,12 @@ import { enforceRateLimit } from '@/lib/rate-limit';
 import { escalationReasonSchema } from '@/lib/validations/ticket';
 // next-auth のセッション型
 import type { Session } from 'next-auth';
+// ステータス変更・担当者割当のメール本文を生成する純粋ヘルパー (Phase 2)
+import { renderTicketStatusChangedEmail, renderAssignedEmail, buildTicketUrl } from '@/lib/ticket-email';
+// EmailSender 実装を取得するファクトリ (環境変数で console / smtp を切り替え)
+import { getEmailSender } from '@/lib/email';
+// メールに埋め込むリンクのベース URL を解決するヘルパー
+import { resolveAppBaseUrl } from '@/lib/app-url';
 
 // セッションがログイン済みであることを保証するアサーション関数
 function assertAuthenticatedUser(session: Session | null): asserts session is Session {
@@ -67,6 +73,11 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
   // (ticket は uow.run 内で取得するため、クロージャ変数として外側に宣言しておく必要がある)
   // 自己更新 (起票者=操作者) では通知を作らないため null のままにし、無駄な SSE 配信を避ける
   let notifiedCreatorId: string | null = null;
+  // メール送信に必要なチケット情報 (起票者 ID・件名) を uow.run 外で参照するために宣言
+  // null のままならメールは送らない (自己更新 or チケット未取得)
+  let ticketSnapshot: { creatorId: string; title: string } | null = null;
+  // ステータス変更前の値 (メール本文でラベルを出すために外側で保持する)
+  let oldStatus: TicketStatus | null = null;
 
   // 1 トランザクションでチケット更新と履歴記録を実行
   await uow.run(async (r) => {
@@ -76,6 +87,10 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
     if (!ticket) throw new Error('チケットが見つかりません');
     // 変更前後が同じなら何もしない (冪等)
     if (ticket.status === newStatus) return;
+    // 変更前のステータスをトランザクション外のメール送信に伝えるために外側変数に保存する
+    oldStatus = ticket.status;
+    // 件名と起票者 ID もメール送信用に外側変数に保存する
+    ticketSnapshot = { creatorId: ticket.creatorId, title: ticket.title };
     // Lite テナントでは newStatus を Lite 3 値 (Open / InProgress / Closed) に強制する
     // 旧データ (Resolved / Escalated / WaitingForUser / New) からの off-ramp は許すが、
     // Lite テナント上で「新規にそれら非 Lite ステータスへ落とす」操作は仕様違反 (Pivot plan §3.1 / §5.2)
@@ -145,6 +160,28 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
   // 通知を実際に書き込んだ場合のみ、起票者の未読件数を SSE でリアルタイム配信する
   // (トランザクションコミット後に呼ぶ。自己更新時は notifiedCreatorId が null なので配信しない)
   if (notifiedCreatorId) await broadcastUnreadCount(notifiedCreatorId, tenantId);
+
+  // Phase 2: ステータス変更を依頼者へメールで通知する (ベストエフォート)
+  // TypeScript の CFA は async クロージャ内の let 変数への再代入を追跡できないため、
+  // 型アサーション (as) を使って「この時点では非 null」と明示する。
+  // ticketSnapshot が null のままの場合 (変更なし / 見つからない) は early-exit している。
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const snapForMail = ticketSnapshot as { creatorId: string; title: string } | null;
+  // oldStatus も同様に const に取り出して null チェックを行う
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const oldStatusForMail = oldStatus as TicketStatus | null;
+  // スナップショットと変更前ステータスが両方揃い、かつ自分以外への通知の場合のみ送信する
+  if (snapForMail !== null && oldStatusForMail !== null && snapForMail.creatorId !== session.user.id) {
+    // メール送信を別関数に切り出して try/catch で囲み、失敗してもチケット更新は巻き戻さない
+    await sendStatusChangedEmailToRequester({
+      ticketId,
+      ticketTitle: snapForMail.title,
+      creatorId: snapForMail.creatorId,
+      oldStatus: oldStatusForMail,
+      newStatus,
+      mode,
+    });
+  }
 
   // チケット詳細ページのキャッシュを無効化して再描画
   revalidatePath(`/tickets/${ticketId}`);
@@ -260,6 +297,29 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
 
   // 新担当者に未読件数を SSE で即時配信 (テナントを伝搬)
   if (newAssigneeId) await broadcastUnreadCount(newAssigneeId, tenantId);
+
+  // Phase 2: 担当者割当を新担当者へメールで通知する (ベストエフォート)
+  // 担当者解除 (null) か自己割当なら送らない
+  if (newAssigneeId && newAssigneeId !== session.user.id && newUser?.email) {
+    // メール送信の失敗でチケット更新が巻き戻るのを防ぐため try/catch に包む
+    try {
+      // ベース URL を解決する (production で NEXTAUTH_URL 未設定なら throw される)
+      const baseUrl = resolveAppBaseUrl();
+      // チケット詳細ページへの導線 URL を組み立てる
+      const ticketUrl = buildTicketUrl(baseUrl, ticketId);
+      // 担当者割当メールの件名 / テキスト / HTML を純粋ヘルパーで生成する
+      const { subject, text, html } = renderAssignedEmail({
+        ticketTitle: ticket.title,
+        ticketUrl,
+      });
+      // 設定された EmailSender (console / smtp) 経由でメール送信
+      await getEmailSender().send({ to: newUser.email, subject, text, html });
+    } catch (err) {
+      // 送信失敗はサーバログに残すだけ (アプリ内通知は既に成立している)
+      console.error('[updateTicketAssignee] 担当者宛メール送信に失敗しました', err);
+    }
+  }
+
   // 詳細ページのキャッシュを無効化
   revalidatePath(`/tickets/${ticketId}`);
 }
@@ -350,3 +410,42 @@ export async function escalateTicket(ticketId: string, reason: string) {
 // 注: コメント追加処理は POST /api/tickets/[id]/comments (Route Handler) に統合した。
 // Server Action の既定 1MB ボディ上限ではスマホ写真添付 (10MB × 5 枚) を扱えないため、
 // 同じロジックを Route Handler に置いて UI / API 双方の入口を一本化している。
+
+// ステータス変更を依頼者へメールで通知する内部ヘルパー (ベストエフォート / 副作用は send のみ)。
+// 例外は呼び出し側に伝播させず、ログに残して握り潰す: メール送信の失敗でチケット更新が
+// 「保存できたのに 500 が返る」事態を避けるため。
+async function sendStatusChangedEmailToRequester(args: {
+  ticketId: string; // 対象チケット ID (URL 構築用)
+  ticketTitle: string; // チケット件名 (メール本文用)
+  creatorId: string; // 起票者ユーザー ID (メールアドレス取得用)
+  oldStatus: TicketStatus; // 変更前のステータス (ラベル変換用)
+  newStatus: TicketStatus; // 変更後のステータス (ラベル変換用)
+  mode: import('@/domain/types').TenantMode; // テナント mode (ラベル変換で Lite/Pro を切替)
+}): Promise<void> {
+  const { ticketId, ticketTitle, creatorId, oldStatus, newStatus, mode } = args;
+  try {
+    // 起票者 (依頼者) のメールアドレスをユーザーリポジトリから引く
+    const creator = await repos.users.findById(creatorId);
+    // 依頼者が見つからない / メール未設定なら送りようがないのでスキップ
+    if (!creator?.email) return;
+    // ベース URL を解決する (production で NEXTAUTH_URL 未設定なら throw → 下で握る)
+    const baseUrl = resolveAppBaseUrl();
+    // チケット詳細ページへの導線 URL を組み立てる
+    const ticketUrl = buildTicketUrl(baseUrl, ticketId);
+    // ステータスの日本語ラベルを取得する (Lite/Pro どちらのモードかに応じて切替)
+    const oldStatusLabel = getStatusLabel(oldStatus, mode);
+    const newStatusLabel = getStatusLabel(newStatus, mode);
+    // ステータス変更メールの件名 / テキスト / HTML を純粋ヘルパーで生成する
+    const { subject, text, html } = renderTicketStatusChangedEmail({
+      ticketTitle,
+      ticketUrl,
+      oldStatusLabel,
+      newStatusLabel,
+    });
+    // 設定された EmailSender (console / smtp) 経由でメール送信
+    await getEmailSender().send({ to: creator.email, subject, text, html });
+  } catch (err) {
+    // 送信失敗はサーバログに残すだけ (アプリ内通知は既に成立している)
+    console.error('[updateTicketStatus] 依頼者宛ステータス変更メール送信に失敗しました', err);
+  }
+}

--- a/src/features/tickets/components/CsvImportForm.tsx
+++ b/src/features/tickets/components/CsvImportForm.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+// CSV インポートフォーム (Phase 3 CSVインポート機能)
+// ファイル選択 → プレビュー → インポート実行 → 結果表示 の UI を担当する Client Component
+
+// 状態管理・非ブロッキング送信のためのフック
+import { useState, useTransition } from 'react';
+// CSV インポートのサーバーアクション
+import { importTickets } from '@/features/tickets/actions/import-tickets';
+// インポート結果の型 (成功件数 + エラー一覧)
+import type { ImportTicketsResult } from '@/features/tickets/actions/import-tickets';
+
+// CSV インポートフォームに渡す Props 型
+// categories は将来のカテゴリ選択 UI 向けに受け取るが、MVP では使用しない
+interface CsvImportFormProps {
+  categories: Array<{ id: string; name: string }>; // カテゴリ一覧 (将来の列マッピング用)
+}
+
+// CSV のプレビュー行を表す型 (ヘッダ名 → 値のマップ)
+interface PreviewRow {
+  件名: string; // 件名セル
+  内容: string; // 内容セル (省略可)
+  期限日: string; // 期限日セル (省略可)
+  優先度: string; // 優先度セル (省略可)
+}
+
+// CSV テキストから先頭 5 件のデータ行をプレビュー用に解析する純粋関数
+function parsePreview(csvText: string): PreviewRow[] {
+  // 改行コード (CRLF / LF どちらにも対応) で行に分割する
+  const lines = csvText.split(/\r?\n/).filter((l) => l.trim() !== '');
+  // 行が 1 行 (ヘッダのみ) か 0 行の場合はプレビューなし
+  if (lines.length < 2) return [];
+  // ヘッダ行を取り出してカンマ分割する
+  const headers = (lines[0] ?? '').split(',').map((h) => h.trim().replace(/^"|"$/g, ''));
+  // データ行は最大 5 件に絞る (プレビューなので多すぎない量に制限)
+  const dataLines = lines.slice(1, 6);
+  // 各データ行を PreviewRow 型にマッピングして返す
+  return dataLines.map((line) => {
+    // 行をカンマ分割してセル配列を得る
+    const cells = line.split(',').map((c) => c.trim().replace(/^"|"$/g, ''));
+    // ヘッダ名から対応するセルの値を取り出すヘルパー (見つからなければ空文字)
+    const get = (name: string): string => {
+      const idx = headers.indexOf(name); // ヘッダのインデックスを検索
+      return idx !== -1 ? (cells[idx] ?? '') : ''; // 対応セルの値を返す
+    };
+    // PreviewRow 型に変換して返す
+    return {
+      件名: get('件名'), // 件名列の値
+      内容: get('内容'), // 内容列の値
+      期限日: get('期限日'), // 期限日列の値
+      優先度: get('優先度'), // 優先度列の値
+    };
+  });
+}
+
+// CSV インポートフォームコンポーネント
+export function CsvImportForm({ categories: _categories }: CsvImportFormProps) {
+  // 読み込んだ CSV テキスト (null = ファイル未選択)
+  const [csvText, setCsvText] = useState<string | null>(null);
+  // プレビューテーブルに表示する先頭 5 行のデータ
+  const [preview, setPreview] = useState<PreviewRow[]>([]);
+  // インポート実行結果 (null = 未実行)
+  const [result, setResult] = useState<ImportTicketsResult | null>(null);
+  // サーバーアクションのエラーメッセージ (throw された場合)
+  const [error, setError] = useState<string | null>(null);
+  // useTransition でインポート中フラグを管理する (ボタン無効化・スピナー表示に使う)
+  const [isPending, startTransition] = useTransition();
+
+  // ファイル選択時のハンドラ: File を読み込んで CSV テキストとプレビューを更新する
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    // 選択されたファイルを取り出す (未選択なら undefined)
+    const file = e.target.files?.[0];
+    // ファイルが選択されていなければ状態をリセットして終了
+    if (!file) {
+      setCsvText(null); // CSV テキストをクリア
+      setPreview([]); // プレビューをクリア
+      setResult(null); // 結果をクリア
+      setError(null); // エラーをクリア
+      return;
+    }
+    // FileReader で CSV ファイルをテキストとして非同期読み込みする
+    const reader = new FileReader();
+    // 読み込み完了時のコールバック
+    reader.onload = (ev) => {
+      // 読み込んだテキストを文字列として取り出す
+      const text = ev.target?.result;
+      if (typeof text !== 'string') return; // 読み込み失敗時は何もしない
+      // CSV テキストをステートに保存する
+      setCsvText(text);
+      // プレビューデータを解析してステートに保存する
+      setPreview(parsePreview(text));
+      // 前回の結果とエラーをクリアする (新しいファイルに切り替えたので)
+      setResult(null);
+      setError(null);
+    };
+    // UTF-8 テキストとして読み込む
+    reader.readAsText(file, 'UTF-8');
+  }
+
+  // インポート実行ボタンのハンドラ
+  function handleImport() {
+    // CSV テキストが未設定の場合は何もしない (ボタンは disabled なので通常は発火しない)
+    if (!csvText) return;
+    // 前回の結果とエラーをクリアしてから実行する
+    setResult(null);
+    setError(null);
+    // useTransition でバックグラウンド実行する (UI がフリーズしない)
+    startTransition(async () => {
+      try {
+        // サーバーアクションを呼び出す
+        const res = await importTickets(csvText);
+        // 成功 (部分成功含む) の場合は結果を表示する
+        setResult(res);
+      } catch (err) {
+        // サーバーアクションが throw した場合はエラーメッセージを表示する
+        setError(err instanceof Error ? err.message : 'インポートに失敗しました');
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* CSV の形式ヒント */}
+      <div className="rounded-lg bg-slate-50 p-4 text-sm text-slate-600 ring-1 ring-slate-200">
+        {/* ヒントのタイトル */}
+        <p className="mb-1 font-semibold text-slate-700">CSV の形式</p>
+        {/* 必須・任意の列名と説明 */}
+        <p className="font-mono text-xs text-slate-500">件名（必須）, 内容, 期限日(YYYY-MM-DD), 優先度（高/中/低）</p>
+        {/* 最大行数の説明 */}
+        <p className="mt-1 text-xs text-slate-400">1 回のインポートは最大 200 行です。</p>
+      </div>
+
+      {/* ファイル選択 (CSV のみ許可) */}
+      <div className="space-y-1">
+        <label htmlFor="csvFile" className="block text-sm font-medium text-slate-700">
+          CSV ファイルを選択
+        </label>
+        <input
+          id="csvFile"
+          type="file"
+          accept=".csv"
+          onChange={handleFileChange}
+          className="block w-full text-sm text-slate-600 file:mr-3 file:rounded-md file:border-0 file:bg-teal-50 file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-teal-700 hover:file:bg-teal-100"
+        />
+      </div>
+
+      {/* プレビューテーブル (先頭 5 行) */}
+      {preview.length > 0 && (
+        <div className="overflow-x-auto">
+          {/* プレビューの件数表示 */}
+          <p className="mb-2 text-sm text-slate-500">プレビュー（先頭 {preview.length} 件）</p>
+          <table className="min-w-full divide-y divide-slate-100 rounded-xl bg-white text-sm ring-1 ring-slate-100">
+            <thead className="bg-slate-50">
+              <tr>
+                {/* ヘッダセル: 件名 */}
+                <th className="px-4 py-2 text-left text-xs font-semibold text-slate-500">件名</th>
+                {/* ヘッダセル: 内容 (省略表示) */}
+                <th className="px-4 py-2 text-left text-xs font-semibold text-slate-500">内容</th>
+                {/* ヘッダセル: 期限日 */}
+                <th className="px-4 py-2 text-left text-xs font-semibold text-slate-500">期限日</th>
+                {/* ヘッダセル: 優先度 */}
+                <th className="px-4 py-2 text-left text-xs font-semibold text-slate-500">優先度</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {preview.map((row: PreviewRow, idx: number) => (
+                /* 各プレビュー行 */
+                <tr key={idx}>
+                  {/* 件名セル */}
+                  <td className="px-4 py-2 text-slate-800">{row.件名}</td>
+                  {/* 内容セル: 長い場合は 20 文字で切り詰める */}
+                  <td className="px-4 py-2 text-slate-500">
+                    {row.内容.length > 20 ? `${row.内容.slice(0, 20)}…` : row.内容}
+                  </td>
+                  {/* 期限日セル */}
+                  <td className="px-4 py-2 text-slate-500">{row.期限日 || '―'}</td>
+                  {/* 優先度セル */}
+                  <td className="px-4 py-2 text-slate-500">{row.優先度 || '中'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* インポート実行ボタン (ファイル未選択 or 実行中は無効) */}
+      <button
+        type="button"
+        onClick={handleImport}
+        disabled={!csvText || isPending}
+        className="rounded-lg bg-teal-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-teal-800 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {/* 実行中はスピナーテキストを表示する */}
+        {isPending ? 'インポート中…' : 'インポート'}
+      </button>
+
+      {/* サーバーアクションの例外エラー表示 (色だけでなくテキストでも状態を伝える) */}
+      {error && (
+        <p className="text-sm text-rose-700" role="alert">
+          {error}
+        </p>
+      )}
+
+      {/* インポート結果表示 (成功件数 + エラー一覧) */}
+      {result && (
+        <div className="space-y-3" role="status" aria-live="polite">
+          {/* 成功件数バナー */}
+          <p className="text-sm font-medium text-teal-700">
+            {result.imported} 件をインポートしました
+            {/* エラーがある場合は合計件数も表示する */}
+            {result.errors.length > 0 && `（${result.errors.length} 件のエラーあり）`}
+          </p>
+          {/* エラー一覧 (エラーがある場合のみ表示) */}
+          {result.errors.length > 0 && (
+            <ul className="space-y-1 rounded-lg bg-rose-50 p-4 ring-1 ring-rose-100">
+              {result.errors.map((e: { row: number; message: string }) => (
+                /* エラー 1 件: 行番号 + エラーメッセージ */
+                <li key={e.row} className="text-sm text-rose-700">
+                  {/* 行番号を強調表示する */}
+                  <span className="font-medium">{e.row} 行目:</span> {e.message}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/tickets/components/CsvImportForm.tsx
+++ b/src/features/tickets/components/CsvImportForm.tsx
@@ -66,6 +66,9 @@ export function CsvImportForm({ categories: _categories }: CsvImportFormProps) {
   // useTransition でインポート中フラグを管理する (ボタン無効化・スピナー表示に使う)
   const [isPending, startTransition] = useTransition();
 
+  // クライアント側のファイルサイズ上限 (512KB)。サーバー側と同値に揃えて早期エラーにする
+  const MAX_FILE_BYTES = 512 * 1024;
+
   // ファイル選択時のハンドラ: File を読み込んで CSV テキストとプレビューを更新する
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     // 選択されたファイルを取り出す (未選択なら undefined)
@@ -76,6 +79,14 @@ export function CsvImportForm({ categories: _categories }: CsvImportFormProps) {
       setPreview([]); // プレビューをクリア
       setResult(null); // 結果をクリア
       setError(null); // エラーをクリア
+      return;
+    }
+    // ファイルサイズが上限を超える場合はエラーを表示して読み込みをスキップ (DoS 防止)
+    if (file.size > MAX_FILE_BYTES) {
+      setCsvText(null); // CSV テキストをクリア
+      setPreview([]); // プレビューをクリア
+      setResult(null); // 結果をクリア
+      setError(`ファイルサイズが大きすぎます（上限 ${MAX_FILE_BYTES / 1024}KB）`); // エラー表示
       return;
     }
     // FileReader で CSV ファイルをテキストとして非同期読み込みする

--- a/src/lib/industry-templates.ts
+++ b/src/lib/industry-templates.ts
@@ -1,0 +1,60 @@
+/**
+ * 業種テンプレート一覧 (Phase 3 業種テンプレ自動投入)
+ *
+ * 新規テナント作成時に業種を選ぶと、ここで定義したカテゴリが自動で初期投入される。
+ * docs/smb-dx-pivot-plan.md §4 Phase 3「業種テンプレ」に対応。
+ * カテゴリの追加・変更はこのファイルだけを編集すれば反映される (一元管理)。
+ */
+
+// 1 業種のテンプレートを表す型
+export interface IndustryTemplate {
+  id: string; // URL 安全な英数字 ID (DB / フォームの value として使う)
+  label: string; // 画面に表示する日本語名
+  categories: string[]; // 自動投入するカテゴリ名の一覧 (初期投入順)
+}
+
+// 全業種テンプレートの配列 (画面のドロップダウン選択肢と投入データの正本)
+export const INDUSTRY_TEMPLATES: IndustryTemplate[] = [
+  {
+    // 製造業: ハード/ネットワーク/設備/勤怠給与ソフト/その他
+    id: 'manufacturing',
+    label: '製造業',
+    categories: ['PC・ハードウェア', 'ネットワーク', '設備・機械', '勤怠・給与ソフト', 'その他'],
+  },
+  {
+    // 飲食業: POS/厨房/衛生/シフト/その他
+    id: 'food',
+    label: '飲食業',
+    categories: ['POS・レジ', '厨房設備', '衛生管理', 'シフト・勤怠', 'その他'],
+  },
+  {
+    // 介護・医療: PC・タブレット/介護ソフト/設備/勤怠シフト/その他
+    id: 'care',
+    label: '介護・医療',
+    categories: ['PC・タブレット', '介護ソフト', '設備・施設', '勤怠・シフト', 'その他'],
+  },
+  {
+    // 不動産: PC・ハード/物件管理システム/契約書類/その他
+    id: 'real-estate',
+    label: '不動産',
+    categories: ['PC・ハードウェア', '物件管理システム', '契約書類', 'その他'],
+  },
+  {
+    // 士業: PC・ハード/会計税務ソフト/セキュリティ/その他
+    id: 'professional',
+    label: '士業（税理士・社労士等）',
+    categories: ['PC・ハードウェア', '会計・税務ソフト', 'セキュリティ', 'その他'],
+  },
+  {
+    // 卸売・小売: PC・ハード/在庫管理システム/ネットワーク/その他
+    id: 'wholesale',
+    label: '卸売・小売',
+    categories: ['PC・ハードウェア', '在庫管理システム', 'ネットワーク', 'その他'],
+  },
+];
+
+// ID でテンプレートを 1 件取得するヘルパー関数 (見つからなければ undefined を返す)
+export function findIndustryTemplate(id: string): IndustryTemplate | undefined {
+  // 配列を線形探索して id が一致するものを返す
+  return INDUSTRY_TEMPLATES.find((t) => t.id === id);
+}

--- a/src/lib/ticket-email.ts
+++ b/src/lib/ticket-email.ts
@@ -69,3 +69,85 @@ export function renderTicketReplyEmail(input: {
   // 3 点セットを返す
   return { subject, text, html };
 }
+
+// ステータス変更を依頼者に知らせるメール本文を生成する純粋関数 (副作用なし)
+// Phase 2 メール通知テンプレート整備 (docs/smb-dx-pivot-plan.md §4 Phase 2)
+export function renderTicketStatusChangedEmail(input: {
+  ticketTitle: string; // 問い合わせの件名
+  ticketUrl: string; // チケット詳細ページの URL
+  oldStatusLabel: string; // 変更前ステータスの日本語ラベル (例: 「受付中」)
+  newStatusLabel: string; // 変更後ステータスの日本語ラベル (例: 「対応中」)
+}): { subject: string; text: string; html: string } {
+  // 件名: 接頭辞 + 変更前後のステータスを明示する (受信箱でひと目で分かるように)
+  const subject = `${SUBJECT_PREFIX} 問い合わせ「${input.ticketTitle}」の状況が「${input.oldStatusLabel}」から「${input.newStatusLabel}」に変わりました`;
+
+  // テキスト本文 (HTML 非対応クライアント向けフォールバック)
+  const text = [
+    `お問い合わせ「${input.ticketTitle}」の状況が変更されました。`,
+    '',
+    `変更前: ${input.oldStatusLabel}`,
+    `変更後: ${input.newStatusLabel}`,
+    '',
+    '詳細の確認は、下のリンクから行えます。',
+    `${input.ticketUrl}`,
+    '',
+    'このメールに心当たりがない場合は破棄してください。',
+  ].join('\n');
+
+  // HTML 本文に差し込む外部由来文字列を個別にエスケープする (XSS / 文面崩れ防止)
+  const escapedTitle = escapeHtml(input.ticketTitle);
+  const escapedOld = escapeHtml(input.oldStatusLabel);
+  const escapedNew = escapeHtml(input.newStatusLabel);
+  const escapedUrl = escapeHtml(input.ticketUrl);
+
+  // HTML 本文 (変更前後を並べて表示し、続きはボタンでアプリへ誘導する)
+  const html = `
+    <p>お問い合わせ「${escapedTitle}」の状況が変更されました。</p>
+    <blockquote style="margin:0 0 16px;padding:12px 16px;border-left:4px solid #0f766e;background:#f1f5f9;color:#0f172a;">
+      変更前: <strong>${escapedOld}</strong><br>
+      変更後: <strong>${escapedNew}</strong>
+    </blockquote>
+    <p><a href="${escapedUrl}" style="display:inline-block;padding:10px 16px;background:#0f766e;color:#ffffff;border-radius:6px;text-decoration:none;font-weight:600;">問い合わせを開く</a></p>
+    <p style="font-size:13px;color:#475569;">うまく開けない場合はこちらの URL をブラウザに貼り付けてください:<br><span style="word-break:break-all;">${escapedUrl}</span></p>
+    <p style="font-size:13px;color:#64748b;">このメールに心当たりがない場合は破棄してください。</p>
+  `.trim();
+
+  // 3 点セットを返す
+  return { subject, text, html };
+}
+
+// 担当者割当を担当者に知らせるメール本文を生成する純粋関数 (副作用なし)
+// Phase 2 メール通知テンプレート整備 (docs/smb-dx-pivot-plan.md §4 Phase 2)
+export function renderAssignedEmail(input: {
+  ticketTitle: string; // 問い合わせの件名
+  ticketUrl: string; // チケット詳細ページの URL
+}): { subject: string; text: string; html: string } {
+  // 件名: 接頭辞 + 担当者割当が起きたことを件名で伝える
+  const subject = `${SUBJECT_PREFIX} 問い合わせ「${input.ticketTitle}」の担当者に割り当てられました`;
+
+  // テキスト本文 (HTML 非対応クライアント向けフォールバック)
+  const text = [
+    `お問い合わせ「${input.ticketTitle}」の担当者に割り当てられました。`,
+    '',
+    '詳細の確認や対応は、下のリンクから行えます。',
+    `${input.ticketUrl}`,
+    '',
+    'このメールに心当たりがない場合は破棄してください。',
+  ].join('\n');
+
+  // HTML 本文に差し込む外部由来文字列を個別にエスケープする (XSS / 文面崩れ防止)
+  const escapedTitle = escapeHtml(input.ticketTitle);
+  const escapedUrl = escapeHtml(input.ticketUrl);
+
+  // HTML 本文 (件名を引用ブロックで目立たせ、続きはボタンでアプリへ誘導する)
+  const html = `
+    <p>お問い合わせ「${escapedTitle}」の担当者に割り当てられました。</p>
+    <blockquote style="margin:0 0 16px;padding:12px 16px;border-left:4px solid #0f766e;background:#f1f5f9;color:#0f172a;white-space:pre-wrap;">${escapedTitle}</blockquote>
+    <p><a href="${escapedUrl}" style="display:inline-block;padding:10px 16px;background:#0f766e;color:#ffffff;border-radius:6px;text-decoration:none;font-weight:600;">問い合わせを開く</a></p>
+    <p style="font-size:13px;color:#475569;">うまく開けない場合はこちらの URL をブラウザに貼り付けてください:<br><span style="word-break:break-all;">${escapedUrl}</span></p>
+    <p style="font-size:13px;color:#64748b;">このメールに心当たりがない場合は破棄してください。</p>
+  `.trim();
+
+  // 3 点セットを返す
+  return { subject, text, html };
+}

--- a/src/lib/ticket-email.ts
+++ b/src/lib/ticket-email.ts
@@ -17,6 +17,14 @@ import { escapeHtml } from '@/lib/html-escape';
 // メール件名の接頭辞。受信箱でのフィルタ/識別を容易にするため一元管理する
 const SUBJECT_PREFIX = '[HelpDesk Hub]';
 
+// メール件名からヘッダインジェクション文字 (CR / LF) を除去するサニタイザ
+// チケットタイトルなどユーザー由来の文字列を件名に埋め込む前に必ず通す
+// 例: "foo\r\nBcc: x@y.com" → "foo Bcc: x@y.com"
+function sanitizeSubject(s: string): string {
+  // \r と \n を半角スペースに置換することで改行による SMTP ヘッダ分割を防ぐ
+  return s.replace(/[\r\n]/g, ' ');
+}
+
 // 指定した baseUrl とチケット ID から、依頼者が開くチケット詳細ページの URL を組み立てる
 // 例: buildTicketUrl('http://localhost:3000', 'abc') -> 'http://localhost:3000/tickets/abc'
 export function buildTicketUrl(baseUrl: string, ticketId: string): string {
@@ -33,8 +41,8 @@ export function renderTicketReplyEmail(input: {
   commentBody: string; // 担当者が投稿した返信本文
   agentName: string; // 返信した担当者の表示名
 }): { subject: string; text: string; html: string } {
-  // 件名: 接頭辞 + 件名規約。専門用語 (チケット等) を避け「問い合わせ」「返信」で表現する
-  const subject = `${SUBJECT_PREFIX} 問い合わせ「${input.ticketTitle}」に新しい返信があります`;
+  // 件名: 接頭辞 + 件名規約。ユーザー入力をサニタイズしてヘッダインジェクションを防ぐ
+  const subject = sanitizeSubject(`${SUBJECT_PREFIX} 問い合わせ「${input.ticketTitle}」に新しい返信があります`);
 
   // テキスト本文 (HTML 非対応クライアント向けフォールバック)
   const text = [
@@ -78,8 +86,8 @@ export function renderTicketStatusChangedEmail(input: {
   oldStatusLabel: string; // 変更前ステータスの日本語ラベル (例: 「受付中」)
   newStatusLabel: string; // 変更後ステータスの日本語ラベル (例: 「対応中」)
 }): { subject: string; text: string; html: string } {
-  // 件名: 接頭辞 + 変更前後のステータスを明示する (受信箱でひと目で分かるように)
-  const subject = `${SUBJECT_PREFIX} 問い合わせ「${input.ticketTitle}」の状況が「${input.oldStatusLabel}」から「${input.newStatusLabel}」に変わりました`;
+  // 件名: 接頭辞 + 変更前後のステータスを明示する。ヘッダインジェクション防止のためサニタイズする
+  const subject = sanitizeSubject(`${SUBJECT_PREFIX} 問い合わせ「${input.ticketTitle}」の状況が「${input.oldStatusLabel}」から「${input.newStatusLabel}」に変わりました`);
 
   // テキスト本文 (HTML 非対応クライアント向けフォールバック)
   const text = [
@@ -122,8 +130,8 @@ export function renderAssignedEmail(input: {
   ticketTitle: string; // 問い合わせの件名
   ticketUrl: string; // チケット詳細ページの URL
 }): { subject: string; text: string; html: string } {
-  // 件名: 接頭辞 + 担当者割当が起きたことを件名で伝える
-  const subject = `${SUBJECT_PREFIX} 問い合わせ「${input.ticketTitle}」の担当者に割り当てられました`;
+  // 件名: 接頭辞 + 担当者割当が起きたことを件名で伝える。ヘッダインジェクション防止のためサニタイズする
+  const subject = sanitizeSubject(`${SUBJECT_PREFIX} 問い合わせ「${input.ticketTitle}」の担当者に割り当てられました`);
 
   // テキスト本文 (HTML 非対応クライアント向けフォールバック)
   const text = [
@@ -139,10 +147,11 @@ export function renderAssignedEmail(input: {
   const escapedTitle = escapeHtml(input.ticketTitle);
   const escapedUrl = escapeHtml(input.ticketUrl);
 
-  // HTML 本文 (件名を引用ブロックで目立たせ、続きはボタンでアプリへ誘導する)
+  // HTML 本文 (割当を通知し、続きはボタンでアプリへ誘導する)
+  // blockquote は「引用」を表す要素なので、返信本文がない担当割当通知には使わない
   const html = `
     <p>お問い合わせ「${escapedTitle}」の担当者に割り当てられました。</p>
-    <blockquote style="margin:0 0 16px;padding:12px 16px;border-left:4px solid #0f766e;background:#f1f5f9;color:#0f172a;white-space:pre-wrap;">${escapedTitle}</blockquote>
+    <p>チケットを確認し、対応を開始してください。</p>
     <p><a href="${escapedUrl}" style="display:inline-block;padding:10px 16px;background:#0f766e;color:#ffffff;border-radius:6px;text-decoration:none;font-weight:600;">問い合わせを開く</a></p>
     <p style="font-size:13px;color:#475569;">うまく開けない場合はこちらの URL をブラウザに貼り付けてください:<br><span style="word-break:break-all;">${escapedUrl}</span></p>
     <p style="font-size:13px;color:#64748b;">このメールに心当たりがない場合は破棄してください。</p>

--- a/src/lib/validations/invite.ts
+++ b/src/lib/validations/invite.ts
@@ -1,5 +1,7 @@
 // Zod (スキーマ検証ライブラリ) をインポート
 import { z } from 'zod';
+// 業種テンプレートの ID 一覧 (サーバー側ホワイトリスト検証に使う)
+import { INDUSTRY_TEMPLATES } from '@/lib/industry-templates';
 
 // 招待リンクで付与できる権限は「メンバー (requester)」か「担当者 (agent)」のみ。
 // admin はリンク経由で付与しない (テナント作成フォームで初代管理者を作る運用)。
@@ -62,6 +64,11 @@ export const acceptInvitationSchema = z.object({
   password: passwordSchema,
 });
 
+// 有効な業種 ID のセット (INDUSTRY_TEMPLATES から動的に生成してホワイトリストとして使う)
+// フォームの <select> 選択肢と同じリストをサーバー側でも検証することで、直接リクエストによる
+// 任意文字列の持ち込みを防ぐ (UI で弾いても HTTP リクエストは直接送れるため)
+const VALID_INDUSTRY_IDS = new Set(INDUSTRY_TEMPLATES.map((t) => t.id));
+
 // テナント作成フォーム (運用者向け最小) の入力検証スキーマ。
 // 組織名 + 業種 (任意) + 初代管理者の氏名 / メール / パスワード。
 export const createTenantSchema = z.object({
@@ -71,11 +78,15 @@ export const createTenantSchema = z.object({
     .trim()
     .min(1, '組織名は必須です')
     .max(NAME_MAX_LENGTH, '組織名が長すぎます'),
-  // 業種テンプレ識別子 (任意。Phase 3 のカテゴリ初期投入で利用予定)
+  // 業種テンプレ識別子 (任意)。空文字は「未選択」として undefined に変換する。
+  // 空文字以外を指定する場合は INDUSTRY_TEMPLATES の ID のいずれかに限定する (ホワイトリスト)
   industry: z
     .string()
     .trim()
-    .max(NAME_MAX_LENGTH, '業種が長すぎます')
+    .refine(
+      (v: string) => v === '' || VALID_INDUSTRY_IDS.has(v),
+      '業種の指定が正しくありません。選択肢から選んでください。'
+    )
     .optional()
     .or(z.literal('').transform(() => undefined)),
   // 初代管理者の氏名

--- a/tests/features/create-tenant.test.ts
+++ b/tests/features/create-tenant.test.ts
@@ -75,7 +75,9 @@ describe('createTenant', () => {
     const result = await createTenant(
       makeForm({
         tenantName: '新組織',
-        industry: '製造業',
+        // industry は INDUSTRY_TEMPLATES の ID を指定する (UI の <select> の value と対応)
+        // 日本語ラベル ('製造業') ではなく英語 ID ('manufacturing') を送る
+        industry: 'manufacturing',
         adminName: '管理 太郎',
         adminEmail: 'newadmin@example.com',
         adminPassword: 'password123',
@@ -83,10 +85,11 @@ describe('createTenant', () => {
     );
     // 作成テナントは呼び出し元テナントとは別 ID
     expect(result.tenantId).not.toBe(CALLER_TENANT);
-    // 作成テナントが store に存在し、業種も保存されている
+    // 作成テナントが store に存在し、業種 ID も保存されている
     const tenant = store.tenants.get(result.tenantId);
     expect(tenant?.name).toBe('新組織');
-    expect(tenant?.industry).toBe('製造業');
+    // DB には industry ID が保存される (UI のラベル '製造業' ではなく)
+    expect(tenant?.industry).toBe('manufacturing');
     // 初代管理者が作成テナントに admin として作られている
     const admin = [...store.users.values()].find((u) => u.email === 'newadmin@example.com');
     expect(admin?.role).toBe('admin');


### PR DESCRIPTION
## 概要

`docs/smb-dx-pivot-plan.md` の未実装項目から3件を実装しました。

### Phase 2 — メール通知テンプレート拡充

**対象**: `smb-dx-pivot-plan.md` Phase 2「メール通知テンプレート拡充」

- `src/lib/ticket-email.ts` に2つの新テンプレート関数を追加
  - `renderTicketStatusChangedEmail`: ステータス変更時に依頼者へ送る件名+本文+HTML
  - `renderAssignedEmail`: 担当者アサイン時に担当者本人へ送る件名+本文+HTML
- `src/features/tickets/actions/update-ticket.ts` に組み込み
  - `updateTicketStatus`: ステータス変更後、依頼者へメールをベストエフォート送信（自己操作はスキップ）
  - `updateTicketAssignee`: アサイン変更後、新担当者へメールをベストエフォート送信（自己アサインはスキップ）

### Phase 3 — 業種テンプレート初期投入

**対象**: `smb-dx-pivot-plan.md` Phase 3「業種テンプレ（カテゴリ自動生成）」

- `src/lib/industry-templates.ts` 新規作成（6業種×4〜5カテゴリ）
- `CategoryRepository` インターフェースに `create` メソッドを追加（port + Prisma + memory アダプタ）
- `src/features/settings/actions/create-tenant.ts`: テナント作成時に業種テンプレートのカテゴリを自動投入
- `CreateTenantForm.tsx`: 業種フィールドをテキスト入力 → セレクトボックスに変更

### Phase 3 — CSV インポート

**対象**: `smb-dx-pivot-plan.md` Phase 3「CSVインポート（チケット一括登録）」

- `src/features/tickets/actions/import-tickets.ts` 新規作成
  - エージェント専用 Server Action（`assertAgentRole` + 流量制限5回/60秒）
  - ヘッダ必須列チェック、最大200行制限
  - Lite/Pro モードで初期ステータスを切り替え（Open / New）
  - 優先度の日本語→英語マッピング（高/中/低）
- `src/features/tickets/components/CsvImportForm.tsx` 新規作成（Client Component）
  - ファイル選択 → 先頭5行プレビュー → インポート実行 → 結果表示のフロー
  - `useTransition` でノンブロッキング送信
- `src/app/(app)/tickets/import/page.tsx` 新規作成（エージェント専用ページ）
- チケット一覧にエージェント向け「CSVインポート」リンクを追加

## テスト計画

- [ ] `npm run typecheck` でエラーなし（環境依存の pre-existing エラーを除く）
- [ ] `npm run lint` でエラーなし
- [ ] `npm run test` でユニットテスト通過
- [ ] `/tickets/import` にアクセスし CSV ファイル選択 → プレビュー → インポート実行が動作すること
- [ ] ステータス変更・担当者変更時にメールがコンソールまたは送信サーバーに出力されること
- [ ] テナント作成時に業種選択したカテゴリが自動登録されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dUjdL7Y2KDiDBcD9CYzLj

---
_Generated by [Claude Code](https://claude.ai/code/session_011dUjdL7Y2KDiDBcD9CYzLj)_