### PR TITLE
feat: バックアップ自動化・Enterprise プラン・SAML SSO の実装（チェック済み未実装項目の解消）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,9 @@ INBOUND_EMAIL_SECRET=""
 # メール取り込みの配信ドメイン (例: inbox.helpdesk-hub.app)。
 # 設定すると宛先ドメイン一致を必須化し誤ルーティングを防ぐ。未設定ならドメイン検証をスキップする。
 INBOUND_EMAIL_DOMAIN=""
+
+# DB バックアップ (Phase 4 運用 / scripts/backup-db.sh)。
+# 保存先ディレクトリ。未設定なら ./var/backups。本番では永続ボリュームを指定する。
+BACKUP_DIR="./var/backups"
+# 保持日数。これより古いダンプは自動削除される (世代管理)。未設定なら 14 日。
+BACKUP_RETENTION_DAYS="14"

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,69 @@
+# Phase 4 運用: PostgreSQL の自動バックアップ (スケジュール実行)。
+# docs/smb-dx-pivot-plan.md §4 Phase 4「監査ログ / バックアップ自動化」に対応。
+#
+# 仕組み:
+#   - 毎日 1 回 (cron) と手動実行 (workflow_dispatch) で scripts/backup-db.sh を走らせる。
+#   - 接続先は Secret `BACKUP_DATABASE_URL`。未設定ならジョブは安全に no-op で終了する
+#     (fail-closed: 認証情報が無い状態でダンプを試みない)。
+#   - 生成したダンプは Actions の artifact として短期保持でアップロードする。
+#
+# セキュリティ上の注意:
+#   - artifact には本番データが含まれ得るため retention を短く設定し、リポジトリ/Actions の
+#     アクセス権限を絞ること。機微データを GitHub に置きたくない運用では、本ワークフローを使わず
+#     ホスト側 cron で scripts/backup-db.sh を実行する (docs/backup.md 参照)。
+#   - BACKUP_DATABASE_URL は読み取り権限のみを持つ DB ロールを推奨する。
+
+name: DB Backup
+
+on:
+  schedule:
+    # UTC 18:00 = JST 03:00 に毎日 1 回実行する (アクセスが少ない深夜帯)
+    - cron: '0 18 * * *'
+  # 手動トリガも許可する (Actions 画面の Run workflow ボタン)
+  workflow_dispatch:
+
+# 既定の GITHUB_TOKEN は読み取りのみで十分 (このジョブはリポジトリに書き込まない)
+permissions:
+  contents: read
+
+jobs:
+  backup:
+    name: pg_dump backup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # PostgreSQL クライアント (pg_dump) を入れる。GitHub の ubuntu-latest には
+      # postgresql-client-16 を明示導入して pg_dump のバージョン差異を避ける。
+      - name: Install postgresql-client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      # Secret が設定されているときだけ実バックアップを実行する。
+      # 未設定なら no-op (このリポジトリを fork した環境でもジョブが赤くならないようにする)。
+      - name: Run backup
+        env:
+          BACKUP_DATABASE_URL: ${{ secrets.BACKUP_DATABASE_URL }}
+        run: |
+          if [ -z "${BACKUP_DATABASE_URL}" ]; then
+            echo "BACKUP_DATABASE_URL secret が未設定のためスキップします (no-op)。" >&2
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # スクリプトに接続先を渡してバックアップを実行する。出力先はワークスペース配下。
+          DATABASE_URL="${BACKUP_DATABASE_URL}" BACKUP_DIR=./var/backups \
+            bash scripts/backup-db.sh
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+        id: backup
+
+      # ダンプを artifact としてアップロードする (Secret 設定時のみファイルが存在する)。
+      - name: Upload backup artifact
+        if: steps.backup.outputs.skipped == 'false'
+        uses: actions/upload-artifact@v4
+        with:
+          name: db-backup-${{ github.run_id }}
+          path: var/backups/*.dump
+          # 本番データを含み得るため保持を 7 日に短縮する
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,17 @@ env:
   NODE_VERSION: '20'
 
 jobs:
+  shellcheck:
+    name: Shellcheck (backup scripts)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # scripts/ 配下の Bash スクリプト (バックアップ等) を静的解析する。
+      # ubuntu-latest には shellcheck がプリインストールされている。
+      - name: Run shellcheck
+        run: shellcheck scripts/*.sh
+
   lint-typecheck-test:
     name: Lint / Typecheck / Unit tests
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,8 @@ next-env.d.ts
 # ローカル開発時の添付ファイル保存先 (Local Storage Adapter のデフォルト)。本番では別ボリュームを使う想定
 /var/uploads/
 
+# DB バックアップの保存先 (scripts/backup-db.sh のデフォルト)。ダンプは機微データを含むため commit しない
+/var/backups/
+
 # Claude Code agent worktrees / scratch state (per-session, never commit)
 .claude/

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,0 +1,85 @@
+# データベースバックアップ運用ガイド
+
+Phase 4「監査ログ / バックアップ自動化」(`docs/smb-dx-pivot-plan.md` §4) の運用手順。
+PostgreSQL を定期的にダンプし、世代管理しながら保管する。
+
+## スクリプト
+
+| スクリプト | 役割 |
+| --- | --- |
+| `scripts/backup-db.sh` | `pg_dump` で custom 形式 (圧縮込み) のダンプを作成し、古い世代を削除する |
+| `scripts/restore-db.sh` | `pg_restore` でダンプから復元する（**既存データを上書き**） |
+
+npm からも実行できる:
+
+```bash
+npm run db:backup           # バックアップ作成 + 世代管理
+npm run db:backup -- --dry-run  # 実行内容だけ確認（dump しない）
+npm run db:restore -- var/backups/helpdesk_hub_YYYYMMDD_HHMMSS.dump
+```
+
+## 設定（環境変数）
+
+| 変数 | 既定 | 説明 |
+| --- | --- | --- |
+| `DATABASE_URL` | （必須） | ダンプ対象 PostgreSQL の接続文字列 |
+| `BACKUP_DIR` | `./var/backups` | ダンプの保存先。本番では永続ボリュームを指定する |
+| `BACKUP_RETENTION_DAYS` | `14` | 保持日数。これより古い `*.dump` は自動削除される |
+
+ダンプは機微データを含むため、`var/backups/` は `.gitignore` 済み（リポジトリにコミットしない）。
+
+## 自動化の選択肢
+
+### 1. GitHub Actions（`.github/workflows/backup.yml`）
+
+毎日 JST 03:00（cron `0 18 * * *` UTC）に実行。手動実行も可。
+リポジトリ Secret `BACKUP_DATABASE_URL` を設定すると有効化され、ダンプを artifact として
+7 日間保持する。**未設定ならジョブは安全に no-op で終了する**（fail-closed）。
+
+> ⚠️ artifact には本番データが含まれ得る。アクセス権限を絞り、可能なら読み取り専用 DB ロールを
+> `BACKUP_DATABASE_URL` に使う。機微データを GitHub に置きたくない場合は次のホスト cron を使う。
+
+### 2. ホスト cron（機微データを外部に出さない運用）
+
+本番サーバー（または DB に到達できるホスト）の crontab に登録する:
+
+```cron
+# 毎日 03:00 にバックアップ（出力は syslog/logger 等へ）
+0 3 * * * cd /opt/helpdesk-hub && DATABASE_URL="postgresql://backup_ro:***@localhost:5432/helpdesk_hub" \
+    BACKUP_DIR=/var/backups/helpdesk-hub BACKUP_RETENTION_DAYS=30 \
+    bash scripts/backup-db.sh >> /var/log/helpdesk-backup.log 2>&1
+```
+
+### 3. Docker 環境
+
+`docker compose` 構成では、`db` コンテナに `pg_dump` が同梱されている。ホストから:
+
+```bash
+docker compose exec -T db pg_dump --format=custom --no-owner --no-privileges \
+    -U postgres helpdesk_hub > "var/backups/helpdesk_hub_$(date +%Y%m%d_%H%M%S).dump"
+```
+
+または、アプリのワークスペースをマウントしたコンテナ内で `scripts/backup-db.sh` を実行する。
+
+## 復元手順
+
+1. 復元先 `DATABASE_URL` を確認する（**上書きされる**ので接続先を間違えない）。
+2. 復元を実行する:
+
+   ```bash
+   DATABASE_URL="postgresql://postgres:***@localhost:5432/helpdesk_hub" \
+       npm run db:restore -- var/backups/helpdesk_hub_YYYYMMDD_HHMMSS.dump
+   ```
+
+3. 復元後、`npm run db:generate` 済みのアプリで起動確認を行う。
+
+## 検証（リストアテスト）
+
+バックアップは「復元できて初めて有効」。定期的に空 DB へリストアして整合を確認する:
+
+```bash
+createdb helpdesk_hub_restore_test
+DATABASE_URL="postgresql://postgres:***@localhost:5432/helpdesk_hub_restore_test" \
+    npm run db:restore -- var/backups/<最新>.dump
+dropdb helpdesk_hub_restore_test
+```

--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -141,9 +141,11 @@
 ### Phase 4 — マネタイズと運用（継続）
 
 - [x] サブスク課金（Stripe Billing）: Free / Standard / Pro の 3 段階
-- [x] 監査ログ / バックアップ自動化
+- [x] 監査ログ / バックアップ自動化（`scripts/backup-db.sh` ＋ スケジュール CI `.github/workflows/backup.yml`。pg_dump + 世代管理。手順は `docs/backup.md`）
 - [x] 多店舗・多拠点対応（テナント内サブグループ）
 - [x] Slack / Chatwork / Microsoft Teams 通知 Adapter
+- [x] Enterprise プラン（§6.1 料金表）: 無制限 + 監査強化。`SubscriptionPlan` に `enterprise` を追加
+- [x] SSO（SAML）— Enterprise 限定（`isSsoAllowed`）。テナント単位の IdP 設定 + SP メタデータ/ACS/ログイン エンドポイント（`/api/auth/sso/<tenantId>/*`）。署名・Issuer・Audience・期限を検証（`@node-saml/node-saml`）。既存メンバーのみログイン許可（JIT 無効）
 
 ### スケジュール感
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@node-saml/node-saml": "^5.1.0",
         "@prisma/client": "^5.22.0",
         "bcryptjs": "^3.0.3",
         "next": "^15.5.15",
@@ -1770,6 +1771,29 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@node-saml/node-saml": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@node-saml/node-saml/-/node-saml-5.1.0.tgz",
+      "integrity": "sha512-t3cJnZ4aC7HhPZ6MGylGZULvUtBOZ6FzuUndaHGXjmIZHXnLfC/7L8a57O9Q9V7AxJGKAiRM5zu2wNm9EsvQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.12",
+        "@types/qs": "^6.9.18",
+        "@types/xml-encryption": "^1.2.4",
+        "@types/xml2js": "^0.4.14",
+        "@xmldom/is-dom-node": "^1.0.1",
+        "@xmldom/xmldom": "^0.8.10",
+        "debug": "^4.4.0",
+        "xml-crypto": "^6.1.2",
+        "xml-encryption": "^3.1.0",
+        "xml2js": "^0.6.2",
+        "xmlbuilder": "^15.1.1",
+        "xpath": "^0.0.34"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2583,6 +2607,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2611,11 +2644,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2630,6 +2668,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
@@ -2649,6 +2693,24 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/xml-encryption": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/xml-encryption/-/xml-encryption-1.2.4.tgz",
+      "integrity": "sha512-I69K/WW1Dv7j6O3jh13z0X8sLWJRXbu5xnHDl9yHzUNDUBtUoBY058eb5s+x/WG6yZC1h8aKdI2EoyEPjyEh+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/xml2js": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3266,6 +3328,24 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xmldom/is-dom-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@xmldom/is-dom-node/-/is-dom-node-1.0.1.tgz",
+      "integrity": "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/acorn": {
@@ -3917,7 +3997,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4285,6 +4364,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -6424,7 +6509,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -7436,6 +7520,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -8226,7 +8319,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -8606,6 +8698,89 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xml-crypto": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.1.2.tgz",
+      "integrity": "sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/is-dom-node": "^1.0.1",
+        "@xmldom/xmldom": "^0.8.10",
+        "xpath": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/xml-crypto/node_modules/xpath": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.33.tgz",
+      "integrity": "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/xml-encryption": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-3.1.0.tgz",
+      "integrity": "sha512-PV7qnYpoAMXbf1kvQkqMScLeQpjCMixddAKq9PtqVrho8HnYbBOWNfG0kA4R7zxQDo7w9kiYAyzS/ullAyO55Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.5",
+        "escape-html": "^1.0.3",
+        "xpath": "0.0.32"
+      }
+    },
+    "node_modules/xml-encryption/node_modules/xpath": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+      "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/xpath": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
+      "integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "test:e2e": "playwright test",
     "db:seed": "tsx prisma/seed.ts",
     "db:migrate": "prisma migrate dev",
-    "db:generate": "prisma generate"
+    "db:generate": "prisma generate",
+    "db:backup": "bash scripts/backup-db.sh",
+    "db:restore": "bash scripts/restore-db.sh"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@node-saml/node-saml": "^5.1.0",
     "@prisma/client": "^5.22.0",
     "bcryptjs": "^3.0.3",
     "next": "^15.5.15",

--- a/prisma/migrations/20260622000100_add_enterprise_plan/migration.sql
+++ b/prisma/migrations/20260622000100_add_enterprise_plan/migration.sql
@@ -1,0 +1,8 @@
+-- Phase 4 課金: 料金プランに Enterprise 階層を追加する (smb-dx-pivot-plan.md §6.1)。
+-- Enterprise は個別見積で、無制限 + SSO(SAML) + 監査強化を提供する。
+-- Stripe の自助チェックアウトは経由せず、運用側が手動で設定する想定。
+--
+-- PostgreSQL の enum へ値を追加する。ADD VALUE は既存値の後ろに追記され、
+-- 既存行・既定値 (free) には影響しない。PG 12+ ではトランザクション内で実行可能
+-- (同一トランザクション内で新値を「使用」しなければよく、本マイグレーションは追加のみ)。
+ALTER TYPE "SubscriptionPlan" ADD VALUE 'enterprise';

--- a/prisma/migrations/20260622000200_add_tenant_sso_config/migration.sql
+++ b/prisma/migrations/20260622000200_add_tenant_sso_config/migration.sql
@@ -1,0 +1,26 @@
+-- Phase 4 Enterprise: テナント単位の SAML SSO 設定テーブルを追加する。
+-- docs/smb-dx-pivot-plan.md §6.1 Enterprise「SSO(SAML)」。
+-- アプリを SAML の Service Provider (SP) として動かすために必要な IdP 情報を保持する。
+-- Enterprise プランのみが構成・利用できる (サーバー側 plan-guard で強制)。
+
+-- SSO 設定テーブル本体
+CREATE TABLE "TenantSsoConfig" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT false,
+    "idpEntityId" TEXT NOT NULL,
+    "idpSsoUrl" TEXT NOT NULL,
+    "idpX509Cert" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TenantSsoConfig_pkey" PRIMARY KEY ("id")
+);
+
+-- 1 テナント 1 設定 (1:1) を担保する一意インデックス
+CREATE UNIQUE INDEX "TenantSsoConfig_tenantId_key" ON "TenantSsoConfig"("tenantId");
+
+-- テナント削除時に SSO 設定も連鎖削除する外部キー制約
+ALTER TABLE "TenantSsoConfig"
+    ADD CONSTRAINT "TenantSsoConfig_tenantId_fkey"
+    FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,6 +79,7 @@ enum SubscriptionPlan {
   free // 無料プラン (制限付き)
   standard // スタンダード: 月額 4,980 円 (Lite フル)
   pro // プロ: 月額 14,800 円 (Pro モード + 監査ログ + LINE 連携)
+  enterprise // エンタープライズ: 個別見積 (無制限 + SSO/SAML + 監査強化)。Stripe 非経由で運用が手動設定
 }
 
 // 添付ファイルの保存先種別 (将来 S3 互換ストレージへの差し替えで使い分ける)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -138,6 +138,25 @@ model Tenant {
   invitations   Invitation[] // メンバー招待リンク (発行〜受諾までのワンタイムトークン)
   emailThreadRefs EmailThreadRef[] // メールスレッド継続用の Message-ID 対応表 (Phase 2)
   locations     Location[] // Phase 4 多拠点: テナント内の店舗・拠点
+  ssoConfig     TenantSsoConfig? // Phase 4 Enterprise: SAML SSO 設定 (1 テナント 1 件・未設定なら null)
+}
+
+// Phase 4 Enterprise: テナント単位の SAML シングルサインオン (SSO) 設定。
+// Enterprise プランのみが構成・利用できる (plan-guard の isSsoAllowed でサーバー側強制)。
+// アプリは SAML の Service Provider (SP) として振る舞い、ここに記録した IdP の情報で
+// 受信アサーションの署名を検証する。docs/smb-dx-pivot-plan.md §6.1 Enterprise「SSO(SAML)」。
+model TenantSsoConfig {
+  id          String   @id @default(cuid()) // 主キー (cuid)
+  tenantId    String   @unique // 所属テナント (1 テナント 1 設定。@unique で 1:1 を担保)
+  enabled     Boolean  @default(false) // SSO ログインを有効化するか (既定 false = 無効)
+  idpEntityId String // IdP の EntityID (= 受信アサーションの Issuer。一致しない応答は拒否)
+  idpSsoUrl   String // IdP の SSO エンドポイント URL (AuthnRequest のリダイレクト先)
+  idpX509Cert String // IdP の署名検証用 X.509 証明書 (PEM またはその base64 本体)
+  createdAt   DateTime @default(now()) // 作成日時
+  updatedAt   DateTime @updatedAt // 更新日時 (Prisma が自動更新)
+
+  // 所属テナント (テナント削除で連鎖削除)
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 }
 
 // ─────────────────────────────────────────────

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Phase 4 運用: PostgreSQL データベースの自動バックアップスクリプト。
+# docs/smb-dx-pivot-plan.md §4 Phase 4「監査ログ / バックアップ自動化」に対応。
+#
+# 何をするか:
+#   1. DATABASE_URL が指す PostgreSQL を pg_dump の custom 形式 (-Fc, 圧縮込み) でダンプする。
+#   2. ダンプを BACKUP_DIR にタイムスタンプ付きファイル名で保存する。
+#   3. BACKUP_RETENTION_DAYS より古いダンプを削除する (世代管理 / ディスク枯渇防止)。
+#
+# 設計方針:
+#   - fail-closed: 失敗したら途中で安全に停止する (set -euo pipefail)。
+#   - 秘密情報 (パスワード) はログに出さない (DATABASE_URL をそのまま echo しない)。
+#   - 純粋な CLI ツール (UI 非依存) なので a11y 規約 §7 は対象外。
+#
+# 使い方:
+#   DATABASE_URL=postgresql://user:pass@host:5432/db ./scripts/backup-db.sh
+#   ./scripts/backup-db.sh --dry-run   # 実際には dump せず動作だけ確認する
+#   ./scripts/backup-db.sh --help      # 使い方を表示する
+
+# エラーで即終了 (-e) / 未定義変数をエラー (-u) / パイプ失敗を検知 (pipefail)
+set -euo pipefail
+
+# ───────────────────────────────────────────────────────────────────────────
+# 設定 (環境変数で上書き可能。既定値はマジックナンバーを避けて名前付き定数化)
+# ───────────────────────────────────────────────────────────────────────────
+
+# バックアップの保存先ディレクトリ (未設定なら ./var/backups を使う)
+BACKUP_DIR="${BACKUP_DIR:-./var/backups}"
+# 何日分のバックアップを残すか (これより古いダンプは削除する。既定 14 日)
+BACKUP_RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-14}"
+# ダンプ対象 DB の接続文字列 (アプリと同じ DATABASE_URL を再利用する)
+DATABASE_URL="${DATABASE_URL:-}"
+
+# ───────────────────────────────────────────────────────────────────────────
+# ログ出力ヘルパー (標準エラー出力に出す。標準出力はファイルパス等の結果専用)
+# ───────────────────────────────────────────────────────────────────────────
+
+# 情報ログを stderr に出す関数 (引数の文字列をそのまま表示)
+log() {
+    # >&2 で標準エラー出力にリダイレクトして出力する
+    echo "[backup-db] $*" >&2
+}
+
+# エラーログを stderr に出して終了コード 1 で停止する関数
+die() {
+    # エラー内容を stderr に出力する
+    echo "[backup-db] ERROR: $*" >&2
+    # 異常終了 (呼び出し元のスクリプトも set -e で停止する)
+    exit 1
+}
+
+# 使い方を表示する関数 (--help で呼ばれる)
+usage() {
+    # ヒアドキュメントで複数行の説明を stderr に出す
+    cat >&2 <<'EOF'
+使い方: backup-db.sh [--dry-run] [--help]
+
+環境変数:
+  DATABASE_URL            (必須) ダンプ対象 PostgreSQL の接続文字列
+  BACKUP_DIR              バックアップ保存先 (既定: ./var/backups)
+  BACKUP_RETENTION_DAYS   保持日数。これより古いダンプは削除 (既定: 14)
+
+オプション:
+  --dry-run   実際には dump / 削除せず、実行内容だけ表示する
+  --help      この使い方を表示する
+EOF
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# 引数パース (--dry-run / --help を受け付ける)
+# ───────────────────────────────────────────────────────────────────────────
+
+# dry-run かどうかのフラグ (既定は false = 実際に実行する)
+DRY_RUN=false
+# 渡された引数を 1 つずつ順番に処理する
+for arg in "$@"; do
+    # 引数の値で分岐する
+    case "$arg" in
+        # --dry-run が来たらフラグを立てる
+        --dry-run) DRY_RUN=true ;;
+        # --help が来たら使い方を表示して正常終了する
+        --help) usage; exit 0 ;;
+        # それ以外の未知の引数はエラーにする (タイプミス検知)
+        *) usage; die "不明な引数: $arg" ;;
+    esac
+done
+
+# ───────────────────────────────────────────────────────────────────────────
+# 事前チェック (fail-closed: 前提が満たせないなら何もせず止める)
+# ───────────────────────────────────────────────────────────────────────────
+
+# DATABASE_URL が空なら処理を続行できないので停止する
+[ -n "$DATABASE_URL" ] || die "DATABASE_URL が設定されていません。"
+# pg_dump コマンドが PATH に存在するか確認する (なければ postgresql-client 未導入)
+command -v pg_dump >/dev/null 2>&1 || die "pg_dump が見つかりません。postgresql-client をインストールしてください。"
+# 保持日数が 0 以上の整数かを正規表現で検証する (不正値での誤削除を防ぐ)
+[[ "$BACKUP_RETENTION_DAYS" =~ ^[0-9]+$ ]] || die "BACKUP_RETENTION_DAYS は 0 以上の整数で指定してください: $BACKUP_RETENTION_DAYS"
+
+# ───────────────────────────────────────────────────────────────────────────
+# バックアップ本体
+# ───────────────────────────────────────────────────────────────────────────
+
+# 保存先ディレクトリを作成する (既に存在しても -p でエラーにしない)
+mkdir -p "$BACKUP_DIR"
+
+# ファイル名に使うタイムスタンプを生成する (例: 20260622_181500)。OS 非依存の標準書式のみ使用
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+# ダンプ先のフルパスを組み立てる (custom 形式は拡張子 .dump が慣例)
+DUMP_FILE="${BACKUP_DIR}/helpdesk_hub_${TIMESTAMP}.dump"
+
+# dry-run なら実行予定だけ表示して終了する
+if [ "$DRY_RUN" = true ]; then
+    # 何をする予定かを stderr に表示する (パスワードを含む DATABASE_URL は出さない)
+    log "[dry-run] pg_dump -> ${DUMP_FILE}"
+    log "[dry-run] ${BACKUP_RETENTION_DAYS} 日より古い *.dump を ${BACKUP_DIR} から削除予定"
+    # 実処理はせず正常終了する
+    exit 0
+fi
+
+# pg_dump を custom 形式 (-Fc, 内部 gzip 圧縮) で実行しファイルへ出力する。
+# --no-owner / --no-privileges で復元先の権限差異による失敗を避ける。
+log "バックアップを開始します -> ${DUMP_FILE}"
+# pg_dump を実行する (接続情報は DATABASE_URL からのみ取得し、コマンドラインに平文展開しない)。
+# --file 指定時は失敗しても途中までのファイルが残るため、失敗時は部分ファイルを消してから止める
+# (空/不完全なダンプを「成功した世代」と誤認させないための後始末)。
+if ! pg_dump --format=custom --no-owner --no-privileges --file="$DUMP_FILE" "$DATABASE_URL"; then
+    # 失敗時に生成された部分ファイルを削除する
+    rm -f "$DUMP_FILE"
+    # 失敗として停止する
+    die "pg_dump に失敗しました。"
+fi
+
+# 生成されたダンプのサイズを取得する (0 バイトなら異常を疑う)
+DUMP_SIZE="$(wc -c < "$DUMP_FILE" | tr -d ' ')"
+# サイズが 0 のダンプは壊れている可能性が高いので削除して失敗扱いにする
+if [ "$DUMP_SIZE" -eq 0 ]; then
+    # 空ファイルを削除する (残すと「成功した世代」と誤認されるため)
+    rm -f "$DUMP_FILE"
+    # 失敗として停止する
+    die "ダンプが 0 バイトでした。バックアップは無効です。"
+fi
+# 成功したことをサイズ付きで記録する
+log "バックアップ完了: ${DUMP_FILE} (${DUMP_SIZE} bytes)"
+
+# ───────────────────────────────────────────────────────────────────────────
+# 世代管理 (保持日数より古いダンプを削除する)
+# ───────────────────────────────────────────────────────────────────────────
+
+# 削除対象 (BACKUP_RETENTION_DAYS 日より古い *.dump) を find で列挙して数える。
+# -mtime +N は「N 日より古い」を意味するため、保持日数からそのまま指定できる。
+PRUNED=0
+# find の結果を while で 1 件ずつ読み (ファイル名に空白があっても安全な -print0 + read -d '')
+while IFS= read -r -d '' old_dump; do
+    # 古いダンプを削除する
+    rm -f "$old_dump"
+    # 削除件数のログを残す
+    log "古いバックアップを削除しました: ${old_dump}"
+    # 削除カウンタを 1 増やす
+    PRUNED=$((PRUNED + 1))
+done < <(find "$BACKUP_DIR" -maxdepth 1 -type f -name 'helpdesk_hub_*.dump' -mtime "+${BACKUP_RETENTION_DAYS}" -print0)
+
+# 何件削除したかを最後にまとめて表示する
+log "世代管理完了: ${PRUNED} 件の古いバックアップを削除しました (保持 ${BACKUP_RETENTION_DAYS} 日)。"
+
+# 作成したダンプのパスを標準出力に出す (呼び出し側スクリプトがパスを受け取れるように)
+echo "$DUMP_FILE"

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Phase 4 運用: backup-db.sh が作成したダンプから PostgreSQL を復元するスクリプト。
+# docs/smb-dx-pivot-plan.md §4 Phase 4「監査ログ / バックアップ自動化」に対応。
+#
+# 何をするか:
+#   pg_restore で custom 形式 (-Fc) のダンプを DATABASE_URL が指す DB に流し込む。
+#   既存オブジェクトと衝突しないよう --clean --if-exists で作り直す。
+#
+# 警告: このスクリプトは対象 DB の内容を上書きする。実行前に必ず接続先を確認すること。
+#
+# 使い方:
+#   DATABASE_URL=postgresql://user:pass@host:5432/db ./scripts/restore-db.sh <dump-file>
+#   ./scripts/restore-db.sh --help
+
+# エラーで即終了 / 未定義変数をエラー / パイプ失敗を検知
+set -euo pipefail
+
+# ダンプ対象 DB の接続文字列 (アプリと同じ DATABASE_URL を再利用する)
+DATABASE_URL="${DATABASE_URL:-}"
+
+# 情報ログを stderr に出す関数
+log() {
+    # 標準エラー出力にメッセージを出す
+    echo "[restore-db] $*" >&2
+}
+
+# エラーログを出して終了コード 1 で停止する関数
+die() {
+    # エラー内容を標準エラー出力に出す
+    echo "[restore-db] ERROR: $*" >&2
+    # 異常終了する
+    exit 1
+}
+
+# 使い方を表示する関数
+usage() {
+    # ヒアドキュメントで説明を stderr に出力する
+    cat >&2 <<'EOF'
+使い方: restore-db.sh <dump-file>
+
+環境変数:
+  DATABASE_URL   (必須) 復元先 PostgreSQL の接続文字列
+
+引数:
+  <dump-file>    backup-db.sh が作成した custom 形式 (.dump) ファイル
+
+注意: 復元先 DB の既存データは上書きされます。
+EOF
+}
+
+# 第 1 引数が --help なら使い方を出して正常終了する
+if [ "${1:-}" = "--help" ]; then
+    # 使い方を表示する
+    usage
+    # 正常終了
+    exit 0
+fi
+
+# 復元元のダンプファイルパスを第 1 引数から取得する (未指定なら空文字)
+DUMP_FILE="${1:-}"
+
+# 前提チェック: DATABASE_URL が空なら停止する
+[ -n "$DATABASE_URL" ] || { usage; die "DATABASE_URL が設定されていません。"; }
+# ダンプファイルパスが空なら停止する
+[ -n "$DUMP_FILE" ] || { usage; die "ダンプファイルを指定してください。"; }
+# 指定ファイルが実在し読み取れるか確認する
+[ -r "$DUMP_FILE" ] || die "ダンプファイルが見つからないか読み取れません: $DUMP_FILE"
+# pg_restore コマンドが存在するか確認する (なければ postgresql-client 未導入)
+command -v pg_restore >/dev/null 2>&1 || die "pg_restore が見つかりません。postgresql-client をインストールしてください。"
+
+# 復元を開始する旨をログに出す (接続先のパスワードは出さない)
+log "復元を開始します: ${DUMP_FILE}"
+# pg_restore でダンプを流し込む。--clean --if-exists で既存オブジェクトを作り直し、
+# --no-owner --no-privileges で権限差異による失敗を避ける。
+pg_restore --clean --if-exists --no-owner --no-privileges --dbname="$DATABASE_URL" "$DUMP_FILE" \
+    || die "pg_restore に失敗しました。"
+
+# 復元成功をログに出す
+log "復元が完了しました: ${DUMP_FILE}"

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -16,8 +16,16 @@ import { NotificationChannelsForm } from '@/features/settings/components/Notific
 import { LocationsSection } from '@/features/settings/components/LocationsSection';
 // Phase 4 課金: サブスクリプション管理セクション (Client Component)
 import { BillingSection } from '@/features/settings/components/BillingSection';
+// Phase 4 Enterprise: SAML SSO 設定セクション (Client Component)
+import { SsoConfigSection } from '@/features/settings/components/SsoConfigSection';
 // テナント情報取得 (slackWebhookUrl / 拠点一覧 / プラン情報の初期値を渡すため)
 import { repos } from '@/data';
+// Enterprise プランのみ SSO を表示するためのプランゲート
+import { isSsoAllowed } from '@/lib/plan-guard';
+// SSO の SP エンドポイント URL を組み立てるヘルパー
+import { buildSpUrls } from '@/lib/saml';
+// アプリの公開ベース URL を解決するヘルパー (SP URL の組み立てに使う)
+import { resolveAppBaseUrl } from '@/lib/app-url';
 
 // /settings : テナント設定ページ (現状は Lite/Pro モードの切替のみ。管理者専用)
 export default async function SettingsPage() {
@@ -45,6 +53,13 @@ export default async function SettingsPage() {
     // 拠点一覧 (LocationsSection の初期値として渡す)
     repos.locations.listByTenant(session.user.tenantId),
   ]);
+
+  // Phase 4 Enterprise: SSO は Enterprise プランのみ表示・設定可能。
+  // プランが許可する場合のみ SSO 設定を取得する (非対象テナントに余計なクエリを投げない)。
+  const ssoAllowed = isSsoAllowed(tenant?.subscriptionPlan ?? 'free');
+  const ssoConfig = ssoAllowed ? await repos.ssoConfigs.findByTenant(session.user.tenantId) : null;
+  // SP の各 URL を組み立てる (Enterprise のときだけ使う)
+  const spUrls = ssoAllowed ? buildSpUrls(resolveAppBaseUrl(), session.user.tenantId) : null;
 
   return (
     <div className="mx-auto max-w-2xl space-y-6">
@@ -139,6 +154,36 @@ export default async function SettingsPage() {
           hasStripeCustomer={!!tenant?.stripeCustomerId}
         />
       </section>
+
+      {/* Phase 4 Enterprise: SAML SSO 設定カード (Enterprise プランのみ表示) */}
+      {ssoAllowed && spUrls && (
+        <section className="space-y-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+          <div>
+            {/* セクション見出し */}
+            <h2 className="text-base font-semibold text-slate-900">シングルサインオン (SAML SSO)</h2>
+            {/* 説明: Enterprise 向けの SSO 設定であることを伝える */}
+            <p className="mt-1 text-sm text-slate-500">
+              社内の IdP (Okta・Microsoft Entra ID・Google Workspace など) と SAML 連携し、
+              メンバーが SSO でログインできるようにします。Enterprise プラン限定の機能です。
+              ログインできるのは、組織に既に登録済みのメンバーのみです。
+            </p>
+          </div>
+          {/* SSO 設定フォームと SP 情報 (現在の設定と SP URL を渡す) */}
+          <SsoConfigSection
+            config={
+              ssoConfig
+                ? {
+                    idpEntityId: ssoConfig.idpEntityId,
+                    idpSsoUrl: ssoConfig.idpSsoUrl,
+                    idpX509Cert: ssoConfig.idpX509Cert,
+                    enabled: ssoConfig.enabled,
+                  }
+                : null
+            }
+            sp={spUrls}
+          />
+        </section>
+      )}
 
       {/* テナント (組織) 作成カード */}
       <section className="space-y-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">

