### PR TITLE
refactor: DRY修正・CSVバリデーションを純粋関数に抽出

### DIFF
--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -65,6 +65,85 @@ export interface ImportTicketsResult {
   errors: Array<{ row: number; message: string }>; // 失敗した行の番号とエラーメッセージ
 }
 
+// CSV 1 行分のバリデーション済みデータ
+interface ValidatedRow {
+  title: string; // 検証済みの件名
+  body: string; // 検証済みの本文
+  priority: Priority; // 変換済みの優先度
+  resolutionDueAt: Date | null; // 変換済みの期限日 (null = 未指定)
+}
+
+// CSV ヘッダの列インデックス一覧
+interface ColumnIndices {
+  titleIndex: number; // 「件名」列
+  bodyIndex: number; // 「内容」列 (-1 = 未指定)
+  dueDateIndex: number; // 「期限日」列 (-1 = 未指定)
+  priorityIndex: number; // 「優先度」列 (-1 = 未指定)
+}
+
+// CSV 1 行分のセルを受け取り、バリデーション・型変換を行う純粋関数。
+// DB アクセスや副作用を持たないため、単体テストが書きやすい。
+// 成功時は { ok: true, data } を返し、失敗時は { ok: false, message } を返す。
+function validateImportRow(
+  cells: string[], // パース済みのセル配列
+  indices: ColumnIndices, // 各列のインデックス
+): { ok: true; data: ValidatedRow } | { ok: false; message: string } {
+  const { titleIndex, bodyIndex, dueDateIndex, priorityIndex } = indices;
+
+  // 件名セルを取り出す
+  const titleRaw = cells[titleIndex] ?? '';
+  // 件名が空の行はエラーとして記録してスキップする (静かにスキップせずユーザーに通知する)
+  if (!titleRaw) {
+    return { ok: false, message: '件名が空です' };
+  }
+  // 件名が長すぎる場合はエラーとして記録する (DB の制約前に弾く)
+  if (titleRaw.length > TITLE_MAX_LENGTH) {
+    return { ok: false, message: `件名が長すぎます（${TITLE_MAX_LENGTH}文字以内にしてください）` };
+  }
+
+  // 本文セルを取り出す (未指定なら空文字)
+  const bodyRaw = bodyIndex !== -1 ? (cells[bodyIndex] ?? '') : '';
+  // 本文が長すぎる場合はエラーとして記録する
+  if (bodyRaw.length > BODY_MAX_LENGTH) {
+    return { ok: false, message: `内容が長すぎます（${BODY_MAX_LENGTH}文字以内にしてください）` };
+  }
+
+  // 優先度セルを日本語から Priority 型へ変換する
+  const priorityRaw = priorityIndex !== -1 ? (cells[priorityIndex] ?? '') : '';
+  // 空文字でない場合に PRIORITY_MAP に存在しない値はタイポや意図しない値なのでエラーとする
+  if (priorityRaw && !(priorityRaw in PRIORITY_MAP)) {
+    return {
+      ok: false,
+      message: `優先度の値が正しくありません: "${priorityRaw}"（高・中・低 のいずれかを指定してください）`,
+    };
+  }
+  // 空文字または未指定の場合は Medium にフォールバックする
+  const priority: Priority = PRIORITY_MAP[priorityRaw] ?? 'Medium';
+
+  // 期限日セルを Date に変換する
+  let resolutionDueAt: Date | null = null;
+  if (dueDateIndex !== -1) {
+    // 期限日セルの値を取り出す
+    const dueDateRaw = cells[dueDateIndex] ?? '';
+    if (dueDateRaw) {
+      // YYYY-MM-DD 形式をローカル時刻の Date に変換する
+      const parsed = parseDateLocal(dueDateRaw);
+      if (parsed === null) {
+        // 変換に失敗した (不正な形式) 場合はエラーとして記録する
+        return {
+          ok: false,
+          message: `期限日の形式が正しくありません: "${dueDateRaw}"（YYYY-MM-DD 形式で入力してください）`,
+        };
+      }
+      // 変換できた値を解決期限として使う
+      resolutionDueAt = parsed;
+    }
+  }
+
+  // 全バリデーション通過: 検証済みデータを返す
+  return { ok: true, data: { title: titleRaw, body: bodyRaw, priority, resolutionDueAt } };
+}
+
 // CSV テキストを受け取ってチケットを一括作成するサーバーアクション
 export async function importTickets(csvText: string): Promise<ImportTicketsResult> {
   // セッション取得 (ログイン状態を確認)
@@ -139,6 +218,9 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
   let imported = 0;
   const errors: Array<{ row: number; message: string }> = [];
 
+  // ヘッダ列インデックスをまとめてバリデーション関数へ渡す
+  const columnIndices: ColumnIndices = { titleIndex, bodyIndex, dueDateIndex, priorityIndex };
+
   // データ行を 1 件ずつ処理する (部分成功を許可するため、1 件エラーでも他を続ける)
   for (let i = 0; i < dataLines.length; i += 1) {
     // CSV の行番号は 1-indexed のヘッダを含めて数えるため +2 する (エラー表示用)
@@ -158,64 +240,15 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
       continue;
     }
 
-    // 件名セルを取り出す
-    const titleRaw = cells[titleIndex] ?? '';
-    // 件名が空の行はエラーとして記録してスキップする (静かにスキップせずユーザーに通知する)
-    if (!titleRaw) {
-      errors.push({ row: rowNum, message: '件名が空です' });
+    // セルのバリデーション・型変換を純粋関数に委譲する (責務の分離)
+    const validation = validateImportRow(cells, columnIndices);
+    if (!validation.ok) {
+      // バリデーションエラーを行番号付きで記録してこの行をスキップする
+      errors.push({ row: rowNum, message: validation.message });
       continue;
     }
-    // 件名が長すぎる場合はエラーとして記録してこの行をスキップ (DB の制約前に弾く)
-    if (titleRaw.length > TITLE_MAX_LENGTH) {
-      errors.push({ row: rowNum, message: `件名が長すぎます（${TITLE_MAX_LENGTH}文字以内にしてください）` });
-      continue;
-    }
-    // 検証済みの件名を確定する
-    const title = titleRaw;
-
-    // 本文セルを取り出す (未指定なら空文字)
-    const bodyRaw = bodyIndex !== -1 ? (cells[bodyIndex] ?? '') : '';
-    // 本文が長すぎる場合はエラーとして記録してこの行をスキップ
-    if (bodyRaw.length > BODY_MAX_LENGTH) {
-      errors.push({ row: rowNum, message: `内容が長すぎます（${BODY_MAX_LENGTH}文字以内にしてください）` });
-      continue;
-    }
-    // 検証済みの本文を確定する
-    const body = bodyRaw;
-
-    // 優先度セルを日本語から Priority 型へ変換する
-    const priorityRaw = priorityIndex !== -1 ? (cells[priorityIndex] ?? '') : '';
-    // 空文字は「未指定」として Medium にフォールバック (省略を許容する)。
-    // ただし空文字でない場合に PRIORITY_MAP に存在しない値は、タイポや意図しない値の可能性が高いため
-    // エラーとして記録してスキップする (サイレントに Medium 扱いすると誤ったデータが入ってしまうため)。
-    if (priorityRaw && !(priorityRaw in PRIORITY_MAP)) {
-      errors.push({
-        row: rowNum,
-        message: `優先度の値が正しくありません: "${priorityRaw}"（高・中・低 のいずれかを指定してください）`,
-      });
-      continue;
-    }
-    // 空文字または未指定の場合は Medium にフォールバックする
-    const priority: Priority = PRIORITY_MAP[priorityRaw] ?? 'Medium';
-
-    // 期限日セルを Date に変換する (形式が不正なら null として解決期限なしにする)
-    let resolutionDueAt: Date | null = null;
-    if (dueDateIndex !== -1) {
-      // 期限日セルの値を取り出す
-      const dueDateRaw = cells[dueDateIndex] ?? '';
-      if (dueDateRaw) {
-        // YYYY-MM-DD 形式をローカル時刻の Date に変換する
-        // (`new Date('YYYY-MM-DD')` は UTC 午前 0 時なので JST 環境で前日になるバグを回避)
-        const parsed = parseDateLocal(dueDateRaw);
-        if (parsed === null) {
-          // 変換に失敗した (不正な形式) 場合はエラーとして記録してこの行をスキップ
-          errors.push({ row: rowNum, message: `期限日の形式が正しくありません: "${dueDateRaw}"（YYYY-MM-DD 形式で入力してください）` });
-          continue;
-        }
-        // 変換できた値を解決期限として使う
-        resolutionDueAt = parsed;
-      }
-    }
+    // バリデーション通過: 検証済みデータを展開する
+    const { title, body, priority, resolutionDueAt } = validation.data;
 
     // チケットを 1 件作成する (失敗してもループを続けて部分成功を許可する)
     try {

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -88,6 +88,7 @@ function validateImportRow(
   cells: string[], // パース済みのセル配列
   indices: ColumnIndices, // 各列のインデックス
 ): { ok: true; data: ValidatedRow } | { ok: false; message: string } {
+  // 引数オブジェクトから各列インデックスを取り出す
   const { titleIndex, bodyIndex, dueDateIndex, priorityIndex } = indices;
 
   // 件名セルを取り出す
@@ -111,7 +112,8 @@ function validateImportRow(
   // 優先度セルを日本語から Priority 型へ変換する
   const priorityRaw = priorityIndex !== -1 ? (cells[priorityIndex] ?? '') : '';
   // 空文字でない場合に PRIORITY_MAP に存在しない値はタイポや意図しない値なのでエラーとする
-  if (priorityRaw && !(priorityRaw in PRIORITY_MAP)) {
+  // Object.hasOwn を使い、Object.prototype 上のキー (__proto__ 等) を誤って通過させない
+  if (priorityRaw && !Object.hasOwn(PRIORITY_MAP, priorityRaw)) {
     return {
       ok: false,
       message: `優先度の値が正しくありません: "${priorityRaw}"（高・中・低 のいずれかを指定してください）`,

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -114,9 +114,11 @@ function validateImportRow(
   // 空文字でない場合に PRIORITY_MAP に存在しない値はタイポや意図しない値なのでエラーとする
   // Object.hasOwn を使い、Object.prototype 上のキー (__proto__ 等) を誤って通過させない
   if (priorityRaw && !Object.hasOwn(PRIORITY_MAP, priorityRaw)) {
+    // エラーメッセージにセル値を反映する際は 100 文字に切り詰め、レスポンス肥大化を防ぐ
+    const priorityDisplay = priorityRaw.length > 100 ? `${priorityRaw.slice(0, 100)}…` : priorityRaw;
     return {
       ok: false,
-      message: `優先度の値が正しくありません: "${priorityRaw}"（高・中・低 のいずれかを指定してください）`,
+      message: `優先度の値が正しくありません: "${priorityDisplay}"（高・中・低 のいずれかを指定してください）`,
     };
   }
   // 空文字または未指定の場合は Medium にフォールバックする
@@ -132,9 +134,11 @@ function validateImportRow(
       const parsed = parseDateLocal(dueDateRaw);
       if (parsed === null) {
         // 変換に失敗した (不正な形式) 場合はエラーとして記録する
+        // エラーメッセージにセル値を反映する際は 100 文字に切り詰め、レスポンス肥大化を防ぐ
+        const dueDateDisplay = dueDateRaw.length > 100 ? `${dueDateRaw.slice(0, 100)}…` : dueDateRaw;
         return {
           ok: false,
-          message: `期限日の形式が正しくありません: "${dueDateRaw}"（YYYY-MM-DD 形式で入力してください）`,
+          message: `期限日の形式が正しくありません: "${dueDateDisplay}"（YYYY-MM-DD 形式で入力してください）`,
         };
       }
       // 変換できた値を解決期限として使う

--- a/src/lib/outbound-notify.ts
+++ b/src/lib/outbound-notify.ts
@@ -23,6 +23,28 @@ interface ResolvedChannel {
   notifier: OutboundNotifier; // 実際の送信を行う Adapter
 }
 
+// Webhook URL を SSRF チェックして安全なら channels リストへ追加する共通ヘルパー。
+// Slack / Teams のように「ユーザーが入力した URL を保存して後で叩く」チャネルに共通して使う。
+// Chatwork のような固定ホスト宛チャネルには不要なため呼ばない。
+// 将来チャネルを追加するときも、このヘルパーを呼べば SSRF 二重防御を取り込める。
+function addWebhookChannel(
+  channels: ResolvedChannel[], // 追加先のチャネル一覧 (破壊的に追加する)
+  name: string, // ログ表示用のチャネル名
+  url: string, // ユーザーが設定した Webhook URL
+  factory: (url: string) => OutboundNotifier, // URL を受け取って Adapter を生成するファクトリ
+): void {
+  // SSRF 二重防御: 保存時 (update-notification-channels.ts) に検証済みだが、
+  // DNS リバインディング攻撃 (登録後に内部 IP へ変更) を緩和するため送信直前にも再検証する。
+  if (isUnsafeUrl(url)) {
+    // 安全でない URL が DB に残っている場合はスキップしてエラーログを残す
+    console.error(`[outbound-notify] SSRF ガード: 安全でない ${name} Webhook URL をスキップしました`);
+    // 安全でない URL にはリクエストを送らずここで終わる
+    return;
+  }
+  // URL が安全であればチャネル一覧へ追加する
+  channels.push({ name, notifier: factory(url) });
+}
+
 // 指定テナントの設定済み外部通知チャネルにメッセージを送信する。
 // - チャネルが 1 つも設定されていなければ何もしない (通知無効の正常系)
 // - 各チャネルの送信失敗はコンソールエラーに留め、呼び出し元 (Server Action) を止めない
@@ -40,27 +62,15 @@ export async function sendOutboundNotification(
   const channels: ResolvedChannel[] = [];
 
   // ── Slack ───────────────────────────────────────────────────────────────────
-  // slackWebhookUrl が設定済みかつ SSRF 安全なら Slack チャネルを追加する。
-  // SSRF 二重防御: 保存時 (update-notification-channels.ts) に検証済みだが、
-  // DNS リバインディング攻撃 (登録時はパブリック IP → 後に内部 IP に変更) を緩和するため
-  // 送信直前にもリテラル IP パターンを再検証する。
+  // slackWebhookUrl が設定済みであれば SSRF 検証のうえチャネルへ追加する
   if (tenant.slackWebhookUrl) {
-    if (isUnsafeUrl(tenant.slackWebhookUrl)) {
-      // 安全でない URL が DB に残っている場合はスキップしてエラーをログに残す
-      console.error('[outbound-notify] SSRF ガード: 安全でない Slack Webhook URL をスキップしました');
-    } else {
-      channels.push({ name: 'Slack', notifier: createSlackNotifier(tenant.slackWebhookUrl) });
-    }
+    addWebhookChannel(channels, 'Slack', tenant.slackWebhookUrl, createSlackNotifier);
   }
 
   // ── Teams ───────────────────────────────────────────────────────────────────
-  // teamsWebhookUrl が設定済みかつ SSRF 安全なら Teams チャネルを追加する (Slack と同様の二重防御)
+  // teamsWebhookUrl が設定済みであれば SSRF 検証のうえチャネルへ追加する
   if (tenant.teamsWebhookUrl) {
-    if (isUnsafeUrl(tenant.teamsWebhookUrl)) {
-      console.error('[outbound-notify] SSRF ガード: 安全でない Teams Webhook URL をスキップしました');
-    } else {
-      channels.push({ name: 'Teams', notifier: createTeamsNotifier(tenant.teamsWebhookUrl) });
-    }
+    addWebhookChannel(channels, 'Teams', tenant.teamsWebhookUrl, createTeamsNotifier);
   }
 
   // ── Chatwork ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 概要

Phase 2-4 の実装コードに対するコードレビューで発見した 2 件の品質問題を修正します。

### 変更内容

#### 1. `src/lib/outbound-notify.ts` — DRY 違反の解消

**問題**: Slack と Teams の Webhook URL 処理で、以下のパターンが完全に重複していた。
```ts
if (isUnsafeUrl(url)) {
  console.error(`[outbound-notify] SSRF ガード: ...`);
} else {
  channels.push({ name, notifier: factory(url) });
}
```

**修正**: `addWebhookChannel(channels, name, url, factory)` ヘルパー関数を抽出し、SSRF 検証ロジックを一箇所に集約。将来のチャネル追加時も同じヘルパーを呼ぶだけで SSRF 二重防御を取り込める設計。

#### 2. `src/features/tickets/actions/import-tickets.ts` — SRP 違反の解消

**問題**: 98行の `for` ループ内に CSV パース・バリデーション・型変換・DB 挿入が混在しており、単一責務の原則に違反。バリデーションロジックが副作用のあるコードに埋め込まれており、単体テストが困難だった。

**修正**: `validateImportRow(cells, indices)` 純粋関数を抽出。DB アクセスなし・副作用なし・判別共用体（`{ ok: true; data: ValidatedRow } | { ok: false; message: string }`）で返すため、単体テストが可能な状態に。ループ本体はDB挿入のみに絞られ、可読性が向上。

## テスト計画

- [ ] `npm run lint` — ESLint でエラーなし
- [ ] `npm run typecheck` — 型エラーなし（CI で検証）
- [ ] `npm run test` — 既存ユニットテストが通過
- [ ] E2E: チケット CSV インポート機能が引き続き動作する
- [ ] E2E: Slack/Teams/Chatwork 通知が引き続き送信される

## 関連

`docs/smb-dx-pivot-plan.md` Phase 2-4 の実装コードに対するコードレビュー品質改善。
spec/design match ・可読性と保守性・機能とセキュリティ・チームルール準拠の観点で指摘された DRY・SRP 違反を解消。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtTGDHZjoGuxCWwPxEGZVC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtTGDHZjoGuxCWwPxEGZVC)_