### PR TITLE
docs(inbound): 陳腐化した DKIM/SPF コメントを更新

### DIFF
--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -123,7 +123,8 @@ async function readInboundFields(req: Request): Promise<InboundFields> {
     const rawHeaders = str(form.get('headers'));
     // 宛先 (ルーティング): envelope の RCPT を優先する (ヘッダ To より実配送先として確実)。
     // 送信者 (本人特定): ヘッダ From を優先する (人間が送った差出人。envelope from=MAIL FROM は
-    // 戻り先で本人性が弱い)。いずれも DKIM/SPF 検証は将来課題で、現状は既知メンバー判定で守る。
+    // 戻り先で本人性が弱い)。本人性は既知メンバー判定に加え、INBOUND_EMAIL_AUTH=enforce のとき
+    // 下流で SPF/DKIM/DMARC の明示 fail を隔離して守る (#147 で実装)。
     return {
       to: envTo ?? str(form.get('to')),
       from: str(form.get('from')) ?? envFrom,


### PR DESCRIPTION
## 背景
`src/app/api/inbound/email/route.ts` L126 に「DKIM/SPF 検証は将来課題」とする陳腐化コメントが残存していた。#147 で SPF/DKIM/DMARC 送信元認証を実装済みのため、実態に合わせて更新する。

## 変更
- 当該コメントを「本人性は既知メンバー判定に加え、`INBOUND_EMAIL_AUTH=enforce` のとき下流で SPF/DKIM/DMARC の明示 fail を隔離して守る（#147 で実装）」に更新。
- 他に同種の陳腐化コメント（「将来課題/未実装」）が残っていないことを grep で確認済み。

**コメントのみの変更**（ロジック差分なし）。typecheck / lint 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcbVsvr9vGRHUSBnmZPg5K)_