### PR TITLE
feat(line): LINE ユーザーとメンバーの紐付け (メンバー改善 #2)

### DIFF
--- a/prisma/migrations/20260624000000_add_line_user_link/migration.sql
+++ b/prisma/migrations/20260624000000_add_line_user_link/migration.sql
@@ -1,0 +1,17 @@
+-- Phase 2 β 解消 (docs/smb-dx-pivot-plan.md §4 Phase 2「LINE 公式アカウント連携」):
+-- LINE ユーザーとテナントメンバーを紐付けるための列を User に追加する。
+-- 紐付け後は LINE 起票チケットの起票者が本人になり、自己解決 UI (creatorId = 自分) が開通する。
+
+-- 確定リンク (紐付け済み LINE ユーザー ID。未連携は NULL)
+ALTER TABLE "User" ADD COLUMN "lineUserId" TEXT;
+-- 発行中ワンタイムコードの SHA-256 ハッシュ (生コードは保存しない)
+ALTER TABLE "User" ADD COLUMN "lineLinkCodeHash" TEXT;
+-- 上記コードの失効時刻 (NULL なら発行中コードなし)
+ALTER TABLE "User" ADD COLUMN "lineLinkCodeExpiresAt" TIMESTAMP(3);
+
+-- ワンタイムコードのハッシュは一意 (同じハッシュが 2 件存在しない)
+CREATE UNIQUE INDEX "User_lineLinkCodeHash_key" ON "User"("lineLinkCodeHash");
+
+-- テナント内で 1 LINE ユーザー = 1 メンバーを保証する複合一意制約。
+-- PostgreSQL は NULL を互いに区別するため、未連携 (lineUserId IS NULL) のユーザーは何人でも共存できる。
+CREATE UNIQUE INDEX "User_tenantId_lineUserId_key" ON "User"("tenantId", "lineUserId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -173,6 +173,14 @@ model User {
   createdAt    DateTime @default(now()) // 作成日時 (自動で現在時刻)
   updatedAt    DateTime @updatedAt // 更新日時 (Prisma が自動更新)
 
+  // LINE メンバー紐付け (Phase 2 β 解消 / docs/smb-dx-pivot-plan.md §4 Phase 2)
+  // 確定リンク: この LINE ユーザー ID から起票されたチケットは本人が起票者になる (自己解決 UI 開通)。
+  // 未連携は null。テナント内で 1 LINE ユーザー = 1 メンバーに保つため (tenantId, lineUserId) を一意にする
+  // (NULL は重複可なので未連携ユーザーは何人でも共存できる)。
+  lineUserId           String? // 紐付け済み LINE ユーザー ID (未連携なら null)
+  lineLinkCodeHash     String? @unique // 発行中ワンタイムコードの SHA-256 (生コードは保存しない)
+  lineLinkCodeExpiresAt DateTime? // 上記コードの失効時刻 (null なら発行中コードなし)
+
   // 所属テナント (マルチテナント化の必須キー)
   tenantId String
   tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
@@ -186,6 +194,7 @@ model User {
   notifications       Notification[] // このユーザー宛の通知
   uploadedAttachments Attachment[] // このユーザーがアップロードした添付ファイル
 
+  @@unique([tenantId, lineUserId]) // テナント内で 1 LINE ユーザー = 1 メンバー (NULL は重複可)
   @@index([tenantId]) // テナントスコープ検索用
 }
 

--- a/src/app/(app)/settings/line/page.tsx
+++ b/src/app/(app)/settings/line/page.tsx
@@ -1,0 +1,44 @@
+// 現在のセッション (ログイン情報) を取得
+import { auth } from '@/lib/auth';
+// データ層の Composition Root (連携状態の取得に使う)
+import { repos } from '@/data';
+// LINE 連携の自己サービス UI (コード発行 / 解除)
+import { LineLinkSection } from '@/features/settings/components/LineLinkSection';
+
+// /settings/line : LINE 連携ページ。
+// テナント設定 (/settings) は管理者専用だが、このページは「自分の LINE を自分のアカウントに紐付ける」
+// 自己サービスなので requester を含む全ロールがアクセスできる (認証のみ要求)。
+export default async function LineLinkPage() {
+  // セッション取得 (middleware で未ログインは弾かれている前提)
+  const session = await auth();
+  // 未ログイン or tenantId 不在なら何も描画しない (middleware が先に弾く想定の保険)
+  if (!session?.user?.id || !session.user.tenantId) return null;
+
+  // 現在のユーザーを取得し、LINE 連携済みか (lineUserId が入っているか) を判定する
+  const me = await repos.users.findById(session.user.id);
+  // lineUserId が非 null・非空なら連携済みとみなす
+  const connected = !!me?.lineUserId;
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      {/* ヘッダー: タイトル + 説明文 */}
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">LINE 連携</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          LINE 公式アカウントとあなたのアカウントを連携すると、LINE から送った問い合わせを
+          自分の問い合わせ一覧で確認・追跡できるようになります。
+        </p>
+      </div>
+
+      {/* 連携設定カード */}
+      <section className="space-y-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+        <div>
+          {/* セクション見出し */}
+          <h2 className="text-base font-semibold text-slate-900">LINE アカウントの連携</h2>
+        </div>
+        {/* 連携状態に応じたフォーム本体 (連携済み / 未連携で表示を切り替える) */}
+        <LineLinkSection connected={connected} />
+      </section>
+    </div>
+  );
+}

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -9,8 +9,11 @@
  *  - 1 テナント / 1 LINE チャネル構成を env var で決め打ち (マルチチャネルは将来課題)。
  *    LINE_CHANNEL_SECRET: Webhook 署名の検証に使うチャネルシークレット
  *    LINE_TARGET_TENANT_ID: メッセージを受け付けるテナント ID
- *  - LINE ユーザーとテナントメンバーの紐付けは未実装。テナントの最初の管理者をプロキシ起票者とする。
- *    チケット本文に LINE ユーザー ID を記録するため、担当者が手動で連絡できる。
+ *  - LINE ユーザーとテナントメンバーの紐付け: メンバーが Web 設定画面で発行したワンタイムコードを
+ *    LINE に送ると、その送信元 LINE ユーザー ID をメンバーへ紐付ける。紐付け済みなら起票者は本人になり
+ *    自己解決 UI が開通する。未紐付けの LINE ユーザーは従来どおりテナント内担当者をプロキシ起票者とする
+ *    (本文に LINE ユーザー ID を残すので担当者が手動連絡できる)。アウトバウンド LINE 返信は未実装のため、
+ *    連携完了の確認は Web 設定画面の「連携済み」表示で行う。
  *  - DKIM/SPF 相当の送信者検証は LINE 署名のみ (LINE サーバからのみ受信する保証は署名が担う)。
  *
  * セキュリティ要点 (§9):
@@ -31,6 +34,8 @@ import { initialStatusForMode } from '@/domain/ticket-status';
 import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
 // 優先度から解決期限を計算する SLA ヘルパー (他の取り込みチャネルと同じ既定値に揃える)
 import { calculateResolutionDueAt } from '@/lib/sla';
+// LINE メンバー紐付け: 受信テキストの正規化・コード形判定・ハッシュ化 (発行は Web 設定画面側)
+import { hashLineLinkCode, looksLikeLineLinkCode, normalizeLineLinkCode } from '@/lib/line-link';
 
 // このルートは Node ランタイムで動かす (node:crypto / Prisma を使うため Edge では動かない)
 export const runtime = 'nodejs';
@@ -240,6 +245,39 @@ export async function POST(req: Request) {
     const trimmedText = textMessage.text.trim();
     if (!trimmedText) continue;
 
+    // メンバー紐付け: テキストが発行済みワンタイムコードなら、起票せず lineUserId をメンバーへ紐付ける。
+    // (lineUserId が取得できないイベントは紐付けようがないので、この処理を飛ばして通常起票へ進む)
+    if (lineUserId !== '不明') {
+      // 受信テキストを正規化 (ハイフン・空白除去 + 大文字化) してコードの形か軽く判定する
+      const normalizedCode = normalizeLineLinkCode(trimmedText);
+      if (looksLikeLineLinkCode(normalizedCode)) {
+        // 形が一致したらハッシュ化し、有効な発行行があれば原子的に紐付ける
+        const codeHash = await hashLineLinkCode(normalizedCode);
+        const link = await repos.users.linkLineUserByCode({
+          codeHash,
+          tenantId: targetTenantId,
+          lineUserId,
+          now,
+        });
+        // 連携成功 / 競合 (コードとして処理済み) のときは、このメッセージを問い合わせにしない
+        if (link.status === 'linked' || link.status === 'conflict') {
+          // 連携結果をログに残す (アウトバウンド LINE 返信は未実装。利用者は Web 設定で連携状態を確認する)
+          console.info(
+            `[POST /api/inbound/line] line link ${link.status} for tenant`,
+            targetTenantId,
+          );
+          continue;
+        }
+        // invalid (コードの形だが有効な発行行が無い) は通常の問い合わせとして下の起票へ進む
+      }
+    }
+
+    // 起票者を決める: この LINE ユーザーが紐付け済みなら本人を起票者にして自己解決 UI を開通させる。
+    // 未紐付け (または lineUserId 不明) は従来どおりプロキシ担当者を起票者にする (β フォールバック)。
+    const linkedMember =
+      lineUserId !== '不明' ? await repos.users.findByLineUserId(targetTenantId, lineUserId) : null;
+    const creatorId = linkedMember ? linkedMember.id : proxyCreator.id;
+
     // チケットタイトルはメッセージテキストの先頭 MAX_TITLE_LENGTH 文字にする
     const title =
       trimmedText.length > MAX_TITLE_LENGTH
@@ -266,7 +304,7 @@ export async function POST(req: Request) {
         body: ticketBody, // LINE ユーザー ID + 全文
         priority: 'Medium', // LINE 取り込みは優先度 Medium 固定 (他チャネルと揃える)
         categoryId: null, // カテゴリは未分類 (担当者が後で設定)
-        creatorId: proxyCreator.id, // 名前順で最初の担当者をプロキシ起票者とする (β 制約)
+        creatorId, // 紐付け済みなら本人、未紐付けならプロキシ担当者 (上で解決済み)
         tenantId: targetTenantId, // 取り込み先テナント
         status: initialStatus, // Lite は 'Open'、Pro は DB 既定 'New'
         resolutionDueAt, // 優先度 Medium ベースの解決期限

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -37,6 +37,7 @@ const navItems: {
   { href: '/tickets/new', label: '新規登録' },
   { href: '/faq', label: 'FAQ候補', agentOnly: true, proOnly: true },
   { href: '/notifications', label: '通知' },
+  { href: '/settings/line', label: 'LINE連携' }, // Phase 2: 自分の LINE を連携する自己サービス (全ロール)
   { href: '/audit', label: '監査ログ', adminOnly: true }, // Phase 4: 管理者向け変更履歴
   { href: '/settings', label: '設定', adminOnly: true },
   { href: '/help', label: 'ヘルプ' }, // Phase 3: ヘルプセンター (全ロール表示)
@@ -134,9 +135,7 @@ export function Sidebar({ role, mode }: Props) {
             collapsed の効果は md 以上だけに限定 (md:hidden) し、モバイルでは必ず表示する。
             これにより「デスクトップで折りたたみ → 画面幅を縮める → ハンバーガーで開く」のフローで
             メニューが空になる不具合を防ぐ */}
-        <nav
-          className={`flex-1 space-y-1 px-3 py-5 ${collapsed ? 'md:hidden' : ''}`}
-        >
+        <nav className={`flex-1 space-y-1 px-3 py-5 ${collapsed ? 'md:hidden' : ''}`}>
           {visibleItems.map((item) => {
             // この項目が現在のページかどうか
             const isActive = isItemActive(item.href);

--- a/src/data/adapters/memory/user-repository.memory.ts
+++ b/src/data/adapters/memory/user-repository.memory.ts
@@ -107,5 +107,66 @@ export function makeUserRepo(store: Store): UserRepository {
       }
       return count;
     },
+
+    // 紐付け済み LINE ユーザー ID から当該テナントのメンバーを 1 件引く (tenantId スコープ)
+    async findByLineUserId(tenantId, lineUserId) {
+      // 全ユーザーを走査し、テナント一致かつ lineUserId 一致を返す (複製して返却)
+      for (const u of store.users.values()) {
+        if (u.tenantId === tenantId && u.lineUserId === lineUserId) return { ...u };
+      }
+      return null;
+    },
+
+    // メンバー起点でワンタイムコードのハッシュと失効時刻を自分のユーザー行に保存する
+    async setLineLinkCode(userId, tenantId, input) {
+      const u = store.users.get(userId);
+      // 自テナントの自分だけを更新対象にする (他テナント・不在はスキップ)
+      if (!u || u.tenantId !== tenantId) return;
+      // コードのハッシュと失効時刻を書き込む (Map 内のオブジェクトを直接更新)
+      u.lineLinkCodeHash = input.codeHash;
+      u.lineLinkCodeExpiresAt = input.expiresAt;
+    },
+
+    // 受信コードのハッシュに一致する有効な発行行を探し、lineUserId を紐付ける
+    async linkLineUserByCode({ codeHash, tenantId, lineUserId, now }) {
+      // 1) 有効な発行行 (同一テナント・未失効) を探す
+      let candidate: User | undefined;
+      for (const u of store.users.values()) {
+        if (
+          u.tenantId === tenantId &&
+          u.lineLinkCodeHash === codeHash &&
+          u.lineLinkCodeExpiresAt != null &&
+          u.lineLinkCodeExpiresAt.getTime() >= now.getTime()
+        ) {
+          candidate = u;
+          break;
+        }
+      }
+      // 一致する有効コードが無ければ「コードではない」
+      if (!candidate) return { status: 'invalid' };
+
+      // 2) その LINE ユーザー ID が既に別メンバーへ連携済みなら付け替えない (テナント内一意)
+      for (const u of store.users.values()) {
+        if (u.tenantId === tenantId && u.lineUserId === lineUserId && u.id !== candidate.id) {
+          return { status: 'conflict' };
+        }
+      }
+
+      // 3) コード消費 + lineUserId 設定 (Map 内オブジェクトを直接更新)
+      candidate.lineUserId = lineUserId;
+      candidate.lineLinkCodeHash = null;
+      candidate.lineLinkCodeExpiresAt = null;
+      return { status: 'linked', userId: candidate.id };
+    },
+
+    // メンバー起点で LINE 連携を解除する (lineUserId と発行中コードをまとめてクリア)
+    async unlinkLineUser(userId, tenantId) {
+      const u = store.users.get(userId);
+      // 自テナントの自分だけを対象にする
+      if (!u || u.tenantId !== tenantId) return;
+      u.lineUserId = null;
+      u.lineLinkCodeHash = null;
+      u.lineLinkCodeExpiresAt = null;
+    },
   };
 }

--- a/src/data/adapters/prisma/mappers.ts
+++ b/src/data/adapters/prisma/mappers.ts
@@ -55,6 +55,9 @@ export function toUser(row: UserRow): User {
     tenantId: row.tenantId, // 所属テナント (マルチテナント化のキー)
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+    lineUserId: row.lineUserId, // LINE 紐付け先 (未連携なら null)
+    lineLinkCodeHash: row.lineLinkCodeHash, // 発行中ワンタイムコードのハッシュ (なければ null)
+    lineLinkCodeExpiresAt: row.lineLinkCodeExpiresAt, // 上記コードの失効時刻 (なければ null)
   };
 }
 

--- a/src/data/adapters/prisma/user-repository.prisma.ts
+++ b/src/data/adapters/prisma/user-repository.prisma.ts
@@ -73,5 +73,69 @@ export function makeUserRepo(db: PrismaLike): UserRepository {
       // agent と admin のみをカウントする (requester は上限対象外)
       return db.user.count({ where: { tenantId, role: { in: ['agent', 'admin'] } } });
     },
+
+    // 紐付け済み LINE ユーザー ID から当該テナントのメンバーを 1 件引く (tenantId スコープ必須)
+    async findByLineUserId(tenantId, lineUserId) {
+      // (tenantId, lineUserId) は複合一意なので findFirst で最大 1 件
+      const row = await db.user.findFirst({ where: { tenantId, lineUserId } });
+      return row ? toUser(row) : null;
+    },
+
+    // メンバー起点でワンタイムコードのハッシュと失効時刻を自分のユーザー行に保存する。
+    // tenantId スコープ付き updateMany で「自テナントの自分」だけを更新対象にする (他人を書き換えない)
+    async setLineLinkCode(userId, tenantId, input) {
+      await db.user.updateMany({
+        where: { id: userId, tenantId },
+        data: { lineLinkCodeHash: input.codeHash, lineLinkCodeExpiresAt: input.expiresAt },
+      });
+    },
+
+    // 受信コードのハッシュに一致する有効な発行行を探し、原子的に lineUserId を紐付ける
+    async linkLineUserByCode({ codeHash, tenantId, lineUserId, now }) {
+      // 1) 有効な発行行 (同一テナント・未失効) を探す。無ければ「コードではない」
+      const candidate = await db.user.findFirst({
+        where: { tenantId, lineLinkCodeHash: codeHash, lineLinkCodeExpiresAt: { gte: now } },
+      });
+      if (!candidate) return { status: 'invalid' };
+
+      // 2) その LINE ユーザー ID が既に誰かに連携済みかを確認する (テナント内一意制約の事前判定)
+      const existing = await db.user.findFirst({ where: { tenantId, lineUserId } });
+      if (existing && existing.id !== candidate.id) {
+        // 別メンバーへ連携済み: 付け替えはしない (一意制約の衝突を避け、conflict を返す)
+        return { status: 'conflict' };
+      }
+
+      // 3) 原子的に「コード消費 + lineUserId 設定」を行う。発行行がまだ有効な条件を where に再掲し、
+      //    並行リクエストでの二重処理を防ぐ (count===1 のときだけ成功扱い)
+      try {
+        const result = await db.user.updateMany({
+          where: {
+            id: candidate.id,
+            lineLinkCodeHash: codeHash,
+            lineLinkCodeExpiresAt: { gte: now },
+          },
+          data: { lineUserId, lineLinkCodeHash: null, lineLinkCodeExpiresAt: null },
+        });
+        // 0 件 = 並行処理に先を越された (既に消費済み)。コードとしては無効扱いにする
+        if (result.count !== 1) return { status: 'invalid' };
+        // 連携成功 (このメンバーに lineUserId が結び付いた)
+        return { status: 'linked', userId: candidate.id };
+      } catch (err) {
+        // (tenantId, lineUserId) 一意制約違反 (P2002): 事前判定をすり抜けた競合で別メンバーが先に連携。
+        // 付け替え不能として conflict を返す (それ以外の例外は想定外なので上位へ送出)。
+        if (typeof err === 'object' && err !== null && 'code' in err && err.code === 'P2002') {
+          return { status: 'conflict' };
+        }
+        throw err;
+      }
+    },
+
+    // メンバー起点で LINE 連携を解除する (lineUserId と発行中コードをまとめてクリア)
+    async unlinkLineUser(userId, tenantId) {
+      await db.user.updateMany({
+        where: { id: userId, tenantId },
+        data: { lineUserId: null, lineLinkCodeHash: null, lineLinkCodeExpiresAt: null },
+      });
+    },
   };
 }

--- a/src/data/ports/user-repository.ts
+++ b/src/data/ports/user-repository.ts
@@ -1,6 +1,15 @@
 // ドメイン層のユーザー型をインポート
 import type { Role, User, UserSummary } from '@/domain/types';
 
+// LINE ワンタイムコードによる紐付け試行の結果。
+// - linked: 連携成功 (userId は連携されたメンバー)。同一ユーザーの再送 (冪等) もここに含む。
+// - invalid: 一致するコードが無い / 失効済み (= そのテキストはコードではなかった)。
+// - conflict: コードは有効だが、その LINE ユーザー ID が既に別メンバーへ連携済みで付け替えできない。
+export type LineLinkResult =
+  | { status: 'linked'; userId: string }
+  | { status: 'invalid' }
+  | { status: 'conflict' };
+
 // ユーザー取得系リポジトリの契約 (port)
 // 認証フローで使う findById / findByEmail は **tenantId スコープなし** (どのテナントに
 // 属するかを判定するためにこそユーザーを引くので、ここで scope を強制すると鶏卵問題になる)。
@@ -25,4 +34,26 @@ export interface UserRepository {
   // Phase 4 課金: テナント内のスタッフ (agent + admin) 数を返す (プランのシート上限チェック用)
   // requester はカウントしない — シートはヘルプデスクスタッフ分のみ消費する
   countByTenant(tenantId: string): Promise<number>;
+
+  // ── LINE メンバー紐付け (Phase 2 β 解消) ───────────────────────────────
+  // 紐付け済み LINE ユーザー ID から当該テナントのメンバーを 1 件引く (起票時に本人を起票者にするため)。
+  // クロステナント漏洩防止のため tenantId スコープ必須。未連携・別テナントなら null。
+  findByLineUserId(tenantId: string, lineUserId: string): Promise<User | null>;
+  // メンバー起点でワンタイムコード (のハッシュ) と失効時刻を自分のユーザー行に保存する。
+  // userId / tenantId はセッション由来のみを渡す契約 (他人のコードを書き換えさせない)。
+  setLineLinkCode(
+    userId: string,
+    tenantId: string,
+    input: { codeHash: string; expiresAt: Date },
+  ): Promise<void>;
+  // LINE Webhook 側で、受信コードのハッシュに一致する有効な発行行を探して lineUserId を紐付ける。
+  // 原子的に「コード消費 + lineUserId 設定」を行い、二重処理・競合を防ぐ (Invitation.consumeValidToken 方式)。
+  linkLineUserByCode(input: {
+    codeHash: string; // 受信テキストを正規化してハッシュ化した値
+    tenantId: string; // 取り込み先テナント (発行行と同一テナントのみ許可)
+    lineUserId: string; // 紐付ける LINE ユーザー ID (Webhook イベント由来)
+    now: Date; // 失効判定の基準時刻
+  }): Promise<LineLinkResult>;
+  // メンバー起点で LINE 連携を解除する (lineUserId と発行中コードをまとめてクリアする)。
+  unlinkLineUser(userId: string, tenantId: string): Promise<void>;
 }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -107,6 +107,14 @@ export interface User {
   tenantId: string; // 所属テナント ID (マルチテナント化のキー)
   createdAt: Date; // 登録日時
   updatedAt: Date; // 最終更新日時
+  // LINE メンバー紐付け (Phase 2 β 解消)。確定リンク先 LINE ユーザー ID (未連携なら null)。
+  // 既存のフィクスチャ・呼び出しを壊さないよう任意 (optional) とし、アダプタは常に null か値で埋める。
+  lineUserId?: string | null;
+  // 発行中ワンタイムコードの SHA-256 ハッシュ (生コードは保存しない。発行中でなければ null)。
+  // ハッシュであり秘密そのものではないが、セッションには載せない (auth.ts は id/role/tenantId のみ転写)。
+  lineLinkCodeHash?: string | null;
+  // 上記コードの失効時刻 (発行中でなければ null)
+  lineLinkCodeExpiresAt?: Date | null;
 }
 
 // チケット本体。問い合わせ 1 件に対応する中心データ

--- a/src/features/settings/actions/link-line-account.ts
+++ b/src/features/settings/actions/link-line-account.ts
@@ -1,0 +1,97 @@
+'use server';
+
+/**
+ * LINE 連携のメンバー起点アクション (Phase 2 β 解消 / docs/smb-dx-pivot-plan.md §4 Phase 2)。
+ *
+ * - generateLineLinkCode: ログイン中メンバーが自分用のワンタイムコードを 1 つ発行する。生コードは
+ *   戻り値で 1 度だけ返し、DB には SHA-256 ハッシュのみ保存する。メンバーはこのコードを LINE 公式
+ *   アカウントに送信し、Webhook 側 (/api/inbound/line) が照合して送信元 LINE ユーザー ID を紐付ける。
+ * - unlinkLineAccount: ログイン中メンバーが自分の LINE 連携を解除する。
+ *
+ * セキュリティ要点:
+ *  - 操作対象は常にセッション由来の自分 (session.user.id) と自テナント (session.user.tenantId) のみ。
+ *    リクエスト入力からユーザー ID / テナント ID を受け取らない (他人の連携を書き換えさせない)。
+ *  - admin 限定ではなく「ログイン済みなら誰でも自分の LINE を連携できる」自己サービス。
+ *  - 連打・総当たり対策にユーザー単位のレート制限を掛ける。
+ */
+
+// データ層の Composition Root (Prisma 直叩きを避ける入口)
+import { repos } from '@/data';
+// 現在のセッション (ログイン中ユーザー) を取得
+import { auth } from '@/lib/auth';
+// ページキャッシュ無効化 (連携状態の表示を更新する)
+import { revalidatePath } from 'next/cache';
+// 公開操作の連打・総当たり防止 (§9)
+import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
+// 紐付けコードの生成・ハッシュ化・有効期限
+import {
+  generateLineLinkCode,
+  hashLineLinkCode,
+  normalizeLineLinkCode,
+  LINE_LINK_CODE_TTL_MS,
+} from '@/lib/line-link';
+// next-auth のセッション型
+import type { Session } from 'next-auth';
+
+// ログイン済み (ユーザー ID + tenantId を持つ) ことを保証するアサーション。
+// LINE 連携は admin 限定ではなく自己サービスのため、ロールは問わず認証のみを要求する。
+function assertAuthenticated(session: Session | null): asserts session is Session {
+  // ユーザー ID が無ければ未ログイン
+  if (!session?.user?.id) throw new Error('ログインが必要です');
+  // tenantId 不在は middleware で弾く想定だが、Server Action でも防御的にチェック
+  if (!session.user.tenantId) throw new Error('ログインが必要です');
+}
+
+// generateLineLinkCode の戻り値型 (発行した生コードと失効までの分数を返す)
+export interface GenerateLineLinkCodeResult {
+  code: string; // 表示用の生コード (例: "AB7K-9QF2")。この値は発行直後の 1 度だけ表示する
+  expiresInMinutes: number; // 失効までの分数 (画面の案内表示用)
+}
+
+// 自分用の LINE 連携ワンタイムコードを 1 つ発行する
+export async function generateLineLinkCode_action(): Promise<GenerateLineLinkCodeResult> {
+  // セッション取得
+  const session = await auth();
+  // ログイン必須 (自分自身に対してのみ操作する)
+  assertAuthenticated(session);
+  // 操作対象は常にセッション由来の自分・自テナントのみ
+  const userId = session.user.id;
+  const tenantId = session.user.tenantId;
+
+  // ユーザー単位のレート制限 (10 分に 5 回まで)。連打・総当たり的なコード再発行を抑止する
+  try {
+    enforceRateLimit(`line-link-code:${userId}`, { limit: 5, windowMs: LINE_LINK_CODE_TTL_MS });
+  } catch (err) {
+    // 流量超過専用エラーだけをユーザー向けメッセージに変換し、それ以外は上位へ送出する
+    if (err instanceof RateLimitError) {
+      throw new Error('コードの発行が多すぎます。しばらく待ってから再度お試しください。');
+    }
+    throw err;
+  }
+
+  // 生コードを生成し、DB にはハッシュのみ保存する (生は戻り値でのみ返す)
+  const code = generateLineLinkCode();
+  // 保存・照合は Webhook 側と同じ normalizeLineLinkCode (ハイフン除去 + 大文字化) で正規化してからハッシュ化する
+  const codeHash = await hashLineLinkCode(normalizeLineLinkCode(code));
+  // 失効時刻 (現在時刻 + TTL)
+  const expiresAt = new Date(Date.now() + LINE_LINK_CODE_TTL_MS);
+  // 自分のユーザー行にコードのハッシュと失効時刻を保存する (tenantId スコープ付き)
+  await repos.users.setLineLinkCode(userId, tenantId, { codeHash, expiresAt });
+
+  // 連携状態カードの再描画 (発行済み表示へ更新)
+  revalidatePath('/settings/line');
+  // 生コードと失効分数を返す (画面で 1 度だけ表示)
+  return { code, expiresInMinutes: Math.floor(LINE_LINK_CODE_TTL_MS / 60_000) };
+}
+
+// 自分の LINE 連携を解除する
+export async function unlinkLineAccount_action(): Promise<void> {
+  // セッション取得
+  const session = await auth();
+  // ログイン必須
+  assertAuthenticated(session);
+  // 自分の lineUserId と発行中コードをまとめてクリアする (tenantId スコープ付き)
+  await repos.users.unlinkLineUser(session.user.id, session.user.tenantId);
+  // 連携状態カードの再描画 (未連携表示へ更新)
+  revalidatePath('/settings/line');
+}

--- a/src/features/settings/components/LineLinkSection.tsx
+++ b/src/features/settings/components/LineLinkSection.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+// React の状態フックと遷移フック (発行中のローディング表現に使う)
+import { useState, useTransition } from 'react';
+// LINE 連携のコード発行・解除サーバーアクション
+import {
+  generateLineLinkCode_action,
+  unlinkLineAccount_action,
+} from '@/features/settings/actions/link-line-account';
+
+// このセクションが受け取る props (サーバーから現在の連携状態を渡す)
+interface Props {
+  connected: boolean; // 既に LINE と連携済みなら true
+}
+
+// LINE 連携の自己サービス UI (コード発行 → LINE 送信 → 連携、または解除)
+export function LineLinkSection({ connected }: Props) {
+  // サーバーアクション実行中フラグ (ボタンの二重押下防止・表示切替に使う)
+  const [isPending, startTransition] = useTransition();
+  // 発行された生コード (発行直後に 1 度だけ表示する。未発行なら null)
+  const [issuedCode, setIssuedCode] = useState<string | null>(null);
+  // コードの失効までの分数 (案内表示用)
+  const [expiresInMinutes, setExpiresInMinutes] = useState<number | null>(null);
+  // エラーメッセージ (サーバーアクションの日本語メッセージを表示)
+  const [error, setError] = useState<string | null>(null);
+
+  // 「コードを発行」ボタンの処理
+  const handleGenerate = () => {
+    // 直前のエラー表示をクリアしてから実行する
+    setError(null);
+    startTransition(async () => {
+      try {
+        // サーバーで生コードを発行し、画面に 1 度だけ表示する
+        const result = await generateLineLinkCode_action();
+        setIssuedCode(result.code);
+        setExpiresInMinutes(result.expiresInMinutes);
+      } catch (err) {
+        // サーバーアクションの日本語エラーメッセージを表示する
+        setError(err instanceof Error ? err.message : 'コードの発行に失敗しました');
+      }
+    });
+  };
+
+  // 「連携を解除」ボタンの処理
+  const handleUnlink = () => {
+    // 直前のエラー表示をクリアしてから実行する
+    setError(null);
+    startTransition(async () => {
+      try {
+        // サーバーで連携を解除する (成功後はページ再描画で未連携表示に戻る)
+        await unlinkLineAccount_action();
+        // 発行済みコードの残骸が画面に残らないようクリアする
+        setIssuedCode(null);
+        setExpiresInMinutes(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : '連携の解除に失敗しました');
+      }
+    });
+  };
+
+  // 連携済みの表示: 状態バッジ + 解除ボタン
+  if (connected) {
+    return (
+      <div className="space-y-4">
+        {/* 連携済みであることを色だけに頼らずテキストでも明示する (a11y: 状態は文言でも伝える) */}
+        <p className="inline-flex items-center gap-2 rounded-lg bg-teal-50 px-3 py-2 text-sm font-medium text-teal-800 ring-1 ring-teal-100">
+          <span aria-hidden="true">✓</span> LINE と連携済みです
+        </p>
+        <p className="text-sm text-slate-500">
+          LINE から送った問い合わせが、あなたのアカウントの問い合わせとして記録され、
+          一覧から自分で確認できます。
+        </p>
+        {/* 解除ボタン (実行中は無効化) */}
+        <button
+          type="button"
+          onClick={handleUnlink}
+          disabled={isPending}
+          className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isPending ? '処理中…' : '連携を解除する'}
+        </button>
+        {/* エラー表示 (アイコン + テキストで色のみに依存しない) */}
+        {error && (
+          <p role="alert" className="text-sm text-red-600">
+            {error}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  // 未連携の表示: 手順 + コード発行ボタン + 発行後のコード表示
+  return (
+    <div className="space-y-4">
+      {/* 連携手順を番号付きリストで案内する (h2 はページ側にあるので、ここは段落 + ol) */}
+      <ol className="list-decimal space-y-1 pl-5 text-sm text-slate-600">
+        <li>LINE で組織の公式アカウントを友だち追加します。</li>
+        <li>下の「コードを発行」を押し、表示されたコードを LINE のトークに送信します。</li>
+        <li>送信後、この画面を再読み込みすると「連携済み」に変わります。</li>
+      </ol>
+
+      {/* コード発行ボタン (実行中は無効化) */}
+      <button
+        type="button"
+        onClick={handleGenerate}
+        disabled={isPending}
+        className="rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isPending ? '発行中…' : 'コードを発行'}
+      </button>
+
+      {/* 発行された生コードの表示 (発行直後の 1 度だけ。再読込で消える) */}
+      {issuedCode && (
+        <div className="space-y-1 rounded-lg bg-slate-50 p-4 ring-1 ring-slate-200">
+          <p className="text-sm text-slate-500">このコードを LINE のトークに送信してください:</p>
+          {/* コードは等幅・大きめで誤読を防ぐ。aria-label で読み上げ向けに補足する */}
+          <p
+            className="font-mono text-2xl font-bold tracking-widest text-slate-900"
+            aria-label="連携コード"
+          >
+            {issuedCode}
+          </p>
+          {expiresInMinutes != null && (
+            <p className="text-xs text-slate-500">
+              有効期限: 発行から約 {expiresInMinutes} 分です。期限が切れたら再発行してください。
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* エラー表示 */}
+      {error && (
+        <p role="alert" className="text-sm text-red-600">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/line-link.ts
+++ b/src/lib/line-link.ts
@@ -1,0 +1,57 @@
+/**
+ * LINE メンバー紐付け用ワンタイムコードのヘルパー (Phase 2 β 解消 / docs/smb-dx-pivot-plan.md §4 Phase 2)。
+ *
+ * メンバーが Web 設定画面でコードを発行 → LINE 公式アカウントにそのコードを送信 → Webhook 側で照合し、
+ * 送信元 LINE ユーザー ID をそのメンバーへ紐付ける。生コードは発行直後に画面で 1 度だけ表示し、
+ * DB には SHA-256 ハッシュのみ保存する (マジックリンク / 招待と同方式)。
+ *
+ * コードは「LINE のトーク画面に手入力 / 貼り付けする」前提なので、長すぎず・紛らわしくない文字種にする。
+ */
+
+// 生コードのハッシュ化はマジックリンクと共通の SHA-256 実装を再利用する (Web Crypto)
+export { hashMagicLinkToken as hashLineLinkCode } from '@/lib/magic-link';
+
+// コードに使う文字種: Crockford Base32 (数字 + 大文字英字から紛らわしい I/L/O/U を除いた 32 文字)。
+// 見間違い (0/O, 1/I/L 等) を避け、トーク画面で読み上げ・転記しやすくする。
+const CODE_ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+// コードの文字数 (ハイフン等の区切りを除いた実体長)。32^8 ≈ 1.1e12 通りで、
+// 10 分 TTL + 単回使用 + Webhook レート制限 (120/分) の下では総当たり困難。
+export const LINE_LINK_CODE_LENGTH = 8;
+// 発行したコードの有効期限 (10 分)。送信後すぐ照合される前提なので短くして窃取耐性を上げる
+export const LINE_LINK_CODE_TTL_MS = 10 * 60 * 1000;
+
+// ランダムな紐付けコードを 1 つ生成する。表示用に中央へハイフンを 1 つ入れて読みやすくする
+// (例: "AB7K-9QF2")。照合時は normalizeLineLinkCode でハイフンを除いてから突き合わせる。
+export function generateLineLinkCode(): string {
+  // 暗号学的乱数で 1 文字ずつ選ぶためのバッファを用意する
+  const buf = new Uint8Array(LINE_LINK_CODE_LENGTH);
+  globalThis.crypto.getRandomValues(buf);
+  // 各バイトを文字種の範囲に写像して 1 文字ずつ組み立てる
+  let body = '';
+  for (let i = 0; i < LINE_LINK_CODE_LENGTH; i++) {
+    // バイト値を文字数で割った余りでアルファベットの 1 文字を選ぶ (わずかな偏りは実用上無視できる)
+    body += CODE_ALPHABET[buf[i]! % CODE_ALPHABET.length];
+  }
+  // 中央 (4 文字目の後) にハイフンを入れて表示用に整形する
+  const mid = Math.floor(LINE_LINK_CODE_LENGTH / 2);
+  return `${body.slice(0, mid)}-${body.slice(mid)}`;
+}
+
+// 受信テキストを照合用に正規化する: 英数字以外 (ハイフン・空白・全角等) を除去し、大文字へ揃える。
+// ユーザーがハイフン無し / 小文字 / 前後空白付きで送ってきても一致するようにする。
+export function normalizeLineLinkCode(text: string): string {
+  // 大文字化してから、A-Z と 0-9 以外をすべて取り除く
+  return text.toUpperCase().replace(/[^A-Z0-9]/g, '');
+}
+
+// 正規化済みテキストが「紐付けコードの形をしているか」を判定する (DB 照合の前段フィルタ)。
+// 通常の問い合わせ文をいちいちハッシュ化・DB 照合しないための軽量チェックで、
+// 形が一致しても DB に発行行が無ければ単に invalid となり通常起票に進む (誤判定は無害)。
+export function looksLikeLineLinkCode(normalized: string): boolean {
+  // 長さが規定値で、かつ全文字がコード用アルファベットに含まれるときだけ候補とみなす
+  if (normalized.length !== LINE_LINK_CODE_LENGTH) return false;
+  for (const ch of normalized) {
+    if (!CODE_ALPHABET.includes(ch)) return false;
+  }
+  return true;
+}

--- a/tests/data/user-line-link.memory.test.ts
+++ b/tests/data/user-line-link.memory.test.ts
@@ -1,0 +1,152 @@
+// UserRepository の LINE 紐付けメソッド (メモリアダプタ) の単体テスト。
+// findByLineUserId / setLineLinkCode / linkLineUserByCode / unlinkLineUser の挙動と
+// テナント分離・冪等・競合 (conflict) を検証する (DB は持ち込まない)。
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+import type { Repos } from '@/data/ports/unit-of-work';
+import { hashLineLinkCode, normalizeLineLinkCode } from '@/lib/line-link';
+
+const TENANT = 'default-tenant';
+const OTHER_TENANT = 'other-tenant';
+
+let store: Store;
+let repos: Repos;
+
+// テスト用メンバーを 1 人ストアに置く小ヘルパー
+function putUser(id: string, tenantId: string, extra: Record<string, unknown> = {}) {
+  const now = new Date();
+  store.users.set(id, {
+    id,
+    email: `${id}@example.com`,
+    name: id,
+    passwordHash: 'x',
+    role: 'requester',
+    tenantId,
+    createdAt: now,
+    updatedAt: now,
+    ...extra,
+  });
+}
+
+// 生コードを正規化してハッシュ化する (発行側と同じ手順)
+async function codeHashOf(rawCode: string): Promise<string> {
+  return hashLineLinkCode(normalizeLineLinkCode(rawCode));
+}
+
+describe('UserRepository LINE 紐付け (memory)', () => {
+  beforeEach(() => {
+    const ctx = createMemoryContext();
+    store = ctx.store;
+    repos = ctx.repos;
+  });
+
+  // findByLineUserId: 紐付け済みメンバーを返し、別テナントには漏れない
+  it('findByLineUserId はテナントスコープで引く', async () => {
+    putUser('u1', TENANT, { lineUserId: 'Uline1' });
+    // 同 tenant では引ける
+    expect((await repos.users.findByLineUserId(TENANT, 'Uline1'))?.id).toBe('u1');
+    // 別 tenant からは見えない (クロステナント漏洩防止)
+    expect(await repos.users.findByLineUserId(OTHER_TENANT, 'Uline1')).toBeNull();
+    // 未連携の LINE ユーザー ID は null
+    expect(await repos.users.findByLineUserId(TENANT, 'UlineX')).toBeNull();
+  });
+
+  // setLineLinkCode → linkLineUserByCode で連携が成立し、コードは消費される
+  it('発行コードで連携が成立し、コードが消費される', async () => {
+    putUser('u1', TENANT);
+    const expiresAt = new Date(Date.now() + 10 * 60 * 1000);
+    const hash = await codeHashOf('AB7K-9QF2');
+    await repos.users.setLineLinkCode('u1', TENANT, { codeHash: hash, expiresAt });
+
+    const result = await repos.users.linkLineUserByCode({
+      codeHash: hash,
+      tenantId: TENANT,
+      lineUserId: 'Uline1',
+      now: new Date(),
+    });
+    expect(result).toEqual({ status: 'linked', userId: 'u1' });
+    // lineUserId が設定され、発行中コードはクリアされている
+    const u1 = store.users.get('u1');
+    expect(u1?.lineUserId).toBe('Uline1');
+    expect(u1?.lineLinkCodeHash).toBeNull();
+    // 2 回目 (同じコード) はもう有効な発行行が無いので invalid
+    const again = await repos.users.linkLineUserByCode({
+      codeHash: hash,
+      tenantId: TENANT,
+      lineUserId: 'Uline1',
+      now: new Date(),
+    });
+    expect(again.status).toBe('invalid');
+  });
+
+  // 失効済みコードは invalid
+  it('失効したコードは invalid を返す', async () => {
+    putUser('u1', TENANT);
+    const hash = await codeHashOf('AB7K-9QF2');
+    // 既に失効している有効期限を設定する
+    await repos.users.setLineLinkCode('u1', TENANT, {
+      codeHash: hash,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    const result = await repos.users.linkLineUserByCode({
+      codeHash: hash,
+      tenantId: TENANT,
+      lineUserId: 'Uline1',
+      now: new Date(),
+    });
+    expect(result.status).toBe('invalid');
+  });
+
+  // 別テナントのコードは取り込み先テナントでは消費できない (クロステナント防止)
+  it('別テナントのコードは消費できない', async () => {
+    putUser('uOther', OTHER_TENANT);
+    const hash = await codeHashOf('AB7K-9QF2');
+    await repos.users.setLineLinkCode('uOther', OTHER_TENANT, {
+      codeHash: hash,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    // TENANT 側で同じハッシュを照合しても一致しない
+    const result = await repos.users.linkLineUserByCode({
+      codeHash: hash,
+      tenantId: TENANT,
+      lineUserId: 'Uline1',
+      now: new Date(),
+    });
+    expect(result.status).toBe('invalid');
+  });
+
+  // その LINE ユーザー ID が別メンバーに連携済みなら conflict
+  it('LINE ユーザー ID が別メンバーに連携済みなら conflict', async () => {
+    putUser('u1', TENANT, { lineUserId: 'Uline1' }); // 既に Uline1 を持つ
+    putUser('u2', TENANT); // u2 が同じ Uline1 を取りにくる
+    const hash = await codeHashOf('ZZ11-2233');
+    await repos.users.setLineLinkCode('u2', TENANT, {
+      codeHash: hash,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const result = await repos.users.linkLineUserByCode({
+      codeHash: hash,
+      tenantId: TENANT,
+      lineUserId: 'Uline1',
+      now: new Date(),
+    });
+    expect(result.status).toBe('conflict');
+    // u2 は連携されないまま
+    expect(store.users.get('u2')?.lineUserId).toBeFalsy();
+  });
+
+  // unlinkLineUser は lineUserId と発行中コードをまとめてクリアする
+  it('unlinkLineUser で連携を解除する', async () => {
+    putUser('u1', TENANT, {
+      lineUserId: 'Uline1',
+      lineLinkCodeHash: 'h',
+      lineLinkCodeExpiresAt: new Date(),
+    });
+    await repos.users.unlinkLineUser('u1', TENANT);
+    const u1 = store.users.get('u1');
+    expect(u1?.lineUserId).toBeNull();
+    expect(u1?.lineLinkCodeHash).toBeNull();
+    expect(u1?.lineLinkCodeExpiresAt).toBeNull();
+  });
+});

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -1,0 +1,182 @@
+// POST /api/inbound/line (Phase 2 LINE 取り込み) の Route Handler テスト。
+// 署名検証済みの本文を渡し、(a) ワンタイムコード送信での連携 (起票しない)、
+// (b) 連携済みユーザーの起票者が本人になる、(c) 未連携はプロキシ担当者、を検証する (DB は持ち込まない)。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+import type { Repos } from '@/data/ports/unit-of-work';
+import { hashLineLinkCode, normalizeLineLinkCode } from '@/lib/line-link';
+
+const SECRET = 'test-line-channel-secret';
+const TENANT = 'default-tenant';
+const AGENT_ID = 'u-agent-1';
+const MEMBER_ID = 'u-member-1';
+
+let store: Store;
+let repos: Repos;
+
+// @/data を差し替え (getter で beforeEach の上書きを反映)
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+}));
+
+// テナント + プロキシ担当者 1 名をシードする
+function seed() {
+  const now = new Date();
+  store.tenants.set(TENANT, {
+    id: TENANT,
+    name: 'デフォルト組織',
+    mode: 'lite',
+    industry: null,
+    inboundToken: 'tok',
+    slackWebhookUrl: null,
+    subscriptionPlan: 'free' as const,
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+    stripeSubscriptionStatus: null,
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null,
+    createdAt: now,
+  });
+  // プロキシ起票者になる担当者 (未連携ユーザーのフォールバック先)
+  store.users.set(AGENT_ID, {
+    id: AGENT_ID,
+    email: 'agent@example.com',
+    name: '担当 太郎',
+    passwordHash: 'x',
+    role: 'agent',
+    tenantId: TENANT,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+// LINE 署名を計算する (X-Line-Signature = Base64(HMAC-SHA256(body, secret)))
+function sign(body: string): string {
+  return createHmac('sha256', SECRET).update(body, 'utf8').digest('base64');
+}
+
+// 1 件のテキストメッセージイベントを含む署名付きリクエストを組み立てる
+function makeRequest(text: string, userId: string): Request {
+  const body = JSON.stringify({
+    events: [
+      {
+        type: 'message',
+        source: { type: 'user', userId },
+        message: { type: 'text', id: 'm1', text },
+      },
+    ],
+  });
+  return new Request('http://localhost/api/inbound/line', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-line-signature': sign(body) },
+    body,
+  });
+}
+
+describe('POST /api/inbound/line', () => {
+  beforeEach(() => {
+    const ctx = createMemoryContext();
+    store = ctx.store;
+    repos = ctx.repos;
+    seed();
+    vi.stubEnv('LINE_CHANNEL_SECRET', SECRET);
+    vi.stubEnv('LINE_TARGET_TENANT_ID', TENANT);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  // 未連携ユーザーの通常メッセージはプロキシ担当者を起票者にして起票する
+  it('未連携ユーザーのメッセージはプロキシ担当者で起票する', async () => {
+    const { POST } = await import('@/app/api/inbound/line/route');
+    const res = await POST(makeRequest('プリンターが動きません', 'Uunlinked'));
+    expect(res.status).toBe(200);
+    expect(store.tickets.size).toBe(1);
+    const ticket = Array.from(store.tickets.values())[0];
+    // 未連携なので起票者はプロキシ担当者
+    expect(ticket.creatorId).toBe(AGENT_ID);
+  });
+
+  // 連携済みユーザーのメッセージは本人を起票者にする (自己解決 UI 開通)
+  it('連携済みユーザーのメッセージは本人を起票者にする', async () => {
+    // Uline1 を MEMBER_ID に連携済みにしておく
+    const now = new Date();
+    store.users.set(MEMBER_ID, {
+      id: MEMBER_ID,
+      email: 'member@example.com',
+      name: '依頼 花子',
+      passwordHash: 'x',
+      role: 'requester',
+      tenantId: TENANT,
+      createdAt: now,
+      updatedAt: now,
+      lineUserId: 'Uline1',
+    });
+    const { POST } = await import('@/app/api/inbound/line/route');
+    const res = await POST(makeRequest('パソコンが重いです', 'Uline1'));
+    expect(res.status).toBe(200);
+    const ticket = Array.from(store.tickets.values())[0];
+    // 連携済みなので起票者は本人 (担当者ではない)
+    expect(ticket.creatorId).toBe(MEMBER_ID);
+  });
+
+  // 発行済みコードを送ると連携が成立し、チケットは作られない
+  it('発行済みコードの送信で連携し、起票はしない', async () => {
+    const now = new Date();
+    // コード未連携のメンバーに発行中コードをセットしておく
+    const rawCode = 'AB7K-9QF2';
+    const codeHash = await hashLineLinkCode(normalizeLineLinkCode(rawCode));
+    store.users.set(MEMBER_ID, {
+      id: MEMBER_ID,
+      email: 'member@example.com',
+      name: '依頼 花子',
+      passwordHash: 'x',
+      role: 'requester',
+      tenantId: TENANT,
+      createdAt: now,
+      updatedAt: now,
+      lineLinkCodeHash: codeHash,
+      lineLinkCodeExpiresAt: new Date(Date.now() + 60_000),
+    });
+    const { POST } = await import('@/app/api/inbound/line/route');
+    // ユーザーがコードを (小文字・ハイフン無しで) 送ってきても正規化で一致する
+    const res = await POST(makeRequest('ab7k9qf2', 'UlineNew'));
+    expect(res.status).toBe(200);
+    // 連携が成立し、チケットは作られない
+    expect(store.tickets.size).toBe(0);
+    expect(store.users.get(MEMBER_ID)?.lineUserId).toBe('UlineNew');
+    // 発行中コードは消費済み
+    expect(store.users.get(MEMBER_ID)?.lineLinkCodeHash).toBeNull();
+  });
+
+  // コードの形だが発行行が無いテキストは通常の問い合わせとして起票する
+  it('コード形だが未発行のテキストは通常起票する', async () => {
+    const { POST } = await import('@/app/api/inbound/line/route');
+    // looksLike を満たす 8 文字だが発行行が無い
+    const res = await POST(makeRequest('ZZ112233', 'Uunlinked'));
+    expect(res.status).toBe(200);
+    // 連携ではなく通常起票になる
+    expect(store.tickets.size).toBe(1);
+    expect(Array.from(store.tickets.values())[0].creatorId).toBe(AGENT_ID);
+  });
+
+  // 署名が不正なリクエストは 401 で拒否する
+  it('署名が不正なら 401 を返す', async () => {
+    const body = JSON.stringify({ events: [] });
+    const req = new Request('http://localhost/api/inbound/line', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-line-signature': 'wrong' },
+      body,
+    });
+    const { POST } = await import('@/app/api/inbound/line/route');
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    expect(store.tickets.size).toBe(0);
+  });
+});

--- a/tests/line-link.test.ts
+++ b/tests/line-link.test.ts
@@ -1,0 +1,75 @@
+// LINE 紐付けワンタイムコードのヘルパー (純粋ロジック) の単体テスト。
+// 生成形式・正規化・形判定・ハッシュ整合 (発行側と Webhook 側で一致するか) を検証する。
+
+import { describe, expect, it } from 'vitest';
+import {
+  generateLineLinkCode,
+  hashLineLinkCode,
+  looksLikeLineLinkCode,
+  normalizeLineLinkCode,
+  LINE_LINK_CODE_LENGTH,
+} from '@/lib/line-link';
+
+describe('generateLineLinkCode', () => {
+  // 生成コードは「4 文字 + ハイフン + 4 文字」で、正規化すると規定長になる
+  it('ハイフン区切りで生成し、正規化すると規定長になる', () => {
+    const code = generateLineLinkCode();
+    // 表示形式はハイフンを 1 つ含む
+    expect(code).toContain('-');
+    // 正規化 (ハイフン除去) すると LINE_LINK_CODE_LENGTH 文字
+    expect(normalizeLineLinkCode(code)).toHaveLength(LINE_LINK_CODE_LENGTH);
+    // 正規化後はコードの形と判定される
+    expect(looksLikeLineLinkCode(normalizeLineLinkCode(code))).toBe(true);
+  });
+
+  // 紛らわしい文字 (I/L/O/U) を含まない
+  it('紛らわしい文字 (I/L/O/U) を含まない', () => {
+    const normalized = normalizeLineLinkCode(generateLineLinkCode());
+    expect(normalized).not.toMatch(/[ILOU]/);
+  });
+
+  // 連続生成でコードが毎回変わる (乱数性の最低限の確認)
+  it('呼ぶたびに異なるコードを返す', () => {
+    const a = generateLineLinkCode();
+    const b = generateLineLinkCode();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('normalizeLineLinkCode', () => {
+  // 小文字・空白・ハイフンを除去して大文字に揃える
+  it('小文字・空白・ハイフンを正規化する', () => {
+    expect(normalizeLineLinkCode(' ab7k-9qf2 ')).toBe('AB7K9QF2');
+  });
+});
+
+describe('looksLikeLineLinkCode', () => {
+  // 規定長かつ全文字がコード用アルファベットなら true
+  it('規定長のコード形なら true', () => {
+    expect(looksLikeLineLinkCode('AB7K9QF2')).toBe(true);
+  });
+
+  // 長さ違いは false
+  it('長さが違えば false', () => {
+    expect(looksLikeLineLinkCode('AB7K9QF')).toBe(false);
+    expect(looksLikeLineLinkCode('AB7K9QF23')).toBe(false);
+  });
+
+  // 紛らわしい除外文字を含むと false (通常の問い合わせ文を弾く)
+  it('除外文字 (I/L/O/U) を含むと false', () => {
+    expect(looksLikeLineLinkCode('ABILOUXX')).toBe(false);
+  });
+});
+
+describe('hashLineLinkCode', () => {
+  // 同じ正規化入力からは同じハッシュ (発行側と Webhook 側で一致する) になる
+  it('同じ入力から同じハッシュを返す (発行と照合の整合)', async () => {
+    const code = generateLineLinkCode();
+    const fromIssuer = await hashLineLinkCode(normalizeLineLinkCode(code));
+    // Webhook 側はユーザーがハイフン無し・小文字で送ってきても正規化して同じハッシュになる
+    const fromWebhook = await hashLineLinkCode(
+      normalizeLineLinkCode(code.toLowerCase().replace('-', '')),
+    );
+    expect(fromIssuer).toBe(fromWebhook);
+  });
+});


### PR DESCRIPTION
## Context

メンバー向け改善 **#2** の実装。正本 `docs/smb-dx-pivot-plan.md` **Phase 2「LINE 公式アカウント連携（β）」** の β 制約解消。

現状の LINE 起票は代理担当者を起票者にするため、LINE 利用者が自分の問い合わせを追えなかった。**メンバー起点のワンタイムコード**で `lineUserId` をメンバーへ紐付け、紐付け後は起票者を本人にして自己解決 UI（`creatorId = 自分` の RBAC）を開通させる。

## 変更内容

- **スキーマ**: `User` に `lineUserId` / `lineLinkCodeHash` / `lineLinkCodeExpiresAt` を追加（`(tenantId, lineUserId)` 複合一意・コードハッシュ `@unique`）。同一コミットでマイグレーション追加。
- **Data 層（Ports & Adapters）**: `UserRepository` に `findByLineUserId` / `setLineLinkCode` / `linkLineUserByCode` / `unlinkLineUser` を追加（prisma・memory 両実装）。`linkLineUserByCode` は `Invitation.consumeValidToken` に倣い原子的に照合＋紐付けし、別メンバー連携済み・競合（P2002）は `conflict` を返す。
- **LINE inbound（`src/app/api/inbound/line/route.ts`）**: 受信テキストが発行済みコードなら**起票せず紐付け**、紐付け済みユーザーは**本人を起票者**に、未紐付けは従来どおりプロキシ担当者にフォールバック。
- **自己サービス UI**: 全ロールがアクセスできる `/settings/line` ページ＋コード発行/解除 Server Action（操作対象は常にセッション由来の自分のみ・ユーザー単位レート制限）。Sidebar に導線追加。
- **コード生成ヘルパー `src/lib/line-link.ts`**: Crockford Base32 8 桁・10 分 TTL・正規化・形判定。
- **テスト**: ヘルパー単体 / user リポジトリ memory（連携・冪等・conflict・クロステナント）/ LINE ルート（コード連携・本人起票・プロキシ・署名検証）。

### 既知の制約
アウトバウンド LINE 返信は未実装のため、Bot からの「連携完了」自動返信は出ません。連携完了は Web 設定画面の「連携済み」表示で確認します（LINE 返信は別タスク）。

## 検証

- `npm run db:generate` ✅ / `typecheck` ✅ / `lint` ✅ / `vitest` ✅ **378 passed**（新規 19 件含む。Prisma 契約テストは `RUN_PRISMA_CONTRACT` 未設定でスキップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hpoj2yxfjCVzWHu6CaijyN)_