### PR TITLE
fix(tickets,import,dashboard): コードレビュー指摘 8 件を修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1855,7 +1855,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -1889,14 +1889,14 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
       "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
       "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1910,14 +1910,14 @@
       "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
       "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
       "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0",
@@ -1929,7 +1929,7 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
       "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0"
@@ -6984,7 +6984,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -7003,7 +7003,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -7194,7 +7194,7 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
       "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -107,10 +107,10 @@ export default async function DashboardPage() {
   // 担当者別ワークロード (依頼者には表示しないので空配列)
   const workload = isAgent ? stats.workload : [];
 
-  // 表示用に担当者 ID 一覧を抽出 (未割当行は除外)
-  const assigneeIds = workload
-    .filter((w) => w.assigneeId !== null)
-    .map((w) => w.assigneeId as string);
+  // 表示用に担当者 ID 一覧を抽出 (未割当行は除外)。
+  // TypeScript は .filter() 後の null 除外を自動的に型に反映しないため、
+  // flatMap で「null なら空配列、string なら 1 要素配列」に変換して型安全に string[] を得る。
+  const assigneeIds = workload.flatMap((w) => (w.assigneeId !== null ? [w.assigneeId] : []));
 
   // 担当者名を解決するため、当該テナント内のユーザー情報をまとめて取得 (port 経由)
   const assigneeNames =

--- a/src/app/(app)/tickets/page.tsx
+++ b/src/app/(app)/tickets/page.tsx
@@ -20,8 +20,7 @@ import { TicketFilters } from '@/features/tickets/components/TicketFilters';
 import { TicketTabs } from '@/features/tickets/components/TicketTabs';
 // フィルタ組み立て共有モジュール (エクスポート API と同一ロジックを使う)
 // - buildTicketListFilter: URL クエリパラメータから TicketListFilter を組み立てる
-// - parseTabParam       : クエリの tab 文字列を TicketTabId に正規化する
-import { buildTicketListFilter, parseTabParam } from '@/features/tickets/build-filter';
+import { buildTicketListFilter } from '@/features/tickets/build-filter';
 // CSV エクスポートボタン (Client Component — Suspense でラップして使う)
 import { CsvExportButton } from '@/features/tickets/components/CsvExportButton';
 
