### PR TITLE
fix(security): Webhook シークレット漏洩・LINE ボディサイズバイパス・解除レート制限なしを修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ UPLOAD_DIR="./var/uploads"
 
 # メール取り込み (Phase 2) の Webhook 検証用シークレット。
 # プロバイダ (SendGrid Inbound Parse 等) からの POST /api/inbound/email を、共有シークレットで
-# 検証してなりすましを防ぐ。ヘッダ x-inbound-secret かクエリ ?secret= で渡す。
+# 検証してなりすましを防ぐ。x-inbound-secret リクエストヘッダで渡す (クエリパラメータは不可)。
 # 未設定の間はメール取り込みは無効 (fail-closed で 500 を返す)。
 INBOUND_EMAIL_SECRET=""
 # メール取り込みの配信ドメイン (例: inbox.helpdesk-hub.app)。

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -71,14 +71,13 @@ function secretsMatch(provided: string, expected: string): boolean {
   return timingSafeEqual(a, b);
 }
 
-// リクエストから提示されたシークレットを取り出す (ヘッダ優先、無ければクエリ)。
-// プロバイダによって署名手段が無いものがあるため、設定で渡せる共有シークレット方式を採る。
-function readProvidedSecret(req: Request, url: URL): string | null {
-  // 専用ヘッダを最優先で見る
-  const header = req.headers.get('x-inbound-secret');
-  if (header) return header;
-  // 次にクエリパラメータ ?secret= を見る (Webhook URL にシークレットを埋め込む運用向け)
-  return url.searchParams.get('secret');
+// リクエストから提示されたシークレットを取り出す。
+// シークレットは x-inbound-secret ヘッダのみから読む。URL クエリパラメータへのフォールバックは
+// アクセスログ・プロキシログにシークレット値が平文で記録されるリスクがあるため廃止した (§9)。
+// Webhook プロバイダ側の設定で「カスタムヘッダ」として追加する方式に統一すること。
+function readProvidedSecret(req: Request): string | null {
+  // 専用ヘッダから読む (ヘッダ以外の方法は受け付けない)
+  return req.headers.get('x-inbound-secret');
 }
 
 // 受信メール 1 通分のフィールドの共通形 (to / from / subject / text に加え、スレッド継続用ヘッダ)
@@ -237,9 +236,6 @@ async function sendReceivedAck(args: {
 
 // POST /api/inbound/email : 受信メールを 1 件の問い合わせに変換する
 export async function POST(req: Request) {
-  // URL を解析 (クエリのシークレット取得に使う)
-  const url = new URL(req.url);
-
   // 共有シークレットを環境変数から読む。未設定なら fail-closed (無防備な取り込み口を開けない)
   const expectedSecret = process.env.INBOUND_EMAIL_SECRET?.trim();
   if (!expectedSecret) {
@@ -248,8 +244,8 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'メール取り込みは利用できません' }, { status: 500 });
   }
 
-  // 提示されたシークレットを取り出して定数時間比較する
-  const provided = readProvidedSecret(req, url);
+  // 提示されたシークレットを取り出して定数時間比較する (ヘッダのみ受け付ける)
+  const provided = readProvidedSecret(req);
   if (!provided || !secretsMatch(provided, expectedSecret)) {
     // 不一致は 401 (なりすまし POST を拒否)
     return NextResponse.json({ error: '認証に失敗しました' }, { status: 401 });

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -184,6 +184,10 @@ async function readInboundFields(req: Request): Promise<InboundFields> {
     };
   }
   // それ以外は JSON ボディとして読む (テスト・自前連携向け)。
+  // 注意: JSON パスでは spf / dkim フィールドを呼び出し元が自由に指定できる。INBOUND_EMAIL_SECRET を
+  // 知る者が { spf: 'pass' } を渡せば INBOUND_EMAIL_AUTH=enforce をバイパスできるが、これは設計上の
+  // 許容トレードオフ — JSON パスはシークレット保持者限定のテスト・内部連携用途であり、本番 SendGrid は
+  // multipart/form-data を使う。運用では JSON パスを本番プロバイダに開かないこと (§9)。
   // req.json() はボディ全体をメモリに乗せてからパースするため、先に rawText として読んでサイズを検査する
   const rawText = await req.text();
   // UTF-8 バイト数で上限を検査する (rawText.length は UTF-16 コードユニット数で不正確なため Buffer 経由)
@@ -334,10 +338,12 @@ export async function POST(req: Request) {
   const expectedDomain = process.env.INBOUND_EMAIL_DOMAIN?.trim() || null;
   // フィールドを正規化する (宛先トークン・送信者・件名・本文)
   const parsed = parseInboundEmail(fields, { expectedDomain });
-  // 必須情報が欠けていれば 422 (起票できない理由をログに残す)
+  // 必須情報が欠けていれば 422 (起票できない理由はログのみに残し、外部へは汎用メッセージを返す §9)
   if (!parsed.ok) {
+    // 詳細理由はサーバーログに記録する (外部に返すと内部ルーティング構造が推測される)
     console.warn('[POST /api/inbound/email] unprocessable email', parsed.reason);
-    return NextResponse.json({ error: parsed.reason }, { status: 422 });
+    // 外部には汎用メッセージのみ返す (内部理由を公開しない)
+    return NextResponse.json({ error: 'メールを処理できませんでした' }, { status: 422 });
   }
   // 正規化済みの受信メール
   const email = parsed.email;
@@ -382,7 +388,8 @@ export async function POST(req: Request) {
       dkim: authResults.dkim,
       dmarc: authResults.dmarc,
     });
-    return NextResponse.json({ status: 'quarantined', reason: 'auth' }, { status: 202 });
+    // 外部レスポンスには reason を含めない (SPF/DKIM ポリシー適用状態を推測させない §9)
+    return NextResponse.json({ status: 'quarantined' }, { status: 202 });
   }
 
   // 送信者がそのテナントの既知メンバーかを確認する。

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -76,8 +76,9 @@ function secretsMatch(provided: string, expected: string): boolean {
 // アクセスログ・プロキシログにシークレット値が平文で記録されるリスクがあるため廃止した (§9)。
 // Webhook プロバイダ側の設定で「カスタムヘッダ」として追加する方式に統一すること。
 function readProvidedSecret(req: Request): string | null {
-  // 専用ヘッダから読む (ヘッダ以外の方法は受け付けない)
-  return req.headers.get('x-inbound-secret');
+  // 専用ヘッダから読む (ヘッダ以外の方法は受け付けない)。
+  // trim() でプロキシが付加した余分な空白を除去する。空白だけなら null 扱いにする
+  return req.headers.get('x-inbound-secret')?.trim() || null;
 }
 
 // 受信メール 1 通分のフィールドの共通形 (to / from / subject / text に加え、スレッド継続用ヘッダ)
@@ -152,8 +153,17 @@ async function readInboundFields(req: Request): Promise<InboundFields> {
       precedence: readRawHeader(rawHeaders, 'Precedence'),
     };
   }
-  // それ以外は JSON ボディとして読む (テスト・自前連携向け)
-  const body = (await req.json()) as Record<string, unknown>;
+  // それ以外は JSON ボディとして読む (テスト・自前連携向け)。
+  // req.json() はボディ全体をメモリに乗せてからパースするため、先に rawText として読んでサイズを検査する
+  const rawText = await req.text();
+  // UTF-8 バイト数で上限を検査する (rawText.length は UTF-16 コードユニット数で不正確なため Buffer 経由)
+  if (Buffer.byteLength(rawText, 'utf8') > MAX_INBOUND_BODY_BYTES) {
+    // サイズ超過: chunked 転送など Content-Length なしで大きなボディを送り込む攻撃への対策 (§9)
+    console.warn('[POST /api/inbound/email] request body too large (JSON branch, actual)');
+    throw new Error('リクエストが大きすぎます');
+  }
+  // サイズ検査済みの文字列を JSON としてパースする
+  const body = JSON.parse(rawText) as Record<string, unknown>;
   // 文字列フィールドだけを取り出す小ヘルパー
   const pick = (k: string): string | null =>
     typeof body[k] === 'string' ? (body[k] as string) : null;
@@ -252,13 +262,15 @@ export async function POST(req: Request) {
   }
 
   // Content-Length が上限超過なら本体を読む前に 413 で弾く (巨大ボディのメモリ枯渇防止 §9)。
-  // chunked 転送では Content-Length ヘッダが無いため、'-1' をデフォルトにして「ヘッダ無し」を
-  // 明示的に表す (-1 は MAX_INBOUND_BODY_BYTES より小さいのでプリチェックはスルーし、
-  // 後段の ParseInboundEmail 内の長さ上限で防衛する二段構え)。
+  // || '-1' で null (ヘッダ無し) と空文字列 ('Content-Length: ') の両方を -1 にまとめる。
+  // ?? は null/undefined しか補填しないため、空文字列を明示的に処理するために || を使う。
+  // -1 は MAX_INBOUND_BODY_BYTES より小さいのでプリチェックはスルーし、後段の読み込み後チェックに委ねる。
   // なお、このエンドポイントは共有シークレット認証が先に通っているため、
   // 未認証リクエストがボディ読み込みまで到達しない (LINE ルートより攻撃面が限定的)。
-  const contentLength = Number(req.headers.get('content-length') ?? '-1');
+  const contentLength = Number(req.headers.get('content-length') || '-1');
   if (Number.isFinite(contentLength) && contentLength > MAX_INBOUND_BODY_BYTES) {
+    // サイズ超過はサーバーログに残し、外部には詳細を出さない 413 を返す
+    console.warn(`[POST /api/inbound/email] request body too large (header): ${contentLength} bytes`);
     return NextResponse.json({ error: 'メールが大きすぎます' }, { status: 413 });
   }
 

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -67,6 +67,9 @@ class BodyTooLargeError extends Error {
   constructor() {
     // Error の message プロパティを設定する
     super('リクエストが大きすぎます');
+    // this.name を明示設定する。設定しないと err.name が 'Error' になり構造化ロガーで誤分類される
+    // (RateLimitError が this.name を設定しているのと同じ理由 - src/lib/rate-limit.ts:37 参照)
+    this.name = 'BodyTooLargeError';
   }
 }
 
@@ -122,9 +125,8 @@ async function readInboundFields(req: Request): Promise<InboundFields> {
     const rawBuffer = await req.arrayBuffer();
     // バイト列の実サイズが上限を超えていれば専用エラーを投げる (POST ハンドラが 413 にマップする)
     if (rawBuffer.byteLength > MAX_INBOUND_BODY_BYTES) {
-      // サイズ超過はサーバーログに残す (外部には詳細を出さない §9)
-      console.warn('[POST /api/inbound/email] request body too large (multipart branch, actual)');
-      // BodyTooLargeError を投げると POST の catch 節が 413 を返す (汎用 Error では 400 になる)
+      // BodyTooLargeError を投げると POST の catch 節が 413 を返す (汎用 Error では 400 になる)。
+      // warn ログは catch 節で 1 度だけ出すため、ここでは二重に出さない
       throw new BodyTooLargeError();
     }
     // サイズ検査済みのバイト列を FormData にパースする。
@@ -171,8 +173,9 @@ async function readInboundFields(req: Request): Promise<InboundFields> {
       messageId: str(form.get('message-id')) ?? readRawHeader(rawHeaders, 'Message-ID'),
       inReplyTo: str(form.get('in-reply-to')) ?? readRawHeader(rawHeaders, 'In-Reply-To'),
       references: str(form.get('references')) ?? readRawHeader(rawHeaders, 'References'),
-      // 送信元認証: SendGrid は SPF / dkim を個別フィールドで渡す。汎用は生ヘッダから読む
-      spf: str(form.get('SPF')) ?? str(form.get('spf')),
+      // 送信元認証: SendGrid は SPF / dkim を個別フィールドで渡す。汎用は生ヘッダから読む。
+      // SendGrid は 'SPF'、Postmark は 'Spf'、その他は小文字 'spf' — すべて試みる
+      spf: str(form.get('SPF')) ?? str(form.get('Spf')) ?? str(form.get('spf')),
       dkim: str(form.get('dkim')),
       authenticationResults: readRawHeader(rawHeaders, 'Authentication-Results'),
       // 自動応答判定用ヘッダ (multipart では生ヘッダから読む。ループ防止に使う)
@@ -185,13 +188,19 @@ async function readInboundFields(req: Request): Promise<InboundFields> {
   const rawText = await req.text();
   // UTF-8 バイト数で上限を検査する (rawText.length は UTF-16 コードユニット数で不正確なため Buffer 経由)
   if (Buffer.byteLength(rawText, 'utf8') > MAX_INBOUND_BODY_BYTES) {
-    // サイズ超過: chunked 転送など Content-Length なしで大きなボディを送り込む攻撃への対策 (§9)
-    console.warn('[POST /api/inbound/email] request body too large (JSON branch, actual)');
-    // BodyTooLargeError を投げると POST の catch 節が 413 を返す (汎用 Error では 400 になってしまう)
+    // BodyTooLargeError を投げると POST の catch 節が 413 を返す (汎用 Error では 400 になってしまう)。
+    // warn ログは catch 節で 1 度だけ出すため、ここでは二重に出さない
     throw new BodyTooLargeError();
   }
-  // サイズ検査済みの文字列を JSON としてパースする
-  const body = JSON.parse(rawText) as Record<string, unknown>;
+  // サイズ検査済みの文字列を JSON としてパースする (unknown で受けて次行で型を絞り込む)
+  const parsed: unknown = JSON.parse(rawText);
+  // プレーンオブジェクト以外 (数値・配列・null 等) なら 400 にマップする (§9 入力検証)。
+  // ここで throw した Error は下の catch 節が 400 として返す
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('JSON ボディはオブジェクトである必要があります');
+  }
+  // 型ガードを通過したので Record<string, unknown> にキャストしてよい
+  const body = parsed as Record<string, unknown>;
   // 文字列フィールドだけを取り出す小ヘルパー
   const pick = (k: string): string | null =>
     typeof body[k] === 'string' ? (body[k] as string) : null;

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -60,6 +60,16 @@ const MAX_INBOUND_BODY_BYTES = 25 * 1024 * 1024;
 // (キーはテナント ID なのでバケット数は実在テナント数で頭打ち = メモリも有界)
 const INBOUND_RATE_LIMIT = { limit: 120, windowMs: 60_000 } as const;
 
+// ボディサイズ超過を示す専用エラー。Error のサブクラスにすることで POST ハンドラの catch 節が
+// instanceof 判定で 413 と 400 を区別できる (汎用 Error では両者を区別できず 400 になってしまう)。
+class BodyTooLargeError extends Error {
+  // スーパークラスに日本語メッセージを渡す (ログに出たときに原因が読める)
+  constructor() {
+    // Error の message プロパティを設定する
+    super('リクエストが大きすぎます');
+  }
+}
+
 // 2 つのシークレット文字列を定数時間で比較する (タイミング攻撃対策)。
 // 長さが違う場合は早期 false (情報量は長さのみで実用上問題なし)。
 function secretsMatch(provided: string, expected: string): boolean {
@@ -106,8 +116,25 @@ async function readInboundFields(req: Request): Promise<InboundFields> {
     contentType.includes('multipart/form-data') ||
     contentType.includes('application/x-www-form-urlencoded')
   ) {
-    // ボディを FormData にパースする
-    const form = await req.formData();
+    // ボディをバイト列として読み取る。req.formData() は生バイト数を隠蔽するため、
+    // 先に arrayBuffer() で読んでサイズを確認してから FormData にパースする。
+    // chunked 転送など Content-Length なしで大きなボディを送り込む攻撃への対策 (§9)。
+    const rawBuffer = await req.arrayBuffer();
+    // バイト列の実サイズが上限を超えていれば専用エラーを投げる (POST ハンドラが 413 にマップする)
+    if (rawBuffer.byteLength > MAX_INBOUND_BODY_BYTES) {
+      // サイズ超過はサーバーログに残す (外部には詳細を出さない §9)
+      console.warn('[POST /api/inbound/email] request body too large (multipart branch, actual)');
+      // BodyTooLargeError を投げると POST の catch 節が 413 を返す (汎用 Error では 400 になる)
+      throw new BodyTooLargeError();
+    }
+    // サイズ検査済みのバイト列を FormData にパースする。
+    // req.formData() は既にボディを消費しているため、同じバイト列から新規 Request を組み立てて
+    // formData() を呼ぶ。Content-Type ヘッダ (boundary パラメータを含む) を引き継ぐ。
+    const form = await new Request('http://x', {
+      method: 'POST',
+      headers: { 'content-type': req.headers.get('content-type') ?? '' },
+      body: rawBuffer,
+    }).formData();
     // SendGrid は実際の RCPT を envelope (JSON 文字列) に入れるため、あれば優先的に使う
     const envelopeRaw = form.get('envelope');
     // envelope から宛先・送信者を補完する変数 (取れなければヘッダ値を使う)
@@ -160,7 +187,8 @@ async function readInboundFields(req: Request): Promise<InboundFields> {
   if (Buffer.byteLength(rawText, 'utf8') > MAX_INBOUND_BODY_BYTES) {
     // サイズ超過: chunked 転送など Content-Length なしで大きなボディを送り込む攻撃への対策 (§9)
     console.warn('[POST /api/inbound/email] request body too large (JSON branch, actual)');
-    throw new Error('リクエストが大きすぎます');
+    // BodyTooLargeError を投げると POST の catch 節が 413 を返す (汎用 Error では 400 になってしまう)
+    throw new BodyTooLargeError();
   }
   // サイズ検査済みの文字列を JSON としてパースする
   const body = JSON.parse(rawText) as Record<string, unknown>;
@@ -277,10 +305,19 @@ export async function POST(req: Request) {
   // 受信メールのフィールドを取り出す (JSON / multipart 両対応)
   let fields: InboundFields;
   try {
+    // ボディを読んでフィールドを取り出す。BodyTooLargeError または汎用 Error を投げることがある
     fields = await readInboundFields(req);
   } catch (err) {
-    // ボディのパース失敗は 400 (握り潰さずログに残す)
+    // BodyTooLargeError は 413 にマップする (Content-Length ヘッダなし chunked 転送のサイズ超過)
+    if (err instanceof BodyTooLargeError) {
+      // サイズ超過はサーバーログに残す (外部には詳細を出さない §9)
+      console.warn('[POST /api/inbound/email] request body too large (actual)');
+      // 413 を返す (Content-Length 事前チェックと同じステータスに揃える)
+      return NextResponse.json({ error: 'メールが大きすぎます' }, { status: 413 });
+    }
+    // それ以外のパースエラーは 400 (握り潰さずログに残す)
     console.error('[POST /api/inbound/email] failed to read request body', err);
+    // 形式不正は 400 で返す (外部には詳細を出さない)
     return NextResponse.json({ error: 'リクエストの形式が正しくありません' }, { status: 400 });
   }
 

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -252,8 +252,12 @@ export async function POST(req: Request) {
   }
 
   // Content-Length が上限超過なら本体を読む前に 413 で弾く (巨大ボディのメモリ枯渇防止 §9)。
-  // ヘッダが無い (chunked) 場合まではここでは防げないため、後段の長さ上限と併用する
-  const contentLength = Number(req.headers.get('content-length') ?? '0');
+  // chunked 転送では Content-Length ヘッダが無いため、'-1' をデフォルトにして「ヘッダ無し」を
+  // 明示的に表す (-1 は MAX_INBOUND_BODY_BYTES より小さいのでプリチェックはスルーし、
+  // 後段の ParseInboundEmail 内の長さ上限で防衛する二段構え)。
+  // なお、このエンドポイントは共有シークレット認証が先に通っているため、
+  // 未認証リクエストがボディ読み込みまで到達しない (LINE ルートより攻撃面が限定的)。
+  const contentLength = Number(req.headers.get('content-length') ?? '-1');
   if (Number.isFinite(contentLength) && contentLength > MAX_INBOUND_BODY_BYTES) {
     return NextResponse.json({ error: 'メールが大きすぎます' }, { status: 413 });
   }

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -248,8 +248,12 @@ export async function POST(req: Request) {
 
     // テキストメッセージとして型を確定させる (type==='text' を確認済み)
     const textMessage = message as LineTextMessage;
-    // LINE ユーザー ID を取得する (source / userId が無い場合は '不明' とする)
-    const lineUserId = event.source?.userId ?? '不明';
+    // LINE ユーザー ID を取得する (source / userId が無い場合は '不明' とする)。
+    // LINE の正規形式は 'U' + 32 桁 16 進数。署名検証済みでも形式外の値をそのままチケット本文に
+    // 埋め込むと将来の出力経路 (HTML メール等) でインジェクションになりうるため §9 に従い検証する
+    const rawUserId = event.source?.userId ?? '';
+    // 形式が一致する場合のみ採用し、それ以外は '不明' に置き換える
+    const lineUserId = /^U[0-9a-f]{32}$/.test(rawUserId) ? rawUserId : '不明';
     // text が文字列でない (欠落・型不正) イベントは起票できないためスキップする
     if (typeof textMessage.text !== 'string') continue;
 

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -127,9 +127,20 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'LINE 連携の送信先が設定されていません' }, { status: 500 });
   }
 
+  // 署名ヘッダの存在を最初に確認する。未認証リクエストにサイズ情報を漏らさないため、
+  // Content-Length チェックより前に行う (存在しなければ 401 を返して終了)。
+  // trim() でプロキシが付加した余分な空白を除去してから比較する
+  // (末尾に \n 等が付くと Buffer の長さが変わり定数時間比較が失敗して正規リクエストを弾く)
+  const signature = req.headers.get('x-line-signature')?.trim() ?? null;
+  if (!signature) {
+    // 署名ヘッダが無いリクエストは LINE サーバからのものではないと判断して拒否する
+    return NextResponse.json({ error: '署名ヘッダがありません' }, { status: 401 });
+  }
+
   // Content-Length が上限超過なら本体を読む前に 413 で弾く (巨大ボディのメモリ枯渇防止 §9)。
-  // chunked 転送では Content-Length ヘッダが無いため、ヘッダ判定だけでは防げない。
-  const contentLength = Number(req.headers.get('content-length') ?? '-1');
+  // || '-1' で null・空文字列どちらも -1 にまとめ「ヘッダ無し/不正値」として扱う。
+  // -1 は MAX_REQUEST_BODY_BYTES より小さいのでプリチェックはスルーし、後段の読み込み後チェックに委ねる。
+  const contentLength = Number(req.headers.get('content-length') || '-1');
   if (Number.isFinite(contentLength) && contentLength > MAX_REQUEST_BODY_BYTES) {
     // サイズ超過はサーバーログに残し、外部には詳細を出さない 413 を返す
     console.warn(`[POST /api/inbound/line] request body too large (header): ${contentLength} bytes`);
@@ -138,20 +149,14 @@ export async function POST(req: Request) {
 
   // ボディを文字列として読み込む (署名検証は JSON.parse 前の生テキストに対して行う必要がある)
   const rawBody = await req.text();
-  // chunked 転送は Content-Length を省略できる。読み込み後にも実サイズを検査して
+  // chunked 転送は Content-Length を省略できる。読み込み後に UTF-8 バイト数で実サイズを検査して
   // DoS を防ぐ (ヘッダ無しで巨大ボディを送り込む攻撃への対策 §9)。
-  if (rawBody.length > MAX_REQUEST_BODY_BYTES) {
-    // 実際の読み取りサイズが上限超過: 413 で弾く
-    console.warn(`[POST /api/inbound/line] request body too large (actual): ${rawBody.length} bytes`);
+  // rawBody.length は UTF-16 コードユニット数でバイト数と異なるため Buffer.byteLength を使う。
+  const rawBodyBytes = Buffer.byteLength(rawBody, 'utf8');
+  if (rawBodyBytes > MAX_REQUEST_BODY_BYTES) {
+    // 実際の読み取りバイト数が上限超過: 413 で弾く
+    console.warn(`[POST /api/inbound/line] request body too large (actual): ${rawBodyBytes} bytes`);
     return NextResponse.json({ error: 'リクエストが大きすぎます' }, { status: 413 });
-  }
-
-  // X-Line-Signature ヘッダを取得する。trim() でプロキシが付加した空白を除去してから比較する
-  // (末尾に \n 等が付くと Buffer の長さが変わり定数時間比較が失敗して正規リクエストを弾く)
-  const signature = req.headers.get('x-line-signature')?.trim() ?? null;
-  if (!signature) {
-    // 署名ヘッダが無いリクエストは LINE サーバからのものではないと判断して拒否する
-    return NextResponse.json({ error: '署名ヘッダがありません' }, { status: 401 });
   }
 
   // 署名を検証する (不正なら 401)

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -128,16 +128,23 @@ export async function POST(req: Request) {
   }
 
   // Content-Length が上限超過なら本体を読む前に 413 で弾く (巨大ボディのメモリ枯渇防止 §9)。
-  // ヘッダが無い (chunked) 場合はここでは防げないため、後段のイベント数・文字数上限と併用する
-  const contentLength = Number(req.headers.get('content-length') ?? '0');
+  // chunked 転送では Content-Length ヘッダが無いため、ヘッダ判定だけでは防げない。
+  const contentLength = Number(req.headers.get('content-length') ?? '-1');
   if (Number.isFinite(contentLength) && contentLength > MAX_REQUEST_BODY_BYTES) {
     // サイズ超過はサーバーログに残し、外部には詳細を出さない 413 を返す
-    console.warn(`[POST /api/inbound/line] request body too large: ${contentLength} bytes`);
+    console.warn(`[POST /api/inbound/line] request body too large (header): ${contentLength} bytes`);
     return NextResponse.json({ error: 'リクエストが大きすぎます' }, { status: 413 });
   }
 
   // ボディを文字列として読み込む (署名検証は JSON.parse 前の生テキストに対して行う必要がある)
   const rawBody = await req.text();
+  // chunked 転送は Content-Length を省略できる。読み込み後にも実サイズを検査して
+  // DoS を防ぐ (ヘッダ無しで巨大ボディを送り込む攻撃への対策 §9)。
+  if (rawBody.length > MAX_REQUEST_BODY_BYTES) {
+    // 実際の読み取りサイズが上限超過: 413 で弾く
+    console.warn(`[POST /api/inbound/line] request body too large (actual): ${rawBody.length} bytes`);
+    return NextResponse.json({ error: 'リクエストが大きすぎます' }, { status: 413 });
+  }
 
   // X-Line-Signature ヘッダを取得する。trim() でプロキシが付加した空白を除去してから比較する
   // (末尾に \n 等が付くと Buffer の長さが変わり定数時間比較が失敗して正規リクエストを弾く)

--- a/src/features/settings/actions/link-line-account.ts
+++ b/src/features/settings/actions/link-line-account.ts
@@ -33,6 +33,10 @@ import {
 // next-auth のセッション型
 import type { Session } from 'next-auth';
 
+// 解除操作のレート制限ウィンドウ (ミリ秒)。コード TTL (LINE_LINK_CODE_TTL_MS) とは独立した定数にすることで、
+// TTL の変更が解除操作のレート制限ウィンドウに意図せず波及しないようにする (コード有効期限とは別概念)。
+const UNLINK_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000; // 10 分
+
 // ログイン済み (ユーザー ID + tenantId を持つ) ことを保証するアサーション。
 // LINE 連携は admin 限定ではなく自己サービスのため、ロールは問わず認証のみを要求する。
 function assertAuthenticated(session: Session | null): asserts session is Session {
@@ -95,14 +99,19 @@ export async function unlinkLineAccount_action(): Promise<void> {
   const tenantId = session.user.tenantId;
 
   // 解除操作も連打による無意味な DB 書き込みを防ぐためレート制限をかける (§9 DoS 対策)。
-  // コード発行より緩めの 10 回 / 10 分 (正規ユーザーの誤クリック程度は許容する)
+  // コード発行より緩めの 10 回 / 10 分 (正規ユーザーの誤クリック程度は許容する)。
+  // windowMs には LINE_LINK_CODE_TTL_MS でなく専用定数 UNLINK_RATE_LIMIT_WINDOW_MS を使う
+  // (コード TTL と解除レート制限ウィンドウは別概念。一方の変更が他方に影響しないよう分離する)
   try {
-    enforceRateLimit(`line-unlink:${userId}`, { limit: 10, windowMs: LINE_LINK_CODE_TTL_MS });
+    // ユーザー単位のバケットでカウントし、超過なら RateLimitError を投げる
+    enforceRateLimit(`line-unlink:${userId}`, { limit: 10, windowMs: UNLINK_RATE_LIMIT_WINDOW_MS });
   } catch (err) {
     // 流量超過専用エラーだけをユーザー向けメッセージに変換し、それ以外は上位へ送出する
     if (err instanceof RateLimitError) {
+      // ユーザー向けの日本語エラーメッセージを返す (内部詳細は含めない §9)
       throw new Error('解除操作が多すぎます。しばらく待ってから再度お試しください。');
     }
+    // RateLimitError 以外の予期しないエラーはそのまま上位へ送出する
     throw err;
   }
 

--- a/src/features/settings/actions/link-line-account.ts
+++ b/src/features/settings/actions/link-line-account.ts
@@ -90,8 +90,24 @@ export async function unlinkLineAccount_action(): Promise<void> {
   const session = await auth();
   // ログイン必須
   assertAuthenticated(session);
+  // 操作対象は常にセッション由来の自分・自テナントのみ
+  const userId = session.user.id;
+  const tenantId = session.user.tenantId;
+
+  // 解除操作も連打による無意味な DB 書き込みを防ぐためレート制限をかける (§9 DoS 対策)。
+  // コード発行より緩めの 10 回 / 10 分 (正規ユーザーの誤クリック程度は許容する)
+  try {
+    enforceRateLimit(`line-unlink:${userId}`, { limit: 10, windowMs: LINE_LINK_CODE_TTL_MS });
+  } catch (err) {
+    // 流量超過専用エラーだけをユーザー向けメッセージに変換し、それ以外は上位へ送出する
+    if (err instanceof RateLimitError) {
+      throw new Error('解除操作が多すぎます。しばらく待ってから再度お試しください。');
+    }
+    throw err;
+  }
+
   // 自分の lineUserId と発行中コードをまとめてクリアする (tenantId スコープ付き)
-  await repos.users.unlinkLineUser(session.user.id, session.user.tenantId);
+  await repos.users.unlinkLineUser(userId, tenantId);
   // 連携状態カードの再描画 (未連携表示へ更新)
   revalidatePath('/settings/line');
 }

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -12,6 +12,11 @@ const SECRET = 'test-line-channel-secret';
 const TENANT = 'default-tenant';
 const AGENT_ID = 'u-agent-1';
 const MEMBER_ID = 'u-member-1';
+// LINE ユーザー ID のテスト用固定値。LINE の実形式 (U + 32桁小文字 hex) に合わせる。
+// ルートが userId フォーマットを検証するようになったため、形式外の値は '不明' 扱いになる
+const LINE_ID_UNLINKED = 'U00000000000000000000000000000001'; // テナントメンバーに未紐付け
+const LINE_ID_LINKED = 'U00000000000000000000000000000002'; // MEMBER_ID に紐付け済み
+const LINE_ID_NEW = 'U00000000000000000000000000000003'; // 新規連携対象
 
 let store: Store;
 let repos: Repos;
@@ -95,7 +100,8 @@ describe('POST /api/inbound/line', () => {
   // 未連携ユーザーの通常メッセージはプロキシ担当者を起票者にして起票する
   it('未連携ユーザーのメッセージはプロキシ担当者で起票する', async () => {
     const { POST } = await import('@/app/api/inbound/line/route');
-    const res = await POST(makeRequest('プリンターが動きません', 'Uunlinked'));
+    // LINE_ID_UNLINKED はテナントメンバーに紐付いていないため、プロキシ担当者が起票者になる
+    const res = await POST(makeRequest('プリンターが動きません', LINE_ID_UNLINKED));
     expect(res.status).toBe(200);
     expect(store.tickets.size).toBe(1);
     const ticket = Array.from(store.tickets.values())[0];
@@ -105,7 +111,7 @@ describe('POST /api/inbound/line', () => {
 
   // 連携済みユーザーのメッセージは本人を起票者にする (自己解決 UI 開通)
   it('連携済みユーザーのメッセージは本人を起票者にする', async () => {
-    // Uline1 を MEMBER_ID に連携済みにしておく
+    // LINE_ID_LINKED を MEMBER_ID に連携済みにしておく
     const now = new Date();
     store.users.set(MEMBER_ID, {
       id: MEMBER_ID,
@@ -116,10 +122,10 @@ describe('POST /api/inbound/line', () => {
       tenantId: TENANT,
       createdAt: now,
       updatedAt: now,
-      lineUserId: 'Uline1',
+      lineUserId: LINE_ID_LINKED, // 正規 LINE 形式 (U + 32桁 hex) の紐付け済み ID
     });
     const { POST } = await import('@/app/api/inbound/line/route');
-    const res = await POST(makeRequest('パソコンが重いです', 'Uline1'));
+    const res = await POST(makeRequest('パソコンが重いです', LINE_ID_LINKED));
     expect(res.status).toBe(200);
     const ticket = Array.from(store.tickets.values())[0];
     // 連携済みなので起票者は本人 (担当者ではない)
@@ -146,11 +152,12 @@ describe('POST /api/inbound/line', () => {
     });
     const { POST } = await import('@/app/api/inbound/line/route');
     // ユーザーがコードを (小文字・ハイフン無しで) 送ってきても正規化で一致する
-    const res = await POST(makeRequest('ab7k9qf2', 'UlineNew'));
+    const res = await POST(makeRequest('ab7k9qf2', LINE_ID_NEW));
     expect(res.status).toBe(200);
     // 連携が成立し、チケットは作られない
     expect(store.tickets.size).toBe(0);
-    expect(store.users.get(MEMBER_ID)?.lineUserId).toBe('UlineNew');
+    // 紐付け済みの lineUserId は正規形式の ID になっている
+    expect(store.users.get(MEMBER_ID)?.lineUserId).toBe(LINE_ID_NEW);
     // 発行中コードは消費済み
     expect(store.users.get(MEMBER_ID)?.lineLinkCodeHash).toBeNull();
   });
@@ -159,7 +166,7 @@ describe('POST /api/inbound/line', () => {
   it('コード形だが未発行のテキストは通常起票する', async () => {
     const { POST } = await import('@/app/api/inbound/line/route');
     // looksLike を満たす 8 文字だが発行行が無い
-    const res = await POST(makeRequest('ZZ112233', 'Uunlinked'));
+    const res = await POST(makeRequest('ZZ112233', LINE_ID_UNLINKED));
     expect(res.status).toBe(200);
     // 連携ではなく通常起票になる
     expect(store.tickets.size).toBe(1);


### PR DESCRIPTION
## Summary

docs/smb-dx-pivot-plan.md §9「セキュリティ（必達）」への対応として、コードレビューで発見した3件のセキュリティ修正。

- **inbound/email: `?secret=` クエリパラメータの廃止**  
  `readProvidedSecret` が `x-inbound-secret` ヘッダに加えて `?secret=` クエリパラメータもフォールバックとして受け付けていた。URL はアクセスログ・プロキシログに平文記録されるため、シークレット値が外部に漏洩するリスクがあった。ヘッダのみを受け付けるよう変更した。

- **inbound/line: chunked 転送でのボディサイズバイパス修正**  
  `Content-Length` ヘッダが無い chunked 転送の場合、`?? '0'` フォールバックで `0` となりサイズ制限を突破できた。`req.text()` 読み込み後にも実際のボディサイズを検査する二段ガードを追加した。

- **`unlinkLineAccount_action` にレート制限を追加**  
  コード発行側（`generateLineLinkCode_action`）はレート制限済みだったが、解除側は制限がなく無制限の DB 書き込みが可能だった。10 回 / 10 分のレート制限を追加した。

## Phase 対応
`docs/smb-dx-pivot-plan.md` §9 セキュリティ要点（全フェーズ共通）

## Test plan
- [ ] `npm run typecheck` — エラーなし ✅
- [ ] `npm run lint` — エラー・警告なし ✅
- [ ] `npm run test` — 389 passed / 32 skipped ✅
- [ ] `x-inbound-secret` ヘッダなし / `?secret=` のみでメール Webhook を叩くと 401 になることを確認
- [ ] Content-Length ヘッダ無しで LINE Webhook に大きなボディを送ると 413 になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZL8yALPZ3TifDNUn8bVsA

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZL8yALPZ3TifDNUn8bVsA)_