--- a/src/app/api/auth/sso/[tenantId]/acs/route.ts
+++ b/src/app/api/auth/sso/[tenantId]/acs/route.ts
@@ -1,0 +1,106 @@
+// Phase 4 Enterprise: SAML SSO の Assertion Consumer Service (ACS)。
+// docs/smb-dx-pivot-plan.md §6.1 Enterprise「SSO(SAML)」。
+//
+// POST /api/auth/sso/<tenantId>/acs
+//   IdP がユーザー認証後に署名付き SAMLResponse をこの URL へ POST する。
+//   署名・Issuer・Audience・期限を検証し、本人のメールでテナント内のユーザーを特定して
+//   セッションを発行する。セッション発行は実績あるマジックリンク経路を再利用する
+//   (ワンタイムトークンを 1 件発行 → マジックリンクのコールバックに 303 リダイレクト)。
+//
+// セキュリティ:
+//   - 署名検証は node-saml に委譲し fail-closed (検証失敗は即ログイン拒否)。
+//   - IdP が主張したメールのユーザーが「この tenantId に属する」ことを必須化し、
+//     別 IdP/別テナントのなりすましでクロステナントログインさせない。
+//   - 自動ユーザー作成 (JIT) は行わない。既存ユーザーのみ SSO ログインを許可する。
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+// HTTP レスポンス生成
+import { NextResponse } from 'next/server';
+// データ層 (ユーザー検索・トークン発行)
+import { repos } from '@/data';
+// SSO 有効性チェック
+import { loadEnabledSsoContext } from '@/lib/sso-context';
+// SAML SP 構築とアサーション検証
+import { createSamlInstance, validateSamlResponse } from '@/lib/saml';
+// マジックリンクのワンタイムトークン生成・ハッシュ・コールバック URL 構築 (セッション発行に再利用)
+import {
+  buildMagicLinkUrl,
+  generateMagicLinkToken,
+  hashMagicLinkToken,
+} from '@/lib/magic-link';
+
+// SSO ハンドオフトークンの有効期限 (2 分)。ACS → コールバックの即時引き渡し専用なので短くする
+const SSO_HANDOFF_TTL_MS = 2 * 60 * 1000;
+
+// 動的セグメント (tenantId) の型
+type Params = { params: Promise<{ tenantId: string }> };
+
+// POST ハンドラ: IdP からの SAMLResponse を受け取り検証してログインさせる
+export async function POST(req: Request, { params }: Params) {
+  // URL の tenantId を取り出す
+  const { tenantId } = await params;
+  // 失敗時のエラーリダイレクト (理由コードをログイン画面に渡す)。303 でブラウザを GET 遷移させる
+  const errorRedirect = (code: string) =>
+    NextResponse.redirect(new URL(`/login?error=${code}`, req.url), 303);
+
+  // SSO が利用可能か検証する (不可ならログイン画面へ)
+  const ctx = await loadEnabledSsoContext(tenantId);
+  if (!ctx.ok) return errorRedirect('sso-unavailable');
+
+  // POST ボディ (application/x-www-form-urlencoded) から SAMLResponse を取り出す
+  let samlResponse: string;
+  try {
+    // フォームデータをパースする
+    const form = await req.formData();
+    // SAMLResponse フィールドを取得する
+    const value = form.get('SAMLResponse');
+    // 文字列でなければ不正な応答として扱う
+    if (typeof value !== 'string' || value.length === 0) return errorRedirect('sso-invalid');
+    samlResponse = value;
+  } catch {
+    // ボディが壊れている場合は不正扱い
+    return errorRedirect('sso-invalid');
+  }
+
+  // 署名・条件を検証して本人のメールを取り出す
+  let email: string;
+  try {
+    // テナントの SSO 設定から SP を構築する
+    const saml = createSamlInstance(ctx.config, ctx.baseUrl, tenantId);
+    // アサーションを検証する (署名不正・Issuer/Audience 不一致・期限切れは例外)。
+    // expectedIssuer に設定の IdP EntityID を渡し、Issuer 一致も多層防御として検証する
+    const identity = await validateSamlResponse(saml, samlResponse, ctx.config.idpEntityId);
+    // 取り出したメール (検証済み)
+    email = identity.email;
+  } catch (err) {
+    // 検証失敗は内部詳細を返さずログイン画面へ戻す (なりすまし/設定ミスを区別せず拒否)
+    console.error('[sso-acs] アサーション検証に失敗しました:', err);
+    return errorRedirect('sso-invalid');
+  }
+
+  // メールに対応する既存ユーザーを引く
+  const user = await repos.users.findByEmail(email);
+  // ユーザーが存在しない、または別テナントのユーザーなら拒否する (クロステナント防止 + JIT 無効)
+  if (!user || user.tenantId !== tenantId) {
+    // 監査用に警告ログを残す (メールアドレスはログに残さず件数のみ気付ける程度に留める)
+    console.warn('[sso-acs] SSO 本人に対応するテナント内ユーザーが見つかりません。');
+    return errorRedirect('sso-no-user');
+  }
+
+  // セッション発行: ワンタイムトークンを 1 件発行してマジックリンクのコールバックへ渡す
+  // 生トークンは URL でのみ運び、DB には SHA-256 ハッシュを保存する (マジックリンクと同方式)
+  const rawToken = generateMagicLinkToken();
+  // 生トークンを SHA-256 ハッシュ化して DB 検索キーにする
+  const tokenHash = await hashMagicLinkToken(rawToken);
+  // ハンドオフ用の短い失効時刻を設定する
+  const expiresAt = new Date(Date.now() + SSO_HANDOFF_TTL_MS);
+  // 発行元 IP を監査用に取得する (プロキシ経由の x-forwarded-for を優先)
+  const requestedIp = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || null;
+  // ワンタイムトークンを保存する (consume はマジックリンクのコールバックが原子的に行う)
+  await repos.magicLinks.create({ email: user.email, tokenHash, expiresAt, requestedIp });
+
+  // マジックリンクのコールバック URL を組み立て、そこへ 303 リダイレクトしてセッションを発行させる
+  const callbackUrl = buildMagicLinkUrl(ctx.baseUrl, rawToken);
+  return NextResponse.redirect(callbackUrl, 303);
+}

