### PR TITLE
feat(api): メール起票時に受領自動返信を送る (メンバー改善 #1)

### DIFF
--- a/src/app/(app)/tickets/[id]/page.tsx
+++ b/src/app/(app)/tickets/[id]/page.tsx
@@ -18,6 +18,8 @@ import {
 } from '@/lib/constants';
 // 現在ログイン中のテナントの動作モード (lite | pro) を取得するヘルパー
 import { getCurrentTenantMode } from '@/lib/tenant';
+// チケットの短縮参照番号 (受付番号) を組み立てる共有ヘルパー (メールの受領自動返信と同じ表記)
+import { formatTicketRef } from '@/lib/ticket-ref';
 // 日本時間 (Asia/Tokyo) で日付・日時を文字列化するユーティリティ
 import { formatDateJP, formatDateTimeJP } from '@/lib/format-date';
 // ステータス変更プルダウン
@@ -87,7 +89,7 @@ export default async function TicketDetailPage({ params }: Props) {
     <div className="mx-auto max-w-4xl space-y-6">
       {/* タイトル領域 (短縮 ID + 件名) */}
       <div>
-        <p className="text-sm text-gray-500">#{ticket.id.slice(0, 8)}</p>
+        <p className="text-sm text-gray-500">{formatTicketRef(ticket.id)}</p>
         <h1 className="mt-1 text-2xl font-bold text-gray-900">{ticket.title}</h1>
       </div>
 
@@ -98,7 +100,7 @@ export default async function TicketDetailPage({ params }: Props) {
           {/* 問い合わせ本文 */}
           <section className="rounded-lg bg-white p-5 shadow-sm">
             <h2 className="mb-3 text-sm font-semibold text-gray-500">問い合わせ内容</h2>
-            <p className="whitespace-pre-wrap text-sm text-gray-800">{ticket.body}</p>
+            <p className="text-sm whitespace-pre-wrap text-gray-800">{ticket.body}</p>
             {/* チケット本体に直接添付された画像のサムネ一覧 (0 件なら描画しない) */}
             {ticket.attachments.length > 0 && (
               <div className="mt-4">
@@ -128,7 +130,7 @@ export default async function TicketDetailPage({ params }: Props) {
                         {formatDateTimeJP(c.createdAt)}
                       </span>
                     </div>
-                    <p className="whitespace-pre-wrap text-sm text-gray-700">{c.body}</p>
+                    <p className="text-sm whitespace-pre-wrap text-gray-700">{c.body}</p>
                     {/* コメントに紐づく添付があれば直下にサムネを描画する */}
                     {c.attachments.length > 0 && (
                       <div className="mt-2">

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -41,6 +41,14 @@ import { isAgent } from '@/lib/role';
 import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
 // 優先度から解決期限を計算する SLA ヘルパー (Web フォーム起票と同じ既定値に揃える)
 import { calculateResolutionDueAt } from '@/lib/sla';
+// 受領自動返信 (メンバー改善 #1) のための送信基盤・本文生成・リンク組み立てヘルパー
+import { getEmailSender } from '@/lib/email';
+import { renderTicketReceivedEmail, buildTicketUrl } from '@/lib/ticket-email';
+import { resolveAppBaseUrl } from '@/lib/app-url';
+// 受領メールに付ける決定的 Message-ID (依頼者が受領メールに返信したら同じチケットへ追記できるようにする)
+import { buildReplyMessageId, resolveMessageIdDomain } from '@/lib/email-message-id';
+// 受付番号 (短縮 ID) の共有フォーマッタ (画面のチケット詳細ヘッダと同じ表記)
+import { formatTicketRef } from '@/lib/ticket-ref';
 
 // このルートは Node ランタイムで動かす (node:crypto / Prisma を使うため Edge では動かない)
 export const runtime = 'nodejs';
@@ -85,6 +93,8 @@ interface InboundFields {
   spf?: string | null; // 送信元認証: SPF 結果 (プロバイダ算出。SendGrid の "SPF" フィールド等)
   dkim?: string | null; // 送信元認証: DKIM 結果 (プロバイダ算出。SendGrid の "dkim" フィールド等)
   authenticationResults?: string | null; // 送信元認証: 生 Authentication-Results ヘッダ (汎用)
+  autoSubmitted?: string | null; // RFC 3834 の Auto-Submitted ヘッダ (自動応答メール判定 = ループ防止)
+  precedence?: string | null; // Precedence ヘッダ (bulk/list/junk なら自動配信・メーリングリスト判定)
 }
 
 // 受信メール 1 通分のフィールドを、JSON / multipart のどちらのボディからでも取り出して共通形に揃える。
@@ -138,6 +148,9 @@ async function readInboundFields(req: Request): Promise<InboundFields> {
       spf: str(form.get('SPF')) ?? str(form.get('spf')),
       dkim: str(form.get('dkim')),
       authenticationResults: readRawHeader(rawHeaders, 'Authentication-Results'),
+      // 自動応答判定用ヘッダ (multipart では生ヘッダから読む。ループ防止に使う)
+      autoSubmitted: readRawHeader(rawHeaders, 'Auto-Submitted'),
+      precedence: readRawHeader(rawHeaders, 'Precedence'),
     };
   }
   // それ以外は JSON ボディとして読む (テスト・自前連携向け)
@@ -158,7 +171,68 @@ async function readInboundFields(req: Request): Promise<InboundFields> {
     spf: pick('SPF') ?? pick('spf'),
     dkim: pick('dkim'),
     authenticationResults: pick('authenticationResults') ?? pick('authentication-results'),
+    // 自動応答判定用ヘッダ (camelCase / ヘッダ表記の両方を受ける)
+    autoSubmitted: pick('autoSubmitted') ?? pick('auto-submitted'),
+    precedence: pick('precedence') ?? pick('Precedence'),
   };
+}
+
+// 受信メールが「自動配信メール」かどうかを判定する (受領自動返信のループ防止 §9 fail-safe)。
+// 自動応答や配信専用 (no-reply) 宛に受領メールを返すと、相手も自動返信して無限ループ (メールストーム)
+// になりうるため、自動配信と分かるメールには受領返信を送らない。
+function isAutomatedEmail(fields: InboundFields): boolean {
+  // RFC 3834: Auto-Submitted が "no" 以外 (auto-generated / auto-replied 等) なら自動応答メール
+  const autoSubmitted = (fields.autoSubmitted ?? '').trim().toLowerCase();
+  if (autoSubmitted && autoSubmitted !== 'no') return true;
+  // Precedence が bulk / list / junk はメーリングリストや一斉配信なので自動返信しない
+  const precedence = (fields.precedence ?? '').trim().toLowerCase();
+  if (precedence === 'bulk' || precedence === 'list' || precedence === 'junk') return true;
+  // いずれにも該当しなければ通常の人手メールとみなす
+  return false;
+}
+
+// 初回メール起票の受領自動返信を 1 通送る (メンバー改善 #1)。ベストエフォート: 送信失敗で 500 を返すと
+// プロバイダ再送 → 二重起票になりかねないため、例外は握ってログに残す (副作用は send と Message-ID 登録のみ)。
+async function sendReceivedAck(args: {
+  to: string; // 送信元 (= 既知メンバー) のメールアドレス
+  ticketId: string; // 作成されたチケット ID (受付番号・URL 構築用)
+  ticketTitle: string; // チケット件名 (メール本文用)
+  tenantId: string; // テナント (Message-ID 対応表のスコープ)
+}): Promise<void> {
+  const { to, ticketId, ticketTitle, tenantId } = args;
+  try {
+    // メール内リンクのベース URL を解決 (production で NEXTAUTH_URL 未設定なら throw → 下で握る)
+    const baseUrl = resolveAppBaseUrl();
+    // チケット詳細ページへの導線 URL を組み立てる
+    const ticketUrl = buildTicketUrl(baseUrl, ticketId);
+    // 件名 / 本文 (Text / HTML) を純粋ヘルパーで構築 (受付番号は画面と同じ短縮 ID 表記)
+    const { subject, text, html } = renderTicketReceivedEmail({
+      ticketTitle,
+      ticketRef: formatTicketRef(ticketId),
+      ticketUrl,
+    });
+    // 受領メールに決定的 Message-ID を付与し、依頼者がこの受領メールに返信したら In-Reply-To 経由で
+    // 同じチケットへ追記できるよう、返信メールと同じ仕組みで対応表へ先に登録する (冪等)
+    const ackMessageId = buildReplyMessageId(ticketId, resolveMessageIdDomain());
+    await repos.emailThreads.register({
+      messageId: ackMessageId.normalized, // 山括弧なしの正規化値 (受信側の表記と一致)
+      ticketId,
+      tenantId,
+    });
+    // 設定された EmailSender (console / smtp) 経由で送信。Auto-Submitted で相手の自動返信ループを防ぐ
+    await getEmailSender().send({
+      to,
+      subject,
+      text,
+      html,
+      messageId: ackMessageId.header,
+      // RFC 3834: このメール自身が自動応答であることを示し、相手サーバの自動返信を抑止する
+      headers: { 'Auto-Submitted': 'auto-replied' },
+    });
+  } catch (err) {
+    // 送信失敗はサーバログに残すだけ (チケットは既に作成済みで、起票自体は成功扱いにする)
+    console.error('[POST /api/inbound/email] 受領自動返信メールの送信に失敗しました', err);
+  }
 }
 
 // POST /api/inbound/email : 受信メールを 1 件の問い合わせに変換する
@@ -378,6 +452,19 @@ export async function POST(req: Request) {
     } catch (err) {
       console.warn('[POST /api/inbound/email] failed to register inbound message id', err);
     }
+  }
+
+  // 初回メール起票の受領自動返信 (メンバー改善 #1): 送信元へ「受け付けました」を 1 通返す。
+  // Web フォーム起票は送信後すぐ画面に出るが、メール起票は受領確認が無いと「届いたか不明」になる穴を埋める。
+  // 自動配信メール (Auto-Submitted / Precedence: bulk 等) には返信しない (メールループ防止 §9 fail-safe)。
+  // スレッド追記・重複再送のパスは上で return 済みなので、ここに来るのは「新規起票」だけ。
+  if (!isAutomatedEmail(fields)) {
+    await sendReceivedAck({
+      to: sender.email,
+      ticketId: ticket.id,
+      ticketTitle: email.subject,
+      tenantId: tenant.id,
+    });
   }
 
   // 作成された問い合わせ ID を 201 で返す (プロバイダは本文を使わないが疎通確認に役立つ)

--- a/src/lib/email/email-sender.ts
+++ b/src/lib/email/email-sender.ts
@@ -17,6 +17,9 @@ export interface EmailMessage {
   // Phase 2 スレッド継続で、依頼者がこのメールに返信したとき In-Reply-To で元チケットへ
   // 紐付けられるよう、呼び出し側が決定的な Message-ID を指定して送る。未指定なら送信側に委ねる。
   messageId?: string;
+  // 任意: 追加で付与するメールヘッダ。自動応答メール (受領自動返信) に
+  // `Auto-Submitted: auto-replied` を付け、相手サーバの自動返信ループ (メールストーム) を防ぐ等に使う。
+  headers?: Record<string, string>;
 }
 
 // 任意のトランスポート (Console / Nodemailer SMTP / 将来の SES など) を抽象化する契約

--- a/src/lib/email/nodemailer-email-sender.ts
+++ b/src/lib/email/nodemailer-email-sender.ts
@@ -56,6 +56,8 @@ export function createNodemailerEmailSender(config: NodemailerEmailSenderConfig)
         html: message.html,
         // 指定があれば Message-ID を明示する (スレッド継続の紐付けに使う)。未指定なら nodemailer が自動採番
         messageId: message.messageId,
+        // 任意の追加ヘッダ (例: Auto-Submitted: auto-replied) をそのまま付与する。未指定なら付けない
+        headers: message.headers,
       });
     },
   };

--- a/src/lib/ticket-email.ts
+++ b/src/lib/ticket-email.ts
@@ -42,7 +42,9 @@ export function renderTicketReplyEmail(input: {
   agentName: string; // 返信した担当者の表示名
 }): { subject: string; text: string; html: string } {
   // 件名: 接頭辞 + 件名規約。ユーザー入力をサニタイズしてヘッダインジェクションを防ぐ
-  const subject = sanitizeSubject(`${SUBJECT_PREFIX} 問い合わせ「${input.ticketTitle}」に新しい返信があります`);
+  const subject = sanitizeSubject(
+    `${SUBJECT_PREFIX} 問い合わせ「${input.ticketTitle}」に新しい返信があります`,
+  );
 
   // テキスト本文 (HTML 非対応クライアント向けフォールバック)
   const text = [
@@ -78,6 +80,57 @@ export function renderTicketReplyEmail(input: {
   return { subject, text, html };
 }
 
+// 初回メール起票の受領自動返信メール本文を生成する純粋関数 (副作用なし)
+// メンバー改善 #1 / Phase 2「依頼者がアプリにログインしなくても完結」(docs/smb-dx-pivot-plan.md §4 Phase 2)。
+// Web フォーム起票は送信後すぐ画面に出るが、メール起票は受領確認が無いと「届いたか不明」になるため、
+// 起票成功時に「受け付けました」を 1 通だけ返して不安を解消する。
+export function renderTicketReceivedEmail(input: {
+  ticketTitle: string; // 問い合わせの件名
+  ticketRef: string; // 受付番号 (例: "#ab12cd34" / 画面の短縮 ID と同じ表記)
+  ticketUrl: string; // チケット詳細ページの URL
+}): { subject: string; text: string; html: string } {
+  // 件名: 接頭辞 + 受付番号 + 件名。受信箱で「受け付けられた」ことと対象がすぐ分かるようにする。
+  // ヘッダインジェクション防止のためサニタイズする
+  const subject = sanitizeSubject(
+    `${SUBJECT_PREFIX} お問い合わせを受け付けました（${input.ticketRef}）「${input.ticketTitle}」`,
+  );
+
+  // テキスト本文 (HTML 非対応クライアント向けフォールバック)
+  const text = [
+    'お問い合わせを受け付けました。担当者が確認のうえご連絡します。',
+    '',
+    `受付番号: ${input.ticketRef}`,
+    `件名: ${input.ticketTitle}`,
+    '',
+    '対応状況の確認や追加の連絡は、下のリンクから行えます。',
+    `${input.ticketUrl}`,
+    '',
+    'このメールにそのまま返信すると、お問い合わせへの追記として担当者に届きます。',
+    'お心当たりがない場合は破棄してください。',
+  ].join('\n');
+
+  // HTML 本文に差し込む外部由来文字列を個別にエスケープする (XSS / 文面崩れ防止)
+  const escapedTitle = escapeHtml(input.ticketTitle);
+  const escapedRef = escapeHtml(input.ticketRef);
+  const escapedUrl = escapeHtml(input.ticketUrl);
+
+  // HTML 本文 (受付番号と件名を示し、続きはボタンでアプリへ誘導する)
+  const html = `
+    <p>お問い合わせを受け付けました。担当者が確認のうえご連絡します。</p>
+    <blockquote style="margin:0 0 16px;padding:12px 16px;border-left:4px solid #0f766e;background:#f1f5f9;color:#0f172a;">
+      受付番号: <strong>${escapedRef}</strong><br>
+      件名: <strong>${escapedTitle}</strong>
+    </blockquote>
+    <p><a href="${escapedUrl}" style="display:inline-block;padding:10px 16px;background:#0f766e;color:#ffffff;border-radius:6px;text-decoration:none;font-weight:600;">問い合わせを開く</a></p>
+    <p style="font-size:13px;color:#475569;">うまく開けない場合はこちらの URL をブラウザに貼り付けてください:<br><span style="word-break:break-all;">${escapedUrl}</span></p>
+    <p style="font-size:13px;color:#475569;">このメールにそのまま返信すると、お問い合わせへの追記として担当者に届きます。</p>
+    <p style="font-size:13px;color:#64748b;">お心当たりがない場合は破棄してください。</p>
+  `.trim();
+
+  // 3 点セットを返す
+  return { subject, text, html };
+}
+
 // ステータス変更を依頼者に知らせるメール本文を生成する純粋関数 (副作用なし)
 // Phase 2 メール通知テンプレート整備 (docs/smb-dx-pivot-plan.md §4 Phase 2)
 export function renderTicketStatusChangedEmail(input: {
@@ -87,7 +140,9 @@ export function renderTicketStatusChangedEmail(input: {
   newStatusLabel: string; // 変更後ステータスの日本語ラベル (例: 「対応中」)
 }): { subject: string; text: string; html: string } {
   // 件名: 接頭辞 + 変更前後のステータスを明示する。ヘッダインジェクション防止のためサニタイズする
-  const subject = sanitizeSubject(`${SUBJECT_PREFIX} 問い合わせ「${input.ticketTitle}」の状況が「${input.oldStatusLabel}」から「${input.newStatusLabel}」に変わりました`);
+  const subject = sanitizeSubject(
+    `${SUBJECT_PREFIX} 問い合わせ「${input.ticketTitle}」の状況が「${input.oldStatusLabel}」から「${input.newStatusLabel}」に変わりました`,
+  );
 
   // テキスト本文 (HTML 非対応クライアント向けフォールバック)
   const text = [
@@ -131,7 +186,9 @@ export function renderAssignedEmail(input: {
   ticketUrl: string; // チケット詳細ページの URL
 }): { subject: string; text: string; html: string } {
   // 件名: 接頭辞 + 担当者割当が起きたことを件名で伝える。ヘッダインジェクション防止のためサニタイズする
-  const subject = sanitizeSubject(`${SUBJECT_PREFIX} 問い合わせ「${input.ticketTitle}」の担当者に割り当てられました`);
+  const subject = sanitizeSubject(
+    `${SUBJECT_PREFIX} 問い合わせ「${input.ticketTitle}」の担当者に割り当てられました`,
+  );
 
   // テキスト本文 (HTML 非対応クライアント向けフォールバック)
   const text = [

--- a/src/lib/ticket-ref.ts
+++ b/src/lib/ticket-ref.ts
@@ -1,0 +1,16 @@
+/**
+ * チケットの短縮参照番号 (受付番号) を組み立てる共有ヘルパー。
+ *
+ * チケット ID は cuid なのでそのままだと長い。画面のチケット詳細ヘッダと、メール
+ * (初回メール起票の受領自動返信) で「同じ表記の受付番号」を使うため、1 か所に集約する (§6 一元管理)。
+ * 別々に `id.slice(0, 8)` を直書きすると、片方だけ桁数を変えたときに表記がズレるのを防ぐ。
+ */
+
+// 短縮 ID として使う先頭文字数。cuid 先頭 8 文字で日常の識別には十分な一意性がある。
+export const TICKET_REF_SHORT_LENGTH = 8;
+
+// チケット ID から表示用の参照番号 "#xxxxxxxx" を作る純粋関数。
+export function formatTicketRef(ticketId: string): string {
+  // 先頭 N 文字を切り出し、頭に "#" を付けて「受付番号」らしい見た目にする
+  return `#${ticketId.slice(0, TICKET_REF_SHORT_LENGTH)}`;
+}

--- a/tests/features/inbound-email-route.test.ts
+++ b/tests/features/inbound-email-route.test.ts
@@ -45,6 +45,20 @@ vi.mock('@/lib/sse-subscribers', () => ({
   broadcast: vi.fn(),
 }));
 
+// 受領自動返信 (メンバー改善 #1) の送信を捕捉する。実ファイル (.magic-link-outbox.jsonl) へ
+// 書き込む console ドライバを避け、送信内容を配列に貯めて検証する。
+// vi.hoisted で先に配列を作り、vi.mock のファクトリから参照できるようにする (巻き上げ順序対策)。
+const { sentEmails } = vi.hoisted(() => ({
+  sentEmails: [] as Array<{ to: string; subject: string }>,
+}));
+vi.mock('@/lib/email', () => ({
+  getEmailSender: () => ({
+    send: async (message: { to: string; subject: string }) => {
+      sentEmails.push(message);
+    },
+  }),
+}));
+
 // テナント (Lite) + 既知メンバー 1 人をシードする
 function seed() {
   const now = new Date();
@@ -55,7 +69,14 @@ function seed() {
     mode: 'lite',
     industry: null,
     inboundToken: TOKEN,
-    slackWebhookUrl: null, subscriptionPlan: 'free' as const, stripeCustomerId: null, stripeSubscriptionId: null, stripeSubscriptionStatus: null, teamsWebhookUrl: null, chatworkApiToken: null, chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
+    slackWebhookUrl: null,
+    subscriptionPlan: 'free' as const,
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+    stripeSubscriptionStatus: null,
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
     createdAt: now,
   });
   // テナント所属の既知メンバー (送信者として許可される)
@@ -102,6 +123,8 @@ describe('POST /api/inbound/email', () => {
     uow = ctx.uow;
     seed();
     vi.stubEnv('INBOUND_EMAIL_SECRET', SECRET);
+    // 各テストで送信捕捉バッファを空にする (テスト間で送信が混ざらないように)
+    sentEmails.length = 0;
   });
 
   // 環境変数スタブを毎回戻す
@@ -174,7 +197,14 @@ describe('POST /api/inbound/email', () => {
       mode: 'lite',
       industry: null,
       inboundToken: 'other-token',
-      slackWebhookUrl: null, subscriptionPlan: 'free' as const, stripeCustomerId: null, stripeSubscriptionId: null, stripeSubscriptionStatus: null, teamsWebhookUrl: null, chatworkApiToken: null, chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
+      slackWebhookUrl: null,
+      subscriptionPlan: 'free' as const,
+      stripeCustomerId: null,
+      stripeSubscriptionId: null,
+      stripeSubscriptionStatus: null,
+      teamsWebhookUrl: null,
+      chatworkApiToken: null,
+      chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
       createdAt: now,
     });
     store.users.set('u-other', {
@@ -405,5 +435,59 @@ describe('POST /api/inbound/email', () => {
     const res = await POST(makeRequest({ ...VALID_EMAIL, dkim: '{@example.com : fail}' }));
     expect(res.status).toBe(202);
     expect(store.tickets.size).toBe(0);
+  });
+
+  // ── 受領自動返信 (メンバー改善 #1) ────────────────────────────────────────
+  // 新規起票が成功したら、送信元へ受付番号付きの受領メールを 1 通だけ返す
+  it('新規起票時に送信元へ受領自動返信を 1 通送る', async () => {
+    const { POST } = await import('@/app/api/inbound/email/route');
+    const res = await POST(makeRequest(VALID_EMAIL));
+    expect(res.status).toBe(201);
+    const { ticketId } = (await res.json()) as { ticketId: string };
+    // 送信は 1 通だけ。宛先は送信元の既知メンバー
+    expect(sentEmails).toHaveLength(1);
+    expect(sentEmails[0].to).toBe(MEMBER_EMAIL);
+    // 件名に受付番号 (短縮 ID) と件名が含まれる
+    expect(sentEmails[0].subject).toContain(`#${ticketId.slice(0, 8)}`);
+    expect(sentEmails[0].subject).toContain('プリンターが動きません');
+  });
+
+  // スレッド継続 (既存チケットへの追記) では受領自動返信を送らない (既に会話中のため)
+  it('スレッド追記では受領自動返信を送らない', async () => {
+    const { POST } = await import('@/app/api/inbound/email/route');
+    // 1 通目: 新規起票 → 受領返信 1 通
+    await POST(makeRequest({ ...VALID_EMAIL, messageId: '<orig-ack@example.com>' }));
+    expect(sentEmails).toHaveLength(1);
+    // 2 通目: 同じスレッドへの返信 (In-Reply-To) → 追記なので受領返信は増えない
+    const res2 = await POST(
+      makeRequest({
+        ...VALID_EMAIL,
+        subject: 'Re: プリンターが動きません',
+        text: 'まだ直りません',
+        messageId: '<reply-ack@example.com>',
+        inReplyTo: '<orig-ack@example.com>',
+      }),
+    );
+    expect(res2.status).toBe(200);
+    expect(sentEmails).toHaveLength(1);
+  });
+
+  // 同一 Message-ID の再送 (重複) では受領自動返信を送らない (二重送信防止)
+  it('重複再送では受領自動返信を送らない', async () => {
+    const { POST } = await import('@/app/api/inbound/email/route');
+    const req = () => makeRequest({ ...VALID_EMAIL, messageId: '<dup-ack@example.com>' });
+    await POST(req()); // 1 通目: 起票 + 受領返信
+    await POST(req()); // 2 通目: 重複なので何もしない
+    expect(sentEmails).toHaveLength(1);
+  });
+
+  // 自動配信メール (Auto-Submitted) には受領自動返信を送らない (メールループ防止)
+  it('Auto-Submitted の自動配信メールには受領自動返信を送らない', async () => {
+    const { POST } = await import('@/app/api/inbound/email/route');
+    const res = await POST(makeRequest({ ...VALID_EMAIL, 'auto-submitted': 'auto-generated' }));
+    // 起票自体は通常どおり成功するが、受領返信は送らない
+    expect(res.status).toBe(201);
+    expect(store.tickets.size).toBe(1);
+    expect(sentEmails).toHaveLength(0);
   });
 });

--- a/tests/ticket-email.test.ts
+++ b/tests/ticket-email.test.ts
@@ -1,7 +1,11 @@
 // Vitest のテスト DSL
 import { describe, expect, it } from 'vitest';
 // テスト対象 (純粋ヘルパー)
-import { buildTicketUrl, renderTicketReplyEmail } from '@/lib/ticket-email';
+import {
+  buildTicketUrl,
+  renderTicketReplyEmail,
+  renderTicketReceivedEmail,
+} from '@/lib/ticket-email';
 
 describe('buildTicketUrl', () => {
   // baseUrl + チケット ID から詳細ページの URL を組み立てられること
@@ -74,5 +78,44 @@ describe('renderTicketReplyEmail', () => {
       agentName: 'a',
     });
     expect(html).toContain('1 行目<br>2 行目');
+  });
+});
+
+describe('renderTicketReceivedEmail', () => {
+  // 件名規約: 接頭辞 + 受付番号 + 件名 (受信箱で「受け付けられた」ことと対象がすぐ分かる)
+  it('件名に接頭辞・受付番号・件名を含む', () => {
+    const { subject } = renderTicketReceivedEmail({
+      ticketTitle: 'プリンターが動かない',
+      ticketRef: '#ab12cd34',
+      ticketUrl: 'http://localhost:3000/tickets/ab12cd34xxxx',
+    });
+    expect(subject).toBe(
+      '[HelpDesk Hub] お問い合わせを受け付けました（#ab12cd34）「プリンターが動かない」',
+    );
+  });
+
+  // テキスト本文に受付番号・件名・URL と「返信で追記できる」案内が含まれること
+  it('テキスト本文に受付番号・件名・URL・返信案内を含む', () => {
+    const { text } = renderTicketReceivedEmail({
+      ticketTitle: '複合機の不調',
+      ticketRef: '#ffffffff',
+      ticketUrl: 'http://localhost:3000/tickets/2',
+    });
+    expect(text).toContain('#ffffffff');
+    expect(text).toContain('複合機の不調');
+    expect(text).toContain('http://localhost:3000/tickets/2');
+    // このメールに返信するとお問い合わせへ追記される旨の案内
+    expect(text).toContain('返信');
+  });
+
+  // HTML 本文では外部由来文字列がエスケープされ、生のタグが混入しないこと (XSS 防止)
+  it('HTML 本文で件名の危険文字をエスケープする', () => {
+    const { html } = renderTicketReceivedEmail({
+      ticketTitle: '<script>alert(1)</script>',
+      ticketRef: '#deadbeef',
+      ticketUrl: 'http://x/tickets/3',
+    });
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
   });
 });


### PR DESCRIPTION
## Context

メンバー向け改善 **#1（最優先）** の実装。正本 `docs/smb-dx-pivot-plan.md` **Phase 2「既存チャネルからの取り込み」/「依頼者がアプリにログインしなくても完結」** に対応する残課題（穴埋め）。

メール転送で起票したメンバーは、Web フォーム起票（送信後すぐ画面表示）と違い**受領確認が無く「届いたか分からない」**状態だった。新規起票の成功時に **受付番号付きの受領メールを 1 通だけ**返してこの穴を解消する。

## 変更内容

- **`src/lib/ticket-email.ts`**: 受領メール本文を生成する純粋ヘルパー `renderTicketReceivedEmail`（件名 `[HelpDesk Hub] お問い合わせを受け付けました（#xxxxxxxx）「件名」`、Text / HTML、XSS エスケープ済み）を追加。
- **`src/lib/ticket-ref.ts`（新規）**: 受付番号（短縮 ID `#xxxxxxxx`）を**画面とメールで共有**する `formatTicketRef` を新設。チケット詳細ヘッダの `id.slice(0, 8)` 直書きを置き換え（一元管理 / DRY）。
- **`src/app/api/inbound/email/route.ts`**: 新規起票の直後に**ベストエフォート**で受領メールを送信（失敗してもチケットは作成済み・起票は成功扱い）。既存の返信メールと同じく**決定的 Message-ID を `emailThreads` に登録**し、受領メールへの返信が同じチケットへ追記されるようにする。
  - **メールループ防止（§9 fail-safe）**: `Auto-Submitted` が `no` 以外、または `Precedence: bulk/list/junk` の自動配信メールには返信しない。送る受領メール自身には `Auto-Submitted: auto-replied` を付与。
  - スレッド追記・重複再送のパスでは送らない（新規起票のみ送信）。
- **`src/lib/email/email-sender.ts` / `nodemailer-email-sender.ts`**: `EmailMessage` に任意 `headers?` を追加し SMTP へパススルー（ループ防止ヘッダ用）。
- **テスト**: 受領メール本文（件名・本文・エスケープ）と、ルートの送信有無（新規=送る / 追記・重複・自動配信=送らない）を追加。

## 検証

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test`（vitest）✅ 366 passed（Prisma 契約テスト 5 ファイルは `RUN_PRISMA_CONTRACT` 未設定でスキップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hpoj2yxfjCVzWHu6CaijyN)_