### PR TITLE
fix(tickets): CSV インポートが月間チケット上限をすり抜ける不備を修正

### DIFF
--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -22,8 +22,8 @@ import { initialStatusForMode } from '@/domain/ticket-status';
 import { getCurrentTenantMode } from '@/lib/tenant';
 // 'YYYY-MM-DD' を JST 終端 Date に変換するヘルパー (サーバ TZ 非依存)
 import { endOfDayJST } from '@/lib/format-date';
-// Phase 4 課金: プランごとの月間チケット上限チェック
-import { isMonthlyTicketLimitReached, getMonthlyTicketLimit } from '@/lib/plan-guard';
+// Phase 4 課金: プランごとの月間チケット上限チェック (CSV インポート・メール/LINE 取り込みと共有)
+import { getMonthlyTicketQuota } from '@/lib/tenant-plan';
 
 // 422 (バリデーションエラー) を共通フォーマットで返すヘルパー
 function validationError(message: string, path: (string | number)[]) {
@@ -144,28 +144,16 @@ export async function POST(req: Request) {
     }
   }
 
-  // Phase 4 課金: テナントのプランを取得して月間チケット数の上限を確認する
-  const currentTenant = await repos.tenants.findById(tenantId);
-  if (currentTenant) {
-    const plan = currentTenant.subscriptionPlan;
-    // 月間チケット上限がある場合 (Free プランのみ。Infinity なら -1 で上限なし) は件数を確認する
-    if (getMonthlyTicketLimit(plan) !== -1) {
-      // 当月の起票数をカウントする (現在月の開始日時を UTC で計算)
-      const now = new Date();
-      // 月初 00:00:00.000 (UTC) を起点にする
-      const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
-      // 当月起票済み件数をカウントする (tenantId スコープ + createdAfter フィルター)
-      const monthlyCount = await repos.tickets.count({ createdAfter: monthStart }, tenantId);
-      // 上限超過なら 429 でプランアップグレードを促す
-      if (isMonthlyTicketLimitReached(plan, monthlyCount)) {
-        return NextResponse.json(
-          {
-            error: `月間の問い合わせ件数が上限 (${getMonthlyTicketLimit(plan)} 件) に達しました。プランをアップグレードしてください。`,
-          },
-          { status: 429 },
-        );
-      }
-    }
+  // Phase 4 課金: テナントの当月チケット起票の残枠を確認する (§6.1 料金プランの月間上限)
+  const quota = await getMonthlyTicketQuota(tenantId);
+  // 残枠が無い (上限のあるプランで使い切った) 場合は 429 でプランアップグレードを促す
+  if (quota.limited && quota.remaining <= 0) {
+    return NextResponse.json(
+      {
+        error: `月間の問い合わせ件数が上限 (${quota.limit} 件) に達しました。プランをアップグレードしてください。`,
+      },
+      { status: 429 },
+    );
   }
 
   // テナントの動作モードを取得し、Lite モード時の入力強制ルールを適用する

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -23,6 +23,8 @@ import type { Priority, TicketStatus } from '@/domain/types';
 import { initialStatusForMode } from '@/domain/ticket-status';
 // CSV インポート完了後に他エージェントへ未読カウントを即時配信するヘルパー
 import { broadcastUnreadCountToMany } from '@/features/notifications/notify';
+// Phase 4 課金: 月間チケット上限チェック (Web フォーム・メール/LINE 取り込みと共有)
+import { getMonthlyTicketQuota } from '@/lib/tenant-plan';
 
 // 1 インポートあたりの最大行数 (これを超えたらエラー)
 const MAX_ROWS = 200;
@@ -234,6 +236,13 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     throw new Error(`1 回のインポートは最大 ${MAX_ROWS} 行です（${dataLines.length} 行ありました）`);
   }
 