--- a/src/app/api/auth/sso/[tenantId]/acs/route.ts
+++ b/src/app/api/auth/sso/[tenantId]/acs/route.ts
@@ -23,12 +23,10 @@ import { repos } from '@/data';
 import { loadEnabledSsoContext } from '@/lib/sso-context';
 // SAML SP 構築とアサーション検証
 import { createSamlInstance, validateSamlResponse } from '@/lib/saml';
-// マジックリンクのワンタイムトークン生成・ハッシュ・コールバック URL 構築 (セッション発行に再利用)
-import {
-  buildMagicLinkUrl,
-  generateMagicLinkToken,
-  hashMagicLinkToken,
-} from '@/lib/magic-link';
+// マジックリンクのワンタイムトークン生成・ハッシュ (セッション発行に再利用)
+import { generateMagicLinkToken, hashMagicLinkToken } from '@/lib/magic-link';
+// HTML 属性への安全な埋め込み用エスケープ (確認ページのトークン埋め込みに使う)
+import { escapeHtml } from '@/lib/html-escape';
 
 // SSO ハンドオフトークンの有効期限 (2 分)。ACS → コールバックの即時引き渡し専用なので短くする
 const SSO_HANDOFF_TTL_MS = 2 * 60 * 1000;
@@ -100,7 +98,56 @@ export async function POST(req: Request, { params }: Params) {
   // ワンタイムトークンを保存する (consume はマジックリンクのコールバックが原子的に行う)
   await repos.magicLinks.create({ email: user.email, tokenHash, expiresAt, requestedIp });
 
-  // マジックリンクのコールバック URL を組み立て、そこへ 303 リダイレクトしてセッションを発行させる
-  const callbackUrl = buildMagicLinkUrl(ctx.baseUrl, rawToken);
-  return NextResponse.redirect(callbackUrl, 303);
+  // ── ログイン CSRF / セッション固定対策 (ユーザー操作を必須化する確認ページ) ──
+  // ACS は未認証で到達でき、IdP-initiated SSO では未承諾の署名付きアサーションも受理する
+  // (InResponseTo は IdP-initiated を壊し共有キャッシュも要るため使わない)。
+  // ここで自動ログインせず「明示クリックの確認ページ」を挟むことで、攻撃者が被害者ブラウザから
+  // ACS へ自前アサーションを自動 POST させて「攻撃者アカウントでサイレントログイン」させる攻撃を防ぐ。
+  // (マジックリンクのコールバックコメントが示す標準対策と同方針。SP/IdP どちらの起点でも有効。)
+  return new NextResponse(renderSsoContinuePage(rawToken), {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      // 確認ページ自体はキャッシュ・参照させない (トークンを含むため)
+      'Cache-Control': 'no-store',
+      'Referrer-Policy': 'no-referrer',
+    },
+  });
+}
+
+// SSO 認証後に表示する「ログイン続行の確認」ページを描画する。
+// 自動送信せず、ユーザーが明示的にボタンを押したときだけマジックリンクのコールバック (GET) へ
+// 遷移してセッションを発行する。token は HTML 属性として安全にエスケープして埋め込む。
+function renderSsoContinuePage(rawToken: string): string {
+  // トークンを HTML 属性値に安全に埋め込めるようエスケープする (base64url だが防御的に処理)
+  const safeToken = escapeHtml(rawToken);
+  // 確認ページの HTML を返す。lang="ja"・セマンティックなボタン・自動送信なしを満たす。
+  return `<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex,nofollow">
+<title>SSO ログインの確認</title>
+<style>
+  body { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; background: #f0fdfa; color: #0f172a; margin: 0; display: flex; min-height: 100vh; align-items: center; justify-content: center; padding: 1rem; }
+  main { background: #fff; border: 1px solid #ccfbf1; border-radius: 1rem; padding: 2rem; max-width: 28rem; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+  h1 { font-size: 1.25rem; margin: 0 0 .75rem; }
+  p { font-size: .9rem; color: #475569; line-height: 1.6; }
+  button { margin-top: 1.25rem; width: 100%; background: #0f766e; color: #fff; border: 0; border-radius: .5rem; padding: .75rem 1rem; font-size: .95rem; font-weight: 600; cursor: pointer; }
+  button:hover { background: #115e59; }
+  button:focus-visible { outline: 3px solid #5eead4; outline-offset: 2px; }
+</style>
+</head>
+<body>
+<main>
+<h1>SSO ログインの確認</h1>
+<p>シングルサインオン (SSO) の認証が完了しました。下のボタンを押すと、このアプリへのログインが完了します。心当たりがない場合はこのページを閉じてください。</p>
+<form method="get" action="/api/auth/magic-link/callback">
+<input type="hidden" name="token" value="${safeToken}">
+<button type="submit">ログインを続ける</button>
+</form>
+</main>
+</body>
+</html>`;
 }

--- a/src/app/api/auth/sso/[tenantId]/acs/route.ts
+++ b/src/app/api/auth/sso/[tenantId]/acs/route.ts
@@ -111,6 +111,11 @@ export async function POST(req: Request, { params }: Params) {
       // 確認ページ自体はキャッシュ・参照させない (トークンを含むため)
       'Cache-Control': 'no-store',
       'Referrer-Policy': 'no-referrer',
+      // クリックジャッキング防止 (必須): この確認ページの安全性は「ユーザーの明示クリック」に
+      // 依存するため、iframe 埋め込み + UI 偽装でクリックを誘導されると CSRF 対策が無力化する。
+      // フレーム化を全面禁止して埋め込みを防ぐ (frame-ancestors=現代ブラウザ / XFO=レガシー)。
+      'X-Frame-Options': 'DENY',
+      'Content-Security-Policy': "frame-ancestors 'none'",
     },
   });
 }

--- a/src/app/api/auth/sso/[tenantId]/login/route.ts
+++ b/src/app/api/auth/sso/[tenantId]/login/route.ts
@@ -1,0 +1,47 @@
+// Phase 4 Enterprise: SAML SSO ログイン開始エンドポイント。
+// docs/smb-dx-pivot-plan.md §6.1 Enterprise「SSO(SAML)」。
+//
+// GET /api/auth/sso/<tenantId>/login
+//   テナントの SSO が有効なら AuthnRequest を生成し IdP のログイン画面へリダイレクトする。
+//   未認証で到達する想定 (middleware は /api/auth/* を認証ガード対象外にしている)。
+//
+// node-saml は Node 専用ライブラリのため Node ランタイムで動かす。
+export const runtime = 'nodejs';
+// SSO 開始はキャッシュせず毎回動的に処理する
+export const dynamic = 'force-dynamic';
+
+// HTTP レスポンス生成
+import { NextResponse } from 'next/server';
+// SSO 有効性チェック (テナント存在・プラン・設定・有効フラグ)
+import { loadEnabledSsoContext } from '@/lib/sso-context';
+// SAML SP インスタンス生成とログイン URL 生成
+import { createSamlInstance, getSsoLoginUrl } from '@/lib/saml';
+
+// 動的セグメント (tenantId) の型 (Next.js 15 では params は Promise)
+type Params = { params: Promise<{ tenantId: string }> };
+
+// GET ハンドラ: SSO ログインを開始する
+export async function GET(req: Request, { params }: Params) {
+  // URL の tenantId を取り出す
+  const { tenantId } = await params;
+  // 失敗時に共通で使うエラーリダイレクト (ログイン画面へ理由付きで戻す)
+  const errorRedirect = () =>
+    NextResponse.redirect(new URL('/login?error=sso-unavailable', req.url), 303);
+
+  // SSO が利用可能か検証する (不可ならログイン画面へ)
+  const ctx = await loadEnabledSsoContext(tenantId);
+  if (!ctx.ok) return errorRedirect();
+
+  try {
+    // テナントの SSO 設定から SAML SP インスタンスを構築する
+    const saml = createSamlInstance(ctx.config, ctx.baseUrl, tenantId);
+    // AuthnRequest を生成し IdP のログイン URL を得る
+    const redirectUrl = await getSsoLoginUrl(saml);
+    // IdP のログイン画面へリダイレクトする (外部 URL)
+    return NextResponse.redirect(redirectUrl, 303);
+  } catch (err) {
+    // 設定不備や AuthnRequest 生成失敗は内部詳細を返さずログイン画面へ戻す (§9)
+    console.error('[sso-login] AuthnRequest の生成に失敗しました:', err);
+    return errorRedirect();
+  }
+}

--- a/src/app/api/auth/sso/[tenantId]/metadata/route.ts
+++ b/src/app/api/auth/sso/[tenantId]/metadata/route.ts
@@ -1,0 +1,41 @@
+// Phase 4 Enterprise: SAML SP メタデータエンドポイント。
+// docs/smb-dx-pivot-plan.md §6.1 Enterprise「SSO(SAML)」。
+//
+// GET /api/auth/sso/<tenantId>/metadata
+//   IdP 側に登録するための SP メタデータ (EntityDescriptor) XML を返す。
+//   IdP 証明書が未設定の段階でも参照できる必要があるため、SSO 設定の有無は問わず
+//   テナントの存在と Enterprise プランだけを条件にする (中身は秘密情報を含まない)。
+export const runtime = 'nodejs';
+
+// HTTP レスポンス生成
+import { NextResponse } from 'next/server';
+// データ層 (テナント取得)
+import { repos } from '@/data';
+// プラン別の SSO 可否ゲート (Enterprise のみ)
+import { isSsoAllowed } from '@/lib/plan-guard';
+// アプリの公開ベース URL 解決
+import { resolveAppBaseUrl } from '@/lib/app-url';
+// SP メタデータ XML 生成 (純粋関数)
+import { buildSpMetadataXml } from '@/lib/saml';
+
+// 動的セグメント (tenantId) の型
+type Params = { params: Promise<{ tenantId: string }> };
+
+// GET ハンドラ: SP メタデータ XML を返す
+export async function GET(_req: Request, { params }: Params) {
+  // URL の tenantId を取り出す
+  const { tenantId } = await params;
+  // テナントを取得する
+  const tenant = await repos.tenants.findById(tenantId);
+  // テナントが存在しない、または Enterprise プランでなければ 404 (機能非提供)
+  if (!tenant || !isSsoAllowed(tenant.subscriptionPlan)) {
+    return new NextResponse('SSO はこのテナントでは利用できません。', { status: 404 });
+  }
+  // SP メタデータ XML を組み立てる (秘密情報を含まない SP の URL のみ)
+  const xml = buildSpMetadataXml(resolveAppBaseUrl(), tenantId);
+  // XML として返す
+  return new NextResponse(xml, {
+    status: 200,
+    headers: { 'Content-Type': 'application/xml; charset=utf-8' },
+  });
+}

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -155,12 +155,17 @@ async function handleSubscriptionUpsert(subscriptionObject: Record<string, unkno
     return;
   }
 
+  // Enterprise は個別見積で Stripe の自助課金外 (運用が手動設定)。万一 Enterprise テナントに
+  // 無関係な Stripe サブスク (旧 Pro 等) が残っていても、Stripe イベントでプランを降格させない。
+  // Stripe 連携情報 (customer/subscription/status) は最新化しつつ、プランは enterprise を維持する。
+  const nextPlan = existingTenant.subscriptionPlan === 'enterprise' ? 'enterprise' : plan;
+
   // テナントのサブスク情報を更新する
   await repos.tenants.updateStripeSubscription(tenantId, {
     stripeCustomerId: customerId,
     stripeSubscriptionId: subscriptionId,
     stripeSubscriptionStatus: status,
-    subscriptionPlan: plan,
+    subscriptionPlan: nextPlan,
   });
 }
 
@@ -189,11 +194,14 @@ async function handleSubscriptionDeleted(subscriptionObject: Record<string, unkn
     return;
   }
 
-  // サブスクリプション削除後は free に降格し、canceled 状態を記録する
+  // Enterprise は Stripe 管理外のため、削除イベントでも free に降格させない (手動設定を尊重)。
+  const nextPlan = existingTenant.subscriptionPlan === 'enterprise' ? 'enterprise' : 'free';
+
+  // サブスクリプション削除後は (Enterprise を除き) free に降格し、canceled 状態を記録する
   await repos.tenants.updateStripeSubscription(tenantId, {
     stripeCustomerId: customerId,
     stripeSubscriptionId: subscriptionId,
     stripeSubscriptionStatus: 'canceled', // Stripe の deleted イベントは canceled 扱いにする
-    subscriptionPlan: 'free', // free プランに降格
+    subscriptionPlan: nextPlan, // Enterprise 以外は free に降格
   });
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -10,6 +10,18 @@ function getInitialError(errorCode: string | undefined): string | undefined {
   if (errorCode === 'magic-link-invalid') {
     return 'ログインリンクが無効です。もう一度メール送信からやり直してください。';
   }
+  // SSO (SAML) が利用不可 (未設定・無効・プラン外など)
+  if (errorCode === 'sso-unavailable') {
+    return 'SSO ログインは現在利用できません。管理者にお問い合わせください。';
+  }
+  // SSO の応答検証に失敗 (署名不正・期限切れ・なりすまし等)
+  if (errorCode === 'sso-invalid') {
+    return 'SSO ログインに失敗しました。お手数ですが、もう一度お試しください。';
+  }
+  // SSO は成功したが、組織内に対応するメンバーが見つからない
+  if (errorCode === 'sso-no-user') {
+    return 'SSO は成功しましたが、組織にあなたのアカウントが見つかりません。管理者に招待を依頼してください。';
+  }
   return undefined;
 }
 

--- a/src/data/adapters/memory/index.ts
+++ b/src/data/adapters/memory/index.ts
@@ -9,6 +9,7 @@ import { makeInvitationRepo } from './invitation-repository.memory';
 import { makeLocationRepo } from './location-repository.memory';
 import { makeMagicLinkRepo } from './magic-link-repository.memory';
 import { makeNotificationRepo } from './notification-repository.memory';
+import { makeSsoConfigRepo } from './sso-config-repository.memory';
 import { cloneStore, createEmptyStore, overwriteStore, type Store } from './store';
 import { makeTenantRepo } from './tenant-repository.memory';
 import { makeTicketCommentRepo } from './ticket-comment-repository.memory';
@@ -37,6 +38,7 @@ export function buildMemoryRepos(store: Store): Repos {
     attachments: makeAttachmentRepo(store),
     emailThreads: makeEmailThreadRepo(store),
     locations: makeLocationRepo(store), // Phase 4 多拠点
+    ssoConfigs: makeSsoConfigRepo(store), // Phase 4 Enterprise: SAML SSO 設定
   };
 }
 

--- a/src/data/adapters/memory/sso-config-repository.memory.ts
+++ b/src/data/adapters/memory/sso-config-repository.memory.ts
@@ -1,0 +1,75 @@
+// SSO 設定リポジトリの契約 (port)
+import type { SsoConfigRepository } from '@/data/ports/sso-config-repository';
+// テスト用メモリストア
+import type { Store } from './store';
+
+// メモリストアを使った SSO 設定リポジトリを生成するファクトリ関数 (テスト用)
+export function makeSsoConfigRepo(store: Store): SsoConfigRepository {
+  return {
+    // テナントの SSO 設定を取得する (未設定なら null)
+    async findByTenant(tenantId) {
+      // ストアの値から tenantId が一致する設定を線形探索する
+      for (const cfg of store.ssoConfigs.values()) {
+        // 一致したらその設定を返す (1 テナント 1 設定)
+        if (cfg.tenantId === tenantId) return cfg;
+      }
+      // 見つからなければ null
+      return null;
+    },
+
+    // SSO 設定を作成または更新する (tenantId をキーに upsert)
+    async upsert(input) {
+      // 既存設定を探す
+      let existing = null as null | string;
+      for (const [id, cfg] of store.ssoConfigs.entries()) {
+        // tenantId が一致する設定の Map キー (id) を控える
+        if (cfg.tenantId === input.tenantId) existing = id;
+      }
+      // 現在時刻 (作成/更新日時に使う)
+      const now = new Date();
+      if (existing) {
+        // 既存設定を取り出して値を更新する
+        const cfg = store.ssoConfigs.get(existing)!;
+        // 更新後の設定オブジェクトを組み立てる (createdAt は維持、updatedAt を更新)
+        const updated = {
+          ...cfg,
+          enabled: input.enabled,
+          idpEntityId: input.idpEntityId,
+          idpSsoUrl: input.idpSsoUrl,
+          idpX509Cert: input.idpX509Cert,
+          updatedAt: now,
+        };
+        // ストアへ書き戻す
+        store.ssoConfigs.set(existing, updated);
+        // 更新後の設定を返す
+        return updated;
+      }
+      // 新規作成: 連番から ID を払い出す
+      const id = `sso_${++store.idSeq.value}`;
+      // 新規設定オブジェクトを組み立てる
+      const created = {
+        id,
+        tenantId: input.tenantId,
+        enabled: input.enabled,
+        idpEntityId: input.idpEntityId,
+        idpSsoUrl: input.idpSsoUrl,
+        idpX509Cert: input.idpX509Cert,
+        createdAt: now,
+        updatedAt: now,
+      };
+      // ストアへ保存する
+      store.ssoConfigs.set(id, created);
+      // 作成した設定を返す
+      return created;
+    },
+
+    // テナントの SSO 設定を削除する (tenantId スコープ)
+    async delete(tenantId) {
+      // tenantId が一致する設定を探して削除する
+      for (const [id, cfg] of store.ssoConfigs.entries()) {
+        // 一致したら Map から削除する
+        if (cfg.tenantId === tenantId) store.ssoConfigs.delete(id);
+      }
+    },
+  };
+}

