### PR TITLE
fix(webhook): Webhook 応答本文の上限読み取りをストリームで実効化

### DIFF
--- a/src/lib/webhook-fetch.ts
+++ b/src/lib/webhook-fetch.ts
@@ -72,9 +72,68 @@ export async function postWebhook(
     throw new Error('Webhook 送信失敗: リダイレクト応答は SSRF 対策のため許可されません');
   }
 
-  // レスポンス本文を上限バイト数まで読む (巨大な本文をそのまま保持しない)
-  const bodyText = await response.text().then((t) => t.slice(0, options.maxResponseBytes));
+  // レスポンス本文を上限バイト数まで読む (巨大な本文をそのまま保持しない §8/§9)
+  const bodyText = await readBodyCapped(response, options.maxResponseBytes);
 
   // HTTP の成否・ステータス・本文を呼び出し側へ返す
   return { ok: response.ok, status: response.status, bodyText };
+}
+
+// レスポンス本文を上限バイト数まで読み取り、超過分は読み込まずに打ち切る内部ヘルパー。
+// `response.text()` は本文全体をメモリに読み切ってから返すため、それに `.slice()` を後掛けする
+// だけでは「上限バイト数」が名目上の値になり、乗っ取られた/悪意ある Webhook 先が巨大な本文を
+// 送り続けた場合にサーバーのメモリを消費してしまう (§8 リソース解放 / §9 DoS 対策)。
+// ここでは response.body の ReadableStream を直接読み、上限に達した時点で reader.cancel() して
+// それ以降のバイト列を読まずに接続を閉じる。
+async function readBodyCapped(response: Response, maxBytes: number): Promise<string> {
+  // body ストリームを取得できない実行環境 (一部のテスト用モック等) では
+  // 上限保護が効かなくなるが、素直に text() へフォールバックして機能を壊さない
+  const body = response.body;
+  if (!body) {
+    // 全文を読んでから文字数で切り詰める (従来どおりの挙動)
+    const text = await response.text();
+    return text.slice(0, maxBytes);
+  }
+
+  // ストリームを 1 チャンクずつ読み取るためのリーダー
+  const reader = body.getReader();
+  // 受信済みチャンクを蓄えるバッファ (上限を超えたら以降は積まない)
+  const chunks: Uint8Array[] = [];
+  // ここまでに受信したバイト数の合計
+  let received = 0;
+  try {
+    // ストリームが終わるか上限に達するまで読み続ける
+    for (;;) {
+      const { done, value } = await reader.read();
+      // ストリームが正常終了したらループを抜ける
+      if (done) break;
+      if (value) {
+        chunks.push(value);
+        received += value.length;
+        // 上限に達したら、残りのバイト列は読まずに接続を閉じてメモリを守る
+        if (received >= maxBytes) {
+          await reader.cancel().catch(() => {
+            // cancel 自体の失敗は無視する (既に十分なデータは確保できている)
+          });
+          break;
+        }
+      }
+    }
+  } finally {
+    // 例外発生時もリーダーのロックを解放してストリームを解放する
+    reader.releaseLock();
+  }
+
+  // 蓄えたチャンクを 1 本の Uint8Array に連結する (上限超過分は既に読んでいないため安全なサイズ)
+  const combined = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.length;
+  }
+  // UTF-8 として上限バイト数までデコードする (マルチバイト文字の境界を跨ぐ可能性はあるが
+  // TextDecoder は不正なバイト列を U+FFFD に置換するだけで例外にはならないため安全側に倒せる)
+  const decoded = new TextDecoder().decode(combined.subarray(0, maxBytes));
+  // 文字数ベースでも上限を掛けておく (呼び出し側の従来仕様と挙動を揃える)
+  return decoded.slice(0, maxBytes);
 }

--- a/tests/webhook-fetch.test.ts
+++ b/tests/webhook-fetch.test.ts
@@ -20,12 +20,7 @@ const OPTIONS = {
 };
 
 // HTTP レスポンスのモックを作るヘルパー (type は redirect 判定用に任意指定)