+  // Phase 4 課金: 当月チケット起票の残枠を取得する (§6.1 料金プランの月間上限)。
+  // CSV インポートは 1 回で最大 MAX_ROWS 件を一括作成できるため、Web フォームと同じ上限チェックを
+  // 行わないと Free プランの月間上限 (50 件) を 1 回のインポートで容易に超過できてしまう。
+  // remaining はループ内で残り作成可能数として消費し、使い切ったら以降の行をエラーとして記録する。
+  // (ここまでの検証を通過したリクエストのみ DB 参照するため、形式エラーで無駄なクエリを発生させない)
+  const quota = await getMonthlyTicketQuota(tenantId);
+
   // 集計用カウンタとエラーリストを初期化する
   let imported = 0;
   const errors: Array<{ row: number; message: string }> = [];
@@ -282,6 +291,16 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     // バリデーション通過: 検証済みデータを展開する
     const { title, body, priority, resolutionDueAt } = validation.data;
 
+    // Phase 4 課金: 残枠を使い切っていたらこの行以降は起票せずエラーとして記録する
+    // (Web フォーム / メール / LINE 取り込みと同じ上限を CSV インポートにも適用する)
+    if (quota.limited && quota.remaining <= 0) {
+      errors.push({
+        row: rowNum,
+        message: `月間の問い合わせ件数が上限 (${quota.limit} 件) に達したため取り込めませんでした。プランをアップグレードしてください。`,
+      });
+      continue;
+    }
+
     // チケットを 1 件作成する (失敗してもループを続けて部分成功を許可する)
     try {
       // リポジトリ経由でチケットを DB に保存する
@@ -297,6 +316,9 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
       });
       // 成功カウンタをインクリメント
       imported += 1;
+      // 上限のあるプランでは残枠を消費する (無制限プランは remaining が Infinity のため減算不要だが、
+      // 明示的にガードして意図を示す)
+      if (quota.limited) quota.remaining -= 1;
     } catch (err) {
       // 内部エラー (Prisma 例外等) をサーバーログに記録する (スキーマ情報の漏洩防止のため UI には返さない)
       console.error(`[importTickets] 行 ${rowNum} のチケット作成に失敗:`, err);

--- a/src/lib/tenant-plan.ts
+++ b/src/lib/tenant-plan.ts
@@ -11,6 +11,8 @@
 import { repos } from '@/data';
 // 課金プランの型
 import type { SubscriptionPlan } from '@/domain/types';
+// 月間チケット上限の判定ヘルパー (プランごとの上限値は plan-guard.ts が単一の源)
+import { getMonthlyTicketLimit } from '@/lib/plan-guard';
 
 // 指定テナントの現在の課金プランを返す。テナントが見つからない場合は 'free' として扱う
 // (fail-closed: 存在しない/取得できないテナントに Pro/Enterprise 限定機能を渡さない)。
@@ -19,4 +21,37 @@ export async function resolveTenantPlan(tenantId: string): Promise<SubscriptionP
   const tenant = await repos.tenants.findById(tenantId);
   // 見つからなければ 'free' にフォールバックする
   return tenant?.subscriptionPlan ?? 'free';
+}
+
+// 月間チケット起票数の残枠を表す (Web フォーム・CSV インポート・メール/LINE 取り込みが共有する)
+export interface MonthlyTicketQuota {
+  limited: boolean; // 上限のあるプランか (無制限プランなら false)
+  limit: number; // 上限件数 (無制限なら -1。表示用に plan-guard.ts の規約をそのまま流用)
+  remaining: number; // 今すぐ作成できる残り件数 (無制限なら Infinity)
+}
+
+// 指定テナントの当月チケット起票の残枠を取得する。
+// Web フォーム (POST /api/tickets) だけでなく、CSV インポート・メール取り込み・LINE 取り込みなど
+// チケットを作成する全ての入口で同じ判定を使うための共通ヘルパー (§6.1 料金プランの月間上限)。
+// plan を既に把握している呼び出し側は渡せる (二重の tenant 取得を避ける)。
+export async function getMonthlyTicketQuota(
+  tenantId: string,
+  plan?: SubscriptionPlan,
+): Promise<MonthlyTicketQuota> {
+  // プラン未指定なら解決する
+  const resolvedPlan = plan ?? (await resolveTenantPlan(tenantId));
+  // このプランの月間上限を取得する (-1 = 無制限)
+  const limit = getMonthlyTicketLimit(resolvedPlan);
+  // 無制限プランは DB 集計を行わず即座に返す (不要なクエリを避ける)
+  if (limit === -1) {
+    return { limited: false, limit: -1, remaining: Infinity };
+  }
+  // 当月の起票数をカウントする (現在月の開始日時を UTC で計算)
+  const now = new Date();
+  // 月初 00:00:00.000 (UTC) を起点にする
+  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  // 当月起票済み件数をカウントする (tenantId スコープ + createdAfter フィルター)
+  const currentCount = await repos.tickets.count({ createdAfter: monthStart }, tenantId);
+  // 残枠は 0 未満にならないようクランプする
+  return { limited: true, limit, remaining: Math.max(0, limit - currentCount) };
 }