--- a/src/data/adapters/memory/store.ts
+++ b/src/data/adapters/memory/store.ts
@@ -6,6 +6,7 @@ import type {
   MagicLinkToken,
   Notification,
   Tenant,
+  TenantSsoConfig,
   Ticket,
   TicketComment,
   TicketHistory,
@@ -49,6 +50,7 @@ export interface Store {
   attachments: Map<string, Attachment>; // 添付ファイルのメタ情報 (画像)
   emailThreadRefs: Map<string, EmailThreadRefRow>; // メール Message-ID → チケット 対応表 (Phase 2)
   locations: Map<string, Location>; // Phase 4 多拠点: テナント内の店舗・拠点
+  ssoConfigs: Map<string, TenantSsoConfig>; // Phase 4 Enterprise: テナント単位の SAML SSO 設定
   idSeq: { value: number }; // 連番生成用のカウンタ (オブジェクトに包んで参照共有)
 }
 
@@ -69,6 +71,7 @@ export function createEmptyStore(): Store {
     attachments: new Map(),
     emailThreadRefs: new Map(),
     locations: new Map(), // Phase 4 多拠点: テナント内の店舗・拠点
+    ssoConfigs: new Map(), // Phase 4 Enterprise: SAML SSO 設定
     idSeq: { value: 0 },
   };
 }
@@ -90,6 +93,7 @@ export function cloneStore(src: Store): Store {
     attachments: new Map(src.attachments),
     emailThreadRefs: new Map(src.emailThreadRefs),
     locations: new Map(src.locations), // Phase 4 多拠点
+    ssoConfigs: new Map(src.ssoConfigs), // Phase 4 Enterprise: SAML SSO 設定
     idSeq: { value: src.idSeq.value },
   };
 }
@@ -110,6 +114,7 @@ export function overwriteStore(dst: Store, src: Store): void {
   dst.attachments = new Map(src.attachments);
   dst.emailThreadRefs = new Map(src.emailThreadRefs);
   dst.locations = new Map(src.locations); // Phase 4 多拠点
+  dst.ssoConfigs = new Map(src.ssoConfigs); // Phase 4 Enterprise: SAML SSO 設定
   // 連番も元に戻す
   dst.idSeq.value = src.idSeq.value;
 }

--- a/src/data/adapters/prisma/index.ts
+++ b/src/data/adapters/prisma/index.ts
@@ -10,6 +10,7 @@ import { makeInvitationRepo } from './invitation-repository.prisma';
 import { makeLocationRepo } from './location-repository.prisma';
 import { makeMagicLinkRepo } from './magic-link-repository.prisma';
 import { makeNotificationRepo } from './notification-repository.prisma';
+import { makeSsoConfigRepo } from './sso-config-repository.prisma';
 import { makeTenantRepo } from './tenant-repository.prisma';
 import { makeTicketCommentRepo } from './ticket-comment-repository.prisma';
 import { makeTicketHistoryRepo } from './ticket-history-repository.prisma';
@@ -38,6 +39,7 @@ export function buildPrismaRepos(db: PrismaLike): Repos {
     attachments: makeAttachmentRepo(db),
     emailThreads: makeEmailThreadRepo(db),
     locations: makeLocationRepo(db), // Phase 4 多拠点
+    ssoConfigs: makeSsoConfigRepo(db), // Phase 4 Enterprise: SAML SSO 設定
   };
 }
 

--- a/src/data/adapters/prisma/sso-config-repository.prisma.ts
+++ b/src/data/adapters/prisma/sso-config-repository.prisma.ts
@@ -1,0 +1,70 @@
+// SSO 設定リポジトリの契約 (port)
+import type { SsoConfigRepository } from '@/data/ports/sso-config-repository';
+// ドメイン型
+import type { TenantSsoConfig } from '@/domain/types';
+// Prisma の行型
+import type { Prisma } from '@/generated/prisma';
+// Prisma クライアント/トランザクション共通型
+import type { PrismaLike } from './types';
+
+// Prisma の TenantSsoConfig 行 (include なし) の型エイリアス
+type SsoConfigRow = Prisma.TenantSsoConfigGetPayload<Record<string, never>>;
+
+// Prisma の行をドメイン型に変換する関数
+function toSsoConfig(row: SsoConfigRow): TenantSsoConfig {
+  // 必要なフィールドだけ詰め替えて返す
+  return {
+    id: row.id, // 設定 ID
+    tenantId: row.tenantId, // 所属テナント (マルチテナント化のキー)
+    enabled: row.enabled, // 有効フラグ
+    idpEntityId: row.idpEntityId, // IdP の EntityID
+    idpSsoUrl: row.idpSsoUrl, // IdP の SSO エンドポイント
+    idpX509Cert: row.idpX509Cert, // IdP の署名検証用証明書
+    createdAt: row.createdAt, // 作成日時
+    updatedAt: row.updatedAt, // 更新日時
+  };
+}
+
+// Prisma クライアントを使った SSO 設定リポジトリを生成するファクトリ関数
+export function makeSsoConfigRepo(db: PrismaLike): SsoConfigRepository {
+  return {
+    // テナントの SSO 設定を取得する (未設定なら null)
+    async findByTenant(tenantId) {
+      // tenantId は @unique なので findUnique で 1 件取得する
+      const row = await db.tenantSsoConfig.findUnique({ where: { tenantId } });
+      // 見つからなければ null、見つかればドメイン型に変換して返す
+      return row ? toSsoConfig(row) : null;
+    },
+
+    // SSO 設定を作成または更新する (tenantId をキーに upsert)
+    async upsert(input) {
+      // tenantId が既存なら update、なければ create される
+      const row = await db.tenantSsoConfig.upsert({
+        where: { tenantId: input.tenantId },
+        // 新規作成時の値
+        create: {
+          tenantId: input.tenantId, // 所属テナント (セッション由来のみ)
+          enabled: input.enabled, // 有効フラグ
+          idpEntityId: input.idpEntityId, // IdP の EntityID
+          idpSsoUrl: input.idpSsoUrl, // IdP の SSO エンドポイント
+          idpX509Cert: input.idpX509Cert, // IdP の署名検証用証明書
+        },
+        // 既存更新時の値 (tenantId は変更しない)
+        update: {
+          enabled: input.enabled,
+          idpEntityId: input.idpEntityId,
+          idpSsoUrl: input.idpSsoUrl,
+          idpX509Cert: input.idpX509Cert,
+        },
+      });
+      // 作成/更新後の行をドメイン型に変換して返す
+      return toSsoConfig(row);
+    },
+
+    // テナントの SSO 設定を削除する (tenantId スコープ)
+    async delete(tenantId) {
+      // deleteMany は該当行が無くてもエラーにならない (冪等)。tenantId スコープでクロステナント防止
+      await db.tenantSsoConfig.deleteMany({ where: { tenantId } });
+    },
+  };
+}

--- a/src/data/ports/sso-config-repository.ts
+++ b/src/data/ports/sso-config-repository.ts
@@ -1,0 +1,21 @@
+// Phase 4 Enterprise: SAML SSO 設定リポジトリの契約 (port)
+// docs/smb-dx-pivot-plan.md §6.1 Enterprise「SSO(SAML)」
+
+// SSO 設定ドメイン型
+import type { TenantSsoConfig } from '@/domain/types';
+
+// SSO 設定リポジトリの契約 (port)。1 テナント 1 設定をテナントスコープで操作する
+export interface SsoConfigRepository {
+  // テナントの SSO 設定を取得する (未設定なら null)
+  findByTenant(tenantId: string): Promise<TenantSsoConfig | null>;
+  // SSO 設定を作成または更新する (1 テナント 1 設定なので tenantId で upsert)
+  upsert(input: {
+    tenantId: string; // 所属テナント (セッション由来のみ許可。クロステナント設定防止)
+    enabled: boolean; // SSO ログインを有効化するか
+    idpEntityId: string; // IdP の EntityID (Issuer)
+    idpSsoUrl: string; // IdP の SSO エンドポイント URL
+    idpX509Cert: string; // IdP の署名検証用 X.509 証明書
+  }): Promise<TenantSsoConfig>;
+  // テナントの SSO 設定を削除する (tenantId スコープで他テナントは no-op)
+  delete(tenantId: string): Promise<void>;
+}

--- a/src/data/ports/unit-of-work.ts
+++ b/src/data/ports/unit-of-work.ts
@@ -7,6 +7,7 @@ import type { InvitationRepository } from './invitation-repository';
 import type { LocationRepository } from './location-repository';
 import type { MagicLinkRepository } from './magic-link-repository';
 import type { NotificationRepository } from './notification-repository';
+import type { SsoConfigRepository } from './sso-config-repository';
 import type { TenantRepository } from './tenant-repository';
 import type { TicketCommentRepository } from './ticket-comment-repository';
 import type { TicketHistoryRepository } from './ticket-history-repository';
@@ -28,6 +29,7 @@ export interface Repos {
   attachments: AttachmentRepository; // 添付ファイル (画像) のメタ情報操作
   emailThreads: EmailThreadRepository; // メール Message-ID → チケット 対応表 (スレッド継続 / Phase 2)
   locations: LocationRepository; // Phase 4 多拠点: テナント内の店舗・拠点
+  ssoConfigs: SsoConfigRepository; // Phase 4 Enterprise: テナント単位の SAML SSO 設定
 }
 
 // トランザクション境界を表す契約 (Unit of Work パターン)

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -62,6 +62,19 @@ export interface Tenant {
   createdAt: Date; // 作成日時
 }
 
