### PR TITLE
fix: レート制限メモリリーク・デッドコード・月次集計のJST不整合を修正

### DIFF
--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -48,3 +48,29 @@ export function endOfDayJST(yyyyMmDd: string): Date | null {
   }
   return d;
 }
+
+// 指定した日時が属する「JST の月初 00:00:00.000」を表す Date を返す関数
+// - サーバの実行タイムゾーンが UTC/JST どちらでも結果が変わらないよう、'Asia/Tokyo' で
+//   年・月を取り出してから明示的に +09:00 オフセット付きで組み立てる
+// - 月間チケット上限の集計 (src/lib/tenant-plan.ts) など、JST の暦月境界で
+//   件数を数えたい箇所から共通で使う (endOfDayJST と同じ Intl.DateTimeFormat パターン)
+// - 引数省略時は現在時刻 (Date.now()) を基準にする
+export function startOfMonthJST(date: Date = new Date()): Date {
+  // 'Asia/Tokyo' で年・月だけを取り出す (日は月初固定の 01 なので不要)
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+  }).formatToParts(date);
+  // parts から年・月の文字列を取り出すヘルパー
+  const valueOf = (type: 'year' | 'month') => parts.find((p) => p.type === type)?.value;
+  const year = valueOf('year');
+  const month = valueOf('month');
+  // year/month が取れない (実行環境の Intl 実装異常等) 場合は fail-closed で例外にする。
+  // 呼び出し側 (集計処理) が誤って「無制限」扱いにならないよう、黙ってフォールバックしない。
+  if (!year || !month) {
+    throw new Error('startOfMonthJST: Asia/Tokyo の年月を取得できませんでした');
+  }
+  // YYYY-MM-01T00:00:00.000+09:00 を組み立てて JST の月初を表す Date にする
+  return new Date(`${year}-${month}-01T00:00:00.000+09:00`);
+}

--- a/src/lib/plan-guard.ts
+++ b/src/lib/plan-guard.ts
@@ -78,17 +78,6 @@ export function isUserLimitReached(plan: SubscriptionPlan, currentCount: number)
   return currentCount >= USER_LIMIT[plan];
 }
 