--- a/src/lib/tenant-plan.ts
+++ b/src/lib/tenant-plan.ts
@@ -34,6 +34,18 @@ export interface MonthlyTicketQuota {
 // Web フォーム (POST /api/tickets) だけでなく、CSV インポート・メール取り込み・LINE 取り込みなど
 // チケットを作成する全ての入口で同じ判定を使うための共通ヘルパー (§6.1 料金プランの月間上限)。
 // plan を既に把握している呼び出し側は渡せる (二重の tenant 取得を避ける)。
+//
+// 注意点 (best-effort な上限であり、DB レベルの原子性は持たない):
+// - テナントが見つからない場合は resolveTenantPlan の規約どおり 'free' として扱う (fail-closed)。
+//   旧 tickets/route.ts のインライン実装は tenant が null なら上限チェック自体を skip していたが、
+//   本来ここには到達しない (User.tenantId → Tenant は Prisma スキーマで cascade 削除のため、
+//   セッションの tenantId が指す Tenant 行が消えることはない) ため実害はなく、より安全な
+//   fail-closed 側へ寄せている。
+// - この関数は「呼び出し時点のスナップショット」を返すだけで、以降の作成処理と同一トランザクション
+//   では実行されない。同一テナントへの同時並行インポート/起票がある場合、複数の呼び出しが同じ
+//   残枠を見て、合計では上限をわずかに超えることがありうる (check-then-act)。課金プランの利用制限
+//   は完全な原子性を要求しない運用上のソフトリミットとして扱っており、原子的なカウンタが必要になれば
+//   ここを DB 側の集計 (トランザクション内 SELECT ... FOR UPDATE 等) に差し替える。
 export async function getMonthlyTicketQuota(
   tenantId: string,
   plan?: SubscriptionPlan,

--- a/tests/features/import-tickets.test.ts
+++ b/tests/features/import-tickets.test.ts
@@ -216,6 +216,49 @@ describe('importTickets', () => {
     });
   });
 