+// Phase 4 Enterprise: テナント単位の SAML SSO 設定 1 件分。
+// アプリ (SP) が IdP からの受信アサーション署名を検証するために必要な情報を保持する。
+export interface TenantSsoConfig {
+  id: string; // 設定 ID (主キー)
+  tenantId: string; // 所属テナント ID (1 テナント 1 設定)
+  enabled: boolean; // SSO ログインを有効化するか (false なら無効 = fail-closed)
+  idpEntityId: string; // IdP の EntityID (= 受信アサーションの Issuer。一致必須)
+  idpSsoUrl: string; // IdP の SSO エンドポイント URL (AuthnRequest 送信先)
+  idpX509Cert: string; // IdP の署名検証用 X.509 証明書 (PEM またはその base64 本体)
+  createdAt: Date; // 作成日時
+  updatedAt: Date; // 更新日時
+}
+
 // Phase 4 多拠点: テナント内の店舗・拠点 1 件分
 export interface Location {
   id: string; // 拠点 ID (主キー)

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -35,8 +35,9 @@ export type NotificationType = 'assigned' | 'escalated' | 'commented' | 'statusC
 export type TenantMode = 'lite' | 'pro';
 
 // Phase 4 課金: サブスクリプションプラン
-// Free: 3 名・月 50 件 / Standard: 10 名・Lite フル / Pro: 30 名・Pro モード
-export type SubscriptionPlan = 'free' | 'standard' | 'pro';
+// Free: 3 名・月 50 件 / Standard: 10 名・Lite フル / Pro: 30 名・Pro モード /
+// Enterprise: 個別見積・無制限・SSO(SAML)・監査強化 (smb-dx-pivot-plan.md §6.1)
+export type SubscriptionPlan = 'free' | 'standard' | 'pro' | 'enterprise';
 
 // テナント (組織) 本体。マルチテナントの境界を表す
 export interface Tenant {

--- a/src/features/settings/actions/create-checkout-session.ts
+++ b/src/features/settings/actions/create-checkout-session.ts
@@ -42,7 +42,13 @@ export async function createCheckoutSession(
     return { error: 'Free プランへの変更はサブスクリプション解約から行ってください' };
   }
 
-  // 対象プランの Stripe Price ID を取得する
+  // Enterprise は個別見積で Stripe の自助チェックアウトを経由しない (運用が手動設定)。
+  // ここで弾かないと下のフォールバックで誤って Pro の Price ID が使われてしまうため明示的に拒否する。
+  if (targetPlan === 'enterprise') {
+    return { error: 'Enterprise プランは個別見積です。お問い合わせください。' };
+  }
+
+  // 対象プランの Stripe Price ID を取得する (ここに来る時点で standard | pro に絞られている)
   const priceId = targetPlan === 'standard' ? STRIPE_PRICE_IDS.standard : STRIPE_PRICE_IDS.pro;
   // Price ID が設定されていない場合は課金機能未設定として拒否
   if (!priceId) {

--- a/src/features/settings/actions/delete-sso-config.ts
+++ b/src/features/settings/actions/delete-sso-config.ts
@@ -1,0 +1,59 @@
+'use server';
+
+// Phase 4 Enterprise: SAML SSO 設定を削除する Server Action。
+// Enterprise プランの管理者のみ実行可能。削除すると SSO ログインが無効化される。
+// docs/smb-dx-pivot-plan.md §6.1 Enterprise「SSO(SAML)」。
+
+// Next.js のキャッシュ無効化
+import { revalidatePath } from 'next/cache';
+// 現在のセッション取得
+import { auth } from '@/lib/auth';
+// データリポジトリ
+import { repos } from '@/data';
+// プラン別の SSO 可否ゲート (Enterprise のみ)
+import { isSsoAllowed } from '@/lib/plan-guard';
+
+// 削除結果型 (useActionState 互換)
+export interface DeleteSsoConfigState {
+  error?: string; // エラーメッセージ
+  success?: boolean; // 成功フラグ
+}
+
+// SSO 設定を削除するサーバーアクション
+export async function deleteSsoConfig(
+  _prevState: DeleteSsoConfigState,
+  _formData: FormData,
+): Promise<DeleteSsoConfigState> {
+  // セッション取得と認証チェック
+  const session = await auth();
+  // 未ログインまたは tenantId 不在は拒否
+  if (!session?.user?.id || !session.user.tenantId) {
+    return { error: '認証が必要です' };
+  }
+  // 管理者以外は不可
+  if (session.user.role !== 'admin') {
+    return { error: 'この操作は管理者のみ実行できます' };
+  }
+  // セッション由来の tenantId のみ使う
+  const tenantId = session.user.tenantId;
+
+  // テナントを取得してプランを確認する (Enterprise 以外は SSO 機能自体を提供しない)
+  const tenant = await repos.tenants.findById(tenantId);
+  if (!tenant) return { error: 'テナント情報の取得に失敗しました' };
+  if (!isSsoAllowed(tenant.subscriptionPlan)) {
+    return { error: 'SSO は Enterprise プランでのみ利用できます。' };
+  }
+
+  try {
+    // SSO 設定を削除する (tenantId スコープ)
+    await repos.ssoConfigs.delete(tenantId);
+    // 設定ページのキャッシュを無効化する
+    revalidatePath('/settings');
+    // 成功を返す
+    return { success: true };
+  } catch (err) {
+    // 失敗はログに残して汎用メッセージを返す
+    console.error('[delete-sso-config] SSO 設定の削除に失敗しました:', err);
+    return { error: 'SSO 設定の削除に失敗しました' };
+  }
+}

--- a/src/features/settings/actions/delete-sso-config.ts
+++ b/src/features/settings/actions/delete-sso-config.ts
@@ -6,12 +6,10 @@
 
 // Next.js のキャッシュ無効化
 import { revalidatePath } from 'next/cache';
-// 現在のセッション取得
-import { auth } from '@/lib/auth';
 // データリポジトリ
 import { repos } from '@/data';
-// プラン別の SSO 可否ゲート (Enterprise のみ)
-import { isSsoAllowed } from '@/lib/plan-guard';
+// SSO 設定変更の共有認可ゲート (ログイン済み・admin・Enterprise)
+import { assertSsoConfigAdmin } from '@/lib/sso-context';
 
 // 削除結果型 (useActionState 互換)
 export interface DeleteSsoConfigState {
@@ -24,25 +22,12 @@ export async function deleteSsoConfig(
   _prevState: DeleteSsoConfigState,
   _formData: FormData,
 ): Promise<DeleteSsoConfigState> {
-  // セッション取得と認証チェック
-  const session = await auth();
-  // 未ログインまたは tenantId 不在は拒否
-  if (!session?.user?.id || !session.user.tenantId) {
-    return { error: '認証が必要です' };
-  }
-  // 管理者以外は不可
-  if (session.user.role !== 'admin') {
-    return { error: 'この操作は管理者のみ実行できます' };
-  }
-  // セッション由来の tenantId のみ使う
-  const tenantId = session.user.tenantId;
-
-  // テナントを取得してプランを確認する (Enterprise 以外は SSO 機能自体を提供しない)
-  const tenant = await repos.tenants.findById(tenantId);
-  if (!tenant) return { error: 'テナント情報の取得に失敗しました' };
-  if (!isSsoAllowed(tenant.subscriptionPlan)) {
-    return { error: 'SSO は Enterprise プランでのみ利用できます。' };
-  }
+  // 共有ゲートで「ログイン済み・admin・Enterprise」をまとめて検証する
+  const gate = await assertSsoConfigAdmin();
+  // ゲート不通過ならその理由をそのまま返す
+  if (!gate.ok) return { error: gate.error };
+  // 検証済みの tenantId (セッション由来)
+  const tenantId = gate.tenantId;
 
   try {
     // SSO 設定を削除する (tenantId スコープ)

--- a/src/features/settings/actions/update-sso-config.ts
+++ b/src/features/settings/actions/update-sso-config.ts
@@ -1,0 +1,136 @@
+'use server';
+
+// Phase 4 Enterprise: SAML SSO 設定を作成/更新する Server Action。
+// Enterprise プランの管理者のみ実行可能。docs/smb-dx-pivot-plan.md §6.1 Enterprise「SSO(SAML)」。
+
+// Next.js のキャッシュ無効化 (設定ページの再レンダリングに使う)
+import { revalidatePath } from 'next/cache';
+// Node の X.509 証明書パーサ (証明書の妥当性検証に使う)
+import { X509Certificate } from 'node:crypto';
+// 現在のセッション取得
+import { auth } from '@/lib/auth';
+// データリポジトリ (テナント取得・SSO 設定 upsert)
+import { repos } from '@/data';
+// プラン別の SSO 可否ゲート (Enterprise のみ)
+import { isSsoAllowed } from '@/lib/plan-guard';
+
+// 入力長の上限 (DoS・異常入力対策。EntityID/URL は十分長め、証明書は数 KB を想定)
+const ENTITY_ID_MAX = 1024; // IdP EntityID の最大長
+const SSO_URL_MAX = 2048; // IdP SSO URL の最大長
+const CERT_MAX = 16384; // 証明書 (PEM/base64) の最大長
+
+// PEM 形式の証明書から base64 本体だけを取り出す (保存形式に正規化する)
+function normalizeCert(cert: string): string {
+  // BEGIN/END 行と空白を除去する
+  return cert
+    .replace(/-----BEGIN CERTIFICATE-----/g, '')
+    .replace(/-----END CERTIFICATE-----/g, '')
+    .replace(/\s+/g, '')
+    .trim();
+}
+
+// base64 本体を PEM にラップして X509Certificate でパースできるか検証する。
+// パースできれば正規化済み base64 を返し、できなければ null を返す。
+function validateCert(rawCert: string): string | null {
+  // base64 本体に正規化する
+  const b64 = normalizeCert(rawCert);
+  // 空または長すぎる場合は不正
+  if (!b64 || b64.length > CERT_MAX) return null;
+  // base64 として妥当な文字種かを確認する (不正文字混入を弾く)
+  if (!/^[A-Za-z0-9+/=]+$/.test(b64)) return null;
+  // PEM にラップして X509 としてパースを試みる
+  try {
+    // 64 文字ごとに改行を入れて標準的な PEM を組み立てる
+    const pem = `-----BEGIN CERTIFICATE-----\n${b64.replace(/(.{64})/g, '$1\n')}\n-----END CERTIFICATE-----\n`;
+    // パースに成功すれば妥当な証明書 (例外なら不正)
+    new X509Certificate(pem);
+    // 正規化済み base64 を返す
+    return b64;
+  } catch {
+    // パース失敗は不正な証明書
+    return null;
+  }
+}
+
+// SSO 設定の更新結果型 (useActionState 互換)
+export interface UpdateSsoConfigState {
+  error?: string; // エラーメッセージ
+  success?: boolean; // 成功フラグ
+}
+
+// SSO 設定を作成/更新するサーバーアクション (useActionState 互換シグネチャ)
+export async function updateSsoConfig(
+  _prevState: UpdateSsoConfigState,
+  formData: FormData,
+): Promise<UpdateSsoConfigState> {
+  // セッション取得と認証チェック
+  const session = await auth();
+  // 未ログインまたは tenantId 不在は拒否
+  if (!session?.user?.id || !session.user.tenantId) {
+    return { error: '認証が必要です' };
+  }
+  // 管理者以外は設定変更不可 (UI 非表示に頼らずサーバー側で強制)
+  if (session.user.role !== 'admin') {
+    return { error: 'この操作は管理者のみ実行できます' };
+  }
+  // セッション由来の tenantId のみ使う (クロステナント設定防止)
+  const tenantId = session.user.tenantId;
+
+  // テナントを取得してプランが SSO を許可するか確認する (Enterprise のみ)
+  const tenant = await repos.tenants.findById(tenantId);
+  if (!tenant) return { error: 'テナント情報の取得に失敗しました' };
+  if (!isSsoAllowed(tenant.subscriptionPlan)) {
+    return { error: 'SSO は Enterprise プランでのみ利用できます。' };
+  }
+
+  // フォームから各値を取り出して前後空白を除去する
+  const idpEntityId = String(formData.get('idpEntityId') ?? '').trim();
+  const idpSsoUrl = String(formData.get('idpSsoUrl') ?? '').trim();
+  const idpX509CertRaw = String(formData.get('idpX509Cert') ?? '');
+  // 有効化チェックボックス (チェック時のみ 'on' が送られる)
+  const enabled = formData.get('enabled') === 'on';
+
+  // IdP EntityID の検証 (必須・長さ上限)
+  if (!idpEntityId) return { error: 'IdP の EntityID は必須です' };
+  if (idpEntityId.length > ENTITY_ID_MAX) return { error: 'IdP の EntityID が長すぎます' };
+
+  // IdP SSO URL の検証 (必須・https・URL 形式・長さ上限)
+  if (!idpSsoUrl) return { error: 'IdP の SSO URL は必須です' };
+  if (idpSsoUrl.length > SSO_URL_MAX) return { error: 'IdP の SSO URL が長すぎます' };
+  // https:// で始まる正しい URL であることを確認する (ブラウザのリダイレクト先になるため)
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(idpSsoUrl);
+  } catch {
+    return { error: 'IdP の SSO URL の形式が正しくありません' };
+  }
+  // https 以外のスキームは拒否する (平文 http やカスタムスキームを許さない)
+  if (parsedUrl.protocol !== 'https:') {
+    return { error: 'IdP の SSO URL は https:// で始まる必要があります' };
+  }
+
+  // 証明書の検証 (X509 としてパースできること)
+  const cert = validateCert(idpX509CertRaw);
+  if (!cert) {
+    return { error: 'IdP の X.509 証明書が正しくありません (PEM または base64 本体を貼り付けてください)' };
+  }
+
+  try {
+    // SSO 設定を upsert する (tenantId スコープで他テナントに影響しない)
+    await repos.ssoConfigs.upsert({
+      tenantId,
+      enabled,
+      idpEntityId,
+      idpSsoUrl,
+      idpX509Cert: cert,
+    });
+    // 設定ページのキャッシュを無効化して結果をすぐ反映する
+    revalidatePath('/settings');
+    // 成功を返す
+    return { success: true };
+  } catch (err) {
+    // 失敗はログに残して汎用メッセージを返す (内部詳細を漏らさない)
+    console.error('[update-sso-config] SSO 設定の保存に失敗しました:', err);
+    return { error: 'SSO 設定の保存に失敗しました' };
+  }
+}

--- a/src/features/settings/actions/update-sso-config.ts
+++ b/src/features/settings/actions/update-sso-config.ts
@@ -7,27 +7,17 @@
 import { revalidatePath } from 'next/cache';
 // Node の X.509 証明書パーサ (証明書の妥当性検証に使う)
 import { X509Certificate } from 'node:crypto';
-// 現在のセッション取得
-import { auth } from '@/lib/auth';
-// データリポジトリ (テナント取得・SSO 設定 upsert)
+// データリポジトリ (SSO 設定 upsert)
 import { repos } from '@/data';
-// プラン別の SSO 可否ゲート (Enterprise のみ)
-import { isSsoAllowed } from '@/lib/plan-guard';
+// SSO 設定変更の共有認可ゲート (ログイン済み・admin・Enterprise)
+import { assertSsoConfigAdmin } from '@/lib/sso-context';
+// 証明書の base64 正規化 (SAML SP コアと共有する純粋ヘルパー)
+import { normalizeCert } from '@/lib/saml-cert';
 
 // 入力長の上限 (DoS・異常入力対策。EntityID/URL は十分長め、証明書は数 KB を想定)
 const ENTITY_ID_MAX = 1024; // IdP EntityID の最大長
 const SSO_URL_MAX = 2048; // IdP SSO URL の最大長
 const CERT_MAX = 16384; // 証明書 (PEM/base64) の最大長
-
-// PEM 形式の証明書から base64 本体だけを取り出す (保存形式に正規化する)
-function normalizeCert(cert: string): string {
-  // BEGIN/END 行と空白を除去する
-  return cert
-    .replace(/-----BEGIN CERTIFICATE-----/g, '')
-    .replace(/-----END CERTIFICATE-----/g, '')
-    .replace(/\s+/g, '')
-    .trim();
-}
 
 // base64 本体を PEM にラップして X509Certificate でパースできるか検証する。
 // パースできれば正規化済み base64 を返し、できなければ null を返す。
@@ -63,25 +53,12 @@ export async function updateSsoConfig(
   _prevState: UpdateSsoConfigState,
   formData: FormData,
 ): Promise<UpdateSsoConfigState> {
-  // セッション取得と認証チェック
-  const session = await auth();
-  // 未ログインまたは tenantId 不在は拒否
-  if (!session?.user?.id || !session.user.tenantId) {
-    return { error: '認証が必要です' };
-  }
-  // 管理者以外は設定変更不可 (UI 非表示に頼らずサーバー側で強制)
-  if (session.user.role !== 'admin') {
-    return { error: 'この操作は管理者のみ実行できます' };
-  }
-  // セッション由来の tenantId のみ使う (クロステナント設定防止)
-  const tenantId = session.user.tenantId;
-
-  // テナントを取得してプランが SSO を許可するか確認する (Enterprise のみ)
-  const tenant = await repos.tenants.findById(tenantId);
-  if (!tenant) return { error: 'テナント情報の取得に失敗しました' };
-  if (!isSsoAllowed(tenant.subscriptionPlan)) {
-    return { error: 'SSO は Enterprise プランでのみ利用できます。' };
-  }
+  // 共有ゲートで「ログイン済み・admin・Enterprise」をまとめて検証する
+  const gate = await assertSsoConfigAdmin();
+  // ゲート不通過ならその理由をそのまま返す
+  if (!gate.ok) return { error: gate.error };
+  // 検証済みの tenantId (セッション由来)
+  const tenantId = gate.tenantId;
 
   // フォームから各値を取り出して前後空白を除去する
   const idpEntityId = String(formData.get('idpEntityId') ?? '').trim();

--- a/src/features/settings/components/BillingSection.tsx
+++ b/src/features/settings/components/BillingSection.tsx
@@ -52,6 +52,18 @@ const PLAN_INFO: Record<
       'メール取り込み対応',
     ],
   },
+  // エンタープライズプラン: 個別見積 (無制限 + SSO + 監査強化)。Stripe 非経由で運用が手動設定
+  enterprise: {
+    label: 'Enterprise',
+    price: '個別見積',
+    features: [
+      'メンバー無制限',
+      '月間チケット無制限',
+      'Pro モードの全機能',
+      'SSO (SAML) シングルサインオン',
+      '監査強化・SLA 契約',
+    ],
+  },
 };
 
 // 受け取る props
@@ -158,8 +170,9 @@ export function BillingSection({ currentPlan, stripeStatus, hasStripeCustomer }:
             {isPending ? '処理中…' : 'Standard にアップグレード'}
           </button>
         )}
-        {/* Pro プランへアップグレード (Free または Standard の場合に表示) */}
-        {currentPlan !== 'pro' && (
+        {/* Pro プランへアップグレード (Free または Standard の場合のみ表示)。
+            Enterprise には下位プランへの「アップグレード」を出さない (誤ダウングレード防止) */}
+        {(currentPlan === 'free' || currentPlan === 'standard') && (
           <button
             type="button"
             onClick={() => handleUpgrade('pro')}
@@ -185,6 +198,13 @@ export function BillingSection({ currentPlan, stripeStatus, hasStripeCustomer }:
       <p className="text-xs text-slate-400">
         プランのダウングレードまたは解約は「プランを管理」から行ってください。
       </p>
+      {/* Enterprise の案内 (Enterprise 以外のテナントに向けたアップセル導線) */}
+      {currentPlan !== 'enterprise' && (
+        <p className="text-xs text-slate-400">
+          無制限のメンバー・SSO (SAML)・監査強化が必要な場合は Enterprise プラン (個別見積) を
+          ご検討ください。導入のご相談はサポートまでお問い合わせください。
+        </p>
+      )}
     </div>
   );
 }

--- a/src/features/settings/components/SsoConfigSection.tsx
+++ b/src/features/settings/components/SsoConfigSection.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+// Phase 4 Enterprise: SAML SSO 設定セクション (Enterprise プランの管理者向け)。
+// docs/smb-dx-pivot-plan.md §6.1 Enterprise「SSO(SAML)」。
+// SP 側の情報 (IdP に登録する値) を表示しつつ、IdP の情報を入力して保存する。
+
+// React の Server Action 状態管理フックと送信中フラグ管理フック
+import { useActionState, useTransition } from 'react';
+// SSO 設定の作成/更新・削除サーバーアクション
+import { updateSsoConfig } from '@/features/settings/actions/update-sso-config';
+import { deleteSsoConfig } from '@/features/settings/actions/delete-sso-config';
+
+// 現在の SSO 設定 (未設定なら null)
+interface SsoConfigView {
+  idpEntityId: string; // IdP の EntityID
+  idpSsoUrl: string; // IdP の SSO URL
+  idpX509Cert: string; // IdP の証明書 (公開情報)
+  enabled: boolean; // 有効フラグ
+}
+
+// SP 側の URL 群 (IdP 構成のために表示する。秘密情報ではない)
+interface SpUrls {
+  entityId: string; // SP の EntityID
+  acsUrl: string; // ACS (応答 POST 先)
+  metadataUrl: string; // SP メタデータ URL
+  loginUrl: string; // SSO ログイン開始 URL
+}
+
+// 受け取る props
+interface Props {
+  config: SsoConfigView | null; // 現在の SSO 設定
+  sp: SpUrls; // SP 側の URL 群
+}
+
+// 入力フィールド共通の Tailwind クラス
+const fieldClass =
+  'w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500';
+// ラベル共通の Tailwind クラス
+const labelClass = 'block text-sm font-medium text-slate-700';
+// 補足説明共通の Tailwind クラス
+const helpClass = 'mt-1 text-xs text-slate-500';
+
+// SP 情報を 1 行表示する小コンポーネント (ラベル + コピーしやすい値)
+function SpField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-1">
+      {/* 項目名 */}
+      <p className="text-xs font-semibold text-slate-500">{label}</p>
+      {/* 値 (折り返し可能・等幅でコピーしやすく) */}
+      <p className="break-all rounded bg-slate-50 px-2 py-1 font-mono text-xs text-slate-700 ring-1 ring-slate-200">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+// SSO 設定セクション本体
+export function SsoConfigSection({ config, sp }: Props) {
+  // 設定保存アクションの状態
+  const [saveState, saveAction] = useActionState(updateSsoConfig, {});
+  // 設定削除アクションの状態
+  const [deleteState, deleteAction] = useActionState(deleteSsoConfig, {});
+  // 送信中フラグ (保存・削除で共有)
+  const [isPending, startTransition] = useTransition();
+
+  // 保存フォーム送信ハンドラ
+  function handleSave(e: React.FormEvent<HTMLFormElement>) {
+    // ブラウザ既定の送信を抑止する
+    e.preventDefault();
+    // フォームデータを取り出してアクションに渡す
+    const formData = new FormData(e.currentTarget);
+    // トランジション内で実行して isPending を立てる
+    startTransition(() => saveAction(formData));
+  }
+
+  // 削除ボタンハンドラ
+  function handleDelete() {
+    // 誤操作防止の確認 (削除すると SSO ログインが無効化される)
+    if (!window.confirm('SSO 設定を削除しますか？ SSO ログインが無効になります。')) return;
+    // 空の FormData でアクションを呼ぶ
+    startTransition(() => deleteAction(new FormData()));
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* ── SP 情報 (IdP 側に登録する値) ─────────────────────────── */}
+      <div className="space-y-3 rounded-xl bg-slate-50/60 p-4 ring-1 ring-slate-200">
+        <p className="text-sm font-semibold text-slate-700">IdP 側に登録する SP 情報</p>
+        <p className={helpClass}>
+          ご利用の IdP (Okta・Azure AD・Google Workspace など) に以下の値を登録してください。
+          メタデータ URL を取り込める IdP では、メタデータ URL の指定だけで設定できます。
+        </p>
+        {/* SP の各 URL を表示する */}
+        <SpField label="SP EntityID" value={sp.entityId} />
+        <SpField label="ACS URL (アサーション応答先)" value={sp.acsUrl} />
+        <SpField label="メタデータ URL" value={sp.metadataUrl} />
+        <SpField label="ログイン開始 URL" value={sp.loginUrl} />
+      </div>
+
+      {/* ── IdP 情報の入力フォーム ───────────────────────────────── */}
+      <form onSubmit={handleSave} className="space-y-4">
+        {/* IdP EntityID */}
+        <div className="space-y-1">
+          <label htmlFor="idp-entity-id" className={labelClass}>
+            IdP EntityID (Issuer)
+          </label>
+          <p className={helpClass}>IdP が発行する識別子。受信したログイン応答の発行元検証に使います。</p>
+          <input
+            id="idp-entity-id"
+            name="idpEntityId"
+            type="text"
+            defaultValue={config?.idpEntityId ?? ''}
+            placeholder="https://idp.example.com/entity"
+            autoComplete="off"
+            required
+            className={fieldClass}
+          />
+        </div>
+
+        {/* IdP SSO URL */}
+        <div className="space-y-1">
+          <label htmlFor="idp-sso-url" className={labelClass}>
+            IdP SSO URL
+          </label>
+          <p className={helpClass}>ログイン時にユーザーをリダイレクトする IdP のログイン URL。</p>
+          <input
+            id="idp-sso-url"
+            name="idpSsoUrl"
+            type="url"
+            defaultValue={config?.idpSsoUrl ?? ''}
+            placeholder="https://idp.example.com/sso"
+            autoComplete="off"
+            required
+            className={fieldClass}
+          />
+        </div>
+
+        {/* IdP 証明書 */}
+        <div className="space-y-1">
+          <label htmlFor="idp-cert" className={labelClass}>
+            IdP X.509 証明書
+          </label>
+          <p className={helpClass}>
+            IdP の署名検証用の公開証明書。PEM 形式（-----BEGIN CERTIFICATE-----）または
+            その base64 本体を貼り付けてください。
+          </p>
+          <textarea
+            id="idp-cert"
+            name="idpX509Cert"
+            rows={5}
+            defaultValue={config?.idpX509Cert ?? ''}
+            placeholder="-----BEGIN CERTIFICATE-----&#10;MIID...&#10;-----END CERTIFICATE-----"
+            autoComplete="off"
+            required
+            className={`${fieldClass} font-mono`}
+          />
+        </div>
+
+        {/* 有効化チェックボックス */}
+        <div className="flex items-center gap-2">
+          <input
+            id="sso-enabled"
+            name="enabled"
+            type="checkbox"
+            defaultChecked={config?.enabled ?? false}
+            className="h-4 w-4 rounded border-slate-300 text-teal-600 focus:ring-teal-500"
+          />
+          <label htmlFor="sso-enabled" className="text-sm text-slate-700">
+            SSO ログインを有効にする
+          </label>
+        </div>
+
+        {/* エラーメッセージ (保存) */}
+        {saveState.error && (
+          <p role="alert" className="text-sm text-rose-700">
+            {saveState.error}
+          </p>
+        )}
+        {/* 成功メッセージ (保存) */}
+        {saveState.success && (
+          <p role="status" aria-live="polite" className="text-sm text-teal-700">
+            SSO 設定を保存しました。
+          </p>
+        )}
+        {/* 削除結果メッセージ */}
+        {deleteState.error && (
+          <p role="alert" className="text-sm text-rose-700">
+            {deleteState.error}
+          </p>
+        )}
+        {deleteState.success && (
+          <p role="status" aria-live="polite" className="text-sm text-teal-700">
+            SSO 設定を削除しました。
+          </p>
+        )}
+
+        {/* 操作ボタン群 */}
+        <div className="flex flex-wrap items-center gap-3">
+          {/* 保存ボタン */}
+          <button
+            type="submit"
+            disabled={isPending}
+            className="rounded-lg bg-teal-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-teal-800 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isPending ? '保存中…' : 'SSO 設定を保存'}
+          </button>
+          {/* 削除ボタン (設定が存在する場合のみ表示) */}
+          {config && (
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={isPending}
+              className="rounded-lg px-4 py-2 text-sm font-medium text-rose-600 transition hover:bg-rose-50 disabled:opacity-50"
+            >
+              設定を削除
+            </button>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/lib/plan-guard.ts
+++ b/src/lib/plan-guard.ts
@@ -17,6 +17,7 @@ export const USER_LIMIT: Record<SubscriptionPlan, number> = {
   free: 3, // Free: スタッフ 3 名まで
   standard: 10, // Standard: スタッフ 10 名まで
   pro: 30, // Pro: スタッフ 30 名まで
+  enterprise: Infinity, // Enterprise: 無制限 (個別見積)
 };
 
 // 月間チケット起票数の上限 (プランごと)。Free のみ制限あり
@@ -24,6 +25,7 @@ export const MONTHLY_TICKET_LIMIT: Record<SubscriptionPlan, number> = {
   free: 50, // Free: 月 50 件まで
   standard: Infinity, // Standard: 無制限
   pro: Infinity, // Pro: 無制限
+  enterprise: Infinity, // Enterprise: 無制限
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -36,25 +38,33 @@ export function isEmailInboundAllowed(plan: SubscriptionPlan): boolean {
   return plan !== 'free';
 }
 
-// 監査ログ機能の利用可否 (Pro のみ)
+// 監査ログ機能の利用可否 (Pro 以上)。Enterprise は「監査強化」として当然含む
 export function isAuditLogAllowed(plan: SubscriptionPlan): boolean {
-  // Pro プランのみ監査ログにアクセスできる (smb-dx-pivot-plan.md §6.1)
-  return plan === 'pro';
+  // Pro / Enterprise プランのみ監査ログにアクセスできる (smb-dx-pivot-plan.md §6.1)
+  return plan === 'pro' || plan === 'enterprise';
 }
 
-// LINE 連携機能の利用可否 (Pro のみ)
+// LINE 連携機能の利用可否 (Pro 以上)
 export function isLineIntegrationAllowed(plan: SubscriptionPlan): boolean {
-  // Pro プランのみ LINE 連携が有効
-  return plan === 'pro';
+  // Pro / Enterprise プランで LINE 連携が有効
+  return plan === 'pro' || plan === 'enterprise';
 }
 
 // Pro モード (7 ステータス・SLA・エスカレーション等) の利用可否
 // Standard と Pro の両方で Pro モードを許可する判断については、
 // 画面の mode フラグ (lite/pro) を管理者が個別に切り替える設計のため、
-// プラン上は Pro プランのみが既定で pro mode になる
+// プラン上は Pro / Enterprise プランが既定で pro mode になる
 export function isProModeAllowed(plan: SubscriptionPlan): boolean {
-  // Pro プランのみ Pro モードのフル機能を有効化できる
-  return plan === 'pro';
+  // Pro / Enterprise プランで Pro モードのフル機能を有効化できる
+  return plan === 'pro' || plan === 'enterprise';
+}
+
+// SSO (SAML) シングルサインオンの利用可否 (Enterprise のみ)。
+// docs/smb-dx-pivot-plan.md §6.1 で Enterprise 専用機能として位置づけられている。
+// SSO 設定・ログインの各エンドポイントはこのゲートでサーバー側強制する (UI 非表示に頼らない)。
+export function isSsoAllowed(plan: SubscriptionPlan): boolean {
+  // Enterprise プランのみ SSO を構成・利用できる
+  return plan === 'enterprise';
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -79,9 +89,11 @@ export function isMonthlyTicketLimitReached(
   return Number.isFinite(limit) && currentMonthlyCount >= limit;
 }
 
-// プランのユーザー上限値を返す (UI 表示用)
+// プランのユーザー上限値を返す (UI 表示用)。無制限 (Infinity) の場合は -1 を返す
+// (getMonthlyTicketLimit と同じ規約。呼び出し側は -1 を「無制限」として扱う)
 export function getUserLimit(plan: SubscriptionPlan): number {
-  return USER_LIMIT[plan];
+  const limit = USER_LIMIT[plan];
+  return Number.isFinite(limit) ? limit : -1;
 }
 
 // プランの月間チケット上限値を返す (UI 表示用)。Infinity の場合は -1 を返す

--- a/src/lib/saml-cert.ts
+++ b/src/lib/saml-cert.ts
@@ -1,0 +1,15 @@
+// Phase 4 Enterprise: SAML 証明書の正規化ヘルパー (純粋関数)。
+// SAML SP コア (src/lib/saml.ts) と SSO 設定保存 (update-sso-config.ts) の双方で使うため、
+// node-saml に依存しない独立モジュールに切り出して重複を避ける (DRY)。
+
+// PEM 形式の証明書から base64 本体だけを取り出す。
+// node-saml は base64 本体を期待し、DB にも base64 本体で保存するため正規化する。
+// 既に base64 本体だけが渡された場合はヘッダが無いのでそのまま空白除去して返す。
+export function normalizeCert(cert: string): string {
+  // BEGIN/END CERTIFICATE 行を除去し、すべての空白 (改行含む) を取り除く
+  return cert
+    .replace(/-----BEGIN CERTIFICATE-----/g, '')
+    .replace(/-----END CERTIFICATE-----/g, '')
+    .replace(/\s+/g, '')
+    .trim();
+}

--- a/src/lib/saml.ts
+++ b/src/lib/saml.ts
@@ -20,6 +20,10 @@
 import { SAML } from '@node-saml/node-saml';
 // SSO 設定ドメイン型
 import type { TenantSsoConfig } from '@/domain/types';
+// 証明書の base64 正規化 (SSO 設定保存と共有する純粋ヘルパー)
+import { normalizeCert } from '@/lib/saml-cert';
+// HTML/XML 属性への安全な埋め込み用エスケープ (メタデータ XML 生成に再利用)
+import { escapeHtml } from '@/lib/html-escape';
 
 // 受信アサーションの許容時刻ずれ (IdP とのクロック差吸収)。5 分まで許容する
 const SAML_CLOCK_SKEW_MS = 5 * 60 * 1000;
@@ -38,17 +42,6 @@ export function buildSpUrls(baseUrl: string, tenantId: string) {
     loginUrl: `${prefix}/login`, // SSO ログイン開始 URL
     metadataUrl: `${prefix}/metadata`, // SP メタデータ URL
   };
-}
-
-// PEM 形式の証明書から base64 本体だけを取り出す (node-saml は base64 本体を期待するため正規化)。
-// 既に base64 本体だけが渡された場合はヘッダが無いのでそのまま空白除去して返す。
-function normalizeCert(cert: string): string {
-  // BEGIN/END CERTIFICATE 行を除去し、すべての空白 (改行含む) を取り除く
-  return cert
-    .replace(/-----BEGIN CERTIFICATE-----/g, '')
-    .replace(/-----END CERTIFICATE-----/g, '')
-    .replace(/\s+/g, '')
-    .trim();
 }
 
 // SSO 設定が SAML インスタンス構築に必要な値を満たしているか検証する (満たさなければ throw)。
@@ -137,8 +130,9 @@ export async function validateSamlResponse(
     pickStringAttr(profile, 'email') ??
     pickStringAttr(profile, 'mail') ??
     pickStringAttr(profile, 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress');
-  // NameID が email 形式ならそれを優先、無ければ属性のメールを使う
-  const rawEmail = nameId.includes('@') ? nameId : (attrEmail ?? '');
+  // 明示的なメール属性があればそれを優先する。無い場合のみ NameID が email 形式かで判定する。
+  // (UPN 形式など '@' を含む非メール NameID と、別途正しい email 属性を併送する IdP に対応するため)
+  const rawEmail = attrEmail ?? (nameId.includes('@') ? nameId : '');
   // メールが取れなければ本人特定できないので拒否する (fail-closed)
   const email = rawEmail.trim().toLowerCase();
   if (!email || !email.includes('@')) {
@@ -168,8 +162,8 @@ export function buildSpMetadataXml(baseUrl: string, tenantId: string): string {
   // SP の EntityID / ACS URL を組み立てる
   const sp = buildSpUrls(baseUrl, tenantId);
   // XML 属性に値を埋め込む前に最小限のエスケープを行う (URL 由来の特殊文字対策)
-  const entityId = escapeXmlAttr(sp.entityId);
-  const acsUrl = escapeXmlAttr(sp.acsUrl);
+  const entityId = escapeHtml(sp.entityId);
+  const acsUrl = escapeHtml(sp.acsUrl);
   // SAML 2.0 の SPSSODescriptor を含むメタデータ XML を返す。
   // AuthnRequestsSigned=false (SP 署名なし) / WantAssertionsSigned=true (アサーション署名必須)。
   return `<?xml version="1.0" encoding="UTF-8"?>
@@ -179,15 +173,4 @@ export function buildSpMetadataXml(baseUrl: string, tenantId: string): string {
     <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="${acsUrl}" index="0" isDefault="true"/>
   </SPSSODescriptor>
 </EntityDescriptor>`;
-}
-
-// XML 属性値に安全に埋め込むための最小エスケープ (& < > " ' を実体参照へ変換)。
-function escapeXmlAttr(value: string): string {
-  // 各特殊文字を XML 実体参照に置換して返す
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
 }

--- a/src/lib/saml.ts
+++ b/src/lib/saml.ts
@@ -1,0 +1,193 @@
+// Phase 4 Enterprise: SAML SSO の Service Provider (SP) コア。
+// docs/smb-dx-pivot-plan.md §6.1 Enterprise「SSO(SAML)」。
+//
+// 役割:
+//   - テナントの SSO 設定 (TenantSsoConfig) から SAML SP インスタンスを構築する。
+//   - ログイン用の AuthnRequest リダイレクト URL を生成する。
+//   - IdP から受け取った SAMLResponse の署名・条件 (Issuer/Audience/期限) を検証し、
+//     ログインすべきユーザーのメールアドレスを取り出す。
+//   - SP メタデータ XML を生成する。
+//
+// セキュリティ方針 (CLAUDE.md §9):
+//   - 署名検証・XML 正規化などの暗号処理は自前実装せず、実績ある @node-saml/node-saml に委譲する。
+//   - wantAssertionsSigned=true でアサーション署名を必須化し、未署名/改竄応答を拒否する (fail-closed)。
+//   - Issuer (idpIssuer) と Audience を必ず検証し、別 IdP / 別 SP 宛の応答を受け入れない。
+//
+// 本モジュールは node-saml (Node 専用ライブラリ) を読み込むため、必ず Node ランタイムの
+// ルートハンドラからのみ import すること (Edge ランタイム不可)。
+
+// node-saml の SP 実装
+import { SAML } from '@node-saml/node-saml';
+// SSO 設定ドメイン型
+import type { TenantSsoConfig } from '@/domain/types';
+
+// 受信アサーションの許容時刻ずれ (IdP とのクロック差吸収)。5 分まで許容する
+const SAML_CLOCK_SKEW_MS = 5 * 60 * 1000;
+
+// テナントの SSO 用 SP エンドポイント URL 群を組み立てる純粋関数。
+// SP の EntityID は ACS とは別の安定した URL (metadata) を使う慣例に従う。
+export function buildSpUrls(baseUrl: string, tenantId: string) {
+  // 末尾スラッシュを除いた基底 URL (二重スラッシュ防止)
+  const base = baseUrl.replace(/\/+$/, '');
+  // テナントごとの SSO エンドポイントの接頭辞
+  const prefix = `${base}/api/auth/sso/${encodeURIComponent(tenantId)}`;
+  // 各 URL を返す
+  return {
+    entityId: `${prefix}/metadata`, // SP の EntityID (= Audience。メタデータ URL を兼ねる)
+    acsUrl: `${prefix}/acs`, // Assertion Consumer Service (IdP が応答を POST する先)
+    loginUrl: `${prefix}/login`, // SSO ログイン開始 URL
+    metadataUrl: `${prefix}/metadata`, // SP メタデータ URL
+  };
+}
+
+// PEM 形式の証明書から base64 本体だけを取り出す (node-saml は base64 本体を期待するため正規化)。
+// 既に base64 本体だけが渡された場合はヘッダが無いのでそのまま空白除去して返す。
+function normalizeCert(cert: string): string {
+  // BEGIN/END CERTIFICATE 行を除去し、すべての空白 (改行含む) を取り除く
+  return cert
+    .replace(/-----BEGIN CERTIFICATE-----/g, '')
+    .replace(/-----END CERTIFICATE-----/g, '')
+    .replace(/\s+/g, '')
+    .trim();
+}
+
+// SSO 設定が SAML インスタンス構築に必要な値を満たしているか検証する (満たさなければ throw)。
+function assertConfigComplete(config: TenantSsoConfig): void {
+  // IdP の EntityID (Issuer 検証に必須)
+  if (!config.idpEntityId.trim()) throw new Error('SSO 設定の IdP EntityID が未設定です。');
+  // IdP の SSO エンドポイント (AuthnRequest 送信先に必須)
+  if (!config.idpSsoUrl.trim()) throw new Error('SSO 設定の IdP SSO URL が未設定です。');
+  // 署名検証用の証明書 (これが無いと検証できない = fail-closed)
+  if (!normalizeCert(config.idpX509Cert)) throw new Error('SSO 設定の IdP 証明書が未設定です。');
+}
+
+// テナントの SSO 設定 + 基底 URL から node-saml の SP インスタンスを構築する。
+// 設定不備があれば例外を投げる (呼び出し側で 4xx/5xx に変換する)。
+export function createSamlInstance(config: TenantSsoConfig, baseUrl: string, tenantId: string): SAML {
+  // 設定の完全性を確認する (不備なら throw)
+  assertConfigComplete(config);
+  // SP の各 URL を組み立てる
+  const sp = buildSpUrls(baseUrl, tenantId);
+  // node-saml の SP インスタンスを生成して返す
+  return new SAML({
+    // IdP の署名検証用証明書 (base64 本体に正規化して渡す)
+    idpCert: normalizeCert(config.idpX509Cert),
+    // SP の EntityID (AuthnRequest の Issuer・メタデータの entityID に使われる)
+    issuer: sp.entityId,
+    // IdP が SAMLResponse を POST してくる先 (ACS)。Destination 検証にも使われる
+    callbackUrl: sp.acsUrl,
+    // IdP の SSO エンドポイント (AuthnRequest のリダイレクト先)
+    entryPoint: config.idpSsoUrl,
+    // 受信アサーションの Issuer がこの値と一致することを必須化する (別 IdP 応答を拒否)
+    idpIssuer: config.idpEntityId,
+    // Audience を SP の EntityID に固定する (別 SP 宛の応答を拒否)
+    audience: sp.entityId,
+    // アサーション署名を必須化する (未署名/改竄応答を拒否 = fail-closed)
+    wantAssertionsSigned: true,
+    // Response 全体の署名は任意 (アサーション署名のみの IdP が多いため必須にしない)
+    wantAuthnResponseSigned: false,
+    // クロックずれの許容範囲 (期限検証の厳しすぎる失敗を防ぐ)
+    acceptedClockSkewMs: SAML_CLOCK_SKEW_MS,
+    // 署名アルゴリズムは SHA-256 を既定にする (SHA-1 を避ける)
+    signatureAlgorithm: 'sha256',
+    // SP からの AuthnRequest には署名しない (IdP 側で SP 署名を要求しない一般的構成)
+    // 署名鍵をアプリに持たせない分、構成が単純で運用しやすい
+  });
+}
+
+// SSO ログイン開始用の IdP リダイレクト URL を生成する。
+// relayState には認証後に戻したいアプリ内パス等を載せられる (本実装では未使用なら空文字)。
+export async function getSsoLoginUrl(saml: SAML, relayState = ''): Promise<string> {
+  // node-saml に AuthnRequest を生成させ、IdP へのリダイレクト URL を得る
+  return saml.getAuthorizeUrlAsync(relayState, undefined, {});
+}
+
+// 検証成功時に呼び出し側へ返す最小限の本人情報
+export interface SamlIdentity {
+  email: string; // ログインすべきユーザーのメールアドレス (小文字正規化済み)
+  nameId: string; // IdP が発行した NameID (監査・突き合わせ用)
+}
+
+// SAMLResponse (base64) を検証し、本人のメールアドレスを取り出す。
+// 署名不正・Audience 不一致・期限切れ等は node-saml が例外を投げる (= ログイン拒否)。
+// expectedIssuer には設定の IdP EntityID を渡し、アサーションの Issuer 一致を多層防御として検証する
+// (node-saml は login 経路で idpIssuer を強制しないため、ここで明示的に確認する)。
+export async function validateSamlResponse(
+  saml: SAML,
+  samlResponseB64: string,
+  expectedIssuer: string,
+): Promise<SamlIdentity> {
+  // POST バインディングの SAMLResponse を検証する。失敗時は例外が投げられる
+  const { profile } = await saml.validatePostResponseAsync({ SAMLResponse: samlResponseB64 });
+  // プロファイルが取れない (LogoutResponse 等) 場合は本人特定できないので拒否する
+  if (!profile) throw new Error('SAML レスポンスから本人情報を取得できませんでした。');
+
+  // 多層防御: アサーションの Issuer が設定の IdP EntityID と一致することを必須化する。
+  // 署名検証 (configured idpCert) が一次防御だが、Issuer 文字列も突き合わせて別 IdP を拒否する。
+  const actualIssuer = typeof profile.issuer === 'string' ? profile.issuer : '';
+  if (actualIssuer !== expectedIssuer) {
+    throw new Error('SAML レスポンスの Issuer が設定の IdP と一致しません。');
+  }
+
+  // メールアドレスを決定する: NameID が email 形式ならそれを使い、
+  // そうでなければ一般的なメール属性 (email / mail) を参照する。
+  const nameId = typeof profile.nameID === 'string' ? profile.nameID : '';
+  // 属性からメール候補を取り出す (IdP により属性名が異なるため複数試す)
+  const attrEmail =
+    pickStringAttr(profile, 'email') ??
+    pickStringAttr(profile, 'mail') ??
+    pickStringAttr(profile, 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress');
+  // NameID が email 形式ならそれを優先、無ければ属性のメールを使う
+  const rawEmail = nameId.includes('@') ? nameId : (attrEmail ?? '');
+  // メールが取れなければ本人特定できないので拒否する (fail-closed)
+  const email = rawEmail.trim().toLowerCase();
+  if (!email || !email.includes('@')) {
+    throw new Error('SAML レスポンスにメールアドレスが含まれていません。');
+  }
+  // 本人情報を返す
+  return { email, nameId: nameId || email };
+}
+
+// SAML プロファイルから文字列属性を 1 つ取り出すヘルパー (配列なら先頭、無ければ undefined)。
+function pickStringAttr(profile: Record<string, unknown>, key: string): string | undefined {
+  // 指定キーの値を取り出す
+  const value = profile[key];
+  // 文字列ならそのまま返す
+  if (typeof value === 'string') return value;
+  // 配列なら先頭の文字列要素を返す
+  if (Array.isArray(value) && typeof value[0] === 'string') return value[0];
+  // それ以外は undefined
+  return undefined;
+}
+
+// SP メタデータ XML を生成する純粋関数 (IdP 側に登録するための EntityDescriptor)。
+// IdP 証明書が未設定の段階でも SP メタデータは提示できる必要がある (管理者が IdP を構成する
+// ために先に SP メタデータを使うため)。よって node-saml の SP インスタンスに依存せず、
+// 秘密情報を含まない SP の URL 群だけから XML を組み立てる。
+export function buildSpMetadataXml(baseUrl: string, tenantId: string): string {
+  // SP の EntityID / ACS URL を組み立てる
+  const sp = buildSpUrls(baseUrl, tenantId);
+  // XML 属性に値を埋め込む前に最小限のエスケープを行う (URL 由来の特殊文字対策)
+  const entityId = escapeXmlAttr(sp.entityId);
+  const acsUrl = escapeXmlAttr(sp.acsUrl);
+  // SAML 2.0 の SPSSODescriptor を含むメタデータ XML を返す。
+  // AuthnRequestsSigned=false (SP 署名なし) / WantAssertionsSigned=true (アサーション署名必須)。
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="${entityId}">
+  <SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
+    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="${acsUrl}" index="0" isDefault="true"/>
+  </SPSSODescriptor>
+</EntityDescriptor>`;
+}
+
+// XML 属性値に安全に埋め込むための最小エスケープ (& < > " ' を実体参照へ変換)。
+function escapeXmlAttr(value: string): string {
+  // 各特殊文字を XML 実体参照に置換して返す
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}

--- a/src/lib/sso-context.ts
+++ b/src/lib/sso-context.ts
@@ -5,6 +5,8 @@
 // すべて満たすときだけ SAML SP 構築に必要な情報を返す (fail-closed)。
 // いずれかの条件を欠く場合は理由付きで失敗を返し、呼び出し側がエラーリダイレクトに変換する。
 
+// 現在のセッション取得
+import { auth } from '@/lib/auth';
 // データ層の Composition Root
 import { repos } from '@/data';
 // プラン別の SSO 可否ゲート (Enterprise のみ)
@@ -33,4 +35,35 @@ export async function loadEnabledSsoContext(tenantId: string): Promise<SsoContex
   if (!config.enabled) return { ok: false, reason: 'disabled' };
   // すべて満たしたので SP 構築に必要な情報を返す
   return { ok: true, tenant, config, baseUrl: resolveAppBaseUrl() };
+}
+
+// SSO 設定の作成/更新/削除 Server Action が共有する認可ゲートの結果
+export type SsoAdminGate =
+  | { ok: true; tenantId: string }
+  | { ok: false; error: string };
+
+// SSO 設定変更の前提 (ログイン済み・admin・Enterprise プラン) をまとめて検証する。
+// update/delete-sso-config の両 Server Action で重複していた認可チェックを 1 か所に集約し、
+// セキュリティ上重要な「admin かつ Enterprise」ゲートの実装ドリフトを防ぐ。
+export async function assertSsoConfigAdmin(): Promise<SsoAdminGate> {
+  // セッション取得と認証チェック
+  const session = await auth();
+  // 未ログインまたは tenantId 不在は拒否
+  if (!session?.user?.id || !session.user.tenantId) {
+    return { ok: false, error: '認証が必要です' };
+  }
+  // 管理者以外は設定変更不可 (UI 非表示に頼らずサーバー側で強制)
+  if (session.user.role !== 'admin') {
+    return { ok: false, error: 'この操作は管理者のみ実行できます' };
+  }
+  // セッション由来の tenantId のみ使う (クロステナント設定防止)
+  const tenantId = session.user.tenantId;
+  // テナントを取得してプランが SSO を許可するか確認する (Enterprise のみ)
+  const tenant = await repos.tenants.findById(tenantId);
+  if (!tenant) return { ok: false, error: 'テナント情報の取得に失敗しました' };
+  if (!isSsoAllowed(tenant.subscriptionPlan)) {
+    return { ok: false, error: 'SSO は Enterprise プランでのみ利用できます。' };
+  }
+  // すべて満たしたので tenantId を返す
+  return { ok: true, tenantId };
 }

--- a/src/lib/sso-context.ts
+++ b/src/lib/sso-context.ts
@@ -1,0 +1,36 @@
+// Phase 4 Enterprise: SSO ルート (login / acs) が共通で使う「SSO 有効性チェック」。
+// docs/smb-dx-pivot-plan.md §6.1 Enterprise「SSO(SAML)」。
+//
+// テナントの存在・プラン (Enterprise)・SSO 設定の有無・有効フラグをまとめて検証し、
+// すべて満たすときだけ SAML SP 構築に必要な情報を返す (fail-closed)。
+// いずれかの条件を欠く場合は理由付きで失敗を返し、呼び出し側がエラーリダイレクトに変換する。
+
+// データ層の Composition Root
+import { repos } from '@/data';
+// プラン別の SSO 可否ゲート (Enterprise のみ)
+import { isSsoAllowed } from '@/lib/plan-guard';
+// アプリの公開ベース URL を解決するヘルパー
+import { resolveAppBaseUrl } from '@/lib/app-url';
+// ドメイン型
+import type { Tenant, TenantSsoConfig } from '@/domain/types';
+
+// SSO コンテキストの取得結果 (成功 or 失敗理由つき)
+export type SsoContextResult =
+  | { ok: true; tenant: Tenant; config: TenantSsoConfig; baseUrl: string }
+  | { ok: false; reason: 'not-found' | 'plan' | 'config' | 'disabled' };
+
+// テナントの SSO ログインが利用可能かを検証し、可能なら SP 構築用の情報を返す。
+export async function loadEnabledSsoContext(tenantId: string): Promise<SsoContextResult> {
+  // テナントを取得する (存在しなければ not-found)
+  const tenant = await repos.tenants.findById(tenantId);
+  if (!tenant) return { ok: false, reason: 'not-found' };
+  // Enterprise プランでなければ SSO は使えない (プラン降格後の無効化も含めサーバー側で強制)
+  if (!isSsoAllowed(tenant.subscriptionPlan)) return { ok: false, reason: 'plan' };
+  // テナントの SSO 設定を取得する (未設定なら config)
+  const config = await repos.ssoConfigs.findByTenant(tenantId);
+  if (!config) return { ok: false, reason: 'config' };
+  // 設定はあるが無効化されている場合はログインさせない (fail-closed)
+  if (!config.enabled) return { ok: false, reason: 'disabled' };
+  // すべて満たしたので SP 構築に必要な情報を返す
+  return { ok: true, tenant, config, baseUrl: resolveAppBaseUrl() };
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -65,7 +65,9 @@ export function getStripeWebhookSecret(): string {
 }
 
 // Stripe のサブスクリプション status 文字列を SubscriptionPlan にマップするヘルパー
-// Stripe Webhook の customer.subscription.updated / deleted イベントで使用する
+// Stripe Webhook の customer.subscription.updated / deleted イベントで使用する。
+// 戻り値に 'enterprise' は含めない: Enterprise は個別見積で Stripe チェックアウトを経由せず
+// 運用が手動設定するため、Stripe イベント経由でこのプランへ昇格/降格させることはない。
 export function stripeStatusToPlan(
   status: string,
   priceId: string,

--- a/tests/data/sso-config-repository.contract.prisma.test.ts
+++ b/tests/data/sso-config-repository.contract.prisma.test.ts
@@ -1,0 +1,98 @@
+// SSO 設定リポジトリ (Prisma アダプタ) の契約テスト。
+// クロステナント分離など、本番 Prisma 実装が満たすべき性質を実 DB に対して検証する。
+// docs/smb-dx-pivot-plan.md §6.1 Enterprise「SSO(SAML)」。
+//
+// この DB 依存テストは RUN_PRISMA_CONTRACT=1 のときだけ走り、beforeEach で全テーブルを
+// TRUNCATE するため **開発 DB を指さない** こと (CLAUDE.md §テスト)。
+
+// Vitest の DSL (describe=グループ, beforeAll/afterAll/beforeEach=前後処理, it/expect)
+import { describe, beforeAll, afterAll, beforeEach, expect, it } from 'vitest';
+// Prisma クライアント本体 (生成物。DB へ実際に接続して操作する SDK)
+import { PrismaClient } from '@/generated/prisma';
+// 本番 Prisma 実装の repos 束を組み立てる関数
+import { buildPrismaRepos } from '@/data/adapters/prisma';
+
+// テナント A / B の ID
+const TENANT_A = 'default-tenant';
+const TENANT_B = 'tenant-b';
+
+// この DB 依存テストを実行してよいかどうかの明示フラグ (CI の専用ジョブだけが '1' を立てる)
+const SHOULD_RUN = process.env.RUN_PRISMA_CONTRACT === '1';
+
+// Prisma 実装が SsoConfigRepository 契約を満たすか検証する (フラグが立っているときだけ走る)
+describe.runIf(SHOULD_RUN)('SsoConfigRepository (prisma adapter)', () => {
+  // 後続のテストから参照する PrismaClient
+  let prisma: PrismaClient;
+
+  // スイート開始時に 1 度だけ DB へ接続する
+  beforeAll(async () => {
+    prisma = new PrismaClient();
+    await prisma.$connect();
+  });
+
+  // スイート終了時に接続を確実に閉じる
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  // 各テスト前に全テーブルを空にし、テナント A / B を作成する
+  beforeEach(async () => {
+    // SSO 設定 → Tenant の順に依存するが CASCADE が吸収する。TenantSsoConfig も明示的に含める
+    await prisma.$executeRawUnsafe(
+      'TRUNCATE TABLE "TenantSsoConfig","Attachment","TicketHistory","TicketComment","Notification","FaqCandidate","Ticket","Category","MagicLinkToken","User","Tenant" RESTART IDENTITY CASCADE',
+    );
+    // テナント A / B を作成する
+    await prisma.tenant.create({ data: { id: TENANT_A, name: 'デフォルト組織', mode: 'lite' } });
+    await prisma.tenant.create({ data: { id: TENANT_B, name: '別組織', mode: 'lite' } });
+  });
+
+  // テスト用の SSO 設定入力を作るヘルパー
+  function input(tenantId: string, enabled = true) {
+    return {
+      tenantId,
+      enabled,
+      idpEntityId: `https://idp.example.com/${tenantId}`,
+      idpSsoUrl: 'https://idp.example.com/sso',
+      idpX509Cert: 'MIIBDUMMYCERT',
+    };
+  }
+
+  // upsert で作成し findByTenant で取得できる
+  it('upsert で作成し findByTenant で取得できる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const created = await repos.ssoConfigs.upsert(input(TENANT_A));
+    expect(created.tenantId).toBe(TENANT_A);
+    const found = await repos.ssoConfigs.findByTenant(TENANT_A);
+    expect(found?.idpEntityId).toBe(`https://idp.example.com/${TENANT_A}`);
+  });
+
+  // 同一テナントへの upsert は更新になる (1 テナント 1 設定 = @unique tenantId)
+  it('同一テナントへの upsert は重複作成せず更新になる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const first = await repos.ssoConfigs.upsert(input(TENANT_A, true));
+    const second = await repos.ssoConfigs.upsert(input(TENANT_A, false));
+    // 同一レコードの更新なので ID は不変、値だけ変わる
+    expect(second.id).toBe(first.id);
+    expect(second.enabled).toBe(false);
+  });
+
+  // クロステナント分離: A の設定は B から取得・削除できない
+  it('テナント A の設定はテナント B から取得・削除できない (クロステナント分離)', async () => {
+    const repos = buildPrismaRepos(prisma);
+    // A にだけ設定を作る
+    await repos.ssoConfigs.upsert(input(TENANT_A));
+    // B からは取得できない
+    expect(await repos.ssoConfigs.findByTenant(TENANT_B)).toBeNull();
+    // B の delete は A に影響しない
+    await repos.ssoConfigs.delete(TENANT_B);
+    expect(await repos.ssoConfigs.findByTenant(TENANT_A)).not.toBeNull();
+  });
+
+  // delete で自テナントの設定を削除できる
+  it('delete で自テナントの設定を削除できる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await repos.ssoConfigs.upsert(input(TENANT_A));
+    await repos.ssoConfigs.delete(TENANT_A);
+    expect(await repos.ssoConfigs.findByTenant(TENANT_A)).toBeNull();
+  });
+});

--- a/tests/data/sso-config-repository.memory.test.ts
+++ b/tests/data/sso-config-repository.memory.test.ts
@@ -1,0 +1,91 @@
+// SSO 設定リポジトリ (メモリアダプタ) の単体テスト。
+// upsert / findByTenant / delete が正しく動き、テナント境界を越えないことを確認する。
+// docs/smb-dx-pivot-plan.md §6.1 Enterprise「SSO(SAML)」。
+
+// Vitest の DSL とフック
+import { beforeEach, describe, expect, it } from 'vitest';
+// メモリ context (store/repos)
+import { createMemoryContext } from '@/data/adapters/memory';
+// 型のみ
+import type { Repos } from '@/data/ports/unit-of-work';
+
+// テスト用テナント識別子
+const TENANT_A = 'tenant-a';
+const TENANT_B = 'tenant-b';
+
+// テストごとに作り直す repos
+let repos: Repos;
+
+// SSO 設定の入力サンプルを作るヘルパー
+function sampleInput(tenantId: string, overrides: Partial<{ enabled: boolean; idpEntityId: string }> = {}) {
+  return {
+    tenantId, // 所属テナント
+    enabled: overrides.enabled ?? true, // 既定は有効
+    idpEntityId: overrides.idpEntityId ?? `https://idp.example.com/${tenantId}`, // IdP EntityID
+    idpSsoUrl: 'https://idp.example.com/sso', // IdP SSO URL
+    idpX509Cert: 'MIIBASEBASE64CERT', // 証明書 (テスト用ダミー)
+  };
+}
+
+// SSO 設定リポジトリの仕様確認テスト群
+describe('SsoConfigRepository (memory)', () => {
+  // 各テストの前にメモリ context を作り直す
+  beforeEach(() => {
+    repos = createMemoryContext().repos;
+  });
+
+  // 未設定なら null を返す
+  it('未設定のテナントは findByTenant が null を返す', async () => {
+    expect(await repos.ssoConfigs.findByTenant(TENANT_A)).toBeNull();
+  });
+
+  // upsert が新規作成し、findByTenant で取得できる
+  it('upsert で新規作成し findByTenant で取得できる', async () => {
+    // 新規作成する
+    const created = await repos.ssoConfigs.upsert(sampleInput(TENANT_A));
+    // 作成結果が入力どおりであること
+    expect(created.tenantId).toBe(TENANT_A);
+    expect(created.enabled).toBe(true);
+    expect(created.idpEntityId).toBe(`https://idp.example.com/${TENANT_A}`);
+    // 取得しても同じ内容であること
+    const found = await repos.ssoConfigs.findByTenant(TENANT_A);
+    expect(found?.idpSsoUrl).toBe('https://idp.example.com/sso');
+  });
+
+  // 同一テナントへの upsert は新規作成ではなく更新になる (1 テナント 1 設定)
+  it('同一テナントへの upsert は更新になる (重複作成しない)', async () => {
+    // 1 回目: 有効で作成
+    const first = await repos.ssoConfigs.upsert(sampleInput(TENANT_A, { enabled: true }));
+    // 2 回目: 無効化 + EntityID 変更で更新
+    const second = await repos.ssoConfigs.upsert(
+      sampleInput(TENANT_A, { enabled: false, idpEntityId: 'https://new-idp.example.com' }),
+    );
+    // ID は維持され (同一レコードの更新)、値だけ変わる
+    expect(second.id).toBe(first.id);
+    expect(second.enabled).toBe(false);
+    expect(second.idpEntityId).toBe('https://new-idp.example.com');
+    // 取得結果も更新後の値
+    const found = await repos.ssoConfigs.findByTenant(TENANT_A);
+    expect(found?.enabled).toBe(false);
+  });
+
+  // delete で設定が消える
+  it('delete で設定を削除できる', async () => {
+    // 作成してから削除する
+    await repos.ssoConfigs.upsert(sampleInput(TENANT_A));
+    await repos.ssoConfigs.delete(TENANT_A);
+    // 削除後は null
+    expect(await repos.ssoConfigs.findByTenant(TENANT_A)).toBeNull();
+  });
+
+  // クロステナント分離: テナント A の設定はテナント B から見えない
+  it('テナント A の設定はテナント B から取得できない (クロステナント分離)', async () => {
+    // A にだけ設定を作る
+    await repos.ssoConfigs.upsert(sampleInput(TENANT_A));
+    // B からは取得できない
+    expect(await repos.ssoConfigs.findByTenant(TENANT_B)).toBeNull();
+    // B の delete は A に影響しない
+    await repos.ssoConfigs.delete(TENANT_B);
+    expect(await repos.ssoConfigs.findByTenant(TENANT_A)).not.toBeNull();
+  });
+});

--- a/tests/plan-guard.test.ts
+++ b/tests/plan-guard.test.ts
@@ -1,0 +1,122 @@
+// Vitest のテスト DSL
+import { describe, expect, it } from 'vitest';
+
+// 課金プランの上限・機能フラグ判定ヘルパー (テスト対象)
+import {
+  USER_LIMIT,
+  MONTHLY_TICKET_LIMIT,
+  isEmailInboundAllowed,
+  isAuditLogAllowed,
+  isLineIntegrationAllowed,
+  isProModeAllowed,
+  isSsoAllowed,
+  isUserLimitReached,
+  isMonthlyTicketLimitReached,
+  getUserLimit,
+  getMonthlyTicketLimit,
+} from '../src/lib/plan-guard';
+// プラン型 (網羅性の担保に使う)
+import type { SubscriptionPlan } from '../src/domain/types';
+
+// テスト対象の全プラン (新プラン追加時にここを更新し忘れないよう一覧化)
+const ALL_PLANS: SubscriptionPlan[] = ['free', 'standard', 'pro', 'enterprise'];
+
+// プランごとの上限・機能フラグが仕様 (smb-dx-pivot-plan.md §6.1) どおりかを検証する
+describe('plan-guard: プランごとの上限と機能フラグ', () => {
+  // 全プランが上限テーブルに登録されていること (網羅漏れ検知)
+  it('全プランが USER_LIMIT / MONTHLY_TICKET_LIMIT に存在する', () => {
+    // すべてのプランについてキーが定義されているか確認する
+    for (const plan of ALL_PLANS) {
+      // ユーザー上限が定義されている
+      expect(USER_LIMIT[plan]).toBeDefined();
+      // 月間チケット上限が定義されている
+      expect(MONTHLY_TICKET_LIMIT[plan]).toBeDefined();
+    }
+  });
+
+  // ユーザー上限の具体値 (Free=3, Standard=10, Pro=30, Enterprise=無制限)
+  it('ユーザー上限がプランごとに正しい', () => {
+    expect(USER_LIMIT.free).toBe(3); // Free は 3 名
+    expect(USER_LIMIT.standard).toBe(10); // Standard は 10 名
+    expect(USER_LIMIT.pro).toBe(30); // Pro は 30 名
+    expect(USER_LIMIT.enterprise).toBe(Infinity); // Enterprise は無制限
+  });
+
+  // 月間チケット上限は Free のみ有限、それ以外は無制限
+  it('月間チケット上限は Free のみ 50 件、他は無制限', () => {
+    expect(MONTHLY_TICKET_LIMIT.free).toBe(50); // Free は月 50 件
+    expect(MONTHLY_TICKET_LIMIT.standard).toBe(Infinity); // Standard 無制限
+    expect(MONTHLY_TICKET_LIMIT.pro).toBe(Infinity); // Pro 無制限
+    expect(MONTHLY_TICKET_LIMIT.enterprise).toBe(Infinity); // Enterprise 無制限
+  });
+
+  // メール取り込みは Free 以外で有効
+  it('メール取り込みは Free 以外で有効', () => {
+    expect(isEmailInboundAllowed('free')).toBe(false); // Free は不可
+    expect(isEmailInboundAllowed('standard')).toBe(true); // Standard 可
+    expect(isEmailInboundAllowed('pro')).toBe(true); // Pro 可
+    expect(isEmailInboundAllowed('enterprise')).toBe(true); // Enterprise 可
+  });
+
+  // 監査ログは Pro / Enterprise のみ
+  it('監査ログは Pro / Enterprise のみ', () => {
+    expect(isAuditLogAllowed('free')).toBe(false); // Free 不可
+    expect(isAuditLogAllowed('standard')).toBe(false); // Standard 不可
+    expect(isAuditLogAllowed('pro')).toBe(true); // Pro 可
+    expect(isAuditLogAllowed('enterprise')).toBe(true); // Enterprise 可
+  });
+
+  // LINE 連携は Pro / Enterprise のみ
+  it('LINE 連携は Pro / Enterprise のみ', () => {
+    expect(isLineIntegrationAllowed('free')).toBe(false); // Free 不可
+    expect(isLineIntegrationAllowed('standard')).toBe(false); // Standard 不可
+    expect(isLineIntegrationAllowed('pro')).toBe(true); // Pro 可
+    expect(isLineIntegrationAllowed('enterprise')).toBe(true); // Enterprise 可
+  });
+
+  // Pro モードは Pro / Enterprise のみ
+  it('Pro モードは Pro / Enterprise のみ', () => {
+    expect(isProModeAllowed('free')).toBe(false); // Free 不可
+    expect(isProModeAllowed('standard')).toBe(false); // Standard 不可
+    expect(isProModeAllowed('pro')).toBe(true); // Pro 可
+    expect(isProModeAllowed('enterprise')).toBe(true); // Enterprise 可
+  });
+
+  // SSO (SAML) は Enterprise のみ
+  it('SSO は Enterprise のみ許可', () => {
+    expect(isSsoAllowed('free')).toBe(false); // Free 不可
+    expect(isSsoAllowed('standard')).toBe(false); // Standard 不可
+    expect(isSsoAllowed('pro')).toBe(false); // Pro 不可
+    expect(isSsoAllowed('enterprise')).toBe(true); // Enterprise のみ可
+  });
+});
+
+// 上限到達判定と UI 表示用ヘルパーの境界値を検証する
+describe('plan-guard: 上限到達判定と表示ヘルパー', () => {
+  // ユーザー数が上限と同数なら到達 (>= 判定の境界)
+  it('isUserLimitReached は上限と同数で true', () => {
+    expect(isUserLimitReached('free', 2)).toBe(false); // 2 < 3 は未到達
+    expect(isUserLimitReached('free', 3)).toBe(true); // 3 >= 3 は到達
+  });
+
+  // Enterprise は無制限なのでどれだけ増えても到達しない
+  it('Enterprise はユーザー上限に到達しない', () => {
+    expect(isUserLimitReached('enterprise', 100000)).toBe(false); // 無制限
+  });
+
+  // 月間チケット上限: Free のみ到達し得る、無制限プランは常に false
+  it('isMonthlyTicketLimitReached は無制限プランで常に false', () => {
+    expect(isMonthlyTicketLimitReached('free', 50)).toBe(true); // 50 >= 50 到達
+    expect(isMonthlyTicketLimitReached('free', 49)).toBe(false); // 49 < 50 未到達
+    expect(isMonthlyTicketLimitReached('pro', 999999)).toBe(false); // 無制限
+    expect(isMonthlyTicketLimitReached('enterprise', 999999)).toBe(false); // 無制限
+  });
+
+  // 表示用ヘルパーは無制限を -1 で返す (UI は -1 を「無制限」と解釈する規約)
+  it('getUserLimit / getMonthlyTicketLimit は無制限を -1 で返す', () => {
+    expect(getUserLimit('pro')).toBe(30); // 有限はそのまま
+    expect(getUserLimit('enterprise')).toBe(-1); // 無制限は -1
+    expect(getMonthlyTicketLimit('free')).toBe(50); // 有限はそのまま
+    expect(getMonthlyTicketLimit('enterprise')).toBe(-1); // 無制限は -1
+  });
+});

--- a/tests/saml.test.ts
+++ b/tests/saml.test.ts
@@ -1,0 +1,252 @@
+// Vitest のテスト DSL
+import { beforeAll, describe, expect, it } from 'vitest';
+// 子プロセスで openssl を呼ぶ (テスト用の使い捨て鍵/証明書を生成する)
+import { execFileSync } from 'node:child_process';
+// 一時ディレクトリ・ファイル操作
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+// XML 署名 (テスト内で IdP の署名付き応答を作るために使用。node-saml の依存に含まれる)
+import { SignedXml } from 'xml-crypto';
+
+// テスト対象: SAML SP コア
+import {
+  buildSpUrls,
+  buildSpMetadataXml,
+  createSamlInstance,
+  validateSamlResponse,
+} from '../src/lib/saml';
+// プラン別 SSO ゲート (Enterprise のみ許可)
+import { isSsoAllowed } from '../src/lib/plan-guard';
+// SSO 設定ドメイン型
+import type { TenantSsoConfig } from '../src/domain/types';
+
+// テストで使う固定値
+const BASE_URL = 'https://app.example.com';
+const TENANT_ID = 't-test';
+const IDP_ENTITY_ID = 'https://idp.example.com/entity';
+// SP の URL 群 (Audience / Destination の期待値に使う)
+const SP = buildSpUrls(BASE_URL, TENANT_ID);
+
+// openssl が使えるかを判定する (使えない環境では署名付きテストをスキップする)
+function opensslAvailable(): boolean {
+  try {
+    // バージョン表示が通れば利用可能
+    execFileSync('openssl', ['version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// テスト用の鍵・証明書 (beforeAll で生成)
+let privateKey = '';
+let certPem = '';
+let certB64 = '';
+// 別 IdP を模した 2 つめの証明書 (署名鍵が異なるため検証失敗を確認するのに使う)
+let otherCertB64 = '';
+const hasOpenssl = opensslAvailable();
+
+// openssl で RSA 鍵 + 自己署名証明書を 1 組生成し PEM とプロパティを返す
+function generateKeyPair(): { key: string; certPem: string; certB64: string } {
+  // 一時ディレクトリに鍵と証明書を作る
+  const dir = mkdtempSync(join(tmpdir(), 'saml-test-'));
+  try {
+    execFileSync(
+      'openssl',
+      ['req', '-x509', '-newkey', 'rsa:2048', '-keyout', join(dir, 'k.pem'), '-out', join(dir, 'c.pem'), '-days', '2', '-nodes', '-subj', '/CN=test-idp'],
+      { stdio: 'ignore' },
+    );
+    // 生成物を読み込む
+    const key = readFileSync(join(dir, 'k.pem'), 'utf8');
+    const pem = readFileSync(join(dir, 'c.pem'), 'utf8');
+    // 証明書の base64 本体 (設定に格納する形式) を作る
+    const b64 = pem.replace(/-----[^-]+-----/g, '').replace(/\s+/g, '');
+    return { key, certPem: pem, certB64: b64 };
+  } finally {
+    // 一時ディレクトリを掃除する
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// 署名付き SAML Response を組み立てるオプション
+interface ResponseOptions {
+  email?: string; // NameID に入れるメール
+  audience?: string; // Audience (既定は SP EntityID)
+  issuer?: string; // Issuer (既定は IdP EntityID)
+  notOnOrAfter?: string; // 条件の失効時刻 ISO 文字列 (既定は 5 分後)
+  tamperAfterSign?: boolean; // 署名後に本文を改竄するか
+}
+
+// 指定オプションで署名付き SAML Response を生成し base64 で返す純粋ヘルパー
+function makeSignedResponse(opts: ResponseOptions = {}): string {
+  // 各値の既定を埋める
+  const email = opts.email ?? 'user@example.com';
+  const audience = opts.audience ?? SP.entityId;
+  const issuer = opts.issuer ?? IDP_ENTITY_ID;
+  const now = Date.now();
+  const issueInstant = new Date(now).toISOString();
+  const notOnOrAfter = opts.notOnOrAfter ?? new Date(now + 5 * 60 * 1000).toISOString();
+  // Assertion 本体 (Subject/Conditions/AuthnStatement を含む)
+  const assertion =
+    `<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_a1" Version="2.0" IssueInstant="${issueInstant}">` +
+    `<saml:Issuer>${issuer}</saml:Issuer>` +
+    `<saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">${email}</saml:NameID>` +
+    `<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">` +
+    `<saml:SubjectConfirmationData Recipient="${SP.acsUrl}" NotOnOrAfter="${notOnOrAfter}"/></saml:SubjectConfirmation></saml:Subject>` +
+    `<saml:Conditions NotBefore="${issueInstant}" NotOnOrAfter="${notOnOrAfter}">` +
+    `<saml:AudienceRestriction><saml:Audience>${audience}</saml:Audience></saml:AudienceRestriction></saml:Conditions>` +
+    `<saml:AuthnStatement AuthnInstant="${issueInstant}"><saml:AuthnContext>` +
+    `<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>` +
+    `</saml:AuthnContext></saml:AuthnStatement></saml:Assertion>`;
+  // Response でラップする
+  const responseXml =
+    `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_r1" Version="2.0" IssueInstant="${issueInstant}" Destination="${SP.acsUrl}">` +
+    `<saml:Issuer>${issuer}</saml:Issuer>` +
+    `<samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>` +
+    `${assertion}</samlp:Response>`;
+  // Assertion 要素に enveloped 署名を付与する
+  const sig = new SignedXml({ privateKey, publicCert: certPem });
+  sig.addReference({
+    xpath: `//*[local-name(.)='Assertion']`,
+    transforms: [
+      'http://www.w3.org/2000/09/xmldsig#enveloped-signature',
+      'http://www.w3.org/2001/10/xml-exc-c14n#',
+    ],
+    digestAlgorithm: 'http://www.w3.org/2001/04/xmlenc#sha256',
+  });
+  sig.signatureAlgorithm = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
+  sig.canonicalizationAlgorithm = 'http://www.w3.org/2001/10/xml-exc-c14n#';
+  // 署名は Assertion の Issuer の直後に挿入する
+  sig.computeSignature(responseXml, {
+    location: { reference: `//*[local-name(.)='Assertion']/*[local-name(.)='Issuer']`, action: 'after' },
+  });
+  let signed = sig.getSignedXml();
+  // 署名後に本文を改竄する (署名検証が失敗することを確認するため)
+  if (opts.tamperAfterSign) {
+    signed = signed.replace(email, 'attacker@evil.com');
+  }
+  // base64 にして返す (POST バインディングの SAMLResponse 形式)
+  return Buffer.from(signed).toString('base64');
+}
+
+// テスト用の SSO 設定を組み立てるヘルパー
+function makeConfig(overrides: Partial<TenantSsoConfig> = {}): TenantSsoConfig {
+  return {
+    id: 'cfg1',
+    tenantId: TENANT_ID,
+    enabled: true,
+    idpEntityId: IDP_ENTITY_ID,
+    idpSsoUrl: 'https://idp.example.com/sso',
+    idpX509Cert: certB64,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+// テスト開始前に使い捨て鍵/証明書を 2 組生成する (本物の IdP と別 IdP)
+beforeAll(() => {
+  // openssl が無ければスキップ (署名付きテストは下で個別に skip 判定)
+  if (!hasOpenssl) return;
+  // 1 組目: 設定に登録する正規の IdP 証明書
+  const primary = generateKeyPair();
+  privateKey = primary.key;
+  certPem = primary.certPem;
+  certB64 = primary.certB64;
+  // 2 組目: 署名鍵が異なる別証明書 (証明書不一致の検証に使う)
+  otherCertB64 = generateKeyPair().certB64;
+});
+
+// プランゲート (純粋・openssl 不要)
+describe('SSO プランゲート', () => {
+  // Enterprise のみ SSO を許可する
+  it('isSsoAllowed は Enterprise のみ true', () => {
+    expect(isSsoAllowed('enterprise')).toBe(true); // Enterprise 可
+    expect(isSsoAllowed('pro')).toBe(false); // Pro 不可
+    expect(isSsoAllowed('free')).toBe(false); // Free 不可
+  });
+});
+
+// SP メタデータ (純粋・openssl 不要)
+describe('SP メタデータ生成', () => {
+  // entityID と ACS URL が含まれること
+  it('EntityDescriptor に EntityID と ACS URL を含む', () => {
+    const xml = buildSpMetadataXml(BASE_URL, TENANT_ID);
+    expect(xml).toContain(`entityID="${SP.entityId}"`); // SP の EntityID
+    expect(xml).toContain(SP.acsUrl); // ACS の Location
+    expect(xml).toContain('WantAssertionsSigned="true"'); // アサーション署名必須を宣言
+  });
+});
+
+// 署名検証 (openssl が必要なので無い環境ではスキップ)
+describe.skipIf(!hasOpenssl)('SAML アサーション検証', () => {
+  // 正常系: 正しく署名された応答から本人メールを取り出せる
+  it('正しい署名・Issuer・Audience の応答を受理しメールを取り出す', async () => {
+    const saml = createSamlInstance(makeConfig(), BASE_URL, TENANT_ID);
+    const identity = await validateSamlResponse(saml, makeSignedResponse(), IDP_ENTITY_ID);
+    expect(identity.email).toBe('user@example.com'); // 検証済みメール
+  });
+
+  // メールは小文字化される
+  it('メールアドレスを小文字に正規化する', async () => {
+    const saml = createSamlInstance(makeConfig(), BASE_URL, TENANT_ID);
+    const identity = await validateSamlResponse(saml, makeSignedResponse({ email: 'User@Example.com' }), IDP_ENTITY_ID);
+    expect(identity.email).toBe('user@example.com'); // 小文字化
+  });
+
+  // 異常系: 署名後に本文を改竄すると拒否される
+  it('署名後に改竄された応答を拒否する', async () => {
+    const saml = createSamlInstance(makeConfig(), BASE_URL, TENANT_ID);
+    await expect(
+      validateSamlResponse(saml, makeSignedResponse({ tamperAfterSign: true }), IDP_ENTITY_ID),
+    ).rejects.toThrow();
+  });
+
+  // 異常系: Audience が別 SP 宛だと拒否される
+  it('Audience が一致しない応答を拒否する (別 SP 宛)', async () => {
+    const saml = createSamlInstance(makeConfig(), BASE_URL, TENANT_ID);
+    await expect(
+      validateSamlResponse(saml, makeSignedResponse({ audience: 'https://other-sp.example.com' }), IDP_ENTITY_ID),
+    ).rejects.toThrow();
+  });
+
+  // 異常系: Issuer が設定の IdP と異なると拒否される (別 IdP のなりすまし)
+  it('Issuer が設定の IdP と異なる応答を拒否する', async () => {
+    const saml = createSamlInstance(makeConfig(), BASE_URL, TENANT_ID);
+    await expect(
+      validateSamlResponse(saml, makeSignedResponse({ issuer: 'https://evil-idp.example.com' }), IDP_ENTITY_ID),
+    ).rejects.toThrow();
+  });
+
+  // 異常系: 期限切れ (NotOnOrAfter が過去) の応答を拒否する
+  it('期限切れの応答を拒否する', async () => {
+    const saml = createSamlInstance(makeConfig(), BASE_URL, TENANT_ID);
+    // 10 分前に失効した条件を持つ応答を作る
+    const expired = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    await expect(
+      validateSamlResponse(saml, makeSignedResponse({ notOnOrAfter: expired }), IDP_ENTITY_ID),
+    ).rejects.toThrow();
+  });
+
+  // 異常系: 別の鍵で署名された (証明書が一致しない) 応答を拒否する
+  it('設定の証明書と一致しない署名を拒否する', async () => {
+    // idpX509Cert を「別 IdP の証明書 (署名鍵が異なる)」に差し替える。
+    // 応答は正規の鍵 (key1) で署名されているため、別証明書の公開鍵では検証に失敗する。
+    const wrongConfig = makeConfig({ idpX509Cert: otherCertB64 });
+    const saml = createSamlInstance(wrongConfig, BASE_URL, TENANT_ID);
+    await expect(validateSamlResponse(saml, makeSignedResponse(), IDP_ENTITY_ID)).rejects.toThrow();
+  });
+});
+
+// 設定不備のガード (純粋・openssl 不要だが証明書が要るものは skip)
+describe('SSO 設定の不備ガード', () => {
+  // 証明書が空の設定は SAML 構築時に弾かれる
+  it('証明書が空の設定は createSamlInstance が例外を投げる', () => {
+    expect(() => createSamlInstance(makeConfig({ idpX509Cert: '   ' }), BASE_URL, TENANT_ID)).toThrow();
+  });
+  // IdP SSO URL が空の設定も弾かれる
+  it('IdP SSO URL が空の設定は例外を投げる', () => {
+    expect(() => createSamlInstance(makeConfig({ idpSsoUrl: '' }), BASE_URL, TENANT_ID)).toThrow();
+  });
+});


### PR DESCRIPTION
## 背景

`docs/smb-dx-pivot-plan.md` で `[x]` 済みだが実態が無かった 2 項目を検証・実装する。

| 項目 | 検証結果 |
| --- | --- |
| バックアップ自動化（Phase 4） | 監査ログは実装済みだが、バックアップは `audit/page.tsx` のコメント文字列のみ。スクリプト・CI・cron いずれも無し → **未実装を確認** |
| Enterprise プラン / SSO(SAML)（§6.1） | `SubscriptionPlan` は `free/standard/pro` のみ。SSO コードはゼロ → **未実装を確認** |

## 実装（3 コミット）

### 1. `feat(ops)` PostgreSQL バックアップ自動化
- `scripts/backup-db.sh`（pg_dump custom 形式 + 保持日数による世代管理、fail-closed、秘密情報非ログ、pg_dump 失敗時の部分ファイル後始末）/ `scripts/restore-db.sh`
- スケジュール CI `.github/workflows/backup.yml`（毎日 cron + 手動。`BACKUP_DATABASE_URL` 未設定なら no-op、ダンプは artifact 7日保持）
- `ci.yml` に shellcheck ジョブ追加、`db:backup`/`db:restore` npm スクリプト、`docs/backup.md`
- **ephemeral PostgreSQL で backup→restore（行一致）→prune を end-to-end 検証済み**

### 2. `feat(billing)` Enterprise プラン階層
- `SubscriptionPlan` に `enterprise` 追加（型 / Prisma enum / migration）
- `plan-guard`: enterprise は無制限。監査ログ・LINE・Pro モードを `pro|enterprise` に拡張、`isSsoAllowed`（enterprise のみ）新設
- `create-checkout-session`: enterprise は個別見積のため明示拒否（Pro 価格への誤フォールバックを防止）
- `BillingSection`: Enterprise カード追加、Pro ボタン表示条件を `free|standard` に限定（誤ダウングレード排除）

### 3. `feat(sso)` Enterprise 向け SAML SSO
- **データ層**: `TenantSsoConfig`（1テナント1設定）+ port/prisma/memory アダプタ
- **コア** `src/lib/saml.ts`: `@node-saml/node-saml` に署名検証を委譲。アサーション署名必須・Audience 固定・**Issuer 一致を多層防御で明示検証**・SP メタデータは純粋関数で生成
- **エンドポイント** `/api/auth/sso/<tenantId>/{login,acs,metadata}`（Node ランタイム、Enterprise + 有効フラグを fail-closed 強制）
  - ACS は本人メールが「その tenantId のユーザー」であることを必須化（**クロステナント防止・JIT 無効**）。セッション発行は実績あるマジックリンク経路を再利用
- **UI**: 設定ページに SSO セクション（Enterprise のみ）+ upsert/delete アクション（X509 を `node:crypto` でパース検証）
- login ページに SSO エラーの日本語メッセージ

## テスト / 検証

- `tests/saml.test.ts`（11 件）: 正常系 + **改竄・Audience/Issuer 不一致・期限切れ・別証明書をすべて拒否**（fixture 署名、openssl で使い捨て鍵生成）
- `tests/plan-guard.test.ts`（12 件）/ `tests/data/sso-config-repository.memory.test.ts`（5 件、クロステナント分離）
- ローカル: **lint ✅ / typecheck ✅ / 343 ユニットテスト ✅ / `next build` ✅ / `migrate deploy` ✅**

## セキュリティ上の注意

- SSO は完全に**追加的**で既存認証（パスワード / マジックリンク）に非侵襲。Enterprise プラン **かつ** テナント単位の有効フラグでのみ作動（既定は無効）
- 署名・暗号処理は自前実装せず実績ライブラリに委譲（§9 準拠）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcbVsvr9vGRHUSBnmZPg5K)_