-// 月間チケット起票数が上限に達しているかを判定する
-// plan: テナントの現在プラン / currentMonthlyCount: 今月起票済み件数
-export function isMonthlyTicketLimitReached(
-  plan: SubscriptionPlan,
-  currentMonthlyCount: number,
-): boolean {
-  const limit = MONTHLY_TICKET_LIMIT[plan];
-  // Infinity の場合は常に false (制限なし)
-  return Number.isFinite(limit) && currentMonthlyCount >= limit;
-}
-
 // プランのユーザー上限値を返す (UI 表示用)。無制限 (Infinity) の場合は -1 を返す
 // (getMonthlyTicketLimit と同じ規約。呼び出し側は -1 を「無制限」として扱う)
 export function getUserLimit(plan: SubscriptionPlan): number {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -23,8 +23,20 @@ export type RateLimitOptions = {
   windowMs: number; // 判定に使う時間窓の長さ (ミリ秒)
 };
 
-// キー (userId:scope) ごとの実行タイムスタンプ一覧を持つバケット
-const buckets = new Map<string, number[]>();
+// 1 キー分のバケット。タイムスタンプ配列に加えて、そのキーの直近の呼び出しで
+// 使われた windowMs も保持する (キーごとに異なる呼び出し元が異なる窓長を渡すため、
+// 掃除処理で「このバケットはもう完全に期限切れか」を判定するのに必要)
+type Bucket = {
+  timestamps: number[]; // 実行タイムスタンプの一覧 (時系列昇順)
+  windowMs: number; // このバケットの直近呼び出し時の時間窓長 (ミリ秒)
+};
+
+// キー (userId:scope や userId:scope:ticketId 等) ごとのバケットを持つ Map。
+// `ticket-status:${userId}:${ticketId}` のようにチケット ID を含む使い捨てキーは
+// 一度しか呼ばれず二度と prune されないため、何もしないと Map が単調増加する。
+// enforceRateLimit の呼び出しごとに sweepStaleBuckets() で全体を掃除することで
+// 実質的に「アクティブな (直近 windowMs 以内に呼ばれた) キーの数」に上限を保つ。
+const buckets = new Map<string, Bucket>();
 
 // レート制限超過を表す専用エラー。
 // Server Action からは従来どおり Error として message が画面に surface する一方、
@@ -60,7 +72,7 @@ export function enforceRateLimit(
   // 窓の開始時刻を計算 (この時刻より古い記録は無視)
   const cutoff = now - windowMs;
   // 既存の履歴を取得 (なければ空配列)
-  const existing = buckets.get(key) ?? [];
+  const existing = buckets.get(key)?.timestamps ?? [];
   // 窓内に残る履歴だけに絞り込む
   const live = prune(existing, cutoff);
 
@@ -80,8 +92,36 @@ export function enforceRateLimit(
 
   // 今回の実行時刻を履歴の末尾に追加
   live.push(now);
-  // バケットを更新して保存
-  buckets.set(key, live);
+  // バケットを更新して保存 (このキー自身の windowMs も一緒に覚えておく)
+  buckets.set(key, { timestamps: live, windowMs });
+
+  // このキー以外のバケットも含めて、既に完全に期限切れになったものを掃除する。
+  // cron 等の定期実行ジョブが無いため、enforceRateLimit の呼び出しに便乗して
+  // 「ながら掃除」する (呼び出し頻度がそのまま掃除頻度になる)。
+  sweepStaleBuckets(now);
+}
+
+// buckets 全体を走査し、prune() 後に空配列になったバケットを Map から削除する。
+// 各バケットは自分自身が最後に使われた時の windowMs を保持しているため、
+// そのバケット固有の cutoff で判定できる (呼び出し元ごとに窓長が異なっても正しく動く)。
+// `ticket-status:${userId}:${ticketId}` のように一度しか呼ばれないキーは、
+// この掃除がなければ prune() 済みの空配列にすらならず Map に残り続けてしまう
+// (prune はローカル変数を返すだけで Map を書き換えないため)。
+function sweepStaleBuckets(now: number): void {
+  // Map の全エントリを走査する
+  for (const [key, bucket] of buckets) {
+    // このバケット自身の窓長を基準に cutoff を計算する
+    const cutoff = now - bucket.windowMs;
+    // 窓内に残る履歴だけに絞り込む
+    const live = prune(bucket.timestamps, cutoff);
+    if (live.length === 0) {
+      // 生き残りが 0 件 = このキーはもう追跡不要なので Map から削除する
+      buckets.delete(key);
+    } else if (live.length !== bucket.timestamps.length) {
+      // 一部だけ間引かれた場合は、間引いた結果で Map を更新しておく
+      buckets.set(key, { timestamps: live, windowMs: bucket.windowMs });
+    }
+  }
 }
 
 /** Testing helper: clear all buckets between test cases. */
@@ -89,4 +129,11 @@ export function enforceRateLimit(
 export function __resetRateLimits(): void {
   // 全バケットを空にする
   buckets.clear();
+}
+
+/** Testing helper: current number of tracked keys (used to assert no memory leak). */
+// buckets Map が保持しているキー数を返すテスト専用ヘルパー (本番コードからは呼ばない)
+export function __getRateLimitBucketCount(): number {
+  // Map のサイズをそのまま返す
+  return buckets.size;
 }

--- a/src/lib/tenant-plan.ts
+++ b/src/lib/tenant-plan.ts
@@ -13,6 +13,8 @@ import { repos } from '@/data';
 import type { SubscriptionPlan } from '@/domain/types';
 // 月間チケット上限の判定ヘルパー (プランごとの上限値は plan-guard.ts が単一の源)
 import { getMonthlyTicketLimit } from '@/lib/plan-guard';
+// JST (日本時間) 基準の月初を計算する共通ヘルパー (endOfDayJST と同じファイルに集約)
+import { startOfMonthJST } from '@/lib/format-date';
 
 // 指定テナントの現在の課金プランを返す。テナントが見つからない場合は 'free' として扱う
 // (fail-closed: 存在しない/取得できないテナントに Pro/Enterprise 限定機能を渡さない)。
@@ -58,10 +60,10 @@ export async function getMonthlyTicketQuota(
   if (limit === -1) {
     return { limited: false, limit: -1, remaining: Infinity };
   }
-  // 当月の起票数をカウントする (現在月の開始日時を UTC で計算)
-  const now = new Date();
-  // 月初 00:00:00.000 (UTC) を起点にする
-  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  // 当月の起票数をカウントする (「当月」は JST 基準。UTC 月境界だと JST 深夜帯で
+  // 集計対象月がずれてしまうため、他の日付処理 (endOfDayJST 等) と同じく JST に統一する)
+  // 月初 00:00:00.000 (JST) を起点にする
+  const monthStart = startOfMonthJST();
   // 当月起票済み件数をカウントする (tenantId スコープ + createdAfter フィルター)
   const currentCount = await repos.tickets.count({ createdAfter: monthStart }, tenantId);
   // 残枠は 0 未満にならないようクランプする

--- a/tests/format-date.test.ts
+++ b/tests/format-date.test.ts
@@ -1,7 +1,7 @@
 // Vitest のテスト DSL
 import { describe, expect, it } from 'vitest';
-// 検証対象 (YYYY-MM-DD → JST 終端 Date 変換ヘルパー)
-import { endOfDayJST } from '@/lib/format-date';
+// 検証対象 (YYYY-MM-DD → JST 終端 Date 変換ヘルパー / JST 月初計算ヘルパー)
+import { endOfDayJST, startOfMonthJST } from '@/lib/format-date';
 
 // JST 終端 Date 変換の境界値テスト
 describe('endOfDayJST', () => {
@@ -33,5 +33,42 @@ describe('endOfDayJST', () => {
     const d = endOfDayJST('2026-12-31');
     // JST 12/31 23:59:59 → UTC 12/31 14:59:59
     expect(d!.toISOString()).toBe('2026-12-31T14:59:59.999Z');
+  });
+});
+
+// JST 月初計算の境界値テスト (月間チケット上限の集計基準)
+describe('startOfMonthJST', () => {
+  // UTC で見ると前日 (5/31) の午後だが、JST では 6/1 になっている時刻。
+  // Date.UTC ベースの旧実装だとここで月初が 1 ヶ月分ずれていた (5/1 のまま)。
+  it('resolves to the JST month even when UTC is still in the previous month', () => {
+    // 2026-06-01 00:30 JST = 2026-05-31 15:30 UTC
+    const jstJustAfterMidnight = new Date('2026-05-31T15:30:00.000Z');
+    const start = startOfMonthJST(jstJustAfterMidnight);
+    // JST 6/1 00:00:00.000 = UTC 5/31 15:00:00.000
+    expect(start.toISOString()).toBe('2026-05-31T15:00:00.000Z');
+  });
+
+  // UTC で見ると翌日 (6/1) の午前だが、JST ではまだ 5/31 のうち (=5月扱い) の時刻。
+  it('resolves to the JST month even when UTC has already rolled over to the next month', () => {
+    // 2026-05-31 23:30 JST = 2026-05-31 14:30 UTC
+    const stillMayInJst = new Date('2026-05-31T14:30:00.000Z');
+    const start = startOfMonthJST(stillMayInJst);
+    // JST 5/1 00:00:00.000 = UTC 4/30 15:00:00.000
+    expect(start.toISOString()).toBe('2026-04-30T15:00:00.000Z');
+  });
+
+  // 年をまたぐ場合 (JST 1/1 直後) も正しく年初月初になる
+  it('handles the year boundary correctly', () => {
+    // 2027-01-01 00:30 JST = 2026-12-31 15:30 UTC
+    const jstNewYear = new Date('2026-12-31T15:30:00.000Z');
+    const start = startOfMonthJST(jstNewYear);
+    // JST 2027-01-01 00:00:00.000 = UTC 2026-12-31 15:00:00.000
+    expect(start.toISOString()).toBe('2026-12-31T15:00:00.000Z');
+  });
+
+  // 引数省略時は現在時刻を基準にする (例外を投げず Date を返すことだけ確認)
+  it('defaults to the current time when no argument is given', () => {
+    expect(() => startOfMonthJST()).not.toThrow();
+    expect(startOfMonthJST()).toBeInstanceOf(Date);
   });
 });

--- a/tests/plan-guard.test.ts
+++ b/tests/plan-guard.test.ts
@@ -11,7 +11,6 @@ import {
   isProModeAllowed,
   isSsoAllowed,
   isUserLimitReached,
-  isMonthlyTicketLimitReached,
   getUserLimit,
   getMonthlyTicketLimit,
 } from '../src/lib/plan-guard';
@@ -102,14 +101,6 @@ describe('plan-guard: 上限到達判定と表示ヘルパー', () => {
   // Enterprise は無制限なのでどれだけ増えても到達しない
   it('Enterprise はユーザー上限に到達しない', () => {
     expect(isUserLimitReached('enterprise', 100000)).toBe(false); // 無制限
-  });
-
-  // 月間チケット上限: Free のみ到達し得る、無制限プランは常に false
-  it('isMonthlyTicketLimitReached は無制限プランで常に false', () => {
-    expect(isMonthlyTicketLimitReached('free', 50)).toBe(true); // 50 >= 50 到達
-    expect(isMonthlyTicketLimitReached('free', 49)).toBe(false); // 49 < 50 未到達
-    expect(isMonthlyTicketLimitReached('pro', 999999)).toBe(false); // 無制限
-    expect(isMonthlyTicketLimitReached('enterprise', 999999)).toBe(false); // 無制限
   });
 
   // 表示用ヘルパーは無制限を -1 で返す (UI は -1 を「無制限」と解釈する規約)

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,8 +1,12 @@
 // Vitest のテスト DSL (フック/グルーピング/期待値/個別テスト)
 import { beforeEach, describe, expect, it } from 'vitest';
 
-// レート制限の本体と、テスト用に内部状態をリセットする関数
-import { __resetRateLimits, enforceRateLimit } from '../src/lib/rate-limit';
+// レート制限の本体と、テスト用に内部状態をリセット/参照する関数
+import {
+  __resetRateLimits,
+  __getRateLimitBucketCount,
+  enforceRateLimit,
+} from '../src/lib/rate-limit';
 
 // レート制限ヘルパーの仕様確認テスト群
 describe('enforceRateLimit', () => {
@@ -54,5 +58,32 @@ describe('enforceRateLimit', () => {
     }
     // user-b 側はカウントが別なので呼び出し可能
     expect(() => enforceRateLimit('user-b', { limit: 3, windowMs: 10_000 }, now)).not.toThrow();
+  });
+
+  // メモリリーク修正: チケット ID を含む使い捨てキー (ticket-status:user:ticket 等) が
+  // 二度と呼ばれなくても、後続の別呼び出しに便乗した掃除で Map から削除されること
+  it('removes fully-expired one-off keys from the internal map (no unbounded growth)', () => {
+    const t0 = 1_000_000;
+    // "ticket-status:u1:ticket-1" のような、二度と呼ばれない使い捨てキーを 1 回だけ使う
+    enforceRateLimit('ticket-status:u1:ticket-1', { limit: 10, windowMs: 10_000 }, t0);
+    // この時点ではまだ窓内なので Map にエントリが残っている
+    expect(__getRateLimitBucketCount()).toBe(1);
+
+    // 窓 (10 秒) より十分先に進めてから、別のキーで呼び出す
+    // (このライブラリには cron が無いので、他キーの呼び出しに便乗して掃除される設計)
+    enforceRateLimit('ticket-status:u2:ticket-2', { limit: 10, windowMs: 10_000 }, t0 + 20_000);
+
+    // 先に使った使い捨てキーは完全に期限切れになっているので削除され、
+    // 直近呼び出し分の 1 件だけが残る (2 件のまま溜まり続けない)
+    expect(__getRateLimitBucketCount()).toBe(1);
+  });
+
+  // 同じキーを繰り返し使う通常の利用パターンでは、窓内である限りエントリが保持される
+  it('keeps a key alive while it is still within its own window', () => {
+    const t0 = 1_000_000;
+    enforceRateLimit('ticket-comment:u1', { limit: 5, windowMs: 60_000 }, t0);
+    // 窓 (60 秒) の途中で他キーを呼んでも、まだ生きているキーは消えない
+    enforceRateLimit('other-key', { limit: 5, windowMs: 60_000 }, t0 + 5_000);
+    expect(__getRateLimitBucketCount()).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- `src/lib/plan-guard.ts` の未参照関数 `isMonthlyTicketLimitReached` を削除(直近リファクタで `getMonthlyTicketQuota()` に置き換え済みだった残存デッドコード)
- `src/lib/rate-limit.ts` の `buckets` Map がチケットIDを含む使い捨てキーで単調増加していた問題を修正(他キー呼び出しに便乗した掃除方式でstaleエントリを削除)
- `src/lib/tenant-plan.ts` の月間チケット上限集計がUTC月境界だったのをJST基準(`startOfMonthJST`)に統一し、他の日付処理との整合を取った

## Test plan
- [x] `npm run lint` 合格
- [x] `npx vitest run tests/plan-guard.test.ts tests/rate-limit.test.ts tests/format-date.test.ts` 合格(新規テスト含む)
- [x] `npm run test` 全体446件合格
- [ ] `npm run typecheck` / 契約テスト: サンドボックスのネットワーク制限でPrismaクライアント生成(`prisma generate`)不可のため未実行。変更ファイルは個別に `tsc --noEmit` で確認済み。CI環境での実行を推奨。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyGEziutof6SRbUozwS7XA)_