+  // ── Phase 4 課金: 月間チケット上限 (プランゲート) ──────────────────
+  describe('月間チケット上限 (§6.1 料金プラン)', () => {
+    // Free プランは月 50 件まで。CSV インポートも Web フォームと同じ上限を守ることを確認する
+    it('Free プランで残枠を超える分はエラーとして記録され、残枠分だけ取り込まれる', async () => {
+      // 当月分としてテナントに 48 件のチケットを事前に作成しておく (残枠 2 件)
+      for (let i = 0; i < 48; i += 1) {
+        await repos.tickets.create({
+          title: `既存${i}`,
+          body: '',
+          priority: 'Medium',
+          categoryId: null,
+          creatorId: 'u-agt-1',
+          tenantId: TENANT,
+          status: 'Open',
+          resolutionDueAt: null,
+        });
+      }
+      const importTickets = await loadAction();
+      // 5 行の CSV を取り込む (残枠 2 件を超える)
+      const csv = `件名\n行1\n行2\n行3\n行4\n行5`;
+      const result = await importTickets(csv);
+      // 残枠 2 件分だけ成功する
+      expect(result.imported).toBe(2);
+      // 残り 3 件は上限エラーとして記録される
+      expect(result.errors).toHaveLength(3);
+      expect(result.errors[0]?.message).toContain('月間の問い合わせ件数が上限');
+      // DB 上のチケット総数は上限の 50 件を超えない
+      expect(store.tickets.size).toBe(50);
+    });
+
+    // Free 以外のプランは無制限なので、残枠チェックで取り込みが妨げられない
+    it('Pro プランでは月間上限に妨げられず全件取り込まれる', async () => {
+      // テナントのプランを Pro に切り替える (Free の 50 件上限は適用されない)
+      store.tenants.set(TENANT, { ...store.tenants.get(TENANT)!, subscriptionPlan: 'pro' as const });
+      const importTickets = await loadAction();
+      const csv = `件名\n行1\n行2\n行3`;
+      const result = await importTickets(csv);
+      // 3 件とも成功する
+      expect(result.imported).toBe(3);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
   // ── RBAC ────────────────────────────────────────
   describe('RBAC (権限管理)', () => {
     // 依頼者 (requester) はエージェント専用操作のため拒否される


### PR DESCRIPTION
## Context

前PR (#165) のフォローアップ調査で発見した、同種の「プラン制限が宣言されているのに一部の入口だけ強制されていない」バグ。

`docs/smb-dx-pivot-plan.md` §6.1「料金プラン」の Free プラン月間上限（50 件）は
Web フォーム起票（`POST /api/tickets`）では正しく強制されていたが、CSV 一括インポート
（`importTickets` Server Action）は同じチェックを行っておらず、1 回のインポート（最大 200 行）で
容易に上限を超過できた。CSV インポートはメール取り込み／LINE 連携と異なり全プランで利用可能な
機能のため、Free プランの月間上限をチャネル横断で守るには CSV インポート側にも同じ判定が必要。

対応する Phase: Phase 3「Excel インポート」／Phase 4「サブスク課金」（§4, §6.1）。

なお、メール取り込み・LINE 取り込みは `isEmailInboundAllowed`/`isLineIntegrationAllowed` で
Free プランを既に除外しており、Free 以外のプランは月間上限が無制限のため、この 2 経路には
同種のチェックを追加していない（追加すると到達しない dead code になるため）。

## 変更内容

- `src/lib/tenant-plan.ts`: 月間チケット残枠を返す `getMonthlyTicketQuota()` を追加。
  Web フォーム・CSV インポートが計算ロジックを共有できるようにする（DRY）。
- `src/app/api/tickets/route.ts`: 既存の月間上限チェックをこのヘルパー呼び出しに置換
  （挙動は変えず重複ロジックを解消）。
- `src/features/tickets/actions/import-tickets.ts`: 行ごとの取り込みループで残枠を消費し、
  使い切った行は「上限に達しました」エラーとして記録して部分成功を維持する
  （他の行バリデーションエラーと同じパターン）。

## テスト

`tests/features/import-tickets.test.ts` に新しい describe ブロック
「月間チケット上限 (§6.1 料金プラン)」を追加:

- Free プランで残枠を超える分はエラーとして記録され、残枠分だけ取り込まれる
- Pro プランでは月間上限に妨げられず全件取り込まれる

- [x] `npm run lint` — pass
- [x] `npm run test` — 441 tests pass（DB 接続が必要な `*.contract.prisma.test.ts` 5 ファイルは
      未接続環境での既知の制約で対象外。本 PR による新規失敗ではない）
- [ ] `npm run typecheck` — 本セッションのサンドボックスで `prisma generate` がエンジンバイナリの
      ダウンロードで `ECONNRESET`（プロキシ越しの大容量ダウンロード不安定、複数回リトライ済み）
      となり実行不可だった。前PR (#165) では同じ制約下でも CI 側の typecheck は green だったため、
      本 PR も CI 側での確認をお願いしたい。

## 影響範囲

Free プランのテナントが CSV インポートで当月 50 件を超えて起票しようとした場合のみ挙動が変わる
（超過分がエラー行として記録される）。他プラン・他チャネルの挙動は変更なし。


---
_Generated by [Claude Code](https://claude.ai/code/session_017HCNUTMPaKiRorEke7JdPj)_