### PR TITLE
feat(tickets,dashboard): CSV エクスポートと品質メトリクスの実装 (issue-backlog #25, #27)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1855,7 +1855,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -1889,14 +1889,14 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
       "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
       "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1910,14 +1910,14 @@
       "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
       "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
       "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0",
@@ -1929,7 +1929,7 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
       "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0"
@@ -6984,7 +6984,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -7003,7 +7003,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -7194,7 +7194,7 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
       "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -281,7 +281,11 @@ export default async function DashboardPage() {
                 </p>
                 <p className="mt-1 text-xs text-slate-500">
                   再オープン率{' '}
-                  <span className="text-slate-400">(全 {metrics.totalCount} 件中)</span>
+                  {/* 分母ラベルは再オープン率が実際に計算されたときだけ表示する。
+                      null (データ不足) の場合は「—」と並べて件数を出すと誤解を招くため非表示にする */}
+                  {metrics.reopenRate != null && (
+                    <span className="text-slate-400">(全 {metrics.totalCount} 件中)</span>
+                  )}
                 </p>
               </div>
             </div>

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -48,13 +48,16 @@ const TUTORIAL_TICKET_THRESHOLD = 10;
 export default async function DashboardPage() {
   // セッション取得
   const session = await auth();
-  // 未ログインなら何も描画しない (middleware 通過後の保険)
-  if (!session?.user?.id) return null;
+  // 未ログイン、または tenantId が取得できない場合は何も描画しない。
+  // tenantId 欠落のまま進むと Prisma が undefined を「条件なし」として扱い、
+  // 全テナントのデータが見える可能性があるため早期に弾く (§9 セキュリティ / クロステナント漏洩防止)
+  if (!session?.user?.id || !session.user.tenantId) return null;
 
   // ロール判定
   const isAgent = checkIsAgent(session.user.role);
-  // セッションから tenantId を取り出して以降の port 呼び出しに伝搬する
-  const tenantId = session.user.tenantId;
+  // セッションから tenantId を取り出して以降の port 呼び出しに伝搬する。
+  // 上の null チェックを通過しているため tenantId は string として確定している
+  const tenantId: string = session.user.tenantId;
   // SLA / 期限 判定基準時刻 (現在時刻)
   const now = new Date();
   // テナントの動作モード (lite | pro) を取得し、表示内容を切り替える

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -83,14 +83,20 @@ export default async function DashboardPage() {
   // - slaOverdue / workload: 当該テナント内全件対象 (表示は呼び出し側で role 制御)
   // - qualityMetrics: 平均初回応答時間・平均解決時間・再オープン率 (エージェント向け)
   const [stats, metrics] = await Promise.all([
+    // チケット集計 (byStatus / slaOverdue / workload) を取得する
     repos.tickets.dashboardStats({
+      // 依頼者は自分が起票したチケットのみ集計する (RBAC)
       creatorId: isAgent ? undefined : session.user.id,
+      // SLA 期限判定の基準時刻
       now,
+      // ワークロード集計で完了済みを除外するステータス一覧
       excludeStatusesForWorkload: ['Resolved', 'Closed'],
+      // テナントスコープ (クロステナント漏洩防止)
       tenantId,
     }),
-    // 品質メトリクスはエージェントのみに表示するが、取得は常に行う (条件分岐より並列化優先)
-    repos.tickets.qualityMetrics({ tenantId }),
+    // 品質メトリクスはエージェントにのみ表示する重い全件集計クエリ。
+    // 依頼者には不要なため取得も省略し、DB 負荷を抑える (§8 パフォーマンス)。
+    isAgent ? repos.tickets.qualityMetrics({ tenantId }) : Promise.resolve(null),
   ]);
 
   // SLA 超過件数 (依頼者には表示しないので 0 にしておく)
@@ -230,8 +236,9 @@ export default async function DashboardPage() {
         </section>
       )}
 
-      {/* 品質メトリクス (エージェントのみ。issue-backlog #25) */}
-      {isAgent && (
+      {/* 品質メトリクス (エージェントのみ。issue-backlog #25)
+          metrics は isAgent=false のとき null なので null チェックを必ず通す */}
+      {isAgent && metrics && (
         <section>
           <h2 className="mb-4 text-xs font-semibold tracking-wider text-slate-500 uppercase">
             対応品質
@@ -285,7 +292,7 @@ export default async function DashboardPage() {
 /**
  * ミリ秒を「X 日 Y 時間」または「Y 時間 Z 分」という日本語の所要時間文字列に変換する。
  * ダッシュボードの品質メトリクスカードに使用する (issue-backlog #25)。
- * 0 ms は「0 分」と表示し、null 渡しは呼び出し元で処理する。
+ * 30 秒未満 (四捨五入で 0 分) は「< 1 分」と表示し、null 渡しは呼び出し元で処理する。
  */
 function formatDurationMs(ms: number): string {
   // NaN は Math.max(0, NaN) === NaN になるため、先に有限数かどうかを確認する。
@@ -307,6 +314,9 @@ function formatDurationMs(ms: number): string {
     const minutes = totalMinutes % 60; // 余り分
     return minutes > 0 ? `${hours} 時間 ${minutes} 分` : `${hours} 時間`;
   }
+  // 1 分未満 (30 秒未満で四捨五入が 0 になる場合) は「< 1 分」と表示する。
+  // 「0 分」は平均が 0 の場合と見分けがつかず、速い応答チームに誤解を与えるため使わない。
+  if (totalMinutes === 0) return '< 1 分';
   // 1 時間未満は「X 分」形式で返す
   return `${totalMinutes} 分`;
 }

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -78,15 +78,20 @@ export default async function DashboardPage() {
   }
 
   // 以降は Pro モードの従来ダッシュボード (情シス向けのフル集計)
-  // ダッシュボード用 3 指標を 1 メソッドで取得 (内部は groupBy で 3 クエリに集約、tenantId スコープ)
+  // ダッシュボード用 3 指標 + 品質メトリクスを並列取得する
   // - byStatus: 7 状態それぞれの件数 (依頼者なら自身のチケットに限定)
   // - slaOverdue / workload: 当該テナント内全件対象 (表示は呼び出し側で role 制御)
-  const stats = await repos.tickets.dashboardStats({
-    creatorId: isAgent ? undefined : session.user.id,
-    now,
-    excludeStatusesForWorkload: ['Resolved', 'Closed'],
-    tenantId,
-  });
+  // - qualityMetrics: 平均初回応答時間・平均解決時間・再オープン率 (エージェント向け)
+  const [stats, metrics] = await Promise.all([
+    repos.tickets.dashboardStats({
+      creatorId: isAgent ? undefined : session.user.id,
+      now,
+      excludeStatusesForWorkload: ['Resolved', 'Closed'],
+      tenantId,
+    }),
+    // 品質メトリクスはエージェントのみに表示するが、取得は常に行う (条件分岐より並列化優先)
+    repos.tickets.qualityMetrics({ tenantId }),
+  ]);
 
   // SLA 超過件数 (依頼者には表示しないので 0 にしておく)
   const slaOverdueCount = isAgent ? stats.slaOverdue : 0;
@@ -224,8 +229,80 @@ export default async function DashboardPage() {
           </div>
         </section>
       )}
+
+      {/* 品質メトリクス (エージェントのみ。issue-backlog #25) */}
+      {isAgent && (
+        <section>
+          <h2 className="mb-4 text-xs font-semibold tracking-wider text-slate-500 uppercase">
+            対応品質
+          </h2>
+          {/* 解決済み件数が 0 のときはデータ不足を明示し、誤解を招かないようにする */}
+          {metrics.resolvedCount === 0 ? (
+            <p className="text-sm text-slate-400">解決済みのチケットが蓄積されると指標が表示されます。</p>
+          ) : (
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              {/* 平均初回応答時間 */}
+              <div className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-100">
+                <p className="text-2xl font-bold text-slate-900">
+                  {metrics.avgFirstResponseMs != null
+                    ? formatDurationMs(metrics.avgFirstResponseMs)
+                    : '—'}
+                </p>
+                <p className="mt-1 text-xs text-slate-500">平均初回応答時間</p>
+              </div>
+              {/* 平均解決時間 */}
+              <div className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-100">
+                <p className="text-2xl font-bold text-slate-900">
+                  {metrics.avgResolutionMs != null
+                    ? formatDurationMs(metrics.avgResolutionMs)
+                    : '—'}
+                </p>
+                <p className="mt-1 text-xs text-slate-500">平均解決時間</p>
+              </div>
+              {/* 再オープン率 */}
+              <div className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-100">
+                <p className="text-2xl font-bold text-slate-900">
+                  {metrics.reopenRate != null
+                    ? `${Math.round(metrics.reopenRate * 100)} %`
+                    : '—'}
+                </p>
+                <p className="mt-1 text-xs text-slate-500">
+                  再オープン率{' '}
+                  <span className="text-slate-400">({metrics.resolvedCount} 件対象)</span>
+                </p>
+              </div>
+            </div>
+          )}
+        </section>
+      )}
     </div>
   );
+}
+
+/**
+ * ミリ秒を「X 日 Y 時間」または「Y 時間 Z 分」という日本語の所要時間文字列に変換する。
+ * ダッシュボードの品質メトリクスカードに使用する (issue-backlog #25)。
+ * 0 ms は「0 分」と表示し、null 渡しは呼び出し元で処理する。
+ */
+function formatDurationMs(ms: number): string {
+  // 負値は丸めて 0 扱いにする (データ異常の保護)
+  const totalMs = Math.max(0, ms);
+  // ミリ秒 → 分に変換する
+  const totalMinutes = Math.round(totalMs / 60_000);
+  // 1 日以上の場合は「X 日 Y 時間」形式で返す
+  if (totalMinutes >= 60 * 24) {
+    const days = Math.floor(totalMinutes / (60 * 24)); // 日数
+    const hours = Math.floor((totalMinutes % (60 * 24)) / 60); // 余り時間
+    return hours > 0 ? `${days} 日 ${hours} 時間` : `${days} 日`;
+  }
+  // 1 時間以上の場合は「X 時間 Y 分」形式で返す
+  if (totalMinutes >= 60) {
+    const hours = Math.floor(totalMinutes / 60); // 時間
+    const minutes = totalMinutes % 60; // 余り分
+    return minutes > 0 ? `${hours} 時間 ${minutes} 分` : `${hours} 時間`;
+  }
+  // 1 時間未満は「X 分」形式で返す
+  return `${totalMinutes} 分`;
 }
 
 // Lite モード用の簡易ダッシュボード (自分の未対応 / 期限切れ の 2 枚タイル + チュートリアル)

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -236,12 +236,15 @@ export default async function DashboardPage() {
           <h2 className="mb-4 text-xs font-semibold tracking-wider text-slate-500 uppercase">
             対応品質
           </h2>
-          {/* 解決済み件数が 0 のときはデータ不足を明示し、誤解を招かないようにする */}
-          {metrics.resolvedCount === 0 ? (
-            <p className="text-sm text-slate-400">解決済みのチケットが蓄積されると指標が表示されます。</p>
+          {/* 3 指標がすべて null のときはデータ不足を明示する
+              各指標はそれぞれ独立した分母を持つため、個別の null チェックで表示を制御する */}
+          {metrics.avgFirstResponseMs == null &&
+          metrics.avgResolutionMs == null &&
+          metrics.reopenRate == null ? (
+            <p className="text-sm text-slate-400">対応済みのチケットが蓄積されると指標が表示されます。</p>
           ) : (
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-              {/* 平均初回応答時間 */}
+              {/* 平均初回応答時間 (分母: 初回応答済みチケット数) */}
               <div className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-100">
                 <p className="text-2xl font-bold text-slate-900">
                   {metrics.avgFirstResponseMs != null
@@ -250,7 +253,7 @@ export default async function DashboardPage() {
                 </p>
                 <p className="mt-1 text-xs text-slate-500">平均初回応答時間</p>
               </div>
-              {/* 平均解決時間 */}
+              {/* 平均解決時間 (分母: resolvedCount = 解決済みチケット数) */}
               <div className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-100">
                 <p className="text-2xl font-bold text-slate-900">
                   {metrics.avgResolutionMs != null
@@ -259,7 +262,7 @@ export default async function DashboardPage() {
                 </p>
                 <p className="mt-1 text-xs text-slate-500">平均解決時間</p>
               </div>
-              {/* 再オープン率 */}
+              {/* 再オープン率 (分母: totalCount = 全チケット数。resolvedCount ではない) */}
               <div className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-100">
                 <p className="text-2xl font-bold text-slate-900">
                   {metrics.reopenRate != null
@@ -268,7 +271,7 @@ export default async function DashboardPage() {
                 </p>
                 <p className="mt-1 text-xs text-slate-500">
                   再オープン率{' '}
-                  <span className="text-slate-400">({metrics.resolvedCount} 件対象)</span>
+                  <span className="text-slate-400">(全 {metrics.totalCount} 件中)</span>
                 </p>
               </div>
             </div>
@@ -285,6 +288,9 @@ export default async function DashboardPage() {
  * 0 ms は「0 分」と表示し、null 渡しは呼び出し元で処理する。
  */
 function formatDurationMs(ms: number): string {
+  // NaN は Math.max(0, NaN) === NaN になるため、先に有限数かどうかを確認する。
+  // DB から Decimal オブジェクトが返り Number() 変換後に NaN になるケースへの保護。
+  if (!Number.isFinite(ms)) return '—';
   // 負値は丸めて 0 扱いにする (データ異常の保護)
   const totalMs = Math.max(0, ms);
   // ミリ秒 → 分に変換する

--- a/src/app/(app)/tickets/page.tsx
+++ b/src/app/(app)/tickets/page.tsx
@@ -17,13 +17,13 @@ import { formatDateJP } from '@/lib/format-date';
 // 検索フィルタフォーム (Client Component)
 import { TicketFilters } from '@/features/tickets/components/TicketFilters';
 // 「自分の未対応 / 期限切れ / すべて」タブナビ (Client Component)
-import { TicketTabs, type TicketTabId } from '@/features/tickets/components/TicketTabs';
-// タブ ('mine' / 'overdue') の絞り込み条件を一元管理する純粋関数 (ダッシュボードと共有)
-import { applyTabFilter } from '@/features/tickets/tab-filter';
-// チケット状態・優先度の列挙型 (正準のドメイン型・URL クエリの型ガード用)
-import type { TicketStatus, Priority } from '@/domain/types';
-// データ層が公開しているチケット一覧フィルタ型 (port 経由クエリの引数)
-import type { TicketListFilter } from '@/data/ports/ticket-repository';
+import { TicketTabs } from '@/features/tickets/components/TicketTabs';
+// フィルタ組み立て共有モジュール (エクスポート API と同一ロジックを使う)
+// - buildTicketListFilter: URL クエリパラメータから TicketListFilter を組み立てる
+// - parseTabParam       : クエリの tab 文字列を TicketTabId に正規化する
+import { buildTicketListFilter, parseTabParam } from '@/features/tickets/build-filter';
+// CSV エクスポートボタン (Client Component — Suspense でラップして使う)
+import { CsvExportButton } from '@/features/tickets/components/CsvExportButton';
 
 // 1 ページあたりの表示件数
 const PAGE_SIZE = 20;
@@ -58,13 +58,6 @@ interface Props {
   }>;
 }
 
-// クエリの tab 文字列を TicketTabId に正規化する (不正値は 'all')
-function parseTabParam(raw: string | undefined): TicketTabId {
-  // 'mine' か 'overdue' に完全一致する場合のみ採用、それ以外は既定の 'all'
-  if (raw === 'mine' || raw === 'overdue') return raw;
-  return 'all';
-}
-
 // /tickets : チケット一覧ページ (検索/フィルタ + ページング)
 export default async function TicketsPage({ searchParams }: Props) {
   // searchParams は Promise なので await して取り出す
@@ -81,34 +74,26 @@ export default async function TicketsPage({ searchParams }: Props) {
   // 要求ページ番号と DB の skip 件数を計算
   const requestedPage = parsePageParam(sp.page);
   const skip = (requestedPage - 1) * PAGE_SIZE;
-  // タブ ID を正規化 ('all' / 'mine' / 'overdue' のいずれか)
+  // タブ ID を正規化 ('all' / 'mine' / 'overdue' のいずれか) — UI 表示・ページング URL 生成に使う
   const tab = parseTabParam(sp.tab);
+  // 現在時刻 (overdue タブの判定と、エクスポート API が同一基準を使えるよう変数化)
+  const now = new Date();
 
-  // データ層に渡す TicketListFilter を組み立てる (検索/絞り込みの基本条件)
-  const baseFilter: TicketListFilter = {
-    // RBAC: 依頼者は自分のチケットのみ (エージェントは creatorId 未指定 = 全件)
-    creatorId: isAgent ? undefined : session.user.id,
-    // フリーワード検索 (タイトル/本文の部分一致、大文字小文字無視)
-    text: sp.q ? { contains: sp.q, caseInsensitive: true } : undefined,
-    // ステータス絞り込み (列挙値として正しい場合のみ適用)
-    status: sp.status && isValidStatus(sp.status) ? sp.status : undefined,
-    // 優先度絞り込み
-    priority: sp.priority && isValidPriority(sp.priority) ? sp.priority : undefined,
-    // カテゴリ絞り込み (空文字は無指定として扱う)
-    categoryId: sp.categoryId || undefined,
-    // 担当者絞り込み (URL クエリの 'unassigned' をここで null に正規化)
-    assigneeId: normalizeAssigneeId(sp.assigneeId),
-    // 拠点絞り込み (空文字は無指定として扱う。Phase 4 多拠点)
-    locationId: sp.locationId || undefined,
-  };
-
-  // タブ別の追加条件 ('mine' / 'overdue') を共通ヘルパーで適用する
-  // (タブの意味はダッシュボードと共有する applyTabFilter に集約し、二重定義を避ける)
-  const filter = applyTabFilter(baseFilter, tab, {
-    isAgent,
-    userId: session.user.id,
-    now: new Date(),
-  });
+  // データ層に渡す TicketListFilter を組み立てる。
+  // build-filter.ts の buildTicketListFilter を使うことで、
+  // GET /api/tickets/export と同一の絞り込みロジックを共有する (DRY 原則)。
+  const filter = buildTicketListFilter(
+    {
+      q: sp.q,
+      status: sp.status,
+      priority: sp.priority,
+      categoryId: sp.categoryId,
+      assigneeId: sp.assigneeId,
+      locationId: sp.locationId,
+      tab: sp.tab,
+    },
+    { isAgent, userId: session.user.id, now },
+  );
 
   // セッションから tenantId を取り出して以降の port 呼び出しに伝搬する
   const tenantId = session.user.tenantId;
@@ -145,8 +130,8 @@ export default async function TicketsPage({ searchParams }: Props) {
             社内からの問い合わせを一元管理し、対応状況を追跡します。
           </p>
         </div>
-        {/* ボタングループ: 新規登録 + CSV インポート (エージェント以上のみ CSV インポートを表示) */}
-        <div className="flex items-center gap-2">
+        {/* ボタングループ: 新規登録 + CSV インポート + CSV エクスポート */}
+        <div className="flex flex-wrap items-center gap-2">
           <Link
             href="/tickets/new"
             className="rounded-lg bg-teal-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-teal-800"
@@ -162,6 +147,11 @@ export default async function TicketsPage({ searchParams }: Props) {
               CSV インポート
             </Link>
           )}
+          {/* CSV エクスポート: 全プランで利用可能 (issue-backlog #27 / smb-dx-pivot-plan §7.2) */}
+          {/* useSearchParams() を使うため Suspense でラップする必要がある */}
+          <Suspense fallback={null}>
+            <CsvExportButton />
+          </Suspense>
         </div>
       </div>
 
@@ -360,33 +350,7 @@ function Pagination({
   );
 }
 
-// クエリ文字列のステータスが TicketStatus に含まれるかを判定 (型ガード)
-function isValidStatus(s: string): s is TicketStatus {
-  return [
-    'New',
-    'Open',
-    'WaitingForUser',
-    'InProgress',
-    'Escalated',
-    'Resolved',
-    'Closed',
-  ].includes(s);
-}
-
-// クエリ文字列の優先度が Priority に含まれるかを判定 (型ガード)
-function isValidPriority(p: string): p is Priority {
-  return ['Low', 'Medium', 'High'].includes(p);
-}
-
-// URL クエリの assigneeId を Port が期待する形 (`undefined` / `null` / 文字列) に正規化する
-// - 空文字 / 未指定 → undefined (フィルタなし)
-// - 'unassigned' → null (未アサインのみ)
-// - その他 → 文字列のまま (担当者 ID で完全一致)
-function normalizeAssigneeId(raw: string | undefined): string | null | undefined {
-  // 値が無ければフィルタなし
-  if (!raw) return undefined;
-  // 'unassigned' は未アサイン (null) を意味する
-  if (raw === 'unassigned') return null;
-  // それ以外はユーザー ID とみなしてそのまま返す
-  return raw;
-}
+// ─────────────────────────────────────────────
+// 注: isValidStatus / isValidPriority / normalizeAssigneeId / parseTabParam は
+// src/features/tickets/build-filter.ts に集約済み。このファイルでは重複定義しない (DRY 原則)。
+// ─────────────────────────────────────────────

--- a/src/app/api/tickets/export/route.ts
+++ b/src/app/api/tickets/export/route.ts
@@ -1,0 +1,166 @@
+// セッション取得
+import { auth } from '@/lib/auth';
+// データ層の Composition Root (Prisma 直叩きを避ける)
+import { repos } from '@/data';
+// エージェント判定ヘルパー
+import { isAgent as checkIsAgent } from '@/lib/role';
+// テナントの動作モード (lite | pro) を取得するヘルパー
+import { getCurrentTenantMode } from '@/lib/tenant';
+// フィルタ組み立て共有関数 (一覧ページと同一ロジックを使う)
+import { buildTicketListFilter } from '@/features/tickets/build-filter';
+// CSV 文字列生成ユーティリティ
+import { buildCsvString } from '@/lib/csv';
+// ステータス日本語ラベル (mode-aware) と優先度ラベル
+import { getStatusLabel, PRIORITY_LABELS } from '@/lib/constants';
+// JST 日時フォーマット
+import { formatDateTimeJP, formatDateJP } from '@/lib/format-date';
+// TicketWithRefs 型 (一覧取得の戻り値)
+import type { TicketWithRefs } from '@/domain/types';
+// テナントモード型
+import type { TenantMode } from '@/generated/prisma';
+
+// 1 リクエストで出力できるチケットの最大件数。
+// 件数無制限の取得は DB 負荷・レスポンスサイズ・処理時間が無制限になるため
+// 上限を設ける (§8 パフォーマンス / §9 DoS 防止)。
+const MAX_EXPORT_ROWS = 10_000;
+
+/**
+ * チケット一覧 (TicketWithRefs) を CSV 文字列に変換する純粋関数。
+ * mode によって日本語ラベルを切り替える。
+ */
+function ticketsToCsv(tickets: TicketWithRefs[], mode: TenantMode): string {
+  // ヘッダー行: CSV エクスポートに含める列名を日本語で定義する
+  const headers = [
+    'ID',
+    '件名',
+    '状況',
+    '優先度',
+    'カテゴリ',
+    '担当者',
+    '起票者',
+    '解決期限',
+    '起票日時',
+    '更新日時',
+  ];
+
+  // データ行: チケット 1 件を文字列の配列 (1 行分) に変換する
+  const rows = tickets.map((t) => [
+    // チケット ID (識別子として先頭に置く)
+    t.id,
+    // 件名 (title)
+    t.title,
+    // 状況: lite / pro モードに応じた日本語ラベル (getStatusLabel が一元管理)
+    getStatusLabel(t.status, mode),
+    // 優先度: PRIORITY_LABELS が一元管理する日本語ラベル
+    PRIORITY_LABELS[t.priority] ?? t.priority,
+    // カテゴリ名 (未分類なら空文字)
+    t.category?.name ?? '',
+    // 担当者名 (未アサインなら空文字)
+    t.assignee?.name ?? '',
+    // 起票者名
+    t.creator.name,
+    // 解決期限: 設定されていれば JST の年月日形式、未設定なら空文字
+    t.resolutionDueAt ? formatDateJP(t.resolutionDueAt) : '',
+    // 起票日時: JST の年月日 時分秒形式
+    formatDateTimeJP(t.createdAt),
+    // 更新日時: JST の年月日 時分秒形式
+    formatDateTimeJP(t.updatedAt),
+  ]);
+
+  // ヘッダー + データ行を BOM 付き CSV 文字列にして返す
+  return buildCsvString(headers, rows);
+}
+
+/**
+ * GET /api/tickets/export
+ *
+ * チケット一覧を CSV ファイルとしてダウンロードする。
+ * クエリパラメータは /tickets 一覧ページと同一の絞り込み条件をそのまま受け取る。
+ *
+ * - 認証必須: 未認証は 401
+ * - tenantId スコープ: セッションの tenantId で必ず絞り込む (クロステナント漏洩防止)
+ * - 最大 MAX_EXPORT_ROWS 件の上限あり
+ */
+export async function GET(req: Request) {
+  // セッション取得 (未認証 / tenantId 欠落は 401 を返す)
+  const session = await auth();
+  // 未ログイン、または tenantId が取得できない場合は 401 を返す
+  // tenantId 欠落のまま進むとクロステナント漏洩になるため早期に弾く (§9 セキュリティ)
+  if (!session?.user?.id || !session.user.tenantId) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // セッションからユーザー情報とテナント ID を取り出す
+  const userId = session.user.id;
+  const tenantId = session.user.tenantId;
+  // ロール判定: 担当者かどうかで RBAC フィルタが変わる
+  const isAgent = checkIsAgent(session.user.role);
+
+  // URL のクエリパラメータを取り出す
+  const { searchParams } = new URL(req.url);
+
+  // フィルタを組み立てる (一覧ページと同一の buildTicketListFilter を使い二重定義を避ける)
+  const filter = buildTicketListFilter(
+    {
+      // フリーワード検索
+      q: searchParams.get('q') ?? undefined,
+      // ステータス絞り込み
+      status: searchParams.get('status') ?? undefined,
+      // 優先度絞り込み
+      priority: searchParams.get('priority') ?? undefined,
+      // カテゴリ絞り込み
+      categoryId: searchParams.get('categoryId') ?? undefined,
+      // 担当者絞り込み
+      assigneeId: searchParams.get('assigneeId') ?? undefined,
+      // 拠点絞り込み
+      locationId: searchParams.get('locationId') ?? undefined,
+      // タブ絞り込み ('mine' / 'overdue' / 'all')
+      tab: searchParams.get('tab') ?? undefined,
+    },
+    { isAgent, userId, now: new Date() },
+  );
+
+  // 絞り込み条件に一致するチケットを最大 MAX_EXPORT_ROWS 件取得する
+  // (件数無制限の取得は DoS / リソース枯渇になるため上限を設ける §8 / §9)
+  const tickets = await repos.tickets.list({
+    filter,
+    page: { skip: 0, take: MAX_EXPORT_ROWS },
+    sort: { field: 'createdAt', direction: 'desc' },
+    tenantId,
+  });
+
+  // テナントの動作モード (lite | pro) を取得して日本語ラベル切り替えに使う
+  const mode = await getCurrentTenantMode(tenantId);
+
+  // チケット一覧を CSV 文字列に変換する
+  const csv = ticketsToCsv(tickets, mode);
+
+  // ファイル名に今日の JST 日付を含める (ダウンロードフォルダで日付識別できる)
+  // サーバーサイドで生成するためブラウザの日付設定に依存しない
+  const today = new Date()
+    .toLocaleDateString('ja-JP', {
+      timeZone: 'Asia/Tokyo',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+    .replace(/\//g, '-'); // YYYY/MM/DD → YYYY-MM-DD
+  const filename = `tickets-${today}.csv`;
+
+  // CSV ファイルとしてダウンロードするレスポンスを返す
+  return new Response(csv, {
+    status: 200,
+    headers: {
+      // UTF-8 の CSV であることを明示する
+      'Content-Type': 'text/csv; charset=utf-8',
+      // ブラウザにファイルとして保存させる (attachment) + ファイル名を指定する
+      // RFC 5987 の filename* は省略 (ASCII ファイル名のため不要)
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      // キャッシュさせない (毎回最新データを取得させる)
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+    },
+  });
+}

--- a/src/app/api/tickets/export/route.ts
+++ b/src/app/api/tickets/export/route.ts
@@ -4,6 +4,8 @@ import { auth } from '@/lib/auth';
 import { repos } from '@/data';
 // エージェント判定ヘルパー
 import { isAgent as checkIsAgent } from '@/lib/role';
+// レート制限 (CSV エクスポートは DB 全件取得を伴う重い操作のため §9 DoS 防止として必須)
+import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
 // テナントの動作モード (lite | pro) を取得するヘルパー
 import { getCurrentTenantMode } from '@/lib/tenant';
 // フィルタ組み立て共有関数 (一覧ページと同一ロジックを使う)
@@ -14,10 +16,9 @@ import { buildCsvString } from '@/lib/csv';
 import { getStatusLabel, PRIORITY_LABELS } from '@/lib/constants';
 // JST 日時フォーマット
 import { formatDateTimeJP, formatDateJP } from '@/lib/format-date';
-// TicketWithRefs 型 (一覧取得の戻り値)
-import type { TicketWithRefs } from '@/domain/types';
-// テナントモード型
-import type { TenantMode } from '@/generated/prisma';
+// TicketWithRefs 型 (一覧取得の戻り値) と TenantMode 型 (mode-aware ラベル用)
+// @/generated/prisma ではなく正準 @/domain/types から import する (lint ルール: no-restricted-imports)
+import type { TicketWithRefs, TenantMode } from '@/domain/types';
 
 // 1 リクエストで出力できるチケットの最大件数。
 // 件数無制限の取得は DB 負荷・レスポンスサイズ・処理時間が無制限になるため
@@ -57,8 +58,8 @@ function ticketsToCsv(tickets: TicketWithRefs[], mode: TenantMode): string {
     t.category?.name ?? '',
     // 担当者名 (未アサインなら空文字)
     t.assignee?.name ?? '',
-    // 起票者名
-    t.creator.name,
+    // 起票者名 (まれに関連ユーザーが取れない場合を考慮してオプショナルチェーンを使う)
+    t.creator?.name ?? '',
     // 解決期限: 設定されていれば JST の年月日形式、未設定なら空文字
     t.resolutionDueAt ? formatDateJP(t.resolutionDueAt) : '',
     // 起票日時: JST の年月日 時分秒形式
@@ -98,6 +99,27 @@ export async function GET(req: Request) {
   const tenantId = session.user.tenantId;
   // ロール判定: 担当者かどうかで RBAC フィルタが変わる
   const isAgent = checkIsAgent(session.user.role);
+
+  // CSV エクスポートは DB 全件取得を伴う重い操作のためレート制限を適用する
+  // (ユーザー単位で 60 秒あたり 5 回まで。DoS / リソース枯渇防止 §8 / §9)
+  try {
+    enforceRateLimit(`csv-export:${userId}`, { limit: 5, windowMs: 60_000 });
+  } catch (err) {
+    // 流量超過の場合のみ 429 を返す。それ以外は想定外エラーとして上位へ投げる
+    if (err instanceof RateLimitError) {
+      return new Response(
+        JSON.stringify({ error: 'エクスポートのリクエストが多すぎます。しばらくしてから再試行してください。' }),
+        {
+          status: 429,
+          headers: {
+            'Content-Type': 'application/json',
+            'Retry-After': '60',
+          },
+        },
+      );
+    }
+    throw err;
+  }
 
   // URL のクエリパラメータを取り出す
   const { searchParams } = new URL(req.url);
@@ -151,16 +173,20 @@ export async function GET(req: Request) {
   const filename = `tickets-${today}.csv`;
 
   // CSV ファイルとしてダウンロードするレスポンスを返す
-  return new Response(csv, {
-    status: 200,
-    headers: {
-      // UTF-8 の CSV であることを明示する
-      'Content-Type': 'text/csv; charset=utf-8',
-      // ブラウザにファイルとして保存させる (attachment) + ファイル名を指定する
-      // RFC 5987 の filename* は省略 (ASCII ファイル名のため不要)
-      'Content-Disposition': `attachment; filename="${filename}"`,
-      // キャッシュさせない (毎回最新データを取得させる)
-      'Cache-Control': 'no-cache, no-store, must-revalidate',
-    },
-  });
+  const responseHeaders: HeadersInit = {
+    // UTF-8 の CSV であることを明示する
+    'Content-Type': 'text/csv; charset=utf-8',
+    // ブラウザにファイルとして保存させる (attachment) + ファイル名を指定する
+    // RFC 5987 の filename* は省略 (ASCII ファイル名のため不要)
+    'Content-Disposition': `attachment; filename="${filename}"`,
+    // キャッシュさせない (毎回最新データを取得させる)
+    'Cache-Control': 'no-cache, no-store, must-revalidate',
+  };
+  // 取得件数が上限に達した場合は打ち切りを呼び出し元に通知する
+  // (サイレント打ち切りは監査目的で「全件取得済み」と誤認させるリスクがある)
+  if (tickets.length === MAX_EXPORT_ROWS) {
+    responseHeaders['X-Truncated'] = 'true';
+    responseHeaders['X-Total-Limit'] = String(MAX_EXPORT_ROWS);
+  }
+  return new Response(csv, { status: 200, headers: responseHeaders });
 }

--- a/src/app/api/tickets/export/route.ts
+++ b/src/app/api/tickets/export/route.ts
@@ -124,6 +124,11 @@ export async function GET(req: Request) {
   // URL のクエリパラメータを取り出す
   const { searchParams } = new URL(req.url);
 
+  // 現在時刻を一度だけ生成する。
+  // フィルタ組み立て (overdue 判定) とファイル名の日付 (JST) の両方に使い回す。
+  // 2 回 new Date() すると真夜中をまたいだ瞬間に日付が食い違うリスクを排除する。
+  const now = new Date();
+
   // フィルタを組み立てる (一覧ページと同一の buildTicketListFilter を使い二重定義を避ける)
   const filter = buildTicketListFilter(
     {
@@ -142,27 +147,32 @@ export async function GET(req: Request) {
       // タブ絞り込み ('mine' / 'overdue' / 'all')
       tab: searchParams.get('tab') ?? undefined,
     },
-    { isAgent, userId, now: new Date() },
+    // overdue タブの期限判定に now を渡す (上で一度だけ生成した値を使い回す)
+    { isAgent, userId, now },
   );
 
-  // 絞り込み条件に一致するチケットを最大 MAX_EXPORT_ROWS 件取得する
-  // (件数無制限の取得は DoS / リソース枯渇になるため上限を設ける §8 / §9)
-  const tickets = await repos.tickets.list({
-    filter,
-    page: { skip: 0, take: MAX_EXPORT_ROWS },
-    sort: { field: 'createdAt', direction: 'desc' },
-    tenantId,
-  });
-
-  // テナントの動作モード (lite | pro) を取得して日本語ラベル切り替えに使う
-  const mode = await getCurrentTenantMode(tenantId);
+  // チケット一覧取得とテナントモード取得は互いに依存しないため並列実行する
+  // (§8 パフォーマンス: 直列では 2 往復かかるところを 1 往復で完了する)
+  const [tickets, mode] = await Promise.all([
+    // 絞り込み条件に一致するチケットを最大 MAX_EXPORT_ROWS 件取得する
+    // (件数無制限の取得は DoS / リソース枯渇になるため上限を設ける §8 / §9)
+    repos.tickets.list({
+      filter,
+      page: { skip: 0, take: MAX_EXPORT_ROWS },
+      sort: { field: 'createdAt', direction: 'desc' },
+      tenantId,
+    }),
+    // テナントの動作モード (lite | pro) を取得して日本語ラベル切り替えに使う
+    getCurrentTenantMode(tenantId),
+  ]);
 
   // チケット一覧を CSV 文字列に変換する
   const csv = ticketsToCsv(tickets, mode);
 
   // ファイル名に今日の JST 日付を含める (ダウンロードフォルダで日付識別できる)
-  // サーバーサイドで生成するためブラウザの日付設定に依存しない
-  const today = new Date()
+  // サーバーサイドで生成するためブラウザの日付設定に依存しない。
+  // 上で一度だけ生成した now を再利用してリクエスト内の日付を一貫させる。
+  const today = now
     .toLocaleDateString('ja-JP', {
       timeZone: 'Asia/Tokyo',
       year: 'numeric',

--- a/src/data/adapters/memory/ticket-repository.memory.ts
+++ b/src/data/adapters/memory/ticket-repository.memory.ts
@@ -69,7 +69,8 @@ function matchesFilter(t: Ticket, filter: TicketListFilter, tenantId: string): b
   if (filter.overdue) {
     if (!t.resolutionDueAt) return false;
     if (t.resolutionDueAt >= filter.overdue.now) return false;
-    if (t.resolvedAt !== null) return false;
+    // != null は null と undefined の両方を弾く (型が将来 Date | null | undefined に広がっても安全)
+    if (t.resolvedAt != null) return false;
     if (t.status === 'Resolved' || t.status === 'Closed') return false;
   }
   // テキスト検索フィルター (title または body の部分一致)
@@ -222,7 +223,7 @@ export function makeTicketRepo(store: Store): TicketRepository {
         if (
           t.resolutionDueAt &&
           t.resolutionDueAt < now &&
-          t.resolvedAt === null &&
+          t.resolvedAt == null &&
           t.status !== 'Resolved' &&
           t.status !== 'Closed'
         ) {
@@ -361,6 +362,8 @@ export function makeTicketRepo(store: Store): TicketRepository {
         avgResolutionMs,
         reopenRate,
         resolvedCount: resolved.length,
+        // 再オープン率の分母は解決済み件数ではなく全対象チケット件数
+        totalCount: allTickets.length,
       } satisfies QualityMetrics;
     },
   };

--- a/src/data/adapters/memory/ticket-repository.memory.ts
+++ b/src/data/adapters/memory/ticket-repository.memory.ts
@@ -11,6 +11,7 @@ import type {
 import type {
   AssigneeWorkloadRow,
   DashboardStats,
+  QualityMetrics,
   TicketDetail,
   TicketListFilter,
   TicketRepository,
@@ -305,6 +306,62 @@ export function makeTicketRepo(store: Store): TicketRepository {
         escalationReason: args.reason,
         updatedAt: new Date(),
       });
+    },
+
+    // 品質メトリクスを算出して返す (tenantId スコープ。since 指定時はその日時以降作成分のみ)
+    async qualityMetrics({ tenantId, since }) {
+      // テナントスコープ + since 条件でチケットを絞り込む
+      const allTickets = [...store.tickets.values()].filter(
+        (t) => t.tenantId === tenantId && (!since || t.createdAt >= since),
+      );
+
+      // 初回応答済みチケット (firstRespondedAt が設定されているもの) を抽出する
+      const responded = allTickets.filter((t) => t.firstRespondedAt != null);
+      // 初回応答時間 (ms) の平均を計算する (対象なしは null)
+      const avgFirstResponseMs =
+        responded.length > 0
+          ? responded.reduce(
+              (sum, t) => sum + (t.firstRespondedAt!.getTime() - t.createdAt.getTime()),
+              0,
+            ) / responded.length
+          : null;
+
+      // 解決済みチケット (resolvedAt が設定されているもの) を抽出する
+      const resolved = allTickets.filter((t) => t.resolvedAt != null);
+      // 解決時間 (ms) の平均を計算する (対象なしは null)
+      const avgResolutionMs =
+        resolved.length > 0
+          ? resolved.reduce(
+              (sum, t) => sum + (t.resolvedAt!.getTime() - t.createdAt.getTime()),
+              0,
+            ) / resolved.length
+          : null;
+
+      // 対象チケットの ID セットを作っておく (履歴検索の絞り込みに使う)
+      const ticketIds = new Set(allTickets.map((t) => t.id));
+      // 再オープン履歴を持つチケット ID を収集する
+      // (field='status', newValue='Open', oldValue='Resolved' or 'Closed' の履歴が 1 件以上存在するもの)
+      const reopenedIds = new Set(
+        [...store.histories.values()]
+          .filter(
+            (h) =>
+              ticketIds.has(h.ticketId) &&
+              h.field === 'status' &&
+              h.newValue === 'Open' &&
+              (h.oldValue === 'Resolved' || h.oldValue === 'Closed'),
+          )
+          .map((h) => h.ticketId),
+      );
+      // 再オープン率 = 再オープン済みチケット数 / 全対象チケット数 (対象なしは null)
+      const reopenRate = allTickets.length > 0 ? reopenedIds.size / allTickets.length : null;
+
+      // QualityMetrics 型に準拠して返す
+      return {
+        avgFirstResponseMs,
+        avgResolutionMs,
+        reopenRate,
+        resolvedCount: resolved.length,
+      } satisfies QualityMetrics;
     },
   };
 }

--- a/src/data/adapters/prisma/ticket-repository.prisma.ts
+++ b/src/data/adapters/prisma/ticket-repository.prisma.ts
@@ -269,55 +269,53 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
       // (Prisma は tagged template の型安全性を保持するため引数型に null を使う)
       const sinceValue: Date | null = since ?? null;
 
-      // ── クエリ 1: 平均初回応答時間 ──
-      // firstRespondedAt - createdAt の平均をミリ秒で返す。
-      // firstRespondedAt が null のチケット (未応答) は除外する。
-      // EXTRACT(EPOCH ...) は秒単位なので × 1000 でミリ秒に変換する。
-      const responseRows = await db.$queryRaw<[{ avg_ms: number | null }]>`
-        SELECT AVG(
-          EXTRACT(EPOCH FROM ("firstRespondedAt" - "createdAt")) * 1000
-        ) AS avg_ms
-        FROM "Ticket"
-        WHERE "tenantId" = ${tenantId}
-          AND "firstRespondedAt" IS NOT NULL
-          AND (${sinceValue}::timestamptz IS NULL OR "createdAt" >= ${sinceValue}::timestamptz)
-      `;
-
-      // ── クエリ 2: 平均解決時間 ──
-      // resolvedAt - createdAt の平均をミリ秒で返す。
-      // resolvedAt が null のチケット (未解決) は除外する。
-      const resolutionRows = await db.$queryRaw<
-        [{ avg_ms: number | null; cnt: bigint }]
-      >`
-        SELECT
-          AVG(EXTRACT(EPOCH FROM ("resolvedAt" - "createdAt")) * 1000) AS avg_ms,
-          COUNT(*) AS cnt
-        FROM "Ticket"
-        WHERE "tenantId" = ${tenantId}
-          AND "resolvedAt" IS NOT NULL
-          AND (${sinceValue}::timestamptz IS NULL OR "createdAt" >= ${sinceValue}::timestamptz)
-      `;
-
-      // ── クエリ 3: 再オープン率 ──
-      // 全チケット数のうち、「Resolved または Closed → Open への遷移履歴」を持つ
-      // チケットの割合を返す。
-      // TicketHistory.field = 'status' かつ newValue = 'Open' かつ
-      // oldValue IN ('Resolved', 'Closed') の行を持つ ticket を「再オープン済み」とみなす。
-      const reopenRows = await db.$queryRaw<
-        [{ total: bigint; reopened: bigint }]
-      >`
-        SELECT
-          COUNT(DISTINCT t.id) AS total,
-          COUNT(DISTINCT th."ticketId") AS reopened
-        FROM "Ticket" t
-        LEFT JOIN "TicketHistory" th
-          ON th."ticketId" = t.id
-          AND th.field = 'status'
-          AND th."newValue" = 'Open'
-          AND th."oldValue" IN ('Resolved', 'Closed')
-        WHERE t."tenantId" = ${tenantId}
-          AND (${sinceValue}::timestamptz IS NULL OR t."createdAt" >= ${sinceValue}::timestamptz)
-      `;
+      // 3 本の SQL クエリを並列実行する (直列だと合計レイテンシが 3 倍になるため)。
+      // クエリ間に依存がないため Promise.all で安全に並列化できる。
+      const [responseRows, resolutionRows, reopenRows] = await Promise.all([
+        // ── クエリ 1: 平均初回応答時間 ──
+        // firstRespondedAt - createdAt の平均をミリ秒で返す。
+        // firstRespondedAt が null のチケット (未応答) は除外する。
+        // EXTRACT(EPOCH ...) は秒単位なので × 1000 でミリ秒に変換する。
+        db.$queryRaw<[{ avg_ms: number | null }]>`
+          SELECT AVG(
+            EXTRACT(EPOCH FROM ("firstRespondedAt" - "createdAt")) * 1000
+          ) AS avg_ms
+          FROM "Ticket"
+          WHERE "tenantId" = ${tenantId}
+            AND "firstRespondedAt" IS NOT NULL
+            AND (${sinceValue}::timestamptz IS NULL OR "createdAt" >= ${sinceValue}::timestamptz)
+        `,
+        // ── クエリ 2: 平均解決時間 ──
+        // resolvedAt - createdAt の平均をミリ秒で返す。
+        // resolvedAt が null のチケット (未解決) は除外する。
+        db.$queryRaw<[{ avg_ms: number | null; cnt: bigint }]>`
+          SELECT
+            AVG(EXTRACT(EPOCH FROM ("resolvedAt" - "createdAt")) * 1000) AS avg_ms,
+            COUNT(*) AS cnt
+          FROM "Ticket"
+          WHERE "tenantId" = ${tenantId}
+            AND "resolvedAt" IS NOT NULL
+            AND (${sinceValue}::timestamptz IS NULL OR "createdAt" >= ${sinceValue}::timestamptz)
+        `,
+        // ── クエリ 3: 再オープン率 ──
+        // 全チケット数のうち、「Resolved または Closed → Open への遷移履歴」を持つ
+        // チケットの割合を返す。
+        // TicketHistory.field = 'status' かつ newValue = 'Open' かつ
+        // oldValue IN ('Resolved', 'Closed') の行を持つ ticket を「再オープン済み」とみなす。
+        db.$queryRaw<[{ total: bigint; reopened: bigint }]>`
+          SELECT
+            COUNT(DISTINCT t.id) AS total,
+            COUNT(DISTINCT th."ticketId") AS reopened
+          FROM "Ticket" t
+          LEFT JOIN "TicketHistory" th
+            ON th."ticketId" = t.id
+            AND th.field = 'status'
+            AND th."newValue" = 'Open'
+            AND th."oldValue" IN ('Resolved', 'Closed')
+          WHERE t."tenantId" = ${tenantId}
+            AND (${sinceValue}::timestamptz IS NULL OR t."createdAt" >= ${sinceValue}::timestamptz)
+        `,
+      ]);
 
       // 平均初回応答時間: Prisma は $queryRaw の数値を Decimal や number で返すことがある
       // Number() で確実に JS の number に変換し、NaN は null に正規化する
@@ -348,6 +346,8 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
         avgResolutionMs,
         reopenRate,
         resolvedCount,
+        // 再オープン率の分母は全チケット件数 (resolvedCount ではない)
+        totalCount: total,
       } satisfies QualityMetrics;
     },
   };

--- a/src/data/adapters/prisma/ticket-repository.prisma.ts
+++ b/src/data/adapters/prisma/ticket-repository.prisma.ts
@@ -6,6 +6,7 @@ import type { TicketStatus } from '@/domain/types';
 import type {
   AssigneeWorkloadRow,
   DashboardStats,
+  QualityMetrics,
   TicketListFilter,
   TicketRepository,
 } from '@/data/ports/ticket-repository';
@@ -257,6 +258,97 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
           escalationReason: args.reason,
         },
       });
+    },
+
+    // 品質メトリクスを算出して返す (issue-backlog #25)
+    // 平均初回応答時間・平均解決時間・再オープン率を 3 本の SQL で並列取得する。
+    // Prisma ORM では日時間隔の AVG を直接計算できないため $queryRaw で PostgreSQL の
+    // EXTRACT(EPOCH FROM ...) 関数を使う。
+    async qualityMetrics({ tenantId, since }) {
+      // 期間フィルタの境界値。since が指定されない場合は全期間が対象
+      // (Prisma は tagged template の型安全性を保持するため引数型に null を使う)
+      const sinceValue: Date | null = since ?? null;
+
+      // ── クエリ 1: 平均初回応答時間 ──
+      // firstRespondedAt - createdAt の平均をミリ秒で返す。
+      // firstRespondedAt が null のチケット (未応答) は除外する。
+      // EXTRACT(EPOCH ...) は秒単位なので × 1000 でミリ秒に変換する。
+      const responseRows = await db.$queryRaw<[{ avg_ms: number | null }]>`
+        SELECT AVG(
+          EXTRACT(EPOCH FROM ("firstRespondedAt" - "createdAt")) * 1000
+        ) AS avg_ms
+        FROM "Ticket"
+        WHERE "tenantId" = ${tenantId}
+          AND "firstRespondedAt" IS NOT NULL
+          AND (${sinceValue}::timestamptz IS NULL OR "createdAt" >= ${sinceValue}::timestamptz)
+      `;
+
+      // ── クエリ 2: 平均解決時間 ──
+      // resolvedAt - createdAt の平均をミリ秒で返す。
+      // resolvedAt が null のチケット (未解決) は除外する。
+      const resolutionRows = await db.$queryRaw<
+        [{ avg_ms: number | null; cnt: bigint }]
+      >`
+        SELECT
+          AVG(EXTRACT(EPOCH FROM ("resolvedAt" - "createdAt")) * 1000) AS avg_ms,
+          COUNT(*) AS cnt
+        FROM "Ticket"
+        WHERE "tenantId" = ${tenantId}
+          AND "resolvedAt" IS NOT NULL
+          AND (${sinceValue}::timestamptz IS NULL OR "createdAt" >= ${sinceValue}::timestamptz)
+      `;
+
+      // ── クエリ 3: 再オープン率 ──
+      // 全チケット数のうち、「Resolved または Closed → Open への遷移履歴」を持つ
+      // チケットの割合を返す。
+      // TicketHistory.field = 'status' かつ newValue = 'Open' かつ
+      // oldValue IN ('Resolved', 'Closed') の行を持つ ticket を「再オープン済み」とみなす。
+      const reopenRows = await db.$queryRaw<
+        [{ total: bigint; reopened: bigint }]
+      >`
+        SELECT
+          COUNT(DISTINCT t.id) AS total,
+          COUNT(DISTINCT th."ticketId") AS reopened
+        FROM "Ticket" t
+        LEFT JOIN "TicketHistory" th
+          ON th."ticketId" = t.id
+          AND th.field = 'status'
+          AND th."newValue" = 'Open'
+          AND th."oldValue" IN ('Resolved', 'Closed')
+        WHERE t."tenantId" = ${tenantId}
+          AND (${sinceValue}::timestamptz IS NULL OR t."createdAt" >= ${sinceValue}::timestamptz)
+      `;
+
+      // 平均初回応答時間: Prisma は $queryRaw の数値を Decimal や number で返すことがある
+      // Number() で確実に JS の number に変換し、NaN は null に正規化する
+      const rawAvgFirstResponse = responseRows[0]?.avg_ms;
+      const avgFirstResponseMs =
+        rawAvgFirstResponse != null && !Number.isNaN(Number(rawAvgFirstResponse))
+          ? Number(rawAvgFirstResponse)
+          : null;
+
+      // 平均解決時間: 同様に number に変換する
+      const rawAvgResolution = resolutionRows[0]?.avg_ms;
+      const avgResolutionMs =
+        rawAvgResolution != null && !Number.isNaN(Number(rawAvgResolution))
+          ? Number(rawAvgResolution)
+          : null;
+
+      // 解決済みチケット件数: BigInt → number に変換 (DB の COUNT は BigInt で返る)
+      const resolvedCount = Number(resolutionRows[0]?.cnt ?? 0);
+
+      // 再オープン率: total が 0 のときは null (0 除算を避ける)
+      const total = Number(reopenRows[0]?.total ?? 0);
+      const reopened = Number(reopenRows[0]?.reopened ?? 0);
+      const reopenRate = total > 0 ? reopened / total : null;
+
+      // 品質メトリクス結果を返す
+      return {
+        avgFirstResponseMs,
+        avgResolutionMs,
+        reopenRate,
+        resolvedCount,
+      } satisfies QualityMetrics;
     },
   };
 }

--- a/src/data/ports/ticket-repository.ts
+++ b/src/data/ports/ticket-repository.ts
@@ -85,6 +85,27 @@ export interface MarkEscalatedInput {
   at: Date; // エスカレーション実行日時
 }
 
+/**
+ * 品質メトリクス (issue-backlog #25: 平均初回応答時間・平均解決時間・再オープン率)
+ *
+ * Pro モードのダッシュボードに表示し、対応品質の傾向を把握するために使う。
+ * 集計対象チケットが 0 件の場合はデータ不足として各値を null で返す (0 との混同を避ける)。
+ */
+export interface QualityMetrics {
+  /** 平均初回応答時間 (ミリ秒)。firstRespondedAt が設定されたチケットの平均値。集計対象なしなら null */
+  avgFirstResponseMs: number | null;
+  /** 平均解決時間 (ミリ秒)。resolvedAt が設定されたチケットの平均値。集計対象なしなら null */
+  avgResolutionMs: number | null;
+  /**
+   * 再オープン率 (0.0〜1.0)。
+   * 全チケットのうち「Resolved または Closed から Open に戻った履歴」を持つ割合。
+   * 集計対象なしなら null
+   */
+  reopenRate: number | null;
+  /** avgFirstResponseMs / avgResolutionMs の計算に使った解決済みチケット件数 */
+  resolvedCount: number;
+}
+
 // チケットリポジトリの契約 (port)
 // 全メソッドの ID 系引数は tenantId 必須化済。テナント越境参照/更新を Adapter 層で遮断する
 export interface TicketRepository {
@@ -119,6 +140,16 @@ export interface TicketRepository {
     excludeStatusesForWorkload: TicketStatus[]; // ワークロード集計で除外する状態
     tenantId: string; // テナントスコープ (必須)
   }): Promise<DashboardStats>; // 上記 3 指標をまとめて返す
+
+  /**
+   * 品質メトリクスを算出して返す (issue-backlog #25)。
+   * - avgFirstResponseMs : 初回応答があったチケットの平均初回応答時間 (ms)
+   * - avgResolutionMs    : 解決済みチケットの平均解決時間 (ms)
+   * - reopenRate         : 全チケット中「再オープンした」チケットの割合 (0.0〜1.0)
+   * @param args.tenantId テナントスコープ (必須)
+   * @param args.since    この日時以降に作成されたチケットのみ対象 (省略時は全期間)
+   */
+  qualityMetrics(args: { tenantId: string; since?: Date }): Promise<QualityMetrics>;
 
   create(input: CreateTicketInput): Promise<TicketWithRefs>; // 新規作成 (input.tenantId 必須)
   // 状態更新 (tenantId スコープ。他テナントの ID なら 0 件更新で no-op)

--- a/src/data/ports/ticket-repository.ts
+++ b/src/data/ports/ticket-repository.ts
@@ -102,8 +102,10 @@ export interface QualityMetrics {
    * 集計対象なしなら null
    */
   reopenRate: number | null;
-  /** avgFirstResponseMs / avgResolutionMs の計算に使った解決済みチケット件数 */
+  /** avgResolutionMs の計算に使った解決済みチケット件数 */
   resolvedCount: number;
+  /** reopenRate の計算に使った全チケット件数 (分母)。再オープン率ラベルに表示する */
+  totalCount: number;
 }
 
 // チケットリポジトリの契約 (port)

--- a/src/features/audit/components/AuditExportButton.tsx
+++ b/src/features/audit/components/AuditExportButton.tsx
@@ -4,30 +4,14 @@
 import type { TicketHistoryWithRefs } from '@/data/ports/ticket-history-repository';
 // 変更履歴フィールドの日本語ラベルマップ (CSV のフィールド列に使う)
 import { HISTORY_FIELD_LABELS } from '@/lib/constants';
+// BOM 付き CSV 文字列生成 + CSV インジェクション対応済みエスケープ (lib/csv.ts に一元化)
+// ローカルコピーを持たず常に共通実装を参照することでエスケープロジックの乖離を防ぐ (§6 DRY)
+import { buildCsvString } from '@/lib/csv';
 
 // AuditExportButton が受け取る props
 interface Props {
   // サーバー側で取得済みのログ一覧 (CSVに変換して書き出す)
   logs: TicketHistoryWithRefs[];
-}
-
-
-// CSV セルを安全にエスケープする関数。
-// ダブルクォート・カンマ・改行を含む値はダブルクォートで囲み、内部のダブルクォートを 2 重化する。
-// さらに CSV インジェクション対策として、スプレッドシートが数式として解釈するプレフィックス
-// (=, +, -, @) で始まる値の先頭にタブを挿入して無害化する (OWASP CSV Injection 対策)。
-function escapeCSVCell(value: string | null | undefined): string {
-  // null/undefined は空文字列として出力する
-  if (value == null) return '';
-  // スプレッドシートの数式として解釈されるプレフィックスを無害化する
-  // (Excel / LibreOffice Calc は =, +, -, @ で始まるセルを数式として評価する)
-  const neutralised = /^[=+\-@]/.test(value) ? `\t${value}` : value;
-  // 特殊文字が含まれる場合はダブルクォートで囲む
-  // \r のみ (CR-only) の改行も Excel が行区切りとして解釈するため \n と同様に処理する
-  if (neutralised.includes(',') || neutralised.includes('"') || neutralised.includes('\n') || neutralised.includes('\r')) {
-    return `"${neutralised.replace(/"/g, '""')}"`;
-  }
-  return neutralised;
 }
 
 // 監査ログを CSV ファイルとしてダウンロードするボタン
@@ -61,17 +45,12 @@ export function AuditExportButton({ logs }: Props) {
       log.newValue ?? '',
     ]);
 
-    // ヘッダーとデータ行をまとめて CSV 文字列に変換する
-    const csvContent = [
-      // ヘッダー行
-      headers.map(escapeCSVCell).join(','),
-      // データ行 (各フィールドをエスケープして結合)
-      ...rows.map((row) => row.map(escapeCSVCell).join(',')),
-    ].join('\n');
-
-    // BOM 付き UTF-8 で出力する (Excel での文字化けを防ぐため BOM を先頭に付与)
-    const bom = '﻿';
-    const blob = new Blob([bom + csvContent], { type: 'text/csv;charset=utf-8;' });
+    // BOM 付き UTF-8 の CSV 文字列を生成する。
+    // buildCsvString が BOM・エスケープ・改行をまとめて処理する (DRY)。
+    // \t を含むセル (OWASP 無害化後) も RFC 4180 準拠でダブルクォート囲みされる。
+    const csv = buildCsvString(headers, rows);
+    // Blob に変換してブラウザにダウンロードさせる準備をする
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     // ブラウザにダウンロードさせるための一時 URL を生成する
     const url = URL.createObjectURL(blob);
 

--- a/src/features/tickets/build-filter.ts
+++ b/src/features/tickets/build-filter.ts
@@ -1,0 +1,123 @@
+/**
+ * チケット一覧のフィルタ条件をURLクエリパラメータから組み立てる純粋関数。
+ *
+ * /tickets ページと GET /api/tickets/export の両方から呼ばれるため、
+ * 一覧と CSV エクスポートが常に同一の絞り込み条件を使えるようにここで一元管理する (DRY 原則)。
+ * 'use server' / 'use client' を付けないことでサーバー側・クライアント側の双方向にインポート可能。
+ */
+
+// ドメイン型のチケットステータスと優先度 (型ガード用)
+import type { TicketStatus, Priority } from '@/domain/types';
+// リポジトリポートが要求するフィルタ型
+import type { TicketListFilter } from '@/data/ports/ticket-repository';
+// タブ絞り込みを共通ヘルパーに委譲する (mine / overdue タブは一覧とダッシュボードで共有)
+import { applyTabFilter } from '@/features/tickets/tab-filter';
+// 一覧タブ型 ('all' / 'mine' / 'overdue')
+import type { TicketTabId } from '@/features/tickets/components/TicketTabs';
+
+// buildTicketListFilter に渡すURL由来の生文字列パラメータ
+export interface TicketFilterParams {
+  q?: string; // フリーワード検索
+  status?: string; // ステータス (URL クエリは文字列として届く)
+  priority?: string; // 優先度 (URL クエリは文字列として届く)
+  categoryId?: string; // カテゴリ ID
+  assigneeId?: string; // 担当者 ID (または 'unassigned')
+  locationId?: string; // 拠点 ID (Phase 4 多拠点)
+  tab?: string; // 一覧タブ ('mine' / 'overdue' / 'all' または未指定)
+}
+
+// buildTicketListFilter が必要とする実行コンテキスト
+export interface TicketFilterContext {
+  isAgent: boolean; // 担当者 (agent/admin) かどうか
+  userId: string; // ログインユーザー ID
+  now: Date; // 現在時刻 (overdue タブの期限判定に使う)
+}
+
+/**
+ * クエリ文字列のステータスが TicketStatus 列挙に含まれるかを判定する型ガード。
+ * URL は信頼できない入力のため、必ずこの関数で検証してから使う。
+ */
+export function isValidStatus(s: string): s is TicketStatus {
+  // 有効な TicketStatus の全一覧。変更時は src/domain/types.ts と同期させること
+  return [
+    'New',
+    'Open',
+    'WaitingForUser',
+    'InProgress',
+    'Escalated',
+    'Resolved',
+    'Closed',
+  ].includes(s);
+}
+
+/**
+ * クエリ文字列の優先度が Priority 列挙に含まれるかを判定する型ガード。
+ */
+export function isValidPriority(p: string): p is Priority {
+  // 有効な Priority の全一覧。変更時は src/domain/types.ts と同期させること
+  return ['Low', 'Medium', 'High'].includes(p);
+}
+
+/**
+ * URL クエリの assigneeId を Port が期待する形 (`undefined` / `null` / 文字列) に正規化する。
+ * - 空文字 / 未指定 → undefined (フィルタなし、全担当者を対象にする)
+ * - 'unassigned'   → null    (未アサイン (担当者なし) のチケットのみ)
+ * - その他         → 文字列のまま (特定のユーザー ID で完全一致)
+ */
+export function normalizeAssigneeId(raw: string | undefined): string | null | undefined {
+  // 値が無ければフィルタなし
+  if (!raw) return undefined;
+  // 'unassigned' は未アサイン (null) を意味する
+  if (raw === 'unassigned') return null;
+  // それ以外はユーザー ID とみなしてそのまま返す
+  return raw;
+}
+
+/**
+ * URL クエリの tab を TicketTabId に正規化する。不正値は 'all' にフォールバックする。
+ */
+export function parseTabParam(raw: string | undefined): TicketTabId {
+  // 'mine' か 'overdue' に完全一致する場合のみ採用、それ以外は既定の 'all'
+  if (raw === 'mine' || raw === 'overdue') return raw;
+  return 'all';
+}
+
+/**
+ * URL 由来の生文字列パラメータ + 実行コンテキストから TicketListFilter を組み立てる。
+ *
+ * /tickets ページ (src/app/(app)/tickets/page.tsx) と
+ * GET /api/tickets/export (src/app/api/tickets/export/route.ts) の両方が
+ * この関数を呼ぶことで、一覧と CSV エクスポートが常に同じ絞り込みロジックを共有する。
+ */
+export function buildTicketListFilter(
+  params: TicketFilterParams,
+  ctx: TicketFilterContext,
+): TicketListFilter {
+  // RBAC: 依頼者 (requester) は自分が起票したチケットのみ閲覧可能
+  // エージェント / 管理者は全チケットを対象にする (creatorId 未指定)
+  const baseFilter: TicketListFilter = {
+    creatorId: ctx.isAgent ? undefined : ctx.userId,
+    // フリーワード検索: タイトルまたは本文を大文字小文字を無視して部分一致
+    text: params.q ? { contains: params.q, caseInsensitive: true } : undefined,
+    // ステータス絞り込み: 列挙値として正しい場合のみ適用 (不正な文字列は無視する)
+    status: params.status && isValidStatus(params.status) ? params.status : undefined,
+    // 優先度絞り込み: 列挙値として正しい場合のみ適用
+    priority:
+      params.priority && isValidPriority(params.priority) ? params.priority : undefined,
+    // カテゴリ絞り込み: 空文字は無指定として扱う
+    categoryId: params.categoryId || undefined,
+    // 担当者絞り込み: 'unassigned' を null に正規化する
+    assigneeId: normalizeAssigneeId(params.assigneeId),
+    // 拠点絞り込み: 空文字は無指定として扱う (Phase 4 多拠点)
+    locationId: params.locationId || undefined,
+  };
+
+  // タブ別の追加条件 ('mine' / 'overdue') を共通ヘルパーで適用する
+  // (ダッシュボードと同一ロジックを共有し、タブの意味を二重定義しない)
+  const tab = parseTabParam(params.tab);
+  return applyTabFilter(baseFilter, tab, {
+    isAgent: ctx.isAgent,
+    userId: ctx.userId,
+    now: ctx.now,
+  });
+}

--- a/src/features/tickets/build-filter.ts
+++ b/src/features/tickets/build-filter.ts
@@ -33,29 +33,36 @@ export interface TicketFilterContext {
   now: Date; // 現在時刻 (overdue タブの期限判定に使う)
 }
 
+// `as const satisfies` で TicketStatus / Priority の全値を列挙する。
+// 型システムが「domain/types.ts の union 型と一致しているか」を検査するため、
+// domain/types.ts に値を追加してここを更新し忘れると TypeScript エラーになる (ドリフト防止)。
+const VALID_STATUSES = [
+  'New',
+  'Open',
+  'WaitingForUser',
+  'InProgress',
+  'Escalated',
+  'Resolved',
+  'Closed',
+] as const satisfies TicketStatus[];
+
+const VALID_PRIORITIES = ['Low', 'Medium', 'High'] as const satisfies Priority[];
+
 /**
  * クエリ文字列のステータスが TicketStatus 列挙に含まれるかを判定する型ガード。
  * URL は信頼できない入力のため、必ずこの関数で検証してから使う。
  */
 export function isValidStatus(s: string): s is TicketStatus {
-  // 有効な TicketStatus の全一覧。変更時は src/domain/types.ts と同期させること
-  return [
-    'New',
-    'Open',
-    'WaitingForUser',
-    'InProgress',
-    'Escalated',
-    'Resolved',
-    'Closed',
-  ].includes(s);
+  // VALID_STATUSES は satisfies TicketStatus[] で型検査済み
+  return (VALID_STATUSES as readonly string[]).includes(s);
 }
 
 /**
  * クエリ文字列の優先度が Priority 列挙に含まれるかを判定する型ガード。
  */
 export function isValidPriority(p: string): p is Priority {
-  // 有効な Priority の全一覧。変更時は src/domain/types.ts と同期させること
-  return ['Low', 'Medium', 'High'].includes(p);
+  // VALID_PRIORITIES は satisfies Priority[] で型検査済み
+  return (VALID_PRIORITIES as readonly string[]).includes(p);
 }
 
 /**

--- a/src/features/tickets/components/CsvExportButton.tsx
+++ b/src/features/tickets/components/CsvExportButton.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+// URL クエリパラメータを読み取る (Suspense 境界が必要)
+import { useSearchParams } from 'next/navigation';
+// ローディング状態を管理する
+import { useState } from 'react';
+
+/**
+ * チケット一覧の現在の絞り込み条件を維持したまま CSV をダウンロードするボタン。
+ *
+ * useSearchParams() でブラウザの URL クエリパラメータをそのまま
+ * GET /api/tickets/export に転送するため、一覧ページとエクスポートが
+ * 常に同じ絞り込み条件を使う (issue-backlog #27 完了条件「一覧条件を引き継いだ CSV ダウンロード可能」)。
+ *
+ * Suspense 境界内に配置しないと Next.js でビルドエラーになる。
+ * 呼び出し側 (tickets/page.tsx) で <Suspense> でラップすること。
+ */
+export function CsvExportButton() {
+  // ブラウザの現在の URL クエリパラメータを取得する (Suspense 必須)
+  const searchParams = useSearchParams();
+  // ダウンロード中かどうかを管理する (多重クリック防止のため)
+  const [loading, setLoading] = useState(false);
+
+  // CSV ダウンロードを実行するハンドラ
+  async function handleDownload() {
+    // ダウンロード中は再クリックを防ぐ
+    setLoading(true);
+    try {
+      // 現在の URL クエリパラメータをそのまま export エンドポイントに転送する
+      // (一覧の絞り込み条件を CSV エクスポートに引き継ぐ)
+      const exportUrl = `/api/tickets/export?${searchParams.toString()}`;
+      // fetch で CSV データを取得する (auth cookie はブラウザが自動付与する)
+      const res = await fetch(exportUrl);
+      // エラーレスポンスの場合は例外を投げる
+      if (!res.ok) {
+        throw new Error(`エクスポートに失敗しました (HTTP ${res.status})`);
+      }
+      // レスポンスを Blob として取得する
+      const blob = await res.blob();
+      // Blob から一時 URL を生成してダウンロードを開始する
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      // ファイル名はサーバーの Content-Disposition ヘッダーから取得するのが理想だが、
+      // クロスオリジン制限があるためクライアント側でも日付付きファイル名を設定する
+      link.download = `tickets-${new Date().toISOString().slice(0, 10)}.csv`;
+      // DOM に一時追加してクリックしてダウンロードを起動し、すぐに削除する
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      // 一時 URL を解放してメモリリークを防ぐ
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      // エラーメッセージをユーザーに表示する (詳細は内部ログに留める)
+      // スタックトレースは漏らさない (§9 セキュリティ)
+      const message =
+        err instanceof Error ? err.message : 'CSV エクスポートに失敗しました。再度お試しください。';
+      alert(message);
+    } finally {
+      // 成功・失敗どちらでもローディング状態を解除する
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleDownload}
+      // ダウンロード中は再クリックを防ぐ
+      disabled={loading}
+      className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+      aria-label="現在の絞り込み条件でチケット一覧を CSV 形式でダウンロードする"
+    >
+      {/* ローディング中はスピナー文字を表示し、待機中であることを明示する */}
+      {loading ? '取得中…' : 'CSV エクスポート'}
+    </button>
+  );
+}

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -31,6 +31,9 @@ export function parseCsvLine(line: string): string[] {
   let current = '';
   // フィールドが引用符で囲まれているかのフラグ
   let inQuotes = false;
+  // 現在のフィールドが引用符で始まったかを記録するフラグ
+  // RFC 4180 §2.7: 引用フィールドの空白は保持すべき値の一部。trim() してはいけない
+  let wasQuoted = false;
   // 1 文字ずつ走査する
   for (let i = 0; i < line.length; i++) {
     const ch = line[i]; // 現在の文字
@@ -54,11 +57,16 @@ export function parseCsvLine(line: string): string[] {
         // バッファに文字が既にある場合 (例: `5"` の `"`) はリテラル文字として扱い、
         // 誤ってコンマを飲み込むクォートモードには入らない。
         inQuotes = true;
+        // このフィールドは引用符付きであることを記録する (trim スキップのため)
+        wasQuoted = true;
       } else if (ch === ',') {
-        // カンマ → フィールド終端。前後の空白を除いてリストに追加する
-        fields.push(current.trim());
+        // カンマ → フィールド終端。
+        // 引用フィールドは空白を保持する (RFC 4180 §2.7)。非引用フィールドのみ trim する。
+        fields.push(wasQuoted ? current : current.trim());
         // バッファをリセットして次のフィールドへ
         current = '';
+        // 次のフィールドのために wasQuoted をリセットする
+        wasQuoted = false;
       } else {
         // 通常文字 (フィールド途中の `"` も含む) をバッファに追加する
         current += ch;
@@ -72,7 +80,8 @@ export function parseCsvLine(line: string): string[] {
     throw new SyntaxError('CSV の引用符が閉じられていません。行を確認してください。');
   }
   // 最後のフィールドを追加する (末尾のカンマがなくても確実に取り込む)
-  fields.push(current.trim());
+  // 引用フィールドは空白を保持する (RFC 4180 §2.7)
+  fields.push(wasQuoted ? current : current.trim());
   // 解析済みフィールド配列を返す
   return fields;
 }
@@ -96,11 +105,14 @@ export function escapeCSVCell(value: string | null | undefined): string {
   const neutralised = /^[=+\-@]/.test(value) ? `\t${value}` : value;
   // 特殊文字 (カンマ・ダブルクォート・改行) が含まれる場合はダブルクォートで囲む
   // \r のみ (CR-only) の改行も Excel が行区切りとして解釈するため \n と同様に処理する
+  // \t (タブ) は OWASP 対策として先頭に付与した場合、RFC 4180 の TEXTDATA 範囲外のため
+  // 引用符で囲んで RFC 準拠にする
   if (
     neutralised.includes(',') ||
     neutralised.includes('"') ||
     neutralised.includes('\n') ||
-    neutralised.includes('\r')
+    neutralised.includes('\r') ||
+    neutralised.includes('\t')
   ) {
     return `"${neutralised.replace(/"/g, '""')}"`;
   }

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,8 +1,9 @@
 /**
  * RFC 4180 準拠の CSV ユーティリティ
  *
- * サーバーアクション (import-tickets.ts) とクライアント UI (CsvImportForm.tsx) の
- * 両方から使えるように、純粋関数として分離したモジュール。
+ * サーバーアクション (import-tickets.ts) / エクスポート API (api/tickets/export) /
+ * クライアント UI (CsvImportForm.tsx, AuditExportButton.tsx) の全方位から使えるよう、
+ * 純粋関数として分離したモジュール。
  * 'use server' / 'use client' を付けないことで双方向にインポート可能にする。
  */
 
@@ -74,4 +75,49 @@ export function parseCsvLine(line: string): string[] {
   fields.push(current.trim());
   // 解析済みフィールド配列を返す
   return fields;
+}
+
+/**
+ * CSV セルを安全にエスケープする関数。
+ *
+ * - ダブルクォート・カンマ・改行を含む値はダブルクォートで囲み、内部の `"` を `""` で 2 重化する。
+ * - CSV インジェクション対策: `=`, `+`, `-`, `@` で始まる値の先頭にタブを挿入して
+ *   スプレッドシートの数式解釈を無害化する (OWASP CSV Injection 対策)。
+ * - null / undefined は空文字列として出力する。
+ *
+ * エクスポート API (api/tickets/export) と監査ログエクスポート (AuditExportButton)
+ * の両方が同一ロジックを参照できるように、ここで一元管理する (§6 DRY 原則)。
+ */
+export function escapeCSVCell(value: string | null | undefined): string {
+  // null/undefined は空文字列として出力する
+  if (value == null) return '';
+  // スプレッドシートが数式として解釈するプレフィックス (=, +, -, @) で始まる場合、
+  // タブを先頭に付与して数式として評価されないようにする (OWASP CSV Injection 対策)
+  const neutralised = /^[=+\-@]/.test(value) ? `\t${value}` : value;
+  // 特殊文字 (カンマ・ダブルクォート・改行) が含まれる場合はダブルクォートで囲む
+  // \r のみ (CR-only) の改行も Excel が行区切りとして解釈するため \n と同様に処理する
+  if (
+    neutralised.includes(',') ||
+    neutralised.includes('"') ||
+    neutralised.includes('\n') ||
+    neutralised.includes('\r')
+  ) {
+    return `"${neutralised.replace(/"/g, '""')}"`;
+  }
+  return neutralised;
+}
+
+/**
+ * ヘッダー行とデータ行の 2 次元配列から BOM 付き UTF-8 の CSV 文字列を生成する。
+ *
+ * BOM (`﻿`) を先頭に付与することで Excel での文字化けを防ぐ。
+ * 各行の末尾には CRLF ではなく LF を使う (Web サーバから配信する際の標準的な改行コード)。
+ */
+export function buildCsvString(headers: string[], rows: string[][]): string {
+  // ヘッダー行をエスケープしてカンマで連結する
+  const headerLine = headers.map(escapeCSVCell).join(',');
+  // データ行を 1 行ずつエスケープしてカンマで連結する
+  const dataLines = rows.map((row) => row.map(escapeCSVCell).join(','));
+  // BOM + ヘッダー + データ行を LF で結合して返す
+  return '﻿' + [headerLine, ...dataLines].join('\n');
 }


### PR DESCRIPTION
## 概要

issue-backlog の未実装項目 #25（品質メトリクス）と #27（CSV エクスポート）を実装します。

## 変更内容

### issue-backlog #27: チケット一覧 CSV エクスポート

- **`GET /api/tickets/export`** (`src/app/api/tickets/export/route.ts`)
  - 一覧ページと同一のフィルタ条件を引き継いで CSV をダウンロードする API
  - `MAX_EXPORT_ROWS = 10,000` 件上限で DoS を防止
  - BOM 付き UTF-8 で Excel 互換性を確保
  - `Content-Disposition: attachment` でダウンロードを強制
  - `Cache-Control: no-cache, no-store` でキャッシュを無効化
  - 認証なし・tenantId なしは 401 を返す

- **`CsvExportButton`** (`src/features/tickets/components/CsvExportButton.tsx`)
  - `useSearchParams()` で現在の URL クエリパラメータを読み取り、そのまま export API に転送
  - ダウンロード中は disabled で多重クリックを防止
  - Suspense 境界が必要なため、呼び出し元の `tickets/page.tsx` で `<Suspense>` でラップ

- **`buildTicketListFilter`** (`src/features/tickets/build-filter.ts`)
  - `tickets/page.tsx` に散在していたフィルタ組み立てロジックを共通モジュールに抽出
  - エクスポート API と一覧ページで同一関数を使い、フィルタ条件のずれを防止 (DRY)

- **`src/lib/csv.ts`** に `escapeCSVCell` / `buildCsvString` を追加
  - OWASP 推奨の tab プレフィックス方式で CSV インジェクション対策

### issue-backlog #25: 品質メトリクス算出

- **`QualityMetrics` 型** (`src/data/ports/ticket-repository.ts`)
  - `avgFirstResponseMs` / `avgResolutionMs` / `reopenRate` / `resolvedCount` を定義
  - `qualityMetrics(args)` メソッドを `TicketRepository` interface に追加

- **Prisma アダプタ実装** (`src/data/adapters/prisma/ticket-repository.prisma.ts`)
  - PostgreSQL の `EXTRACT(EPOCH FROM ...)` を使った `$queryRaw` で平均時間を算出
  - TicketHistory の JOIN で再オープン履歴を検出
  - BigInt → number 変換と null/NaN 正規化を実施

- **メモリアダプタ実装** (`src/data/adapters/memory/ticket-repository.memory.ts`)
  - インメモリストアから同等のメトリクスを計算（ユニットテスト向け）

- **Pro ダッシュボード** (`src/app/(app)/dashboard/page.tsx`)
  - 「対応品質」セクションを追加（エージェントのみ表示）
  - 平均初回応答時間・平均解決時間・再オープン率の 3 枚カード
  - resolvedCount=0 時はデータ不足メッセージを表示し 0 との混同を防止
  - `formatDurationMs()` ヘルパーで「X 日 Y 時間」形式の読みやすい表示

## 対応フェーズ

smb-dx-pivot-plan.md Phase 2（Pro モード機能強化）に対応。

## 検証

- `npm run typecheck`: src/ 以下のエラーなし（環境依存の既存エラーを除く）
- `npx vitest run`: 415 テスト全通過（45 ファイル、32 スキップ）

---
_Generated by [Claude Code](https://claude.ai/code/session_017K4RV1zyRrynfgJgfWSbCX)_