-function mockResponse(opts: {
-  ok: boolean;
-  status: number;
-  body?: string;
-  type?: string;
-}) {
+function mockResponse(opts: { ok: boolean; status: number; body?: string; type?: string }) {
   return {
     ok: opts.ok,
     status: opts.status,
@@ -79,5 +74,51 @@ describe('postWebhook', () => {
     const result = await postWebhook(URL, { ...OPTIONS, maxResponseBytes: 10 });
     // 10 文字に切り詰められている
     expect(result.bodyText).toBe('a'.repeat(10));
+  });
+
+  // メモリ保護: response.body が ReadableStream で提供される場合、上限到達後は
+  // それ以上ストリームを読み進めず reader.cancel() で打ち切ることを検証する。
+  // (text() で全文を読み切ってから slice するだけでは、悪意ある Webhook 先が
+  // 巨大な本文を送り続けたときにサーバーのメモリを消費してしまうため)
+  it('response.body がストリームの場合、上限到達後は読み取りを打ち切る', async () => {
+    // 1 チャンク 100 バイトずつ、合計 50 チャンク (5000 バイト) 送ってくる巨大ストリームを模擬する
+    const CHUNK_SIZE = 100;
+    const TOTAL_CHUNKS = 50;
+    let producedChunks = 0;
+    // cancel() が呼ばれた回数を数える (上限到達後に確実に打ち切られたことを確認するため)
+    let cancelCalls = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        // まだチャンクが残っていれば 1 つ積む
+        if (producedChunks < TOTAL_CHUNKS) {
+          controller.enqueue(new Uint8Array(CHUNK_SIZE).fill(97)); // 'a' の文字コード
+          producedChunks += 1;
+        } else {
+          controller.close();
+        }
+      },
+      cancel() {
+        cancelCalls += 1;
+      },
+    });
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      type: undefined,
+      body: stream,
+      // body がある場合 text() は呼ばれない想定だが、フォールバック経路の安全のため用意しておく
+      text: () => Promise.resolve('a'.repeat(CHUNK_SIZE * TOTAL_CHUNKS)),
+    });
+
+    // 上限 250 バイト (= 3 チャンク目の途中) で読み取る
+    const result = await postWebhook(URL, { ...OPTIONS, maxResponseBytes: 250 });
+
+    // 上限バイト数までに切り詰められている
+    expect(result.bodyText).toBe('a'.repeat(250));
+    // 50 チャンク全部 (5000 バイト) を生成する前に打ち切られている
+    // (上限到達に必要な最小チャンク数である 3 チャンク目まで読んだ時点で cancel されるはず)
+    expect(producedChunks).toBeLessThan(TOTAL_CHUNKS);
+    // reader.cancel() が実際に呼ばれ、ストリームが打ち切られたことを確認する
+    expect(cancelCalls).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

包括的なコードレビュー（`src/features/`, `src/lib/`, `src/app/`, `src/data/` 配下）を実施し、以下の観点で確認しました。

1. `docs/smb-dx-pivot-plan.md` との整合性、マルチテナント境界、`ALLOWED_TRANSITIONS` のバイパス有無、Ports & Adapters の遵守
2. 可読性・保守性（命名・関数分割・DRY・コメント）
3. 機能とセキュリティ（クロステナント漏洩・認可漏れ・入力検証・Webhook 署名検証・SSRF/オープンリダイレクト対策・エラーハンドリング）
4. チームルール準拠（§5 コメント規約・§6 コーディング規約・Prettier 設定）

特にテナントスコープ漏れ・RBAC 漏れ・Webhook のリダイレクト追従（過去に修正歴あり）を重点的に確認しましたが、**これらについては具体的な問題は見つかりませんでした**（`src/data/adapters/prisma/*.prisma.ts` 全 13 ファイル・`src/features/*/actions/*.ts` 全 19 ファイル・`src/app/api/**/route.ts` 全 12 ファイルを精査。テナントスコープ・RBAC はいずれも一貫して正しく実装されていることを確認）。

一方、`src/lib/webhook-fetch.ts` の `postWebhook` に、コメントの主張と実装が乖離している具体的な問題を発見したため修正しました。

### 問題

- `maxResponseBytes` はコメント上「巨大な本文でメモリを消費しないための上限」とされていたが、実装は `response.text()` で本文全体を読み切ってから `.slice()` していたため、実際にはメモリ消費の上限として機能していなかった。
- 乗っ取られた/悪意ある Webhook 先（Slack/Teams/Chatwork の Incoming Webhook URL は管理者が設定する値）が巨大な本文を返した場合、タイムアウト (既定 5 秒) までの間にサーバーのメモリを消費できてしまう。

### 修正

- `response.body` の `ReadableStream` を直接読み取り、上限バイト数に達した時点で `reader.cancel()` してそれ以上ストリームを読み進めないよう変更 (`readBodyCapped` 関数を追加)。
- `body` ストリームを提供しない実行環境向けに従来どおり `response.text()` へのフォールバックも維持。
- 新規テストで、ストリームが上限到達後に打ち切られること (`producedChunks < TOTAL_CHUNKS` かつ `reader.cancel()` が呼ばれること) を検証。

## Test plan

- [x] `npm run typecheck` — 成功
- [x] `npm run lint` — 成功
- [x] `npm run test` — 450 件成功 / 32 件スキップ (契約テストは DB 未接続のため既定どおりスキップ)
- [x] `npx prettier --check` — 変更ファイルとも準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YG3Wvh5cZjKzF679web7c8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YG3Wvh5cZjKzF679web7c8)_