### PR TITLE
fix(attachments): 添付DLルートで tenantId 欠落セッションを 401 で拒否

### DIFF
--- a/src/app/api/attachments/[id]/route.ts
+++ b/src/app/api/attachments/[id]/route.ts
@@ -14,15 +14,19 @@ type Params = { params: Promise<{ id: string }> };
 
 // GET /api/attachments/[id] : 認可されたユーザーに添付ファイルのバイト列を返すエンドポイント。
 // 必要な権限チェック:
-//   1. ログイン済み (未認証は 401)
+//   1. ログイン済み かつ テナントが確定している (未認証・tenantId 欠落は 401)
 //   2. 添付がセッションのテナント内に存在する (他テナントは 404 として握りつぶす)
 //   3. 親チケットの閲覧権限を持つ (requester は自分が起票したチケットのみ可。それ以外は 404)
 //   4. 物理ファイルが存在する (storage.get が null → 404)
 export async function GET(_req: Request, { params }: Params) {
   // セッション取得
   const session = await auth();
-  // 未ログインなら 401 を返す
-  if (!session?.user?.id) {
+  // 未ログイン、または tenantId が欠落しているセッションは 401 を返す。
+  // tenantId が undefined のまま Prisma の findFirst に渡すと where から
+  // tenantId 条件が脱落し、全テナントの添付に一致してしまう (クロステナント漏洩)。
+  // 通常 JWT コールバックが tenantId を補完するため到達しないが、他の認証ルートと
+  // 同様に多層防御として明示的に拒否し、fail-closed に倒す。
+  if (!session?.user?.id || !session.user.tenantId) {
     return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
   }
   // 動的セグメントを取り出す

--- a/tests/features/attachments/serve-attachment.test.ts
+++ b/tests/features/attachments/serve-attachment.test.ts
@@ -1,6 +1,6 @@
 // GET /api/attachments/[id] の認可テスト。
 // 主検証:
-//   1. 未認証 → 401
+//   1. 未認証 (session なし / tenantId 欠落) → 401
 //   2. 同テナント + 自分のチケット → 200 + バイト列
 //   3. 別テナント → 404 (存在を隠す)
 //   4. 同テナント別ユーザー (requester) → 404
@@ -164,6 +164,19 @@ describe('GET /api/attachments/[id]', () => {
     const { attA } = await seed();
     const { GET } = await import('@/app/api/attachments/[id]/route');
     mockSession = null;
+    const res = await GET(buildRequest(), makeParams(attA.id));
+    expect(res.status).toBe(401);
+  });
+
+  // tenantId 欠落セッション → 401 (クロステナント漏洩を防ぐ fail-closed ガード)
+  it('returns 401 when the session has no tenantId', async () => {
+    const { attA } = await seed();
+    // id はあるが tenantId が欠けたセッション (通常は起きないが多層防御を検証する)
+    mockSession = {
+      user: { id: REQ_A, role: 'requester' },
+      expires: new Date(Date.now() + 86_400_000).toISOString(),
+    } as Session;
+    const { GET } = await import('@/app/api/attachments/[id]/route');
     const res = await GET(buildRequest(), makeParams(attA.id));
     expect(res.status).toBe(401);
   });


### PR DESCRIPTION
## 背景・目的（正本: `docs/smb-dx-pivot-plan.md` §5.1 マルチテナント分離 / Phase 0）

セキュリティレビューで発見した多層防御の一貫性ギャップを修正する。

`GET /api/attachments/[id]` は認証ルートの中で唯一 `session.user.tenantId` の有無を確認していなかった。`tenantId` が `undefined` のまま Prisma の `findFirst({ where: { id, tenantId } })` に渡ると、Prisma は `undefined` の条件を**脱落**させ、結果として**全テナントの添付**に一致しうる（クロステナント漏洩）。

通常は `auth.ts` の JWT コールバックが `tenantId` を補完するため実際には到達しないが、他の認証ルート（`tickets` / `comments` / `export` / `stream`）はいずれも `tenantId` を防御的にチェックしている。本ルートのみ例外だったため、fail-closed に揃える。

## 変更内容

- `src/app/api/attachments/[id]/route.ts`：401 ガードを `!session?.user?.id` → `!session?.user?.id || !session.user.tenantId` に拡張し、理由をコメントで明記。
- `tests/features/attachments/serve-attachment.test.ts`：`tenantId` 欠落セッションが 401 になることを検証するテストを追加（ヘッダのケース一覧も更新）。

方針（Lite/Pro 二層・マルチテナント化・用語簡素化 等）に反する変更はなく、Phase 0 の分離不変条件を補強する範囲に限定。

## 検証

- `npx vitest run tests/features/attachments/serve-attachment.test.ts`：**7 passed**（新規1件含む）。
- 対象2ファイルの ESLint：**エラーなし**。
- 補足: 環境の egress 制約で Prisma エンジンバイナリを取得できず、ローカルの `typecheck` と `*.contract.prisma.test.ts` は実行不可（CI では専用 PostgreSQL ＋生成済みクライアントで実行される）。追加変更は既存型のみ使用で型安全。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018S8QraSWuXFkxng6p6QbXc)_