### PR TITLE
fix(tickets,audit): コードレビュー・セキュリティレビュー指摘の修正 (Phase 3 品質改善)

### DIFF
--- a/src/features/audit/components/AuditExportButton.tsx
+++ b/src/features/audit/components/AuditExportButton.tsx
@@ -64,8 +64,10 @@ export function AuditExportButton({ logs }: Props) {
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
-    // 一時 URL を解放してメモリリークを防ぐ
-    URL.revokeObjectURL(url);
+    // Firefox では link.click() 直後に revokeObjectURL() を呼ぶとダウンロードが
+    // キャンセルされることがある (ブラウザが URL を読み込む前に無効化されるため)。
+    // 100ms 遅延させてブラウザがダウンロードを開始する時間を確保する (CsvExportButton と同様の対策)。
+    setTimeout(() => URL.revokeObjectURL(url), 100);
   }
 
   return (

--- a/src/features/audit/components/AuditExportButton.tsx
+++ b/src/features/audit/components/AuditExportButton.tsx
@@ -14,60 +14,78 @@ interface Props {
   logs: TicketHistoryWithRefs[];
 }
 
+// Firefox では link.click() 直後に revokeObjectURL() を呼ぶとダウンロードが
+// キャンセルされることがある。ブラウザがダウンロードを開始するまでの待機時間 (ミリ秒)。
+const REVOKE_URL_DELAY_MS = 100;
+
 // 監査ログを CSV ファイルとしてダウンロードするボタン
 // ダウンロード処理はクライアント側で行う (サーバーへの追加リクエストなし)
 export function AuditExportButton({ logs }: Props) {
   // CSV ダウンロードを実行するハンドラ
   function handleExport() {
-    // CSV ヘッダー行 (各列の名前を日本語で定義する)
-    const headers = ['日時', '担当者', '問い合わせ件名', '変更項目', '変更前', '変更後'];
+    // 予期しない例外をキャッチしてユーザーにフィードバックする (CLAUDE.md §6: エラーを握り潰さない)
+    try {
+      // CSV ヘッダー行 (各列の名前を日本語で定義する)
+      const headers = ['日時', '担当者', '問い合わせ件名', '変更項目', '変更前', '変更後'];
 
-    // データ行を組み立てる (各ログを CSV の 1 行に変換する)
-    const rows = logs.map((log) => [
-      // ISO 8601 形式の日時 (Excel で認識しやすいように '/' 区切りにする)
-      log.createdAt.toLocaleString('ja-JP', {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-      }),
-      // 変更者氏名
-      log.changedByName,
-      // チケット件名
-      log.ticketTitle,
-      // 変更項目の日本語ラベル (constants.ts の HISTORY_FIELD_LABELS と同じ参照元を使う)
-      HISTORY_FIELD_LABELS[log.field as keyof typeof HISTORY_FIELD_LABELS] ?? log.field,
-      // 変更前の値 (null の場合は空文字)
-      log.oldValue ?? '',
-      // 変更後の値 (null の場合は空文字)
-      log.newValue ?? '',
-    ]);
+      // データ行を組み立てる (各ログを CSV の 1 行に変換する)
+      const rows = logs.map((log) => [
+        // ISO 8601 形式の日時 (Excel で認識しやすいように '/' 区切りにする)
+        log.createdAt.toLocaleString('ja-JP', {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+        }),
+        // 変更者氏名
+        log.changedByName,
+        // チケット件名
+        log.ticketTitle,
+        // 変更項目の日本語ラベル (constants.ts の HISTORY_FIELD_LABELS と同じ参照元を使う)
+        HISTORY_FIELD_LABELS[log.field as keyof typeof HISTORY_FIELD_LABELS] ?? log.field,
+        // 変更前の値 (null の場合は空文字)
+        log.oldValue ?? '',
+        // 変更後の値 (null の場合は空文字)
+        log.newValue ?? '',
+      ]);
 
-    // BOM 付き UTF-8 の CSV 文字列を生成する。
-    // buildCsvString が BOM・エスケープ・改行をまとめて処理する (DRY)。
-    // \t を含むセル (OWASP 無害化後) も RFC 4180 準拠でダブルクォート囲みされる。
-    const csv = buildCsvString(headers, rows);
-    // Blob に変換してブラウザにダウンロードさせる準備をする
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-    // ブラウザにダウンロードさせるための一時 URL を生成する
-    const url = URL.createObjectURL(blob);
-
-    // <a> タグを動的に作成してクリックすることでダウンロードを開始する
-    const link = document.createElement('a');
-    link.href = url;
-    // ファイル名に現在日時を含める (ダウンロードフォルダで見つけやすくする)
-    const now = new Date().toISOString().slice(0, 10); // YYYY-MM-DD 形式
-    link.download = `audit-log-${now}.csv`;
-    // DOM に追加してクリックし、すぐに削除する (メモリ節約)
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    // Firefox では link.click() 直後に revokeObjectURL() を呼ぶとダウンロードが
-    // キャンセルされることがある (ブラウザが URL を読み込む前に無効化されるため)。
-    // 100ms 遅延させてブラウザがダウンロードを開始する時間を確保する (CsvExportButton と同様の対策)。
-    setTimeout(() => URL.revokeObjectURL(url), 100);
+      // BOM 付き UTF-8 の CSV 文字列を生成する。
+      // buildCsvString が BOM・エスケープ・改行をまとめて処理する (DRY)。
+      // \t を含むセル (OWASP 無害化後) も RFC 4180 準拠でダブルクォート囲みされる。
+      const csv = buildCsvString(headers, rows);
+      // Blob に変換してブラウザにダウンロードさせる準備をする
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      // ブラウザにダウンロードさせるための一時 URL を生成する
+      const url = URL.createObjectURL(blob);
+      // DOM 操作前にタイマーを登録することで、DOM 操作で例外が発生しても URL が確実に解放される。
+      // catch ブロックで clearTimeout + 即時 revokeObjectURL を呼ぶことで二重解放を防ぐ。
+      const revokeTimer = setTimeout(() => URL.revokeObjectURL(url), REVOKE_URL_DELAY_MS);
+      try {
+        // <a> タグを動的に作成してクリックすることでダウンロードを開始する
+        const link = document.createElement('a');
+        link.href = url;
+        // ファイル名に現在日時を含める (ダウンロードフォルダで見つけやすくする)
+        const now = new Date().toISOString().slice(0, 10); // YYYY-MM-DD 形式
+        link.download = `audit-log-${now}.csv`;
+        // DOM に追加してクリックし、すぐに削除する (メモリ節約)
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      } catch (domErr) {
+        // DOM 操作に失敗した場合はタイマーをキャンセルして URL を即座に解放する
+        clearTimeout(revokeTimer);
+        URL.revokeObjectURL(url);
+        // 外側の catch ブロックへ伝播させてユーザーに通知する
+        throw domErr;
+      }
+    } catch (err) {
+      // デベロッパーツールでエラー詳細を確認できるようにする (エラーを握り潰さない: CLAUDE.md §6)
+      console.error('[AuditExportButton] CSV エクスポートに失敗:', err);
+      // ユーザーには内部詳細を含まない安全なメッセージを表示する (§9)
+      alert('監査ログのエクスポートに失敗しました。再度お試しください。');
+    }
   }
 
   return (

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -336,6 +336,8 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
       // 失敗した通知件数をサーバーログに記録する（チケット作成の成否には影響しない）
       const failedCount = notifyResults.filter((r) => r.status === 'rejected').length;
       if (failedCount > 0) {
+        // 失敗件数をサマリーとして出力する (何件失敗したか数が把握できるようにする)
+        console.warn(`[importTickets] ${failedCount} 件の通知書き込みに失敗しました`);
         // 失敗内容の詳細もログに残す (CLAUDE.md §6: エラーを握り潰さない)
         notifyResults.forEach((r, i) => {
           if (r.status === 'rejected') {

--- a/src/features/tickets/build-filter.ts
+++ b/src/features/tickets/build-filter.ts
@@ -12,8 +12,8 @@ import type { TicketStatus, Priority } from '@/domain/types';
 import type { TicketListFilter } from '@/data/ports/ticket-repository';
 // タブ絞り込みを共通ヘルパーに委譲する (mine / overdue タブは一覧とダッシュボードで共有)
 import { applyTabFilter } from '@/features/tickets/tab-filter';
-// 一覧タブ型 ('all' / 'mine' / 'overdue')
-import type { TicketTabId } from '@/features/tickets/components/TicketTabs';
+// 一覧タブ型 — クライアントコンポーネントではなく共有型ファイルから import する (依存境界の明確化)
+import type { TicketTabId } from '@/features/tickets/types';
 
 // buildTicketListFilter に渡すURL由来の生文字列パラメータ
 export interface TicketFilterParams {

--- a/src/features/tickets/components/CsvExportButton.tsx
+++ b/src/features/tickets/components/CsvExportButton.tsx
@@ -57,9 +57,13 @@ export function CsvExportButton() {
       // サーバーが MAX_EXPORT_ROWS でレスポンスを打ち切った場合に X-Truncated: true を返す。
       // headers はボディ消費後も参照可能だが、意図を明確にするためボディ取得前に読み取る。
       const truncated = res.headers.get('X-Truncated') === 'true';
-      // 上限件数を表示用に取得する。サーバーが空文字や未送信の場合は既定値を使う。
-      // ?? は null/undefined のみ捕捉し空文字は通過するため、|| を使う。
-      const totalLimit = res.headers.get('X-Total-Limit') || '10,000';
+      // 上限件数をレスポンスヘッダーから取得し、数値として検証する。
+      // ヘッダー値を直接 alert に埋め込むと MitM でテキスト偽装が可能になるため (§9 情報漏洩対策)、
+      // 整数以外の値は信頼せず既定値にフォールバックする。
+      const rawLimit = res.headers.get('X-Total-Limit');
+      const limitNum = rawLimit ? parseInt(rawLimit, 10) : NaN;
+      // 数値でない場合はフォールバック値を使い、意図しない文字列が alert に表示されないようにする
+      const totalLimit = Number.isFinite(limitNum) ? limitNum.toLocaleString('ja-JP') : '10,000';
       // レスポンスを Blob として取得する
       const blob = await res.blob();
       // Blob から一時 URL を生成する

--- a/src/features/tickets/components/CsvExportButton.tsx
+++ b/src/features/tickets/components/CsvExportButton.tsx
@@ -62,8 +62,10 @@ export function CsvExportButton() {
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
-      // 一時 URL を解放してメモリリークを防ぐ
-      URL.revokeObjectURL(url);
+      // Firefox では link.click() の直後に revokeObjectURL() を呼ぶとダウンロードが
+      // キャンセルされることがある (ブラウザが URL を読み込む前に無効化されるため)。
+      // 100ms 遅延させてブラウザがダウンロードを開始する時間を確保する。
+      setTimeout(() => URL.revokeObjectURL(url), 100);
     } catch (err) {
       // ブラウザのデベロッパーツールでエラー詳細を確認できるようにする (エラーを握り潰さない: CLAUDE.md §6)
       console.error('[CsvExportButton] CSV エクスポートに失敗:', err);

--- a/src/features/tickets/components/CsvExportButton.tsx
+++ b/src/features/tickets/components/CsvExportButton.tsx
@@ -57,8 +57,9 @@ export function CsvExportButton() {
       // サーバーが MAX_EXPORT_ROWS でレスポンスを打ち切った場合に X-Truncated: true を返す。
       // headers はボディ消費後も参照可能だが、意図を明確にするためボディ取得前に読み取る。
       const truncated = res.headers.get('X-Truncated') === 'true';
-      // 上限件数を表示用に取得する (サーバーが送らない場合は既定の表示値を使う)
-      const totalLimit = res.headers.get('X-Total-Limit') ?? '10,000';
+      // 上限件数を表示用に取得する。サーバーが空文字や未送信の場合は既定値を使う。
+      // ?? は null/undefined のみ捕捉し空文字は通過するため、|| を使う。
+      const totalLimit = res.headers.get('X-Total-Limit') || '10,000';
       // レスポンスを Blob として取得する
       const blob = await res.blob();
       // Blob から一時 URL を生成する

--- a/src/features/tickets/components/CsvExportButton.tsx
+++ b/src/features/tickets/components/CsvExportButton.tsx
@@ -15,6 +15,11 @@ import { useState } from 'react';
  * Suspense 境界内に配置しないと Next.js でビルドエラーになる。
  * 呼び出し側 (tickets/page.tsx) で <Suspense> でラップすること。
  */
+
+// Firefox では link.click() 直後に revokeObjectURL() を呼ぶとダウンロードが
+// キャンセルされることがある。ブラウザがダウンロードを開始するまでの待機時間 (ミリ秒)。
+const REVOKE_URL_DELAY_MS = 100;
+
 export function CsvExportButton() {
   // ブラウザの現在の URL クエリパラメータを取得する (Suspense 必須)
   const searchParams = useSearchParams();
@@ -49,23 +54,43 @@ export function CsvExportButton() {
             : 'CSV エクスポートに失敗しました。しばらくしてから再度お試しください。',
         );
       }
+      // サーバーが MAX_EXPORT_ROWS でレスポンスを打ち切った場合に X-Truncated: true を返す。
+      // headers はボディ消費後も参照可能だが、意図を明確にするためボディ取得前に読み取る。
+      const truncated = res.headers.get('X-Truncated') === 'true';
+      // 上限件数を表示用に取得する (サーバーが送らない場合は既定の表示値を使う)
+      const totalLimit = res.headers.get('X-Total-Limit') ?? '10,000';
       // レスポンスを Blob として取得する
       const blob = await res.blob();
-      // Blob から一時 URL を生成してダウンロードを開始する
+      // Blob から一時 URL を生成する
       const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      // ファイル名はサーバーの Content-Disposition ヘッダーから取得するのが理想だが、
-      // クロスオリジン制限があるためクライアント側でも日付付きファイル名を設定する
-      link.download = `tickets-${new Date().toISOString().slice(0, 10)}.csv`;
-      // DOM に一時追加してクリックしてダウンロードを起動し、すぐに削除する
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      // Firefox では link.click() の直後に revokeObjectURL() を呼ぶとダウンロードが
-      // キャンセルされることがある (ブラウザが URL を読み込む前に無効化されるため)。
-      // 100ms 遅延させてブラウザがダウンロードを開始する時間を確保する。
-      setTimeout(() => URL.revokeObjectURL(url), 100);
+      // DOM 操作前にタイマーを登録することで、DOM 操作で例外が発生しても URL が確実に解放される。
+      // catch ブロックで clearTimeout + 即時 revokeObjectURL を呼ぶことで二重解放を防ぐ。
+      const revokeTimer = setTimeout(() => URL.revokeObjectURL(url), REVOKE_URL_DELAY_MS);
+      try {
+        // <a> タグを動的に生成してダウンロードリンクとして設定する
+        const link = document.createElement('a');
+        link.href = url;
+        // ファイル名はサーバーの Content-Disposition ヘッダーから取得するのが理想だが、
+        // クロスオリジン制限があるためクライアント側でも日付付きファイル名を設定する
+        link.download = `tickets-${new Date().toISOString().slice(0, 10)}.csv`;
+        // DOM に一時追加してクリックしてダウンロードを起動し、すぐに削除する
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      } catch (domErr) {
+        // DOM 操作に失敗した場合はタイマーをキャンセルして URL を即座に解放する
+        clearTimeout(revokeTimer);
+        URL.revokeObjectURL(url);
+        // 呼び出し元の catch ブロックへ伝播させてエラーをユーザーに通知する
+        throw domErr;
+      }
+      // エクスポートが上限件数で打ち切られていた場合はユーザーに警告を表示する。
+      // ダウンロード完了後に通知することで、データ不足に気づかないままレポートを作る事故を防ぐ。
+      if (truncated) {
+        alert(
+          `チケット数が上限 (${totalLimit} 件) を超えているため、CSV には最初の ${totalLimit} 件のみ含まれています。絞り込み条件を変更して再度エクスポートしてください。`,
+        );
+      }
     } catch (err) {
       // ブラウザのデベロッパーツールでエラー詳細を確認できるようにする (エラーを握り潰さない: CLAUDE.md §6)
       console.error('[CsvExportButton] CSV エクスポートに失敗:', err);

--- a/src/features/tickets/components/TicketTabs.tsx
+++ b/src/features/tickets/components/TicketTabs.tsx
@@ -5,7 +5,9 @@ import Link from 'next/link';
 // 現在 URL のクエリパラメータを読み取るフック (アクティブタブ判定用)
 import { useSearchParams } from 'next/navigation';
 
-// タブ識別子のリテラル型は共有型定義から取得する (サーバー側 tab-filter.ts が 'use client' に依存しないよう切り出し済み)
+// 共有型ファイルから import してこのモジュール内で型として使えるようにする
+import type { TicketTabId } from '@/features/tickets/types';
+// 後方互換のため TicketTabs.tsx からも re-export する (他ファイルが TicketTabs から import しても動くようにする)
 export type { TicketTabId } from '@/features/tickets/types';
 
 // タブ 1 つ分の表示メタ

--- a/src/features/tickets/components/TicketTabs.tsx
+++ b/src/features/tickets/components/TicketTabs.tsx
@@ -5,11 +5,8 @@ import Link from 'next/link';
 // 現在 URL のクエリパラメータを読み取るフック (アクティブタブ判定用)
 import { useSearchParams } from 'next/navigation';
 
-// タブ識別子のリテラル型 (一覧ページの ?tab=... と対応)
-// - 'all'     : 既定 (絞り込みなし、全件)
-// - 'mine'    : 自分の未対応 (担当者または起票者として Open / InProgress)
-// - 'overdue' : 期限切れ (resolutionDueAt < now かつ未解決)
-export type TicketTabId = 'all' | 'mine' | 'overdue';
+// タブ識別子のリテラル型は共有型定義から取得する (サーバー側 tab-filter.ts が 'use client' に依存しないよう切り出し済み)
+export type { TicketTabId } from '@/features/tickets/types';
 
 // タブ 1 つ分の表示メタ
 interface TabDef {

--- a/src/features/tickets/tab-filter.ts
+++ b/src/features/tickets/tab-filter.ts
@@ -1,5 +1,5 @@
-// 一覧タブ ('all' / 'mine' / 'overdue') の識別子型を再利用する (型のみ import なので client 境界の影響なし)
-import type { TicketTabId } from './components/TicketTabs';
+// 一覧タブ識別子型 — クライアントコンポーネントではなく共有型ファイルから import する (依存境界の明確化)
+import type { TicketTabId } from '@/features/tickets/types';
 // データ層が公開しているチケット一覧フィルタ型 (タブ条件を差し込む対象)
 import type { TicketListFilter } from '@/data/ports/ticket-repository';
 

--- a/src/features/tickets/types.ts
+++ b/src/features/tickets/types.ts
@@ -1,0 +1,13 @@
+/**
+ * チケット機能の共有型定義。
+ *
+ * 'use client' を持つコンポーネントから切り出すことで、
+ * サーバー側の純粋関数 (tab-filter.ts / build-filter.ts) が
+ * クライアントコンポーネントに依存しない構造にする。
+ */
+
+// 一覧タブの識別子型 (URL クエリ ?tab=... と対応する値)
+// - 'all'     : 既定 (絞り込みなし、全件)
+// - 'mine'    : 自分の未対応 (担当者または起票者として Open / InProgress)
+// - 'overdue' : 期限切れ (resolutionDueAt < now かつ未解決)
+export type TicketTabId = 'all' | 'mine' | 'overdue';


### PR DESCRIPTION
## 概要

`/code-review ultra` および `/security-review ultra` で検出された 11 件の問題を修正します。

対応フェーズ: `docs/smb-dx-pivot-plan.md` Phase 3 (CSV インポート/エクスポート機能) の実装品質改善。

---

## 修正内容

### バグ修正 (correctness)

| # | ファイル | 内容 |
|---|---------|------|
| 1 | `TicketTabs.tsx` | `export type { TicketTabId }` はファイル内スコープにバインドしないため TS2304 — `import type` を追加 |
| 2 | `CsvExportButton.tsx` | Blob URL が DOM 操作例外時にリーク — DOM 操作前に `setTimeout` を登録し `catch` で `clearTimeout` + 即時 revoke |
| 3 | `CsvExportButton.tsx` | `X-Truncated` ヘッダーを未検出のため 10,000 件超で無言打ち切り — ヘッダー検出後に `alert` で通知 |
| 4 | `AuditExportButton.tsx` | `revokeObjectURL` を DOM 操作後に登録するため例外時に Blob URL リーク — CsvExportButton と同じ先行登録パターンに統一 |
| 5 | `AuditExportButton.tsx` | `try/catch` 欠如のため例外がサイレント — 外側 `try/catch` + `alert` を追加 |
| 6 | `AuditExportButton.tsx` | Firefox ダウンロードキャンセル競合 — `setTimeout(REVOKE_URL_DELAY_MS)` で遅延 revoke |
| 7 | `import-tickets.ts` | `failedCount` の数値をサマリーログに出力していなかった (`if` の真偽判定のみ) — `console.warn` で件数を明示 |

### アーキテクチャ改善

| # | 内容 |
|---|------|
| 8 | `TicketTabId` 型を `'use client'` コンポーネント (`TicketTabs.tsx`) から `types.ts` に抽出。サーバー側純粋関数 (`tab-filter.ts`, `build-filter.ts`) がクライアント境界に依存しない構造に改善 |

### セキュリティ

| # | 内容 |
|---|------|
| 9 | `X-Total-Limit` ヘッダー値を `parseInt` + `isFinite` で数値検証してから `alert` に埋め込む (MitM テキスト偽装対策 §9) |

### 定数化・コード品質

| # | 内容 |
|---|------|
| 10 | マジック数 `100` を `REVOKE_URL_DELAY_MS` 定数に変更 (CLAUDE.md §6 マジックナンバー禁止) — `CsvExportButton`・`AuditExportButton` 両方 |
| 11 | `res.headers.get('X-Total-Limit') ?? '10,000'` → `|| '10,000'` に修正 (`??` は空文字を通過するため) |

---

## スキップした指摘

- **`setTimeout` の unmount 時未クリア**: `setLoading(false)` が unmount 後に呼ばれる軽微な React ワーニング。`useRef` + `useEffect` cleanup が必要で大幅リファクタになるため今回スコープ外
- **`AuditExportButton` の `'use client'` re-export 経由 TicketTabId**: 現在の消費者は全員 `types.ts` から直接 import しており実害なし
- **`err.message` の alert 漏洩**: 現コードでは明示構築した日本語エラーのみがこのパスを通る。custom error class への移行は別 PR が適切
