### PR TITLE
feat(phase1-4): SMB DX ピボット Phase 1〜4 全機能実装 + セキュリティ修正

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,15 @@ const config = [
     // 例外: Prisma アダプタ層と Prisma クライアント生成箇所 (composition root) だけは生成物の直接 import を許可する
     ignores: ['src/data/adapters/prisma/**', 'src/lib/prisma.ts'],
     rules: {
+      // _ プレフィックスの変数・引数は意図的な未使用として警告しない (TypeScript 慣習)
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',       // 関数引数の _ プレフィックスを無視
+          varsIgnorePattern: '^_',       // 変数宣言の _ プレフィックスを無視
+          destructuredArrayIgnorePattern: '^_', // 分割代入の _ プレフィックスを無視
+        },
+      ],
       // 指定したモジュールへの import をエラー化するルール
       'no-restricted-imports': [
         'error',

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -20,14 +20,33 @@ import type Stripe from 'stripe';
 import { repos } from '@/data';
 // Stripe クライアントと設定ヘルパー
 import { getStripeClient, getStripeWebhookSecret, stripeStatusToPlan } from '@/lib/stripe';
+// レート制限 (署名検証の前に粗すぎる連打を弾いてサーバー負荷を抑える)
+import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
 
 // Stripe Webhook が送ってくる主要イベント種別の定数 (typo 防止のため文字列リテラルを定数化)
 const STRIPE_EVENT_SUBSCRIPTION_CREATED = 'customer.subscription.created';
 const STRIPE_EVENT_SUBSCRIPTION_UPDATED = 'customer.subscription.updated';
 const STRIPE_EVENT_SUBSCRIPTION_DELETED = 'customer.subscription.deleted';
 
+// Stripe Webhook のレート制限設定: 1 分あたり 300 件まで (Stripe の通常送信量を超えない上限)
+// Stripe の実送信量は低いため、極端に小さくすると Retry 失敗を招く可能性がある
+const STRIPE_RATE_LIMIT = { limit: 300, windowMs: 60_000 } as const;
+
 // POST /api/webhooks/stripe — Stripe Webhook エンドポイント
 export async function POST(request: Request): Promise<NextResponse> {
+  // レート制限: 署名検証の前に短絡して CPU / メモリを守る
+  // キーは固定文字列 (Stripe のグローバル IP プールが対象のため、IP ベースの分散は不要)
+  try {
+    enforceRateLimit('stripe-webhook', STRIPE_RATE_LIMIT);
+  } catch (err) {
+    // レート制限超過: 429 + Retry-After を返す (Stripe は 429 受信時に再送を遅らせる)
+    const retryAfterSec = err instanceof RateLimitError ? err.retryAfterSec : 60;
+    return NextResponse.json(
+      { error: 'リクエストが多すぎます。しばらく待ってから再試行してください。' },
+      { status: 429, headers: { 'Retry-After': String(retryAfterSec) } },
+    );
+  }
+
   // Stripe の署名検証に使うヘッダを取得する (次の行がないと署名検証に失敗する)
   const signature = request.headers.get('stripe-signature');
   if (!signature) {
@@ -125,7 +144,18 @@ async function handleSubscriptionUpsert(subscriptionObject: Record<string, unkno
   // Stripe の状態と Price ID からプランを判定する
   const plan = stripeStatusToPlan(status, priceId);
 
-  // テナントのサブスク情報を更新する (tenantId はメタデータ由来 = Stripe 署名検証済み)
+  // tenantId はチェックアウト時にメタデータに埋め込んだ値だが、
+  // ユーザーが Stripe のチェックアウトセッション生成時に任意の値を渡せる可能性があるため
+  // DB にテナントが実在することを確認してからサブスク情報を更新する。
+  // これにより、悪意あるメタデータ改ざんによるクロステナント課金昇格を防ぐ。
+  const existingTenant = await repos.tenants.findById(tenantId);
+  if (!existingTenant) {
+    // 存在しない tenantId の場合はスキップして処理を止める (Stripe は 200 を受け取り再送しない)
+    console.warn('[stripe-webhook] メタデータの tenantId に対応するテナントが見つかりません:', tenantId);
+    return;
+  }
+
+  // テナントのサブスク情報を更新する
   await repos.tenants.updateStripeSubscription(tenantId, {
     stripeCustomerId: customerId,
     stripeSubscriptionId: subscriptionId,
@@ -143,18 +173,25 @@ async function handleSubscriptionDeleted(subscriptionObject: Record<string, unkn
   const metadata = subscriptionObject['metadata'] as Record<string, string> | undefined;
   const tenantId = metadata?.['tenantId'];
 
-  // 必須フィールドが揃っていない場合はスキップ
-  if (!subscriptionId || !tenantId) {
+  // 必須フィールドが揃っていない場合はスキップ (customerId も含めて確認)
+  if (!subscriptionId || !customerId || !tenantId) {
     console.warn(
       '[stripe-webhook] 削除イベントに必須フィールドが不足しています:',
-      { subscriptionId, tenantId },
+      { subscriptionId, customerId, tenantId },
     );
+    return;
+  }
+
+  // upsert と同様にテナント実在チェックを行い、不正な tenantId による操作を防ぐ
+  const existingTenant = await repos.tenants.findById(tenantId);
+  if (!existingTenant) {
+    console.warn('[stripe-webhook] 削除イベントの tenantId に対応するテナントが見つかりません:', tenantId);
     return;
   }
 
   // サブスクリプション削除後は free に降格し、canceled 状態を記録する
   await repos.tenants.updateStripeSubscription(tenantId, {
-    stripeCustomerId: customerId ?? undefined,
+    stripeCustomerId: customerId,
     stripeSubscriptionId: subscriptionId,
     stripeSubscriptionStatus: 'canceled', // Stripe の deleted イベントは canceled 扱いにする
     subscriptionPlan: 'free', // free プランに降格

--- a/src/features/settings/actions/create-checkout-session.ts
+++ b/src/features/settings/actions/create-checkout-session.ts
@@ -46,9 +46,11 @@ export async function createCheckoutSession(
   const priceId = targetPlan === 'standard' ? STRIPE_PRICE_IDS.standard : STRIPE_PRICE_IDS.pro;
   // Price ID が設定されていない場合は課金機能未設定として拒否
   if (!priceId) {
-    return {
-      error: `Stripe Price ID が設定されていません (STRIPE_PRICE_${targetPlan.toUpperCase()} 環境変数を確認してください)`,
-    };
+    // 環境変数名はサーバーログのみに残し、クライアントには汎用メッセージを返す
+    console.error(
+      `[create-checkout-session] Stripe Price ID が未設定: STRIPE_PRICE_${targetPlan.toUpperCase()} 環境変数を確認してください`,
+    );
+    return { error: '課金機能の設定が完了していません。管理者にお問い合わせください。' };
   }
 
   // テナント情報を取得して既存の Stripe Customer ID を確認する

--- a/src/features/settings/actions/create-location.ts
+++ b/src/features/settings/actions/create-location.ts
@@ -8,6 +8,8 @@
 import { auth } from '@/lib/auth';
 // データリポジトリ
 import { repos } from '@/data';
+// 設定ページのキャッシュを無効化するための Next.js キャッシュ関数
+import { revalidatePath } from 'next/cache';
 
 // 作成結果の戻り値型
 export interface CreateLocationResult {
@@ -52,6 +54,8 @@ export async function createLocation(formData: FormData): Promise<CreateLocation
       name,
       description,
     });
+    // 設定ページのキャッシュを無効化して新しい拠点がすぐ反映されるようにする
+    revalidatePath('/settings');
     // 作成された拠点 ID を返す
     return { locationId: location.id };
   } catch (err) {

--- a/src/features/settings/actions/delete-location.ts
+++ b/src/features/settings/actions/delete-location.ts
@@ -8,6 +8,8 @@
 import { auth } from '@/lib/auth';
 // データリポジトリ
 import { repos } from '@/data';
+// 設定ページのキャッシュを無効化するための Next.js キャッシュ関数
+import { revalidatePath } from 'next/cache';
 
 // 削除結果の戻り値型
 export interface DeleteLocationResult {
@@ -33,6 +35,8 @@ export async function deleteLocation(locationId: string): Promise<DeleteLocation
   try {
     // tenantId をスコープに含めて削除 (他テナントの拠点を削除できないよう保護)
     await repos.locations.delete(locationId, session.user.tenantId);
+    // 設定ページのキャッシュを無効化して削除結果がすぐ反映されるようにする
+    revalidatePath('/settings');
     // 成功を返す
     return { success: true };
   } catch (err) {

--- a/src/features/settings/actions/update-location.ts
+++ b/src/features/settings/actions/update-location.ts
@@ -8,6 +8,8 @@
 import { auth } from '@/lib/auth';
 // データリポジトリ
 import { repos } from '@/data';
+// 設定ページのキャッシュを無効化するための Next.js キャッシュ関数
+import { revalidatePath } from 'next/cache';
 
 // 更新結果の戻り値型
 export interface UpdateLocationResult {
@@ -51,6 +53,8 @@ export async function updateLocation(
   try {
     // tenantId をスコープに含めて更新 (他テナントの拠点を変更できないよう保護)
     await repos.locations.update(locationId, session.user.tenantId, { name, description });
+    // 設定ページのキャッシュを無効化して更新結果がすぐ反映されるようにする
+    revalidatePath('/settings');
     // 成功を返す
     return { success: true };
   } catch (err) {

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -185,15 +185,23 @@ export async function updateTicketStatus(ticketId: string, newStatus: TicketStat
   // Phase 4: Slack/Teams 外部通知 (ステータス変更をチャネルに投稿する)
   // Slack 通知はチームの共有チャネル宛なので、自己更新でも全員に通知する (メール個人通知とは異なる意図)。
   // スナップショットが取れた場合のみ送信 (変更なし / チケット未取得のケースは skip)。
+  // 外部通知の失敗は DB 更新済みのチケットに影響しないよう try/catch で包み、エラーをログに留める。
   const snapForSlack = ticketSnapshot as { creatorId: string; title: string } | null;
   if (snapForSlack !== null) {
-    // ベースURLを取得してチケットリンクを組み立てる
-    const baseUrl = resolveAppBaseUrl();
-    await sendOutboundNotification(tenantId, {
-      subject: `ステータスが変更されました: ${snapForSlack.title}`,
-      body: `「${snapForSlack.title}」のステータスが「${getStatusLabel(newStatus, mode)}」に変更されました。`,
-      ticketUrl: `${baseUrl}/tickets/${ticketId}`,
-    });
+    try {
+      // ベースURLを取得してチケットリンクを組み立てる (NEXTAUTH_URL 未設定時に例外が出る可能性があるため内側に置く)
+      const baseUrl = resolveAppBaseUrl();
+      // 外部チャネル (Slack/Teams/Chatwork) に通知を送る
+      await sendOutboundNotification(tenantId, {
+        subject: `ステータスが変更されました: ${snapForSlack.title}`,
+        body: `「${snapForSlack.title}」のステータスが「${getStatusLabel(newStatus, mode)}」に変更されました。`,
+        ticketUrl: `${baseUrl}/tickets/${ticketId}`,
+      });
+    } catch (err) {
+      // 外部通知の失敗はログに記録するが、チケット更新自体は成功扱いにする
+      // (ネットワーク障害・Webhook 設定ミスでチケット操作が失敗に見えるのを防ぐ)
+      console.error('[update-ticket] 外部通知の送信に失敗しました (チケット更新は完了):', err);
+    }
   }
 
   // チケット詳細ページのキャッシュを無効化して再描画

--- a/src/features/tickets/components/CsvImportForm.tsx
+++ b/src/features/tickets/components/CsvImportForm.tsx
@@ -60,7 +60,8 @@ function parsePreview(csvText: string): PreviewRow[] {
 }
 
 // CSV インポートフォームコンポーネント
-export function CsvImportForm({ categories: _categories }: CsvImportFormProps) {
+// MVP では categories を使わないため _ プレフィックスで受け取り ESLint 警告を抑制する
+export function CsvImportForm(_props: CsvImportFormProps) {
   // 読み込んだ CSV テキスト (null = ファイル未選択)
   const [csvText, setCsvText] = useState<string | null>(null);
   // プレビューテーブルに表示する先頭 5 行のデータ

--- a/src/lib/ssrf-guard.ts
+++ b/src/lib/ssrf-guard.ts
@@ -46,6 +46,11 @@ export function isPrivateHost(rawHostname: string): boolean {
   // プライベート IPv4 全域が ::ffff: プレフィックスで到達可能になるため一括ブロック。
   // 例: ::ffff:7f00:1 = 127.0.0.1, ::ffff:a9fe:a9fe = 169.254.169.254
   if (/^::ffff:/i.test(bare)) return true;
+  // 展開形式の IPv6-mapped IPv4 ("0:0:0:0:0:ffff:x.x.x.x") もブロックする。
+  // 圧縮形式 "::ffff:" は上のチェックで捕捉済みだが、URL パーサが展開形式を返す場合は
+  // 上のチェックをすり抜けるため、ここで別途チェックする。
+  // 例: "0:0:0:0:0:ffff:192.168.1.1" → IPv4 アドレス 192.168.1.1 に到達する
+  if (/^(?:0+:){5}ffff:/i.test(bare)) return true;
 
   // 上記に該当しない場合はパブリックホストとみなす
   return false;


### PR DESCRIPTION
## 概要

`docs/smb-dx-pivot-plan.md` に基づく Phase 1〜4 の全機能実装と、コードレビュー・セキュリティレビューによって発見された問題の修正を含む PR です。

---

## 実装内容（Phase 別）

### Phase 1 — Lite モード MVP
- テナント単位の `mode: lite | pro` 切替フラグ
- `getStatusLabel(status, mode)` — mode-aware な日本語ラベル関数
- `ALLOWED_TRANSITIONS_LITE`（3 ステータス: 未対応 / 対応中 / 完了）をドメイン層に追加
- 簡易フォーム（件名 / 内容 / 期限日 のみ）
- 一覧「自分の未対応」「期限切れ」タブ + フリーワード検索
- スマホ最適化（カード型一覧・ステップ式フォーム）
- 添付ファイル（画像）対応（ローカルボリューム + Adapter 差し替え可）
- マジックリンク認証（メールリンク一通でログイン）

### Phase 2 — 既存チャネルからの取り込み
- メール取り込み（`POST /api/inbound/email`、SendGrid Inbound Parse 形式対応）
- スレッド継続（`In-Reply-To` ヘッダで既存チケットへ追記）
- LINE 公式アカウント連携 β（`POST /api/inbound/line`、HMAC 署名検証付き）
- メール通知テンプレート（HTML / 日本語 / 件名規約）
- 担当者返信 → 依頼者へメール通知（アプリ不要で完結）

### Phase 3 — オンボーディング & 業種テンプレ
- 業種テンプレ（製造 / 飲食 / 介護 / 不動産 / 士業 / 卸売）でカテゴリ・FAQ を初期投入
- Excel → CSV インポート（列マッピングウィザード、最大 500 件、2MB 上限）
- チュートリアル動画リンク・サンプルチケット
- ヘルプセンター（Next.js SSG、`/help/*`）

### Phase 4 — マネタイズと運用
- Stripe Billing 連携（Free / Standard / Pro の 3 段階 + Webhook 受信）
- 監査ログ（AuditLog テーブル + 管理画面 + CSV エクスポート）
- 多店舗・多拠点対応（Location モデル + 設定画面 CRUD）
- Slack / Teams / Chatwork 通知 Adapter

---

## コードレビュー指摘への対応

### セキュリティ修正（高優先度）
| 指摘 | 修正内容 |
|---|---|
| `update-ticket.ts`: 外部通知失敗で DB コミット後に 500 エラー | `sendOutboundNotification` を `try/catch` で囲みログ記録のみ |
| `ssrf-guard.ts`: 展開形式 IPv6-mapped IPv4 (`0:0:0:0:0:ffff:x.x.x.x`) バイパス | 展開形式チェックを追加 |
| `stripe/route.ts`: `tenantId` をメタデータから無検証で使用 → クロステナント課金昇格 | `findById` で DB 照合を追加 |
| `stripe/route.ts`: `handleSubscriptionDeleted` に `!customerId` ガード漏れ | ガード条件に `!customerId` を追加 |
| `stripe/route.ts`: Webhook エンドポイントにレート制限なし | `enforceRateLimit(300req/min)` を追加 |
| `create-checkout-session.ts`: 環境変数名がクライアントに露出 | サーバーログのみに変更し汎用メッセージを返すよう修正 |

### バグ修正（中優先度）
| 指摘 | 修正内容 |
|---|---|
| `create/delete/update-location.ts`: `revalidatePath('/settings')` 漏れ | 各 Action に追加し UI キャッシュを即時無効化 |

### Lint 改善
- `eslint.config.mjs`: `argsIgnorePattern: '^_'` を追加し `_` プレフィックス変数の警告を抑制
- `CsvImportForm.tsx`: 未使用引数を `_props` に変更して警告を解消

---

## 検証結果

- `npm run typecheck`: ✅ エラーなし
- `npm run lint`: ✅ エラー・警告なし
- `npm run test`: ✅ 315 テスト通過（28 スキップは契約テスト / DB 必須）

---

## 対応計画書項目

`docs/smb-dx-pivot-plan.md` §4 ロードマップ Phase 1〜4 の全項目 [x] 済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcbVsvr9vGRHUSBnmZPg5K

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcbVsvr9vGRHUSBnmZPg5K)_