@@ -74,8 +73,6 @@ export default async function TicketsPage({ searchParams }: Props) {
   // 要求ページ番号と DB の skip 件数を計算
   const requestedPage = parsePageParam(sp.page);
   const skip = (requestedPage - 1) * PAGE_SIZE;
-  // タブ ID を正規化 ('all' / 'mine' / 'overdue' のいずれか) — UI 表示・ページング URL 生成に使う
-  const tab = parseTabParam(sp.tab);
   // 現在時刻 (overdue タブの判定と、エクスポート API が同一基準を使えるよう変数化)
   const now = new Date();
 

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -19,6 +19,8 @@ import { getCurrentTenantMode } from '@/lib/tenant';
 import { parseCsvLine, MAX_CSV_BYTES } from '@/lib/csv';
 // 優先度・ステータスのドメイン型
 import type { Priority, TicketStatus } from '@/domain/types';
+// モードに応じた初期ステータスを返す共通関数（メール取り込み・LINE 取り込みと同一ロジックを共有し DRY を維持する）
+import { initialStatusForMode } from '@/domain/ticket-status';
 // CSV インポート完了後に他エージェントへ未読カウントを即時配信するヘルパー
 import { broadcastUnreadCountToMany } from '@/features/notifications/notify';
 
@@ -186,8 +188,11 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
   // テナントの動作モードを取得する (初期ステータスを Lite/Pro で切り替えるために必要)
   const mode = await getCurrentTenantMode(tenantId);
 
-  // Lite モードの初期ステータスは「Open」(未対応)、Pro モードは「New」(新規)
-  const initialStatus: TicketStatus = mode === 'lite' ? 'Open' : 'New';
+  // Lite: 'Open'(未対応)、Pro: undefined → DB 既定値 'New'(新規) を使う。
+  // メール取り込み・LINE 取り込みと同じ initialStatusForMode を呼ぶことで、
+  // モード別初期ステータスの定義が ticket-status.ts に一元化される (DRY 原則)。
+  // ?? 'New' は Pro モードで undefined が返ったときに型を TicketStatus に確定するため必要。
+  const initialStatus: TicketStatus = initialStatusForMode(mode) ?? 'New';
 
   // --- CSV パース開始 ---
   // Excel がエクスポートする UTF-8 CSV は先頭にバイトオーダーマーク (BOM: ﻿) を付けることがある。
@@ -249,8 +254,13 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     let cells: string[];
     try {
       cells = parseCsvLine(line ?? '');
-    } catch {
-      // 引用符の閉じ忘れ等の CSV 書式エラー: 行全体をスキップしてエラーを積む
+    } catch (err) {
+      // parseCsvLine が SyntaxError を投げる（引用符の閉じ忘れ等）のは想定内だが、
+      // 予期しない例外（TypeError 等）はサーバーログに記録して握り潰さない (CLAUDE.md §6)。
+      if (!(err instanceof SyntaxError)) {
+        console.error(`[importTickets] 行 ${rowNum} の CSV パースで予期しないエラー:`, err);
+      }
+      // いずれの例外でも行全体をスキップしてエラーを積み、残り行の処理を続ける
       errors.push({ row: rowNum, message: 'CSV の形式が正しくありません（引用符が閉じられていない可能性があります）' });
       continue;
     }
@@ -290,8 +300,10 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
 
   // インポートでチケットが 1 件以上作成された場合のコミット後処理
   if (imported > 0) {
-    // チケット一覧のキャッシュを無効化する (revalidatePath を呼ばないと古いデータが表示され続ける)
+    // チケット一覧と管理ダッシュボードのキャッシュを無効化する
+    // /dashboard も対象にしないと、インポート後もカウントが旧値のまま最大 60 秒間表示され続ける
     revalidatePath('/tickets');
+    revalidatePath('/dashboard');
 
     // 同テナントの他エージェント (インポート実行者を除く) に一括追加を通知する。
     // 個別チケットごとではなく 1 通にまとめることで通知の過多を防ぐ (200 件追加でも通知は 1 通)。
@@ -299,21 +311,30 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     // インポート実行者自身への通知は不要なので除外する (自分が実施したことは知っているため)
     const otherAgents = agents.filter((a) => a.id !== creatorId);
     if (otherAgents.length > 0) {
-      // 各エージェントへ通知を 1 件ずつ DB に書き込む
-      for (const agent of otherAgents) {
-        await repos.notifications.create({
-          userId: agent.id, // 受信者: 各エージェント
-          type: 'imported', // CSV 一括インポート通知 (NotificationType.imported)
-          message: `${imported} 件のチケットが CSV インポートで追加されました`, // 表示文言
-          ticketId: null, // バッチインポートは単一チケットに紐づかないため null
-          tenantId, // テナントスコープ
-        });
-      }
-      // 未読件数を SSE で即時配信して通知ベルに反映させる
-      await broadcastUnreadCountToMany(
-        otherAgents.map((a) => a.id), // 通知対象の agent ID 一覧
-        tenantId, // テナントスコープ
+      // 各エージェントへの通知を並列で DB に書き込む (直列 await だとエージェント数ぶん往復が増えるため)
+      await Promise.all(
+        otherAgents.map((agent) =>
+          repos.notifications.create({
+            userId: agent.id, // 受信者: 各エージェント
+            type: 'imported', // CSV 一括インポート通知 (NotificationType.imported)
+            message: `${imported} 件のチケットが CSV インポートで追加されました`, // 表示文言
+            ticketId: null, // バッチインポートは単一チケットに紐づかないため null
+            tenantId, // テナントスコープ
+          }),
+        ),
       );
+      // 未読件数を SSE で即時配信して通知ベルに反映させる。
+      // broadcast は通知 DB 書き込みより後に行う必要があるため、上の Promise.all を待ってから実行する。
+      // ここで例外が発生してもチケット作成は完了済みなので、ユーザーに失敗として返さず警告ログに留める。
+      try {
+        await broadcastUnreadCountToMany(
+          otherAgents.map((a) => a.id), // 通知対象の agent ID 一覧
+          tenantId, // テナントスコープ
+        );
+      } catch (err) {
+        // SSE broadcast の失敗はチケット作成の成否に影響しない。通知ベルの更新が遅れるだけなのでログのみ。
+        console.warn('[importTickets] SSE broadcast に失敗しました（チケット作成は成功）:', err);
+      }
     }
   }
 

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -260,8 +260,15 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
       if (!(err instanceof SyntaxError)) {
         console.error(`[importTickets] 行 ${rowNum} の CSV パースで予期しないエラー:`, err);
       }
-      // いずれの例外でも行全体をスキップしてエラーを積み、残り行の処理を続ける
-      errors.push({ row: rowNum, message: 'CSV の形式が正しくありません（引用符が閉じられていない可能性があります）' });
+      // SyntaxError は書式エラー用メッセージ、予期しない例外は汎用メッセージを積む
+      // (TypeError 等に「引用符が閉じられていない」は誤誘導になるため分岐する)
+      errors.push({
+        row: rowNum,
+        message:
+          err instanceof SyntaxError
+            ? 'CSV の形式が正しくありません（引用符が閉じられていない可能性があります）'
+            : 'CSV の読み取りに失敗しました。ファイルの内容を確認してください。',
+      });
       continue;
     }
 
@@ -311,8 +318,11 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     // インポート実行者自身への通知は不要なので除外する (自分が実施したことは知っているため)
     const otherAgents = agents.filter((a) => a.id !== creatorId);
     if (otherAgents.length > 0) {
-      // 各エージェントへの通知を並列で DB に書き込む (直列 await だとエージェント数ぶん往復が増えるため)
-      await Promise.all(
+      // 各エージェントへの通知を並列で DB に書き込む。
+      // Promise.allSettled を使い、1 件の書き込み失敗が他エージェントへの通知配信や
+      // SSE broadcast をブロックしないようにする。チケット作成は完了済みなので
+      // 通知書き込みの一部失敗はエラーとして呼び出し元に返さずログに留める。
+      const notifyResults = await Promise.allSettled(
         otherAgents.map((agent) =>
           repos.notifications.create({
             userId: agent.id, // 受信者: 各エージェント
@@ -323,6 +333,16 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
           }),
         ),
       );
+      // 失敗した通知件数をサーバーログに記録する（チケット作成の成否には影響しない）
+      const failedCount = notifyResults.filter((r) => r.status === 'rejected').length;
+      if (failedCount > 0) {
+        // 失敗内容の詳細もログに残す (CLAUDE.md §6: エラーを握り潰さない)
+        notifyResults.forEach((r, i) => {
+          if (r.status === 'rejected') {
+            console.warn(`[importTickets] エージェント ${otherAgents[i].id} への通知書き込みに失敗:`, r.reason);
+          }
+        });
+      }
       // 未読件数を SSE で即時配信して通知ベルに反映させる。
       // broadcast は通知 DB 書き込みより後に行う必要があるため、上の Promise.all を待ってから実行する。
       // ここで例外が発生してもチケット作成は完了済みなので、ユーザーに失敗として返さず警告ログに留める。

--- a/src/features/tickets/components/CsvExportButton.tsx
+++ b/src/features/tickets/components/CsvExportButton.tsx
@@ -51,8 +51,9 @@ export function CsvExportButton() {
       // 一時 URL を解放してメモリリークを防ぐ
       URL.revokeObjectURL(url);
     } catch (err) {
-      // エラーメッセージをユーザーに表示する (詳細は内部ログに留める)
-      // スタックトレースは漏らさない (§9 セキュリティ)
+      // ブラウザのデベロッパーツールでエラー詳細を確認できるようにする (エラーを握り潰さない: CLAUDE.md §6)
+      console.error('[CsvExportButton] CSV エクスポートに失敗:', err);
+      // ユーザーには安全なメッセージのみ表示する (スタックトレース等の内部詳細は漏らさない: §9)
       const message =
         err instanceof Error ? err.message : 'CSV エクスポートに失敗しました。再度お試しください。';
       alert(message);

--- a/src/features/tickets/components/CsvExportButton.tsx
+++ b/src/features/tickets/components/CsvExportButton.tsx
@@ -37,9 +37,14 @@ export function CsvExportButton() {
       if (!res.ok) {
         // レート制限 (429) やサーバーエラー (5xx) のケースを区別したメッセージをコンソールに記録する
         console.error(`[CsvExportButton] HTTP エラー: ${res.status}`);
-        // alert には汎用メッセージのみ表示しステータスコードを漏洩させない
+        // alert には汎用メッセージのみ表示しステータスコードを漏洩させない。
+        // 401 はセッション切れを意味するため「再ログインを促す」メッセージを返す。
+        // 429 はレート制限なので「しばらく待つよう促す」メッセージを返す。
+        // それ以外のエラー (5xx 等) は汎用メッセージを返す。
         throw new Error(
-          res.status === 429
+          res.status === 401
+            ? 'セッションが切れました。ページを再読み込みしてからログインし直してください。'
+            : res.status === 429
             ? 'しばらくしてから再度お試しください（エクスポートの上限に達しました）。'
             : 'CSV エクスポートに失敗しました。しばらくしてから再度お試しください。',
         );
@@ -62,9 +67,17 @@ export function CsvExportButton() {
     } catch (err) {
       // ブラウザのデベロッパーツールでエラー詳細を確認できるようにする (エラーを握り潰さない: CLAUDE.md §6)
       console.error('[CsvExportButton] CSV エクスポートに失敗:', err);
-      // ユーザーには安全なメッセージのみ表示する (スタックトレース等の内部詳細は漏らさない: §9)
+      // ユーザーには安全なメッセージのみ表示する (スタックトレース等の内部詳細は漏らさない: §9)。
+      // TypeError はオフラインやネットワーク切断で fetch() が失敗したケース。
+      // ブラウザが生成する英語メッセージ ("Failed to fetch" 等) は日本語 UI に表示しない。
+      // throw new Error(...) で作成した制御済みメッセージ (HTTP エラー・429 等) は instanceof TypeError にならないため
+      // そのまま err.message を使う。TypeError のみ日本語の接続エラーメッセージに差し替える。
       const message =
-        err instanceof Error ? err.message : 'CSV エクスポートに失敗しました。再度お試しください。';
+        err instanceof TypeError
+          ? 'ネットワークエラーが発生しました。接続を確認してから再度お試しください。'
+          : err instanceof Error
+          ? err.message
+          : 'CSV エクスポートに失敗しました。再度お試しください。';
       alert(message);
     } finally {
       // 成功・失敗どちらでもローディング状態を解除する

--- a/src/features/tickets/components/CsvExportButton.tsx
+++ b/src/features/tickets/components/CsvExportButton.tsx
@@ -31,9 +31,18 @@ export function CsvExportButton() {
       const exportUrl = `/api/tickets/export?${searchParams.toString()}`;
       // fetch で CSV データを取得する (auth cookie はブラウザが自動付与する)
       const res = await fetch(exportUrl);
-      // エラーレスポンスの場合は例外を投げる
+      // エラーレスポンスの場合は例外を投げる。
+      // HTTP ステータスコードは内部情報のため alert に表示しない。
+      // サーバーログの追跡には X-Request-ID 等を使い、ユーザーには汎用メッセージを見せる (§9)。
       if (!res.ok) {
-        throw new Error(`エクスポートに失敗しました (HTTP ${res.status})`);
+        // レート制限 (429) やサーバーエラー (5xx) のケースを区別したメッセージをコンソールに記録する
+        console.error(`[CsvExportButton] HTTP エラー: ${res.status}`);
+        // alert には汎用メッセージのみ表示しステータスコードを漏洩させない
+        throw new Error(
+          res.status === 429
+            ? 'しばらくしてから再度お試しください（エクスポートの上限に達しました）。'
+            : 'CSV エクスポートに失敗しました。しばらくしてから再度お試しください。',
+        );
       }
       // レスポンスを Blob として取得する
       const blob = await res.blob();


### PR DESCRIPTION
## 概要

`/code-review ultra` による差分レビューで発見された問題を修正。

## 修正内容

### 1. 空の catch ブロックを修正（CLAUDE.md §6 準拠）
**ファイル**: `src/features/tickets/actions/import-tickets.ts:252`

`catch {}` だと `SyntaxError` 以外の予期しない例外（`TypeError` 等）もサーバーログに残らず握り潰される。`catch (err)` に変更し、`SyntaxError` 以外は `console.error` で記録するようにした。

### 2. `initialStatusForMode()` を使用して初期ステータスを一元管理
**ファイル**: `src/features/tickets/actions/import-tickets.ts:190`

メール取り込み・LINE 取り込みは `initialStatusForMode()` を使っているが、CSV インポートだけ `mode === 'lite' ? 'Open' : 'New'` のインライン条件を書いていた。将来モード定義が変わった場合にここだけ更新漏れが起きるリスクがあるため、共通関数に統一した（DRY 原則）。

### 3. 通知ループを `Promise.all` で並列化
**ファイル**: `src/features/tickets/actions/import-tickets.ts:303-311`

エージェント数ぶん逐次 `await` していたため、大人数テナントで CSV インポートするとDB ラウンドトリップが直列になり高負荷時にタイムアウトしやすかった。`Promise.all` で並列化した。

### 4. `broadcastUnreadCountToMany` を try/catch で保護
**ファイル**: `src/features/tickets/actions/import-tickets.ts:313`

SSE broadcast がチケット DB コミット後に失敗すると、Server Action が例外を投げてユーザーには「インポート失敗」と表示される（実際はチケット作成済み）。再インポートで重複起票が生じる恐れがあるため、broadcast 失敗は `console.warn` にとどめてインポート成功を返すようにした。

### 5. `/dashboard` を `revalidatePath` に追加
**ファイル**: `src/features/tickets/actions/import-tickets.ts:294`

CSV インポート後に `/tickets` のみ再検証していたため、ダッシュボードの件数が最大 60 秒間（`unstable_cache` TTL）古い値のまま表示されていた。`/dashboard` も追加した。

### 6. 未使用 `tab` 変数を削除（lint 警告解消）
**ファイル**: `src/app/(app)/tickets/page.tsx:78`

`const tab = parseTabParam(sp.tab)` が宣言されているが一度も使われておらず、lint が warning を出していた。`buildTicketListFilter` が内部で同じ正規化を行うため、外側での宣言は不要。変数と不要になった `parseTabParam` import を削除した。

### 7. `CsvExportButton` catch に `console.error` を追加
**ファイル**: `src/features/tickets/components/CsvExportButton.tsx:53`

Client Component のため `alert()` はユーザー向けだが、エラー詳細がブラウザコンソールにも残らなかった。CLAUDE.md §6「エラーを握り潰さない」に従い `console.error` を追加した。

### 8. `as string` 型アサーションを `flatMap` による型安全な変換に置換
**ファイル**: `src/app/(app)/dashboard/page.tsx:113`

TypeScript は `.filter((w) => w.assigneeId !== null)` 後に型を自動 narrowing しないため `as string` でキャストしていた。`flatMap` で null を空配列・string を 1 要素配列として変換することで、型アサーションなしに `string[]` を型安全に得られる。

## テスト結果

- `npm run lint` — 警告 0 件 ✅
- `npm run test` — 415 件パス ✅（5 ファイルは DB 未接続 contract test のため想定内失敗）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCQ3K8EZUyD48dQkcm62gJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCQ3K8EZUyD48dQkcm62gJ)_