### PR TITLE
fix(security): SSRF/TOCTOU/プランダウングレードの3件のセキュリティ・整合性不備を修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "^19.2.5",
         "react-hook-form": "^7.72.1",
         "stripe": "^22.2.2",
+        "undici": "8.7.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -8313,6 +8314,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.7.0.tgz",
+      "integrity": "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "react-dom": "^19.2.5",
         "react-hook-form": "^7.72.1",
         "stripe": "^22.2.2",
-        "undici": "8.7.0",
+        "undici": "7.28.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -8317,12 +8317,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.7.0.tgz",
-      "integrity": "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.19.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.72.1",
     "stripe": "^22.2.2",
-    "undici": "8.7.0",
+    "undici": "7.28.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.72.1",
     "stripe": "^22.2.2",
+    "undici": "8.7.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -22,6 +22,8 @@ import { timingSafeEqual } from 'node:crypto';
 import { revalidatePath } from 'next/cache';
 // データ層 (テナント / ユーザー / チケットのリポジトリ束 + トランザクション境界)
 import { repos, uow } from '@/data';
+// チケット作成の入力型 (冪等起票ヘルパーの引数に使う)
+import type { CreateTicketInput } from '@/data/ports/ticket-repository';
 // 新規起票時の初期ステータスを mode から決める共通ルール (Web フォーム起票と単一の源を共有)
 import { initialStatusForMode } from '@/domain/ticket-status';
 // コメント通知の宛先決定 (Web フォーム経由コメントと共有するヘルパー)
@@ -72,6 +74,58 @@ class BodyTooLargeError extends Error {
     // this.name を明示設定する。設定しないと err.name が 'Error' になり構造化ロガーで誤分類される
     // (RateLimitError が this.name を設定しているのと同じ理由 - src/lib/rate-limit.ts:37 参照)
     this.name = 'BodyTooLargeError';
+  }
+}
+
+// 受信メールの Message-ID の冪等性を保ったままチケットを起票する。
+//
+// なぜ必要か: メールプロバイダは Webhook 応答が遅延/未受信だと同一メールを再送する
+// (at-least-once)。以前の実装は「対応表を SELECT → 無ければ起票 → 対応表へ INSERT」を
+// 別々の呼び出しで行っており、同一メールの再送が完全に同時 (両方の SELECT が先に走る)
+// だと二重起票の窓が残っていた (TOCTOU)。
+// ここでは SELECT → 起票 → 対応表登録を 1 つの Serializable トランザクションにまとめる。
+// Serializable なら DB 側が競合を検知し、後勝ちのトランザクションを書き込み競合エラーで
+// 中断するため、両方が「未処理」を読み取ったまま起票してしまうことがなくなる。
+// 中断されたリクエストは (勝った方が確定させた) 対応表を読み直して重複として扱う。
+async function createEmailTicketIdempotent(
+  messageId: string | null, // 冪等化キー。取れなかった場合は null (冪等化なしで単発起票)
+  tenantId: string,
+  ticketInput: CreateTicketInput,
+): Promise<{ id: string; alreadyExisted: boolean }> {
+  // Message-ID が取れないメールは突き合わせようがないため、従来どおり単発で起票する
+  if (!messageId) {
+    const created = await repos.tickets.create(ticketInput);
+    return { id: created.id, alreadyExisted: false };
+  }
+
+  try {
+    return await uow.run(
+      async (tx) => {
+        // トランザクション内で再確認する (外側の事前チェックから開始までの間に、
+        // 別リクエストが処理を終えている可能性があるため)
+        const already = await tx.emailThreads.findTicketIdByMessageIds([messageId], tenantId);
+        if (already) return { id: already, alreadyExisted: true };
+        // 起票してから対応表に登録する (同一トランザクション内なので原子的)
+        const created = await tx.tickets.create(ticketInput);
+        await tx.emailThreads.register({ messageId, ticketId: created.id, tenantId });
+        return { id: created.id, alreadyExisted: false };
+      },
+      { isolationLevel: 'Serializable' },
+    );
+  } catch (err) {
+    // 書き込み競合 = 同時に処理された同一メールの別リクエストが先に確定したということ。
+    // 確定後の対応表を読み直せば、そちらが登録したチケット ID が見つかるはずなので重複扱いにする
+    if (uow.isTransactionConflict(err)) {
+      const winnerTicketId = await repos.emailThreads.findTicketIdByMessageIds(
+        [messageId],
+        tenantId,
+      );
+      if (winnerTicketId) {
+        return { id: winnerTicketId, alreadyExisted: true };
+      }
+    }
+    // 書き込み競合以外、または競合なのに対応表が見つからない (想定外) 場合はそのまま伝播する
+    throw err;
   }
 }
 
@@ -313,7 +367,9 @@ export async function POST(req: Request) {
   const contentLength = Number(req.headers.get('content-length') || '-1');
   if (Number.isFinite(contentLength) && contentLength > MAX_INBOUND_BODY_BYTES) {
     // サイズ超過はサーバーログに残し、外部には詳細を出さない 413 を返す
-    console.warn(`[POST /api/inbound/email] request body too large (header): ${contentLength} bytes`);
+    console.warn(
+      `[POST /api/inbound/email] request body too large (header): ${contentLength} bytes`,
+    );
     return NextResponse.json({ error: 'メールが大きすぎます' }, { status: 413 });
   }
 
@@ -494,7 +550,9 @@ export async function POST(req: Request) {
           ),
         );
         // 通知作成に成功した受信者だけを SSE 配信対象にする (失敗分は DB レコードが無いためスキップ)
-        const succeededIds = recipientIds.filter((_, i) => notifyResults[i]?.status === 'fulfilled');
+        const succeededIds = recipientIds.filter(
+          (_, i) => notifyResults[i]?.status === 'fulfilled',
+        );
         const failedCount = recipientIds.length - succeededIds.length;
         if (failedCount > 0) {
           // 失敗件数だけログに残す (受信者 ID は個人情報のため省略)
@@ -527,30 +585,27 @@ export async function POST(req: Request) {
   // メールには期限指定が無いため、Web フォーム起票と同じく優先度 Medium ベースで解決期限を算出する
   const resolutionDueAt = calculateResolutionDueAt('Medium', now);
 
-  // 受信メールを 1 件の問い合わせとして作成する
-  const ticket = await repos.tickets.create({
-    title: email.subject, // 件名 (空メールは既定タイトルに正規化済み)
-    body: email.body, // 本文テキスト
-    priority: 'Medium', // メール取り込みは優先度を Medium 固定 (Lite の既定と揃える)
-    categoryId: null, // メール取り込みではカテゴリ未分類
-    creatorId: sender.id, // 起票者は送信者本人 (既知メンバー)
-    tenantId: tenant.id, // 取り込み先テナント
-    status: initialStatus, // Lite は 'Open'、Pro は undefined (既定 New)
-    resolutionDueAt, // 解決期限 (優先度ベース)
-  });
+  // 受信メールを 1 件の問い合わせとして作成する (起票 + 対応表登録を原子的に行う)
+  const { id: ticketId, alreadyExisted } = await createEmailTicketIdempotent(
+    email.messageId, // 冪等化キー (無い場合は null)
+    tenant.id,
+    {
+      title: email.subject, // 件名 (空メールは既定タイトルに正規化済み)
+      body: email.body, // 本文テキスト
+      priority: 'Medium', // メール取り込みは優先度を Medium 固定 (Lite の既定と揃える)
+      categoryId: null, // メール取り込みではカテゴリ未分類
+      creatorId: sender.id, // 起票者は送信者本人 (既知メンバー)
+      tenantId: tenant.id, // 取り込み先テナント
+      status: initialStatus, // Lite は 'Open'、Pro は undefined (既定 New)
+      resolutionDueAt, // 解決期限 (優先度ベース)
+    },
+  );
 
-  // この受信メールの Message-ID を対応表へ登録する (後続の返信をこのチケットへ紐付けるため)。
-  // ベストエフォート: 登録失敗で 500 を返すと再送 → 二重起票になりかねないので、握ってログに残す。
-  if (email.messageId) {
-    try {
-      await repos.emailThreads.register({
-        messageId: email.messageId,
-        ticketId: ticket.id,
-        tenantId: tenant.id,
-      });
-    } catch (err) {
-      console.warn('[POST /api/inbound/email] failed to register inbound message id', err);
-    }
+  if (alreadyExisted) {
+    // 書き込み競合により、別リクエストが既に起票・受領返信済みと判明したケース。
+    // 二重にチケットや受領メールを作らないよう、ここでは何もせず既存チケット ID を返す
+    console.info('[POST /api/inbound/email] resolved write conflict as duplicate', ticketId);
+    return NextResponse.json({ status: 'duplicate', ticketId }, { status: 200 });
   }
 
   // 初回メール起票の受領自動返信 (メンバー改善 #1): 送信元へ「受け付けました」を 1 通返す。
@@ -560,12 +615,12 @@ export async function POST(req: Request) {
   if (!isAutomatedEmail(fields)) {
     await sendReceivedAck({
       to: sender.email,
-      ticketId: ticket.id,
+      ticketId,
       ticketTitle: email.subject,
       tenantId: tenant.id,
     });
   }
 
   // 作成された問い合わせ ID を 201 で返す (プロバイダは本文を使わないが疎通確認に役立つ)
-  return NextResponse.json({ ticketId: ticket.id }, { status: 201 });
+  return NextResponse.json({ ticketId }, { status: 201 });
 }

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -22,8 +22,11 @@ import { timingSafeEqual } from 'node:crypto';
 import { revalidatePath } from 'next/cache';
 // データ層 (テナント / ユーザー / チケットのリポジトリ束 + トランザクション境界)
 import { repos, uow } from '@/data';
-// チケット作成の入力型 (冪等起票ヘルパーの引数に使う)
-import type { CreateTicketInput } from '@/data/ports/ticket-repository';
+// Webhook 再送に対する冪等起票の共通ヘルパー (LINE/メールで共有)
+import {
+  createTicketIdempotent,
+  emailMessageIdempotencyOps,
+} from '@/lib/idempotent-ticket-creation';
 // 新規起票時の初期ステータスを mode から決める共通ルール (Web フォーム起票と単一の源を共有)
 import { initialStatusForMode } from '@/domain/ticket-status';
 // コメント通知の宛先決定 (Web フォーム経由コメントと共有するヘルパー)
@@ -74,58 +77,6 @@ class BodyTooLargeError extends Error {
     // this.name を明示設定する。設定しないと err.name が 'Error' になり構造化ロガーで誤分類される
     // (RateLimitError が this.name を設定しているのと同じ理由 - src/lib/rate-limit.ts:37 参照)
     this.name = 'BodyTooLargeError';
-  }
-}
-
-// 受信メールの Message-ID の冪等性を保ったままチケットを起票する。
-//
-// なぜ必要か: メールプロバイダは Webhook 応答が遅延/未受信だと同一メールを再送する
-// (at-least-once)。以前の実装は「対応表を SELECT → 無ければ起票 → 対応表へ INSERT」を
-// 別々の呼び出しで行っており、同一メールの再送が完全に同時 (両方の SELECT が先に走る)
-// だと二重起票の窓が残っていた (TOCTOU)。
-// ここでは SELECT → 起票 → 対応表登録を 1 つの Serializable トランザクションにまとめる。
-// Serializable なら DB 側が競合を検知し、後勝ちのトランザクションを書き込み競合エラーで
-// 中断するため、両方が「未処理」を読み取ったまま起票してしまうことがなくなる。
-// 中断されたリクエストは (勝った方が確定させた) 対応表を読み直して重複として扱う。
-async function createEmailTicketIdempotent(
-  messageId: string | null, // 冪等化キー。取れなかった場合は null (冪等化なしで単発起票)
-  tenantId: string,
-  ticketInput: CreateTicketInput,
-): Promise<{ id: string; alreadyExisted: boolean }> {
-  // Message-ID が取れないメールは突き合わせようがないため、従来どおり単発で起票する
-  if (!messageId) {
-    const created = await repos.tickets.create(ticketInput);
-    return { id: created.id, alreadyExisted: false };
-  }
-
-  try {
-    return await uow.run(
-      async (tx) => {
-        // トランザクション内で再確認する (外側の事前チェックから開始までの間に、
-        // 別リクエストが処理を終えている可能性があるため)
-        const already = await tx.emailThreads.findTicketIdByMessageIds([messageId], tenantId);
-        if (already) return { id: already, alreadyExisted: true };
-        // 起票してから対応表に登録する (同一トランザクション内なので原子的)
-        const created = await tx.tickets.create(ticketInput);
-        await tx.emailThreads.register({ messageId, ticketId: created.id, tenantId });
-        return { id: created.id, alreadyExisted: false };
-      },
-      { isolationLevel: 'Serializable' },
-    );
-  } catch (err) {
-    // 書き込み競合 = 同時に処理された同一メールの別リクエストが先に確定したということ。
-    // 確定後の対応表を読み直せば、そちらが登録したチケット ID が見つかるはずなので重複扱いにする
-    if (uow.isTransactionConflict(err)) {
-      const winnerTicketId = await repos.emailThreads.findTicketIdByMessageIds(
-        [messageId],
-        tenantId,
-      );
-      if (winnerTicketId) {
-        return { id: winnerTicketId, alreadyExisted: true };
-      }
-    }
-    // 書き込み競合以外、または競合なのに対応表が見つからない (想定外) 場合はそのまま伝播する
-    throw err;
   }
 }
 
@@ -586,7 +537,8 @@ export async function POST(req: Request) {
   const resolutionDueAt = calculateResolutionDueAt('Medium', now);
 
   // 受信メールを 1 件の問い合わせとして作成する (起票 + 対応表登録を原子的に行う)
-  const { id: ticketId, alreadyExisted } = await createEmailTicketIdempotent(
+  const { id: ticketId, alreadyExisted } = await createTicketIdempotent(
+    emailMessageIdempotencyOps,
     email.messageId, // 冪等化キー (無い場合は null)
     tenant.id,
     {

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -28,10 +28,13 @@
 import { NextResponse } from 'next/server';
 // 署名検証に使う HMAC ユーティリティ (Node ランタイム前提)
 import { createHmac, timingSafeEqual } from 'node:crypto';
-// データ層の Composition Root (テナント / ユーザー / チケットのリポジトリ束 + トランザクション境界)
-import { repos, uow } from '@/data';
-// チケット作成の入力型 (冪等起票ヘルパーの引数に使う)
-import type { CreateTicketInput } from '@/data/ports/ticket-repository';
+// データ層の Composition Root (テナント / ユーザー / チケットのリポジトリ束)
+import { repos } from '@/data';
+// Webhook 再送に対する冪等起票の共通ヘルパー (LINE/メールで共有)
+import {
+  createTicketIdempotent,
+  lineMessageIdempotencyOps,
+} from '@/lib/idempotent-ticket-creation';
 // 新規起票時の初期ステータスを mode から決める共通ルール (Web フォーム起票と単一の源を共有)
 import { initialStatusForMode } from '@/domain/ticket-status';
 // 公開エンドポイントの流量制限 (§9: DoS / リソース枯渇防止)
@@ -121,59 +124,6 @@ function verifyLineSignature(rawBody: string, signature: string, channelSecret: 
   if (a.length !== b.length) return false;
   // 同一長さなら定数時間比較して HMAC 一致を判定する
   return timingSafeEqual(a, b);
-}
-
-// LINE メッセージ ID の冪等性を保ったままチケットを起票する。
-//
-// なぜ必要か: LINE は Webhook 応答が遅延/未受信だと同一メッセージを 5 分以内に再送する
-// (at-least-once)。以前の実装は「対応表を SELECT → 無ければ起票 → 対応表へ INSERT」を
-// 別々の呼び出しで行っており、同一メッセージの再送が完全に同時 (両方の SELECT が先に
-// 走る) だと二重起票の窓が残っていた (TOCTOU)。
-// ここでは SELECT → 起票 → 対応表登録を 1 つの Serializable トランザクションにまとめる。
-// Serializable なら DB 側が競合を検知し、後勝ちのトランザクションを書き込み競合エラーで
-// 中断するため、両方が「未処理」を読み取ったまま起票してしまうことがなくなる。
-// 中断されたリクエストは (勝った方が確定させた) 対応表を読み直して重複として扱う。
-async function createLineTicketIdempotent(
-  messageId: string | null, // 冪等化キー。取れなかった場合は null (冪等化なしで単発起票)
-  tenantId: string,
-  ticketInput: CreateTicketInput,
-): Promise<{ id: string; alreadyExisted: boolean }> {
-  // メッセージ ID が取れないイベントは突き合わせようがないため、従来どおり単発で起票する
-  if (!messageId) {
-    const created = await repos.tickets.create(ticketInput);
-    return { id: created.id, alreadyExisted: false };
-  }
-
-  try {
-    return await uow.run(
-      async (tx) => {
-        // トランザクション内で再確認する (外側の事前チェックから開始までの間に、
-        // 別リクエストが処理を終えている可能性があるため)
-        const already = await tx.lineMessages.findTicketIdByMessageId(messageId, tenantId);
-        if (already) return { id: already, alreadyExisted: true };
-        // 起票してから対応表に登録する (同一トランザクション内なので原子的)
-        const created = await tx.tickets.create(ticketInput);
-        await tx.lineMessages.register({
-          lineMessageId: messageId,
-          ticketId: created.id,
-          tenantId,
-        });
-        return { id: created.id, alreadyExisted: false };
-      },
-      { isolationLevel: 'Serializable' },
-    );
-  } catch (err) {
-    // 書き込み競合 = 同時に処理された同一メッセージの別リクエストが先に確定したということ。
-    // 確定後の対応表を読み直せば、そちらが登録したチケット ID が見つかるはずなので重複扱いにする
-    if (uow.isTransactionConflict(err)) {
-      const winnerTicketId = await repos.lineMessages.findTicketIdByMessageId(messageId, tenantId);
-      if (winnerTicketId) {
-        return { id: winnerTicketId, alreadyExisted: true };
-      }
-    }
-    // 書き込み競合以外、または競合なのに対応表が見つからない (想定外) 場合はそのまま伝播する
-    throw err;
-  }
 }
 
 // POST /api/inbound/line : LINE Webhook を受信してチケットを作成する
@@ -348,7 +298,7 @@ export async function POST(req: Request) {
     // 冪等化の早期チェック (fast path): このメッセージ ID を既に取り込み済みなら、
     // 連携コード判定や起票者解決などの以降の処理を行わずに次のイベントへ進む。
     // LINE は Webhook 応答が遅延/未受信だと同一メッセージを 5 分以内に再送する (at-least-once)。
-    // これは事前チェックに過ぎず、実際の二重起票防止は createLineTicketIdempotent 内の
+    // これは事前チェックに過ぎず、実際の二重起票防止は createTicketIdempotent 内の
     // Serializable トランザクションが保証する (このチェック単体では TOCTOU の窓が残るため)。
     if (messageId) {
       const existingTicketId = await repos.lineMessages.findTicketIdByMessageId(
@@ -423,13 +373,14 @@ export async function POST(req: Request) {
     // 新規チケットを起票する (Web フォーム・メール取り込みと同じ PORT 経由)。
     // 1 件の起票失敗で全体を 500 にすると LINE がバッチ全体を再送し、既に起票済みのチケットが
     // 重複する。そのため起票は個別に try/catch で囲み、失敗は文脈付きでログに残して次のイベントへ
-    // 進み、最後は必ず 200 を返す (再送そのものは createLineTicketIdempotent の Serializable
+    // 進み、最後は必ず 200 を返す (再送そのものは createTicketIdempotent の Serializable
     // トランザクションが二重起票を防ぐ)。
     try {
       // 起票 (+ メッセージ ID 登録) を 1 トランザクションで原子的に行う。
       // alreadyExisted が true のときは、書き込み競合で中断された後の再確認で「他リクエストが
       // 既に起票済み」と判明したケース (通知は既にそちらのリクエストで送られているはず)
-      const { id: ticketId, alreadyExisted } = await createLineTicketIdempotent(
+      const { id: ticketId, alreadyExisted } = await createTicketIdempotent(
+        lineMessageIdempotencyOps,
         messageId,
         targetTenantId,
         {
@@ -511,7 +462,7 @@ export async function POST(req: Request) {
   }
 
   // LINE サーバーはレスポンスを所定時間内に受信しないと再送するため、必ず 200 を返す。
-  // 冪等化 (メッセージ ID による重複排除) は createLineTicketIdempotent の Serializable
+  // 冪等化 (メッセージ ID による重複排除) は createTicketIdempotent の Serializable
   // トランザクションで、起票を伴う通常メッセージについて実施済み (連携コード分岐の既知の制約は
   // 上のコメント参照)。
   return NextResponse.json({ ticketIds }, { status: 200 });

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -28,8 +28,10 @@
 import { NextResponse } from 'next/server';
 // 署名検証に使う HMAC ユーティリティ (Node ランタイム前提)
 import { createHmac, timingSafeEqual } from 'node:crypto';
-// データ層の Composition Root (テナント / ユーザー / チケットのリポジトリ束)
-import { repos } from '@/data';
+// データ層の Composition Root (テナント / ユーザー / チケットのリポジトリ束 + トランザクション境界)
+import { repos, uow } from '@/data';
+// チケット作成の入力型 (冪等起票ヘルパーの引数に使う)
+import type { CreateTicketInput } from '@/data/ports/ticket-repository';
 // 新規起票時の初期ステータスを mode から決める共通ルール (Web フォーム起票と単一の源を共有)
 import { initialStatusForMode } from '@/domain/ticket-status';
 // 公開エンドポイントの流量制限 (§9: DoS / リソース枯渇防止)
@@ -119,6 +121,59 @@ function verifyLineSignature(rawBody: string, signature: string, channelSecret: 
   if (a.length !== b.length) return false;
   // 同一長さなら定数時間比較して HMAC 一致を判定する
   return timingSafeEqual(a, b);
+}
+
+// LINE メッセージ ID の冪等性を保ったままチケットを起票する。
+//
+// なぜ必要か: LINE は Webhook 応答が遅延/未受信だと同一メッセージを 5 分以内に再送する
+// (at-least-once)。以前の実装は「対応表を SELECT → 無ければ起票 → 対応表へ INSERT」を
+// 別々の呼び出しで行っており、同一メッセージの再送が完全に同時 (両方の SELECT が先に
+// 走る) だと二重起票の窓が残っていた (TOCTOU)。
+// ここでは SELECT → 起票 → 対応表登録を 1 つの Serializable トランザクションにまとめる。
+// Serializable なら DB 側が競合を検知し、後勝ちのトランザクションを書き込み競合エラーで
+// 中断するため、両方が「未処理」を読み取ったまま起票してしまうことがなくなる。
+// 中断されたリクエストは (勝った方が確定させた) 対応表を読み直して重複として扱う。
+async function createLineTicketIdempotent(
+  messageId: string | null, // 冪等化キー。取れなかった場合は null (冪等化なしで単発起票)
+  tenantId: string,
+  ticketInput: CreateTicketInput,
+): Promise<{ id: string; alreadyExisted: boolean }> {
+  // メッセージ ID が取れないイベントは突き合わせようがないため、従来どおり単発で起票する
+  if (!messageId) {
+    const created = await repos.tickets.create(ticketInput);
+    return { id: created.id, alreadyExisted: false };
+  }
+
+  try {
+    return await uow.run(
+      async (tx) => {
+        // トランザクション内で再確認する (外側の事前チェックから開始までの間に、
+        // 別リクエストが処理を終えている可能性があるため)
+        const already = await tx.lineMessages.findTicketIdByMessageId(messageId, tenantId);
+        if (already) return { id: already, alreadyExisted: true };
+        // 起票してから対応表に登録する (同一トランザクション内なので原子的)
+        const created = await tx.tickets.create(ticketInput);
+        await tx.lineMessages.register({
+          lineMessageId: messageId,
+          ticketId: created.id,
+          tenantId,
+        });
+        return { id: created.id, alreadyExisted: false };
+      },
+      { isolationLevel: 'Serializable' },
+    );
+  } catch (err) {
+    // 書き込み競合 = 同時に処理された同一メッセージの別リクエストが先に確定したということ。
+    // 確定後の対応表を読み直せば、そちらが登録したチケット ID が見つかるはずなので重複扱いにする
+    if (uow.isTransactionConflict(err)) {
+      const winnerTicketId = await repos.lineMessages.findTicketIdByMessageId(messageId, tenantId);
+      if (winnerTicketId) {
+        return { id: winnerTicketId, alreadyExisted: true };
+      }
+    }
+    // 書き込み競合以外、または競合なのに対応表が見つからない (想定外) 場合はそのまま伝播する
+    throw err;
+  }
 }
 
 // POST /api/inbound/line : LINE Webhook を受信してチケットを作成する
@@ -286,23 +341,25 @@ export async function POST(req: Request) {
     const trimmedText = textMessage.text.trim();
     if (!trimmedText) continue;
 
-    // 冪等化: このメッセージ ID を既に取り込み済みなら、再送とみなして起票し直さない。
+    // 冪等化キー (このメッセージが再送かどうかの突き合わせに使う)。
+    // id が欠落/非文字列 (想定外の応答) のときは突き合わせできないため null にする
+    const messageId = typeof textMessage.id === 'string' && textMessage.id ? textMessage.id : null;
+
+    // 冪等化の早期チェック (fast path): このメッセージ ID を既に取り込み済みなら、
+    // 連携コード判定や起票者解決などの以降の処理を行わずに次のイベントへ進む。
     // LINE は Webhook 応答が遅延/未受信だと同一メッセージを 5 分以内に再送する (at-least-once)。
-    // id が欠落/非文字列 (想定外の応答) のときは突き合わせできないため、通常どおり起票へ進む。
-    // 既知の制約: この確認とチケット作成/register はトランザクションで結ばれていないため、
-    // 理論上は完全に同時 (SELECT が両方とも先に走る) だと二重起票の窓が残る。EmailThreadRepository
-    // (メール取り込み) も同じ read-then-write 方式を採用しており、実運用上は再送が「応答タイムアウト後」
-    // にしか起きないため窓は極めて狭い。同水準のリスク許容として本 PR ではこの制約を踏襲する。
-    if (typeof textMessage.id === 'string' && textMessage.id) {
+    // これは事前チェックに過ぎず、実際の二重起票防止は createLineTicketIdempotent 内の
+    // Serializable トランザクションが保証する (このチェック単体では TOCTOU の窓が残るため)。
+    if (messageId) {
       const existingTicketId = await repos.lineMessages.findTicketIdByMessageId(
-        textMessage.id,
+        messageId,
         targetTenantId,
       );
       if (existingTicketId) {
         // 既知のメッセージ ID: 二重起票を避けて既存チケット ID を記録し、次のイベントへ進む
         ticketIds.push(existingTicketId);
         console.info(
-          `[POST /api/inbound/line] duplicate message id, skipping re-create: ${textMessage.id}`,
+          `[POST /api/inbound/line] duplicate message id, skipping re-create: ${messageId}`,
         );
         continue;
       }
@@ -366,41 +423,32 @@ export async function POST(req: Request) {
     // 新規チケットを起票する (Web フォーム・メール取り込みと同じ PORT 経由)。
     // 1 件の起票失敗で全体を 500 にすると LINE がバッチ全体を再送し、既に起票済みのチケットが
     // 重複する。そのため起票は個別に try/catch で囲み、失敗は文脈付きでログに残して次のイベントへ
-    // 進み、最後は必ず 200 を返す (再送そのものはメッセージ ID の冪等化 [上の findTicketIdByMessageId]
-    // が二重起票を防ぐ)。
+    // 進み、最後は必ず 200 を返す (再送そのものは createLineTicketIdempotent の Serializable
+    // トランザクションが二重起票を防ぐ)。
     try {
-      const ticket = await repos.tickets.create({
-        title, // LINE メッセージから生成したタイトル
-        body: ticketBody, // LINE ユーザー ID + 全文
-        priority: 'Medium', // LINE 取り込みは優先度 Medium 固定 (他チャネルと揃える)
-        categoryId: null, // カテゴリは未分類 (担当者が後で設定)
-        creatorId, // 紐付け済みなら本人、未紐付けならプロキシ担当者 (上で解決済み)
-        tenantId: targetTenantId, // 取り込み先テナント
-        status: initialStatus, // Lite は 'Open'、Pro は DB 既定 'New'
-        resolutionDueAt, // 優先度 Medium ベースの解決期限
-      });
+      // 起票 (+ メッセージ ID 登録) を 1 トランザクションで原子的に行う。
+      // alreadyExisted が true のときは、書き込み競合で中断された後の再確認で「他リクエストが
+      // 既に起票済み」と判明したケース (通知は既にそちらのリクエストで送られているはず)
+      const { id: ticketId, alreadyExisted } = await createLineTicketIdempotent(
+        messageId,
+        targetTenantId,
+        {
+          title, // LINE メッセージから生成したタイトル
+          body: ticketBody, // LINE ユーザー ID + 全文
+          priority: 'Medium', // LINE 取り込みは優先度 Medium 固定 (他チャネルと揃える)
+          categoryId: null, // カテゴリは未分類 (担当者が後で設定)
+          creatorId, // 紐付け済みなら本人、未紐付けならプロキシ担当者 (上で解決済み)
+          tenantId: targetTenantId, // 取り込み先テナント
+          status: initialStatus, // Lite は 'Open'、Pro は DB 既定 'New'
+          resolutionDueAt, // 優先度 Medium ベースの解決期限
+        },
+      );
       // 起票したチケット ID を記録する
-      ticketIds.push(ticket.id);
-      // メッセージ ID → チケット の対応を記録する (次にこのメッセージが再送されたときの冪等化用)。
-      // id が無い場合は上の判定で既にスキップされているためここでは常に文字列のはずだが、
-      // 型ガードとして再度確認してから登録する (欠落時は将来課題どおり再送保護なしで進む)。
-      // チケット起票は既に確定しているため、この登録の失敗で起票全体を失敗扱い (外側の catch) に
-      // しない: 外側の catch に落ちると後段の通知処理までスキップされ、ログも「起票失敗」に
-      // 誤帰属してしまう (§9 fail-safe)。失敗時は次回再送時の冪等化が効かなくなるだけなのでログのみ残す。
-      if (typeof textMessage.id === 'string' && textMessage.id) {
-        try {
-          await repos.lineMessages.register({
-            lineMessageId: textMessage.id,
-            ticketId: ticket.id,
-            tenantId: targetTenantId,
-          });
-        } catch (registerErr) {
-          console.warn(
-            '[POST /api/inbound/line] failed to register message id for idempotency',
-            ticket.id,
-            registerErr,
-          );
-        }
+      ticketIds.push(ticketId);
+      if (alreadyExisted) {
+        // 既に他リクエストが起票・通知済みのため、ここでは何もせず次のイベントへ進む
+        console.info(`[POST /api/inbound/line] resolved write conflict as duplicate: ${messageId}`);
+        continue;
       }
       // 起票成功後に担当者全員へ「新しい問い合わせが届きました」通知を送る (ベストエフォート)。
       // 失敗してもチケット起票自体は確定済みのため、ログを残して次のイベントへ進む (§9 fail-safe)。
@@ -417,7 +465,7 @@ export async function POST(req: Request) {
                 userId: a.id, // 通知受信者: 各担当者
                 type: 'imported', // LINE からの取り込みによる新規起票通知 (inbound チャネルは 'imported' を使う)
                 message: `LINE から新しい問い合わせが届きました：${title}`, // 通知文言
-                ticketId: ticket.id, // 紐付けチケット
+                ticketId, // 紐付けチケット
                 tenantId: targetTenantId, // テナントスコープ
               }),
             ),
@@ -431,7 +479,7 @@ export async function POST(req: Request) {
             // 失敗件数だけログに残す
             console.warn(
               `[POST /api/inbound/line] ${failedCount} notification(s) failed to create for ticket`,
-              ticket.id,
+              ticketId,
             );
           }
           // 未読カウントを SSE で即時配信して通知ベルに反映させる (成功分のみ)
@@ -452,7 +500,7 @@ export async function POST(req: Request) {
         // 通知失敗はログのみ (チケット起票は完了しているため応答は成功扱いのまま)
         console.warn(
           '[POST /api/inbound/line] failed to notify agents for ticket',
-          ticket.id,
+          ticketId,
           notifyErr,
         );
       }
@@ -463,7 +511,8 @@ export async function POST(req: Request) {
   }
 
   // LINE サーバーはレスポンスを所定時間内に受信しないと再送するため、必ず 200 を返す。
-  // 冪等化 (メッセージ ID による重複排除) は上の findTicketIdByMessageId / register で、
-  // 起票を伴う通常メッセージについて実施済み (連携コード分岐の既知の制約は上のコメント参照)。
+  // 冪等化 (メッセージ ID による重複排除) は createLineTicketIdempotent の Serializable
+  // トランザクションで、起票を伴う通常メッセージについて実施済み (連携コード分岐の既知の制約は
+  // 上のコメント参照)。
   return NextResponse.json({ ticketIds }, { status: 200 });
 }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -24,8 +24,8 @@ import { getStripeClient, getStripeWebhookSecret, stripeStatusToPlan } from '@/l
 import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
 // Pro モード (7 ステータス・SLA・エスカレーション等) がそのプランで許可されるかの判定
 import { isProModeAllowed } from '@/lib/plan-guard';
-// テナントのモード / 課金プランの型
-import type { SubscriptionPlan, TenantMode } from '@/domain/types';
+// 課金プランの型
+import type { SubscriptionPlan } from '@/domain/types';
 
 // Stripe Webhook が送ってくる主要イベント種別の定数 (typo 防止のため文字列リテラルを定数化)
 const STRIPE_EVENT_SUBSCRIPTION_CREATED = 'customer.subscription.created';
@@ -130,9 +130,12 @@ async function handleStripeEvent(event: Stripe.Event): Promise<void> {
 // Pro 専用機能がプラン変更後も使い続けられてしまう (§9 認可はサーバー側で強制)。
 // updateStripeSubscription (プラン反映) と updateMode (Pro モード強制解除) を
 // 1 つのトランザクションにまとめ、片方だけ反映される中間状態が残らないようにする。
+//
+// mode の読み取りは呼び出し元からではなく、トランザクション内で tx.tenants.findById により
+// 都度読み直す (呼び出し元の existingTenant はトランザクション開始前に取得したスナップショットで、
+// その後に届いた別の Stripe イベントや管理者操作で mode が変わっていても反映されない古い値になり得るため)。
 async function applyPlanChange(
   tenantId: string,
-  currentMode: TenantMode,
   stripeFields: {
     stripeCustomerId: string;
     stripeSubscriptionId: string;
@@ -140,11 +143,16 @@ async function applyPlanChange(
     subscriptionPlan: SubscriptionPlan;
   },
 ): Promise<void> {
-  // 現在 Pro モードで運用中かつ、新プランが Pro モードを許可しないときだけモードを戻す
-  const shouldResetMode = currentMode === 'pro' && !isProModeAllowed(stripeFields.subscriptionPlan);
   await uow.run(async (tx) => {
+    // トランザクション内で最新のテナント状態を読み直す (呼び出し元のスナップショットに頼らない)
+    const tenant = await tx.tenants.findById(tenantId);
+    // 呼び出し元で存在確認済みだが、念のためここでも安全側 (何もしない) に倒す
+    if (!tenant) return;
     // Stripe 連携情報とプランを反映する
     await tx.tenants.updateStripeSubscription(tenantId, stripeFields);
+    // 現在 Pro モードで運用中かつ、新プランが Pro モードを許可しないときだけモードを戻す
+    const shouldResetMode =
+      tenant.mode === 'pro' && !isProModeAllowed(stripeFields.subscriptionPlan);
     if (shouldResetMode) {
       // Pro 専用機能を使えなくする (Lite モードへ強制的に戻す)
       await tx.tenants.updateMode(tenantId, 'lite');
@@ -203,7 +211,7 @@ async function handleSubscriptionUpsert(
   const nextPlan = existingTenant.subscriptionPlan === 'enterprise' ? 'enterprise' : plan;
 
   // テナントのサブスク情報を更新する (ダウングレードなら Pro モードも同時に強制解除する)
-  await applyPlanChange(tenantId, existingTenant.mode, {
+  await applyPlanChange(tenantId, {
     stripeCustomerId: customerId,
     stripeSubscriptionId: subscriptionId,
     stripeSubscriptionStatus: status,
@@ -247,7 +255,7 @@ async function handleSubscriptionDeleted(
 
   // サブスクリプション削除後は (Enterprise を除き) free に降格し、canceled 状態を記録する
   // (free は Pro モード対象外なので Pro モードも同時に強制解除される)
-  await applyPlanChange(tenantId, existingTenant.mode, {
+  await applyPlanChange(tenantId, {
     stripeCustomerId: customerId,
     stripeSubscriptionId: subscriptionId,
     stripeSubscriptionStatus: 'canceled', // Stripe の deleted イベントは canceled 扱いにする

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -16,12 +16,16 @@
 import { NextResponse } from 'next/server';
 // Stripe SDK の型定義 (Event 型を handleStripeEvent の引数に使う)
 import type Stripe from 'stripe';
-// データリポジトリ (テナント更新用)
-import { repos } from '@/data';
+// データリポジトリ (テナント更新用) + トランザクション境界
+import { repos, uow } from '@/data';
 // Stripe クライアントと設定ヘルパー
 import { getStripeClient, getStripeWebhookSecret, stripeStatusToPlan } from '@/lib/stripe';
 // レート制限 (署名検証の前に粗すぎる連打を弾いてサーバー負荷を抑える)
 import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
+// Pro モード (7 ステータス・SLA・エスカレーション等) がそのプランで許可されるかの判定
+import { isProModeAllowed } from '@/lib/plan-guard';
+// テナントのモード / 課金プランの型
+import type { SubscriptionPlan, TenantMode } from '@/domain/types';
 
 // Stripe Webhook が送ってくる主要イベント種別の定数 (typo 防止のため文字列リテラルを定数化)
 const STRIPE_EVENT_SUBSCRIPTION_CREATED = 'customer.subscription.created';
@@ -60,7 +64,10 @@ export async function POST(request: Request): Promise<NextResponse> {
     rawBody = await request.text();
   } catch {
     // ボディ読み取り失敗は 400 で返す (ボディが壊れている場合)
-    return NextResponse.json({ error: 'リクエストボディの読み取りに失敗しました' }, { status: 400 });
+    return NextResponse.json(
+      { error: 'リクエストボディの読み取りに失敗しました' },
+      { status: 400 },
+    );
   }
 
   // Stripe クライアントと Webhook Secret を取得する
@@ -102,10 +109,7 @@ async function handleStripeEvent(event: Stripe.Event): Promise<void> {
   const obj = event.data.object as unknown as Record<string, unknown>;
 
   // サブスクリプション作成・更新イベント: プランと状態を更新する
-  if (
-    type === STRIPE_EVENT_SUBSCRIPTION_CREATED ||
-    type === STRIPE_EVENT_SUBSCRIPTION_UPDATED
-  ) {
+  if (type === STRIPE_EVENT_SUBSCRIPTION_CREATED || type === STRIPE_EVENT_SUBSCRIPTION_UPDATED) {
     await handleSubscriptionUpsert(obj);
     return;
   }
@@ -119,14 +123,47 @@ async function handleStripeEvent(event: Stripe.Event): Promise<void> {
   // 未対応のイベントは無視する (200 を返すことで Stripe が再送しないようにする)
 }
 
+// Stripe 由来のプラン変更をテナントへ適用する共通ヘルパー。
+//
+// なぜ必要か: 新プランが Pro モードを許可しなくなった (ダウングレード/解約) 場合、
+// tenant.mode がそれまでの 'pro' のまま残ると、エスカレーションや 7 ステータスワークフローなど
+// Pro 専用機能がプラン変更後も使い続けられてしまう (§9 認可はサーバー側で強制)。
+// updateStripeSubscription (プラン反映) と updateMode (Pro モード強制解除) を
+// 1 つのトランザクションにまとめ、片方だけ反映される中間状態が残らないようにする。
+async function applyPlanChange(
+  tenantId: string,
+  currentMode: TenantMode,
+  stripeFields: {
+    stripeCustomerId: string;
+    stripeSubscriptionId: string;
+    stripeSubscriptionStatus: string;
+    subscriptionPlan: SubscriptionPlan;
+  },
+): Promise<void> {
+  // 現在 Pro モードで運用中かつ、新プランが Pro モードを許可しないときだけモードを戻す
+  const shouldResetMode = currentMode === 'pro' && !isProModeAllowed(stripeFields.subscriptionPlan);
+  await uow.run(async (tx) => {
+    // Stripe 連携情報とプランを反映する
+    await tx.tenants.updateStripeSubscription(tenantId, stripeFields);
+    if (shouldResetMode) {
+      // Pro 専用機能を使えなくする (Lite モードへ強制的に戻す)
+      await tx.tenants.updateMode(tenantId, 'lite');
+    }
+  });
+}
+
 // サブスクリプション作成・更新を処理する: テナントのプランと状態を最新に保つ
-async function handleSubscriptionUpsert(subscriptionObject: Record<string, unknown>): Promise<void> {
+async function handleSubscriptionUpsert(
+  subscriptionObject: Record<string, unknown>,
+): Promise<void> {
   // Stripe のサブスクリプションオブジェクトから必要なフィールドを取り出す
   const subscriptionId = subscriptionObject['id'] as string | undefined;
   const customerId = subscriptionObject['customer'] as string | undefined;
   const status = subscriptionObject['status'] as string | undefined;
   // items.data[0].price.id で Price ID を取得する (最初のアイテムのみ使用)
-  const items = subscriptionObject['items'] as { data?: Array<{ price?: { id?: string } }> } | undefined;
+  const items = subscriptionObject['items'] as
+    | { data?: Array<{ price?: { id?: string } }> }
+    | undefined;
   const priceId = items?.data?.[0]?.price?.id ?? '';
   // メタデータから tenantId を取得する (チェックアウト時に metadata.tenantId として設定する)
   const metadata = subscriptionObject['metadata'] as Record<string, string> | undefined;
@@ -134,10 +171,12 @@ async function handleSubscriptionUpsert(subscriptionObject: Record<string, unkno
 
   // 必須フィールドが揃っていない場合はスキップ (不完全なデータで更新しない)
   if (!subscriptionId || !customerId || !status || !tenantId) {
-    console.warn(
-      '[stripe-webhook] サブスクリプションに必須フィールドが不足しています:',
-      { subscriptionId, customerId, status, tenantId },
-    );
+    console.warn('[stripe-webhook] サブスクリプションに必須フィールドが不足しています:', {
+      subscriptionId,
+      customerId,
+      status,
+      tenantId,
+    });
     return;
   }
 
@@ -151,7 +190,10 @@ async function handleSubscriptionUpsert(subscriptionObject: Record<string, unkno
   const existingTenant = await repos.tenants.findById(tenantId);
   if (!existingTenant) {
     // 存在しない tenantId の場合はスキップして処理を止める (Stripe は 200 を受け取り再送しない)
-    console.warn('[stripe-webhook] メタデータの tenantId に対応するテナントが見つかりません:', tenantId);
+    console.warn(
+      '[stripe-webhook] メタデータの tenantId に対応するテナントが見つかりません:',
+      tenantId,
+    );
     return;
   }
 
@@ -160,8 +202,8 @@ async function handleSubscriptionUpsert(subscriptionObject: Record<string, unkno
   // Stripe 連携情報 (customer/subscription/status) は最新化しつつ、プランは enterprise を維持する。
   const nextPlan = existingTenant.subscriptionPlan === 'enterprise' ? 'enterprise' : plan;
 
-  // テナントのサブスク情報を更新する
-  await repos.tenants.updateStripeSubscription(tenantId, {
+  // テナントのサブスク情報を更新する (ダウングレードなら Pro モードも同時に強制解除する)
+  await applyPlanChange(tenantId, existingTenant.mode, {
     stripeCustomerId: customerId,
     stripeSubscriptionId: subscriptionId,
     stripeSubscriptionStatus: status,
@@ -170,7 +212,9 @@ async function handleSubscriptionUpsert(subscriptionObject: Record<string, unkno
 }
 
 // サブスクリプション削除を処理する: free プランに降格してキャンセル状態を記録する
-async function handleSubscriptionDeleted(subscriptionObject: Record<string, unknown>): Promise<void> {
+async function handleSubscriptionDeleted(
+  subscriptionObject: Record<string, unknown>,
+): Promise<void> {
   // サブスクリプション ID と status を取得する
   const subscriptionId = subscriptionObject['id'] as string | undefined;
   const customerId = subscriptionObject['customer'] as string | undefined;
@@ -180,17 +224,21 @@ async function handleSubscriptionDeleted(subscriptionObject: Record<string, unkn
 
   // 必須フィールドが揃っていない場合はスキップ (customerId も含めて確認)
   if (!subscriptionId || !customerId || !tenantId) {
-    console.warn(
-      '[stripe-webhook] 削除イベントに必須フィールドが不足しています:',
-      { subscriptionId, customerId, tenantId },
-    );
+    console.warn('[stripe-webhook] 削除イベントに必須フィールドが不足しています:', {
+      subscriptionId,
+      customerId,
+      tenantId,
+    });
     return;
   }
 
   // upsert と同様にテナント実在チェックを行い、不正な tenantId による操作を防ぐ
   const existingTenant = await repos.tenants.findById(tenantId);
   if (!existingTenant) {
-    console.warn('[stripe-webhook] 削除イベントの tenantId に対応するテナントが見つかりません:', tenantId);
+    console.warn(
+      '[stripe-webhook] 削除イベントの tenantId に対応するテナントが見つかりません:',
+      tenantId,
+    );
     return;
   }
 
@@ -198,7 +246,8 @@ async function handleSubscriptionDeleted(subscriptionObject: Record<string, unkn
   const nextPlan = existingTenant.subscriptionPlan === 'enterprise' ? 'enterprise' : 'free';
 
   // サブスクリプション削除後は (Enterprise を除き) free に降格し、canceled 状態を記録する
-  await repos.tenants.updateStripeSubscription(tenantId, {
+  // (free は Pro モード対象外なので Pro モードも同時に強制解除される)
+  await applyPlanChange(tenantId, existingTenant.mode, {
     stripeCustomerId: customerId,
     stripeSubscriptionId: subscriptionId,
     stripeSubscriptionStatus: 'canceled', // Stripe の deleted イベントは canceled 扱いにする

--- a/src/data/adapters/memory/index.ts
+++ b/src/data/adapters/memory/index.ts
@@ -51,6 +51,8 @@ export function buildMemoryRepos(store: Store): Repos {
 // メモリ版 UnitOfWork。スナップショットを取り、例外時に巻き戻す擬似トランザクション
 export function buildMemoryUow(store: Store): UnitOfWork {
   return {
+    // isolationLevel はメモリ実装では意味を持たない (Node は単一スレッドで、
+    // run() 呼び出しの間に他の run() が割り込んで同じキーを読み書きすることは無いため無視する)
     async run(fn) {
       const snapshot = cloneStore(store); // トランザクション開始時点のスナップショット
       try {
@@ -62,6 +64,10 @@ export function buildMemoryUow(store: Store): UnitOfWork {
         // エラーは呼び出し元に再 throw
         throw error;
       }
+    },
+    // メモリ実装は真の同時実行を扱わないため、書き込み競合エラーは起こり得ない
+    isTransactionConflict() {
+      return false;
     },
   };
 }

--- a/src/data/adapters/prisma/index.ts
+++ b/src/data/adapters/prisma/index.ts
@@ -1,5 +1,5 @@
-// Prisma クライアント型と、リポジトリ束/UnitOfWork の契約型をインポート
-import type { PrismaClient } from '@/generated/prisma';
+// Prisma クライアント型 (トランザクション分離レベルの定数値は実行時に使うため型 import にしない)
+import { Prisma, type PrismaClient } from '@/generated/prisma';
 import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
 // 各エンティティ用の Prisma リポジトリ生成関数を取り込む
 import { makeAttachmentRepo } from './attachment-repository.prisma';
@@ -45,13 +45,32 @@ export function buildPrismaRepos(db: PrismaLike): Repos {
   };
 }
 
+// Serializable 分離レベルで書き込み競合を検知したときに Prisma が投げるエラーコード。
+// ("Transaction failed due to a write conflict or a deadlock. Please retry your transaction.")
+const SERIALIZATION_FAILURE_CODE = 'P2034';
+
 // Prisma の $transaction を用いた UnitOfWork 実装を生成する関数
 export function buildPrismaUow(client: PrismaClient): UnitOfWork {
   return {
     // run に渡した関数をトランザクション内で実行する
-    async run(fn) {
-      // Prisma のトランザクションを開始し、tx クライアント用の Repos を渡して実行
-      return client.$transaction(async (tx) => fn(buildPrismaRepos(tx)));
+    async run(fn, options) {
+      // Prisma のトランザクションを開始し、tx クライアント用の Repos を渡して実行。
+      // isolationLevel は options で明示されたときだけ指定し、それ以外は DB の既定に委ねる
+      return client.$transaction(async (tx) => fn(buildPrismaRepos(tx)), {
+        isolationLevel:
+          options?.isolationLevel === 'Serializable'
+            ? Prisma.TransactionIsolationLevel.Serializable
+            : undefined,
+      });
+    },
+    // Prisma 固有のエラーコードで書き込み競合を判定する (呼び出し側に Prisma の型を持ち込ませない)
+    isTransactionConflict(err) {
+      return (
+        typeof err === 'object' &&
+        err !== null &&
+        'code' in err &&
+        (err as { code?: unknown }).code === SERIALIZATION_FAILURE_CODE
+      );
     },
   };
 }

--- a/src/data/ports/unit-of-work.ts
+++ b/src/data/ports/unit-of-work.ts
@@ -34,8 +34,24 @@ export interface Repos {
   ssoConfigs: SsoConfigRepository; // Phase 4 Enterprise: テナント単位の SAML SSO 設定
 }
 
+// run() のオプション
+export interface RunOptions {
+  // 分離レベル。既定 (未指定) は DB の既定 (PostgreSQL は Read Committed)。
+  // 「既存レコードが無ければ作る」形の冪等化 (Webhook 再送チェック) のように、
+  // 同一キーに対する 2 トランザクションが競合し得る処理では 'Serializable' を指定する。
+  // Read Committed では両トランザクションが「無い」という読み取りを通過してしまい
+  // 二重作成につながるが、Serializable なら DB 側が競合を検知し、後勝ちのトランザクションを
+  // 書き込み競合エラーで中断する (呼び出し側が catch して重複扱いにリトライする前提)。
+  isolationLevel?: 'Serializable';
+}
+
 // トランザクション境界を表す契約 (Unit of Work パターン)
 // run に渡した関数内ではトランザクション対応の Repos が使える
 export interface UnitOfWork {
-  run<T>(fn: (txRepos: Repos) => Promise<T>): Promise<T>;
+  run<T>(fn: (txRepos: Repos) => Promise<T>, options?: RunOptions): Promise<T>;
+
+  // isolationLevel: 'Serializable' で実行した run() が、書き込み競合で中断された
+  // ときの例外かどうかを判定する。DB 固有のエラー形状 (Prisma のエラーコード等) を
+  // 呼び出し側 (Server Action / Route Handler) に漏らさないための判定ヘルパー。
+  isTransactionConflict(err: unknown): boolean;
 }

--- a/src/lib/idempotent-ticket-creation.ts
+++ b/src/lib/idempotent-ticket-creation.ts
@@ -1,0 +1,86 @@
+// Webhook (LINE / メール取り込み) の再送 (at-least-once) に対して冪等にチケットを起票する
+// 共通ヘルパー。LINE (lineMessages) とメール (emailThreads) は対応表の Port 形状が
+// 微妙に異なる (findTicketIdByMessageId は単数キー、findTicketIdByMessageIds は配列キー、
+// register のフィールド名も lineMessageId / messageId で異なる) ため、その差異だけを
+// IdempotencyOps で吸収し、冪等化の本体ロジックは 1 か所にまとめる。
+//
+// なぜ冪等化が必要か: Webhook プロバイダは応答が遅延/未受信だと同一メッセージ/メールを
+// 再送する (at-least-once)。「対応表を SELECT → 無ければ起票 → 対応表へ INSERT」を
+// 別々の呼び出しで行うと、再送が完全に同時に届いた場合、両方が「未処理」を読み取った
+// まま起票してしまい二重起票の窓 (TOCTOU) が生まれる。
+// ここでは SELECT → 起票 → 対応表登録を 1 つの Serializable トランザクションにまとめる。
+// Serializable なら DB 側が競合を検知し、後勝ちのトランザクションを書き込み競合エラーで
+// 中断するため、両方が「未処理」を読み取ったまま起票してしまうことがなくなる。
+// 中断されたリクエストは (勝った方が確定させた) 対応表を読み直して重複として扱う。
+
+// データ層の Composition Root (非トランザクション用の repos と、トランザクション境界の uow)
+import { repos, uow } from '@/data';
+// リポジトリ束の型 (トランザクション内の tx / 非トランザクションの repos 共通の型)
+import type { Repos } from '@/data/ports/unit-of-work';
+// チケット作成の入力型
+import type { CreateTicketInput } from '@/data/ports/ticket-repository';
+
+// チャネル (LINE / メール) ごとの対応表操作を抽象化した契約。
+// tx は「トランザクション内の repos」または (競合後の再確認時は) 「通常の repos」のどちらも渡せる
+// (どちらも Repos 型を満たすため呼び出し側で区別なく使える)。
+export interface IdempotencyOps {
+  // 冪等キーからチケット ID を逆引きする。未処理なら null
+  findExisting(tx: Repos, key: string, tenantId: string): Promise<string | null>;
+  // 冪等キーとチケットの対応を対応表へ登録する
+  register(tx: Repos, key: string, ticketId: string, tenantId: string): Promise<void>;
+}
+
+// 冪等性を保ったままチケットを起票する。
+export async function createTicketIdempotent(
+  ops: IdempotencyOps, // チャネル固有の対応表操作 (LINE/メールで異なる Port 呼び分け)
+  key: string | null, // 冪等化キー。取れなかった場合は null (冪等化なしで単発起票)
+  tenantId: string,
+  ticketInput: CreateTicketInput,
+): Promise<{ id: string; alreadyExisted: boolean }> {
+  // キーが取れないイベント/メールは突き合わせようがないため、従来どおり単発で起票する
+  if (!key) {
+    const created = await repos.tickets.create(ticketInput);
+    return { id: created.id, alreadyExisted: false };
+  }
+
+  try {
+    return await uow.run(
+      async (tx) => {
+        // トランザクション内で再確認する (外側の事前チェックから開始までの間に、
+        // 別リクエストが処理を終えている可能性があるため)
+        const already = await ops.findExisting(tx, key, tenantId);
+        if (already) return { id: already, alreadyExisted: true };
+        // 起票してから対応表に登録する (同一トランザクション内なので原子的)
+        const created = await tx.tickets.create(ticketInput);
+        await ops.register(tx, key, created.id, tenantId);
+        return { id: created.id, alreadyExisted: false };
+      },
+      { isolationLevel: 'Serializable' },
+    );
+  } catch (err) {
+    // 書き込み競合 = 同時に処理された同一メッセージ/メールの別リクエストが先に確定したということ。
+    // 確定後の対応表を読み直せば、そちらが登録したチケット ID が見つかるはずなので重複扱いにする
+    if (uow.isTransactionConflict(err)) {
+      const winnerTicketId = await ops.findExisting(repos, key, tenantId);
+      if (winnerTicketId) {
+        return { id: winnerTicketId, alreadyExisted: true };
+      }
+    }
+    // 書き込み競合以外、または競合なのに対応表が見つからない (想定外) 場合はそのまま伝播する
+    throw err;
+  }
+}
+
+// LINE メッセージ ID を冪等キーとする実装 (src/app/api/inbound/line/route.ts で使用)
+export const lineMessageIdempotencyOps: IdempotencyOps = {
+  findExisting: (tx, key, tenantId) => tx.lineMessages.findTicketIdByMessageId(key, tenantId),
+  register: (tx, key, ticketId, tenantId) =>
+    tx.lineMessages.register({ lineMessageId: key, ticketId, tenantId }),
+};
+
+// メール Message-ID を冪等キーとする実装 (src/app/api/inbound/email/route.ts で使用)
+export const emailMessageIdempotencyOps: IdempotencyOps = {
+  findExisting: (tx, key, tenantId) => tx.emailThreads.findTicketIdByMessageIds([key], tenantId),
+  register: (tx, key, ticketId, tenantId) =>
+    tx.emailThreads.register({ messageId: key, ticketId, tenantId }),
+};

--- a/src/lib/ssrf-guard.ts
+++ b/src/lib/ssrf-guard.ts
@@ -3,6 +3,13 @@
 // 内部ネットワーク・ループバック・クラウドメタデータへ誤って送信しないよう検証する。
 // CLAUDE.md §9「サーバー側の外向きリクエストを検証する（SSRF 対策）」準拠。
 
+// DNS 解決を行い、接続直前に解決済み IP を検証する Dispatcher を作るために使う
+import dns from 'node:dns';
+// dns.lookup のオプション/コールバック型 (net.LookupFunction と同じ形に合わせるため)
+import type { LookupAddress, LookupOptions } from 'node:dns';
+// undici の Agent (Dispatcher) — Node 標準 fetch に接続先解決ロジックを差し込むために使う
+import { Agent } from 'undici';
+
 // プライベート / ループバック / リンクローカル / CGNAT のホスト名を判定する関数。
 // URL をパースした後の hostname 文字列 (IPv6 は "[...]" 括弧付き) を受け取る。
 // DNS 名には対応していない (DNS リバインディングは別レイヤで対処)。
@@ -71,3 +78,57 @@ export function isUnsafeUrl(rawUrl: string): boolean {
   // プライベートホストへのリクエストは拒否する
   return isPrivateHost(parsed.hostname);
 }
+
+// SSRF 対策済みの undici Dispatcher (Agent)。
+//
+// なぜこれが必要か: isUnsafeUrl によるホスト名文字列の検証は「保存時」と「送信直前」に
+// 行っているが、どちらも「検証した時点でそのホスト名が指す IP」までは見ていない。
+// 攻撃者 (悪意あるテナント管理者) が一度パブリック IP に解決されるドメインを Webhook URL
+// として登録して両チェックを通過させたあと、TTL の短い DNS レコードを内部 IP
+// (169.254.169.254 のクラウドメタデータ等) へ差し替える「DNS リバインディング」を行うと、
+// 実際に fetch() が接続する IP はチェック時とは別物になり得る (チェックと接続の間の
+// TOCTOU: Time-Of-Check-Time-Of-Use の空白)。
+//
+// この Dispatcher は実際に TCP 接続する直前、DNS で解決した「その IP」を検証すること
+// で、チェックと接続を同一タイミングにし、上記の空白を無くす。
+//
+// Agent のコンストラクタに直接クロージャを書かずここで名前付き関数として切り出しているのは、
+// ユニットテストから (実際に TCP 接続せず) dns.lookup をモックして直接呼び出せるようにするため。
+export const ssrfSafeLookup = (
+  hostname: string,
+  options: LookupOptions,
+  callback: (
+    err: NodeJS.ErrnoException | null,
+    address: string | LookupAddress[],
+    family?: number,
+  ) => void,
+): void => {
+  // 実際の名前解決は Node 標準の dns.lookup に委譲する。呼び出し元 (undici) が
+  // 何を指定してきても、複数解決先をまとめて検証したいため常に all: true で解決する
+  dns.lookup(hostname, { family: options.family, all: true }, (err, addresses) => {
+    if (err) {
+      // DNS解決自体が失敗した場合はそのままエラーとして伝播する
+      callback(err, []);
+      return;
+    }
+    // 解決された IP のうち 1 つでも内部/ループバック/リンクローカルなら、
+    // DNS ラウンドロビンや rebind 経由の迂回を防ぐため一括で接続を拒否する (fail-closed)
+    const unsafe = addresses.find((entry) => isPrivateHost(entry.address));
+    if (unsafe) {
+      callback(
+        new Error(`SSRFガード: 解決先アドレス ${unsafe.address} への接続は許可されません`),
+        [],
+      );
+      return;
+    }
+    // 検証済みなので、実際に接続する IP としてそのまま返す
+    callback(null, addresses);
+  });
+};
+
+// SSRF 対策済みの undici Dispatcher (Agent)。
+// モジュール読み込み時に一度だけ生成し、コネクションプールとして使い回す
+// (リクエストごとに new Agent() すると毎回別プールになり非効率なため)。
+export const ssrfSafeDispatcher = new Agent({
+  connect: { lookup: ssrfSafeLookup },
+});

--- a/src/lib/ssrf-guard.ts
+++ b/src/lib/ssrf-guard.ts
@@ -103,26 +103,33 @@ export const ssrfSafeLookup = (
     family?: number,
   ) => void,
 ): void => {
-  // 実際の名前解決は Node 標準の dns.lookup に委譲する。呼び出し元 (undici) が
-  // 何を指定してきても、複数解決先をまとめて検証したいため常に all: true で解決する
-  dns.lookup(hostname, { family: options.family, all: true }, (err, addresses) => {
+  // 実際の名前解決は Node 標準の dns.lookup に委譲する。呼び出し元が要求した形式
+  // (options.all の有無で単一アドレス / 配列のどちらを返すか) をそのまま尊重して渡す。
+  // ここで独自に all: true を強制すると、呼び出し元が単一アドレス形式を期待している
+  // 場合に形が食い違い、接続処理側で予期しない不具合につながる恐れがあるため避ける。
+  dns.lookup(hostname, options, (err, address, family) => {
     if (err) {
       // DNS解決自体が失敗した場合はそのままエラーとして伝播する
-      callback(err, []);
+      callback(err, address, family);
       return;
     }
+    // 単一アドレス / 配列のどちらの形で返ってきても、検証は配列に正規化してまとめて行う
+    const resolved: LookupAddress[] = Array.isArray(address)
+      ? address
+      : [{ address, family: family ?? 0 }];
     // 解決された IP のうち 1 つでも内部/ループバック/リンクローカルなら、
     // DNS ラウンドロビンや rebind 経由の迂回を防ぐため一括で接続を拒否する (fail-closed)
-    const unsafe = addresses.find((entry) => isPrivateHost(entry.address));
+    const unsafe = resolved.find((entry) => isPrivateHost(entry.address));
     if (unsafe) {
       callback(
         new Error(`SSRFガード: 解決先アドレス ${unsafe.address} への接続は許可されません`),
-        [],
+        address,
+        family,
       );
       return;
     }
-    // 検証済みなので、実際に接続する IP としてそのまま返す
-    callback(null, addresses);
+    // 検証済みなので、実際に接続する IP として (呼び出し元が要求した形式のまま) 返す
+    callback(null, address, family);
   });
 };
 

--- a/src/lib/webhook-fetch.ts
+++ b/src/lib/webhook-fetch.ts
@@ -9,6 +9,18 @@
 // パブリックホストが 30x で内部アドレス (169.254.169.254 / 10.0.0.0/8 等) へ誘導すると、
 // リダイレクト先は再検証されないまま追従されてしまう。Incoming Webhook は正常時に
 // リダイレクトを返さないため、リダイレクト応答は一律エラー扱いにしてこの抜け道を塞ぐ。
+//
+// なぜ標準の fetch ではなく undici の fetch + Dispatcher を使うか:
+// ホスト名文字列の検証だけでは「検証後に DNS レコードを内部 IP に差し替える」DNS
+// リバインディング攻撃を防げない (src/lib/ssrf-guard.ts の ssrfSafeDispatcher 参照)。
+// 実際に接続する IP を検証するには、DNS 解決を行う undici の Dispatcher レベルで
+// フックする必要があるため、ここでは undici の fetch を明示的に使う。
+
+// SSRF 対策済みの undici fetch (Dispatcher を差し込める版)。標準の fetch は Node 内部の
+// undici を使うがカスタム Dispatcher を渡せないため、ここでは undici を直接 import する
+import { fetch as undiciFetch } from 'undici';
+// 接続直前に解決済み IP を検証する Dispatcher (DNS リバインディング対策)
+import { ssrfSafeDispatcher } from '@/lib/ssrf-guard';
 
 // Webhook レスポンスの最大読み取りサイズ (バイト数)。
 // Slack は "ok" (2 バイト)、Teams は "1" 程度、Chatwork は JSON を返すがエラー確認用に 1KB で十分。
@@ -51,7 +63,7 @@ export async function postWebhook(
   options: WebhookPostOptions,
 ): Promise<WebhookPostResult> {
   // 実際の HTTP リクエストを送る
-  const response = await fetch(url, {
+  const response = await undiciFetch(url, {
     // 通知系はすべて POST
     method: 'POST',
     // 呼び出し側が指定したヘッダをそのまま使う
@@ -63,6 +75,8 @@ export async function postWebhook(
     redirect: 'manual',
     // 一定時間で打ち切る (相手側障害時のハングを防ぐ)
     signal: AbortSignal.timeout(options.timeoutMs),
+    // SSRF 対策: DNS 解決した実際の接続先 IP を検証する (DNS リバインディング対策)
+    dispatcher: ssrfSafeDispatcher,
   });
 
   // redirect: 'manual' のとき、リダイレクト応答は opaqueredirect (type='opaqueredirect',
@@ -79,13 +93,28 @@ export async function postWebhook(
   return { ok: response.ok, status: response.status, bodyText };
 }
 
+// undici の Response 型と lib.dom の Response 型は、それぞれの ReadableStream 型
+// (node:stream/web 版と lib.dom 版) が微妙に非互換で直接代入できないため、
+// readBodyCapped が実際に使うメンバーだけを持つ最小限の構造型で受け取る
+// (どちらの Response の body.getReader() もこの形を満たす)
+interface FetchLikeResponse {
+  body: {
+    getReader(): {
+      read(): Promise<{ done: boolean; value?: Uint8Array }>;
+      cancel(): Promise<void>;
+      releaseLock(): void;
+    };
+  } | null;
+  text(): Promise<string>;
+}
+
 // レスポンス本文を上限バイト数まで読み取り、超過分は読み込まずに打ち切る内部ヘルパー。
 // `response.text()` は本文全体をメモリに読み切ってから返すため、それに `.slice()` を後掛けする
 // だけでは「上限バイト数」が名目上の値になり、乗っ取られた/悪意ある Webhook 先が巨大な本文を
 // 送り続けた場合にサーバーのメモリを消費してしまう (§8 リソース解放 / §9 DoS 対策)。
 // ここでは response.body の ReadableStream を直接読み、上限に達した時点で reader.cancel() して
 // それ以降のバイト列を読まずに接続を閉じる。
-async function readBodyCapped(response: Response, maxBytes: number): Promise<string> {
+async function readBodyCapped(response: FetchLikeResponse, maxBytes: number): Promise<string> {
   // body ストリームを取得できない実行環境 (一部のテスト用モック等) では
   // 上限保護が効かなくなるが、素直に text() へフォールバックして機能を壊さない
   const body = response.body;

--- a/tests/data/chatwork-notifier.test.ts
+++ b/tests/data/chatwork-notifier.test.ts
@@ -7,6 +7,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // テスト対象: Chatwork 通知 Adapter のファクトリ
 import { createChatworkNotifier } from '@/data/adapters/chatwork/chatwork-notifier';
 
+// src/lib/webhook-fetch.ts は SSRF 対策の DNS 検証用 Dispatcher (Agent) を使うため
+// undici の fetch を直接 import している。vi.stubGlobal('fetch', ...) だけでは差し替わらない
+// ため、undici の fetch を globalThis.fetch (下の beforeEach で差し替える) へ委譲するモックにする
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: ((...args: Parameters<typeof globalThis.fetch>) =>
+      globalThis.fetch(...args)) as unknown as typeof actual.fetch,
+  };
+});
+
 // テスト用の API トークンとルーム ID
 const API_TOKEN = 'test-token-123';
 const ROOM_ID = '12345678';
@@ -78,6 +90,8 @@ describe('createChatworkNotifier', () => {
   it('HTTP エラー時は例外を投げる', async () => {
     fetchMock.mockResolvedValue(mockResponse(false, 401, 'Unauthorized'));
     const notifier = createChatworkNotifier(API_TOKEN, ROOM_ID);
-    await expect(notifier.send({ subject: 'x', body: 'y' })).rejects.toThrow(/Chatwork API 送信失敗/);
+    await expect(notifier.send({ subject: 'x', body: 'y' })).rejects.toThrow(
+      /Chatwork API 送信失敗/,
+    );
   });
 });

--- a/tests/data/email-thread-repository.contract.prisma.test.ts
+++ b/tests/data/email-thread-repository.contract.prisma.test.ts
@@ -7,8 +7,8 @@
 import { describe, beforeAll, afterAll, beforeEach, expect, it } from 'vitest';
 // Prisma クライアント本体 (生成物)
 import { PrismaClient } from '@/generated/prisma';
-// 本番 Prisma 実装の repos 束を組み立てる関数
-import { buildPrismaRepos } from '@/data/adapters/prisma';
+// 本番 Prisma 実装の repos 束 / UnitOfWork を組み立てる関数
+import { buildPrismaRepos, buildPrismaUow } from '@/data/adapters/prisma';
 
 // テナント A / B の ID
 const TENANT_A = 'default-tenant';
@@ -125,5 +125,57 @@ describe.runIf(SHOULD_RUN)('EmailThreadRef prisma adapter', () => {
       tenantId: TENANT_B,
     });
     expect(await prisma.emailThreadRef.count()).toBe(2);
+  });
+
+  // 同一 Message-ID に対する「確認 → 起票 → 登録」が完全に同時実行されても、Serializable
+  // 分離レベルなら書き込み競合が検知されて片方が中断され、二重起票にならないことを検証する。
+  // src/app/api/inbound/email/route.ts の createEmailTicketIdempotent が依拠する DB 側の保証。
+  it('Serializable トランザクションが同時実行の書き込み競合を検知し二重起票を防ぐ', async () => {
+    const uow = buildPrismaUow(prisma);
+    const messageId = 'race-1@x.com';
+
+    // createEmailTicketIdempotent と同じ形の「確認 → 起票 → 登録」を 1 トランザクションで行う
+    const attempt = () =>
+      uow.run(
+        async (tx) => {
+          const already = await tx.emailThreads.findTicketIdByMessageIds([messageId], TENANT_A);
+          if (already) return { id: already, alreadyExisted: true };
+          // 両方の試行が「まだ無い」を読んだ直後にここで少し待つことで、読み取りタイミングを
+          // 揃え、書き込み競合を確実に起こす (待ちが無いと片方が先に完了してしまい得る)
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          const created = await tx.tickets.create({
+            title: '同時実行テスト',
+            body: '本文',
+            priority: 'Medium',
+            categoryId: null,
+            creatorId: 'u-a',
+            tenantId: TENANT_A,
+          });
+          await tx.emailThreads.register({
+            messageId,
+            ticketId: created.id,
+            tenantId: TENANT_A,
+          });
+          return { id: created.id, alreadyExisted: false };
+        },
+        { isolationLevel: 'Serializable' },
+      );
+
+    // 2 つの試行を完全に同時実行する
+    const results = await Promise.allSettled([attempt(), attempt()]);
+
+    // ちょうど 1 件が成功し、もう 1 件は書き込み競合で失敗する
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    // 失敗した方は uow.isTransactionConflict が true と判定するエラーであること
+    expect(uow.isTransactionConflict((rejected[0] as PromiseRejectedResult).reason)).toBe(true);
+
+    // DB 上にはチケット・対応表とも 1 件ずつしか作られていない (二重起票していない)
+    expect(
+      await prisma.ticket.count({ where: { tenantId: TENANT_A, title: '同時実行テスト' } }),
+    ).toBe(1);
+    expect(await prisma.emailThreadRef.count({ where: { messageId } })).toBe(1);
   });
 });

--- a/tests/data/line-message-repository.contract.prisma.test.ts
+++ b/tests/data/line-message-repository.contract.prisma.test.ts
@@ -7,8 +7,8 @@
 import { describe, beforeAll, afterAll, beforeEach, expect, it } from 'vitest';
 // Prisma クライアント本体 (生成物)
 import { PrismaClient } from '@/generated/prisma';
-// 本番 Prisma 実装の repos 束を組み立てる関数
-import { buildPrismaRepos } from '@/data/adapters/prisma';
+// 本番 Prisma 実装の repos 束 / UnitOfWork を組み立てる関数
+import { buildPrismaRepos, buildPrismaUow } from '@/data/adapters/prisma';
 
 // テナント A / B の ID
 const TENANT_A = 'default-tenant';
@@ -98,8 +98,68 @@ describe.runIf(SHOULD_RUN)('LineMessageRef prisma adapter', () => {
   // 別テナントが同じメッセージ ID を使っても衝突しない ((tenantId, lineMessageId) 複合一意のため)
   it('テナントが違えば同一メッセージ ID を別々に登録できる', async () => {
     const repos = buildPrismaRepos(prisma);
-    await repos.lineMessages.register({ lineMessageId: 'same', ticketId: 't-a', tenantId: TENANT_A });
-    await repos.lineMessages.register({ lineMessageId: 'same', ticketId: 't-b', tenantId: TENANT_B });
+    await repos.lineMessages.register({
+      lineMessageId: 'same',
+      ticketId: 't-a',
+      tenantId: TENANT_A,
+    });
+    await repos.lineMessages.register({
+      lineMessageId: 'same',
+      ticketId: 't-b',
+      tenantId: TENANT_B,
+    });
     expect(await prisma.lineMessageRef.count()).toBe(2);
+  });
+
+  // 同一メッセージ ID に対する「確認 → 起票 → 登録」が完全に同時実行されても、Serializable
+  // 分離レベルなら書き込み競合が検知されて片方が中断され、二重起票にならないことを検証する。
+  // src/app/api/inbound/line/route.ts の createLineTicketIdempotent が依拠する DB 側の保証。
+  it('Serializable トランザクションが同時実行の書き込み競合を検知し二重起票を防ぐ', async () => {
+    const uow = buildPrismaUow(prisma);
+    const messageId = 'race-1';
+
+    // createLineTicketIdempotent と同じ形の「確認 → 起票 → 登録」を 1 トランザクションで行う
+    const attempt = () =>
+      uow.run(
+        async (tx) => {
+          const already = await tx.lineMessages.findTicketIdByMessageId(messageId, TENANT_A);
+          if (already) return { id: already, alreadyExisted: true };
+          // 両方の試行が「まだ無い」を読んだ直後にここで少し待つことで、読み取りタイミングを
+          // 揃え、書き込み競合を確実に起こす (待ちが無いと片方が先に完了してしまい得る)
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          const created = await tx.tickets.create({
+            title: '同時実行テスト',
+            body: '本文',
+            priority: 'Medium',
+            categoryId: null,
+            creatorId: 'u-a',
+            tenantId: TENANT_A,
+          });
+          await tx.lineMessages.register({
+            lineMessageId: messageId,
+            ticketId: created.id,
+            tenantId: TENANT_A,
+          });
+          return { id: created.id, alreadyExisted: false };
+        },
+        { isolationLevel: 'Serializable' },
+      );
+
+    // 2 つの試行を完全に同時実行する
+    const results = await Promise.allSettled([attempt(), attempt()]);
+
+    // ちょうど 1 件が成功し、もう 1 件は書き込み競合で失敗する
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    // 失敗した方は uow.isTransactionConflict が true と判定するエラーであること
+    expect(uow.isTransactionConflict((rejected[0] as PromiseRejectedResult).reason)).toBe(true);
+
+    // DB 上にはチケット・対応表とも 1 件ずつしか作られていない (二重起票していない)
+    expect(
+      await prisma.ticket.count({ where: { tenantId: TENANT_A, title: '同時実行テスト' } }),
+    ).toBe(1);
+    expect(await prisma.lineMessageRef.count({ where: { lineMessageId: messageId } })).toBe(1);
   });
 });

--- a/tests/data/slack-notifier.test.ts
+++ b/tests/data/slack-notifier.test.ts
@@ -7,6 +7,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // テスト対象: Slack 通知 Adapter のファクトリ
 import { createSlackNotifier } from '@/data/adapters/slack/slack-notifier';
 
+// src/lib/webhook-fetch.ts は SSRF 対策の DNS 検証用 Dispatcher (Agent) を使うため
+// undici の fetch を直接 import している。vi.stubGlobal('fetch', ...) だけでは差し替わらない
+// ため、undici の fetch を globalThis.fetch (下の beforeEach で差し替える) へ委譲するモックにする
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: ((...args: Parameters<typeof globalThis.fetch>) =>
+      globalThis.fetch(...args)) as unknown as typeof actual.fetch,
+  };
+});
+
 // モックする Webhook URL (実際には送信されない)
 const WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/xxx';
 
@@ -73,14 +85,18 @@ describe('createSlackNotifier', () => {
   it('HTTP エラー時は例外を投げる', async () => {
     fetchMock.mockResolvedValue(mockResponse(false, 500, 'Server Error'));
     const notifier = createSlackNotifier(WEBHOOK_URL);
-    await expect(notifier.send({ subject: 'x', body: 'y' })).rejects.toThrow(/Slack Webhook 送信失敗/);
+    await expect(notifier.send({ subject: 'x', body: 'y' })).rejects.toThrow(
+      /Slack Webhook 送信失敗/,
+    );
   });
 
   // 異常系: HTTP 200 でもアプリレベルエラー (本文が "ok" 以外) なら例外を投げる
   it('本文が ok 以外なら例外を投げる', async () => {
     fetchMock.mockResolvedValue(mockResponse(true, 200, 'invalid_payload'));
     const notifier = createSlackNotifier(WEBHOOK_URL);
-    await expect(notifier.send({ subject: 'x', body: 'y' })).rejects.toThrow(/Slack Webhook 送信失敗/);
+    await expect(notifier.send({ subject: 'x', body: 'y' })).rejects.toThrow(
+      /Slack Webhook 送信失敗/,
+    );
   });
 
   // SSRF 防御: リダイレクト応答 (opaqueredirect) は追従せず例外を投げる

--- a/tests/data/teams-notifier.test.ts
+++ b/tests/data/teams-notifier.test.ts
@@ -7,6 +7,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // テスト対象: Teams 通知 Adapter のファクトリ
 import { createTeamsNotifier } from '@/data/adapters/teams/teams-notifier';
 
+// src/lib/webhook-fetch.ts は SSRF 対策の DNS 検証用 Dispatcher (Agent) を使うため
+// undici の fetch を直接 import している。vi.stubGlobal('fetch', ...) だけでは差し替わらない
+// ため、undici の fetch を globalThis.fetch (下の beforeEach で差し替える) へ委譲するモックにする
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: ((...args: Parameters<typeof globalThis.fetch>) =>
+      globalThis.fetch(...args)) as unknown as typeof actual.fetch,
+  };
+});
+
 // モックする Webhook URL (実際には送信されない)
 const WEBHOOK_URL = 'https://example.webhook.office.com/webhookb2/abc';
 
@@ -88,7 +100,9 @@ describe('createTeamsNotifier', () => {
     fetchMock.mockResolvedValue(mockResponse(false, 400, 'Bad Request'));
     const notifier = createTeamsNotifier(WEBHOOK_URL);
     // 送信が reject されること
-    await expect(notifier.send({ subject: 'x', body: 'y' })).rejects.toThrow(/Teams Webhook 送信失敗/);
+    await expect(notifier.send({ subject: 'x', body: 'y' })).rejects.toThrow(
+      /Teams Webhook 送信失敗/,
+    );
   });
 
   // SSRF 防御: リダイレクト応答 (opaqueredirect) は追従せず例外を投げる

--- a/tests/features/attachments/post-comment-route.test.ts
+++ b/tests/features/attachments/post-comment-route.test.ts
@@ -36,6 +36,18 @@ let storage: MemoryStoragePort;
 // セッションをテストごとに差し替えるためのモック対象
 let mockSession: Session | null;
 
+// src/lib/webhook-fetch.ts は SSRF 対策の DNS 検証用 Dispatcher (Agent) を使うため
+// undici の fetch を直接 import している。vi.stubGlobal('fetch', ...) だけでは差し替わらない
+// ため、undici の fetch を globalThis.fetch (呼び出し側で差し替える) へ委譲するモックにする
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: ((...args: Parameters<typeof globalThis.fetch>) =>
+      globalThis.fetch(...args)) as unknown as typeof actual.fetch,
+  };
+});
+
 // @/data モジュールを差し替え
 vi.mock('@/data', () => ({
   get repos() {

--- a/tests/features/create-ticket-outbound-notify.test.ts
+++ b/tests/features/create-ticket-outbound-notify.test.ts
@@ -27,6 +27,18 @@ let uow: UnitOfWork;
 // fetch のモック関数 (Slack Adapter が呼ぶ)
 let fetchMock: ReturnType<typeof vi.fn>;
 
+// src/lib/webhook-fetch.ts は SSRF 対策の DNS 検証用 Dispatcher (Agent) を使うため
+// undici の fetch を直接 import している。vi.stubGlobal('fetch', ...) だけでは差し替わらない
+// ため、undici の fetch を globalThis.fetch (下の beforeEach で差し替える) へ委譲するモックにする
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: ((...args: Parameters<typeof globalThis.fetch>) =>
+      globalThis.fetch(...args)) as unknown as typeof actual.fetch,
+  };
+});
+
 // @/data モジュールを差し替え (getter で参照することで beforeEach の上書きを反映)
 vi.mock('@/data', () => ({
   get repos() {
@@ -94,7 +106,9 @@ beforeEach(() => {
   // 動的 import の結果をリセット (mock 設定を反映させるため)
   vi.resetModules();
   // fetch は常にモックし、成功レスポンスを返す (Slack Adapter が呼ぶ)
-  fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve('ok') });
+  fetchMock = vi
+    .fn()
+    .mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve('ok') });
   vi.stubGlobal('fetch', fetchMock);
 });
 
@@ -108,7 +122,11 @@ describe('POST /api/tickets (外部通知)', () => {
     const { POST } = await import('@/app/api/tickets/route');
 
     const res = await POST(
-      buildJsonRequest({ title: '複合機が印刷できない', body: '朝から紙詰まりが続く', priority: 'Medium' }),
+      buildJsonRequest({
+        title: '複合機が印刷できない',
+        body: '朝から紙詰まりが続く',
+        priority: 'Medium',
+      }),
     );
 
     // チケット作成自体は成功する
@@ -128,7 +146,11 @@ describe('POST /api/tickets (外部通知)', () => {
     const { POST } = await import('@/app/api/tickets/route');
 
     const res = await POST(
-      buildJsonRequest({ title: 'PC が起動しない', body: '電源ボタンを押しても反応なし', priority: 'High' }),
+      buildJsonRequest({
+        title: 'PC が起動しない',
+        body: '電源ボタンを押しても反応なし',
+        priority: 'High',
+      }),
     );
 
     expect(res.status).toBe(201);
@@ -143,7 +165,11 @@ describe('POST /api/tickets (外部通知)', () => {
     const { POST } = await import('@/app/api/tickets/route');
 
     const res = await POST(
-      buildJsonRequest({ title: 'ネットワークに繋がらない', body: 'Wi-Fi が切れる', priority: 'Low' }),
+      buildJsonRequest({
+        title: 'ネットワークに繋がらない',
+        body: 'Wi-Fi が切れる',
+        priority: 'Low',
+      }),
     );
 
     // Slack 送信が失敗してもチケット作成は 201 で成功する (ベストエフォート)

--- a/tests/features/inbound-email-route.test.ts
+++ b/tests/features/inbound-email-route.test.ts
@@ -341,6 +341,55 @@ describe('POST /api/inbound/email', () => {
     expect(store.tickets.size).toBe(1);
   });
 
+  // 書き込み競合 (Serializable 分離レベルでの中断) が起きても、対応表を読み直して
+  // 重複扱いにし、二重にチケットを作らないことを確認する。
+  // 実際の Postgres での競合は契約テスト (RUN_PRISMA_CONTRACT=1 が必要) で検証し、
+  // ここでは createEmailTicketIdempotent のエラーハンドリング分岐
+  // (uow.isTransactionConflict → 対応表の再読込) を検証する。
+  it('書き込み競合が起きても対応表を読み直して重複扱いにする (二重起票しない)', async () => {
+    // 「別リクエストが先に確定させた」チケットをあらかじめ用意しておく
+    const winnerTicket = await repos.tickets.create({
+      title: '先勝ちリクエストが作成',
+      body: '本文',
+      priority: 'Medium',
+      categoryId: null,
+      creatorId: MEMBER_ID,
+      tenantId: TENANT,
+    });
+
+    // findTicketIdByMessageIds: 1 回目 (事前チェック) は null、2 回目以降 (競合後の再確認) は
+    // 先勝ちチケット ID を返す。「事前チェックの時点では未処理だったが、その後 (このリクエストの
+    // トランザクションが競合で中断される間に) 別リクエストが確定させた」という順序を再現する
+    const findTicketIdByMessageIds = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(winnerTicket.id);
+    repos = {
+      ...repos,
+      emailThreads: { ...repos.emailThreads, findTicketIdByMessageIds },
+    };
+
+    // uow.run を「書き込み競合で必ず失敗する」実装に差し替える
+    const conflictError = new Error('simulated write conflict');
+    uow = {
+      run: vi.fn(async () => {
+        throw conflictError;
+      }),
+      isTransactionConflict: (err) => err === conflictError,
+    };
+
+    const { POST } = await import('@/app/api/inbound/email/route');
+    const res = await POST(makeRequest({ ...VALID_EMAIL, messageId: '<race-1@example.com>' }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ticketId: string; status?: string };
+    expect(body.status).toBe('duplicate');
+    expect(body.ticketId).toBe(winnerTicket.id);
+    // 新規チケットは作られず、先勝ちの 1 件のままであること
+    expect(store.tickets.size).toBe(1);
+    // 受領自動返信は既に先勝ちリクエスト側で送られているはずなので、ここでは送らない
+    expect(sentEmails).toHaveLength(0);
+  });
+
   // スレッド継続: 参照先が別テナントの Message-ID なら一致せず、新規起票にフォールバックする
   it('別テナントの Message-ID には紐付かず新規起票する', async () => {
     // 別テナントに Message-ID を直接登録しておく (別テナントのスレッド)

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -5,7 +5,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createHmac } from 'node:crypto';
 import { createMemoryContext, type Store } from '@/data/adapters/memory';
-import type { Repos } from '@/data/ports/unit-of-work';
+import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
 import { hashLineLinkCode, normalizeLineLinkCode } from '@/lib/line-link';
 
 const SECRET = 'test-line-channel-secret';
@@ -20,11 +20,16 @@ const LINE_ID_NEW = 'U00000000000000000000000000000003'; // 新規連携対象
 
 let store: Store;
 let repos: Repos;
+let uow: UnitOfWork;
 
-// @/data を差し替え (getter で beforeEach の上書きを反映)
+// @/data を差し替え (getter で beforeEach の上書きを反映)。
+// ルートは冪等な起票を uow.run (Serializable トランザクション) で行うため uow も必要
 vi.mock('@/data', () => ({
   get repos() {
     return repos;
+  },
+  get uow() {
+    return uow;
   },
 }));
 
@@ -89,6 +94,7 @@ describe('POST /api/inbound/line', () => {
     const ctx = createMemoryContext();
     store = ctx.store;
     repos = ctx.repos;
+    uow = ctx.uow;
     seed();
     vi.stubEnv('LINE_CHANNEL_SECRET', SECRET);
     vi.stubEnv('LINE_TARGET_TENANT_ID', TENANT);
@@ -101,7 +107,10 @@ describe('POST /api/inbound/line', () => {
   // Standard 以下のプランは LINE 連携不可 (§6.1 料金プラン)。署名は正しくても起票しない
   it('Pro 未満のプランのテナントは起票せず 200 (プランゲート)', async () => {
     // シード済みテナントを Standard プランに書き換える
-    store.tenants.set(TENANT, { ...store.tenants.get(TENANT)!, subscriptionPlan: 'standard' as const });
+    store.tenants.set(TENANT, {
+      ...store.tenants.get(TENANT)!,
+      subscriptionPlan: 'standard' as const,
+    });
     const { POST } = await import('@/app/api/inbound/line/route');
     const res = await POST(makeRequest('プリンターが動きません', LINE_ID_UNLINKED));
     expect(res.status).toBe(200);
@@ -201,6 +210,54 @@ describe('POST /api/inbound/line', () => {
     // レスポンスには既存チケット ID がそのまま返る
     const secondBody = (await second.json()) as { ticketIds: string[] };
     expect(secondBody.ticketIds).toEqual([firstTicketId]);
+  });
+
+  // 書き込み競合 (Serializable 分離レベルでの中断) が起きても、対応表を読み直して
+  // 重複扱いにし、二重にチケットを作らないことを確認する。
+  // 実際の Postgres での競合は tests/data/line-message-repository.contract.prisma.test.ts
+  // (RUN_PRISMA_CONTRACT=1 が必要) で検証し、ここでは createLineTicketIdempotent の
+  // エラーハンドリング分岐 (uow.isTransactionConflict → 対応表の再読込) を検証する。
+  it('書き込み競合が起きても対応表を読み直して重複扱いにする (二重起票しない)', async () => {
+    // 「別リクエストが先に確定させた」チケットをあらかじめ用意しておく
+    const winnerTicket = await repos.tickets.create({
+      title: '先勝ちリクエストが作成',
+      body: '本文',
+      priority: 'Medium',
+      categoryId: null,
+      creatorId: AGENT_ID,
+      tenantId: TENANT,
+    });
+
+    // findTicketIdByMessageId: 1 回目 (事前チェック) は null、2 回目以降 (競合後の再確認) は
+    // 先勝ちチケット ID を返す。「事前チェックの時点では未処理だったが、その後 (このリクエストの
+    // トランザクションが競合で中断される間に) 別リクエストが確定させた」という順序を再現する
+    const findTicketIdByMessageId = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(winnerTicket.id);
+    repos = {
+      ...repos,
+      lineMessages: { ...repos.lineMessages, findTicketIdByMessageId },
+    };
+
+    // uow.run を「書き込み競合で必ず失敗する」実装に差し替える
+    const conflictError = new Error('simulated write conflict');
+    uow = {
+      run: vi.fn(async () => {
+        throw conflictError;
+      }),
+      isTransactionConflict: (err) => err === conflictError,
+    };
+
+    const { POST } = await import('@/app/api/inbound/line/route');
+    const res = await POST(makeRequest('プリンターが動きません', LINE_ID_UNLINKED));
+    expect(res.status).toBe(200);
+    // 新規チケットは作られず、先勝ちの 1 件のままであること
+    expect(store.tickets.size).toBe(1);
+    const body = (await res.json()) as { ticketIds: string[] };
+    expect(body.ticketIds).toEqual([winnerTicket.id]);
+    // 事前チェック + 競合後の再確認の 2 回、対応表が引かれている
+    expect(findTicketIdByMessageId).toHaveBeenCalledTimes(2);
   });
 
   // 署名が不正なリクエストは 401 で拒否する

--- a/tests/features/stripe-webhook-route.test.ts
+++ b/tests/features/stripe-webhook-route.test.ts
@@ -1,0 +1,217 @@
+// POST /api/webhooks/stripe (Phase 4 課金 Webhook) のテスト。
+// Stripe 署名検証・Stripe クライアントは @/lib/stripe をモックして回避し、
+// テナントのプラン更新と、ダウングレード時に Pro モードを強制解除する挙動を検証する (DB は持ち込まない)。
+//
+// 検証の背景: 以前は subscriptionPlan だけを更新し tenant.mode は変更していなかったため、
+// Pro モードで運用していたテナントが解約/ダウングレードしても mode='pro' のまま残り、
+// エスカレーション等の Pro 専用機能が使い続けられてしまう不備があった。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
+
+const TENANT = 'default-tenant';
+
+// 各テストで差し替える可変な依存 (Route import 前に値を入れる)
+let store: Store;
+let repos: Repos;
+let uow: UnitOfWork;
+
+// @/data を差し替え (getter で beforeEach の上書きを反映)
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+  get uow() {
+    return uow;
+  },
+}));
+
+// Stripe SDK 呼び出し (署名検証・Price ID→プラン判定) をモックする。
+// vi.hoisted で先に用意することで、vi.mock のファクトリから参照できるようにする (巻き上げ順序対策)。
+// planForNextCall でテストごとに「今回のイベントで判定させたいプラン」を差し替える
+const { planForNextCall } = vi.hoisted(() => ({
+  planForNextCall: { current: 'pro' as 'free' | 'standard' | 'pro' },
+}));
+vi.mock('@/lib/stripe', () => ({
+  // 署名検証はモックし、リクエストボディの JSON をそのまま Stripe イベントとして扱う
+  getStripeClient: () => ({
+    webhooks: {
+      constructEvent: (rawBody: string) => JSON.parse(rawBody),
+    },
+  }),
+  getStripeWebhookSecret: () => 'whsec_test',
+  // 本来は status + priceId から判定するが、テストでは明示的に差し替えて挙動を固定する
+  stripeStatusToPlan: () => planForNextCall.current,
+}));
+
+// テナントをシードする (mode / plan を指定可能)
+function seedTenant(mode: 'lite' | 'pro', plan: 'free' | 'standard' | 'pro' | 'enterprise'): void {
+  const now = new Date();
+  store.tenants.set(TENANT, {
+    id: TENANT,
+    name: 'デフォルト組織',
+    mode,
+    industry: null,
+    inboundToken: null,
+    slackWebhookUrl: null,
+    subscriptionPlan: plan,
+    stripeCustomerId: 'cus_1',
+    stripeSubscriptionId: 'sub_1',
+    stripeSubscriptionStatus: 'active',
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null,
+    createdAt: now,
+  });
+}
+
+// Stripe イベント JSON + 署名ヘッダ (値は何でもよい。constructEvent はモック済み) を組み立てる
+function makeRequest(eventBody: Record<string, unknown>): Request {
+  return new Request('http://localhost/api/webhooks/stripe', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'stripe-signature': 'sig' },
+    body: JSON.stringify(eventBody),
+  });
+}
+
+describe('POST /api/webhooks/stripe', () => {
+  beforeEach(() => {
+    const ctx = createMemoryContext();
+    store = ctx.store;
+    repos = ctx.repos;
+    uow = ctx.uow;
+    planForNextCall.current = 'pro';
+  });
+
+  // 解約 (customer.subscription.deleted) で Pro → Free に降格すると、Pro モードも強制的に lite へ戻る
+  it('Pro テナントが解約されると Free に降格し、mode も lite に戻す', async () => {
+    seedTenant('pro', 'pro');
+    const { POST } = await import('@/app/api/webhooks/stripe/route');
+    const res = await POST(
+      makeRequest({
+        type: 'customer.subscription.deleted',
+        data: {
+          object: {
+            id: 'sub_1',
+            customer: 'cus_1',
+            status: 'canceled',
+            metadata: { tenantId: TENANT },
+          },
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const tenant = store.tenants.get(TENANT)!;
+    expect(tenant.subscriptionPlan).toBe('free');
+    expect(tenant.mode).toBe('lite');
+  });
+
+  // 更新イベント (customer.subscription.updated) で Pro → Standard にダウングレードしても同様
+  it('Pro テナントが Standard にダウングレードされると mode も lite に戻す', async () => {
+    seedTenant('pro', 'pro');
+    planForNextCall.current = 'standard';
+    const { POST } = await import('@/app/api/webhooks/stripe/route');
+    const res = await POST(
+      makeRequest({
+        type: 'customer.subscription.updated',
+        data: {
+          object: {
+            id: 'sub_1',
+            customer: 'cus_1',
+            status: 'active',
+            items: { data: [{ price: { id: 'price_standard' } }] },
+            metadata: { tenantId: TENANT },
+          },
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const tenant = store.tenants.get(TENANT)!;
+    expect(tenant.subscriptionPlan).toBe('standard');
+    expect(tenant.mode).toBe('lite');
+  });
+
+  // Pro のまま更新される (昇格/継続) 場合は mode を変更しない
+  it('Pro のまま更新されるときは mode を変更しない', async () => {
+    seedTenant('pro', 'pro');
+    planForNextCall.current = 'pro';
+    const { POST } = await import('@/app/api/webhooks/stripe/route');
+    const res = await POST(
+      makeRequest({
+        type: 'customer.subscription.updated',
+        data: {
+          object: {
+            id: 'sub_1',
+            customer: 'cus_1',
+            status: 'active',
+            items: { data: [{ price: { id: 'price_pro' } }] },
+            metadata: { tenantId: TENANT },
+          },
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const tenant = store.tenants.get(TENANT)!;
+    expect(tenant.subscriptionPlan).toBe('pro');
+    expect(tenant.mode).toBe('pro');
+  });
+
+  // 既に Lite モードのテナントがダウングレードしても、mode は変更不要 (既に lite) のまま
+  it('Lite モードのテナントがダウングレードしても mode はそのまま', async () => {
+    seedTenant('lite', 'standard');
+    const { POST } = await import('@/app/api/webhooks/stripe/route');
+    const res = await POST(
+      makeRequest({
+        type: 'customer.subscription.deleted',
+        data: {
+          object: {
+            id: 'sub_1',
+            customer: 'cus_1',
+            status: 'canceled',
+            metadata: { tenantId: TENANT },
+          },
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const tenant = store.tenants.get(TENANT)!;
+    expect(tenant.subscriptionPlan).toBe('free');
+    expect(tenant.mode).toBe('lite');
+  });
+
+  // Enterprise は Stripe 管理外: 解約イベントが来てもプランを降格せず、mode も変更しない
+  it('Enterprise テナントは解約イベントでもプランを降格せず mode も変更しない', async () => {
+    seedTenant('pro', 'enterprise');
+    const { POST } = await import('@/app/api/webhooks/stripe/route');
+    const res = await POST(
+      makeRequest({
+        type: 'customer.subscription.deleted',
+        data: {
+          object: {
+            id: 'sub_1',
+            customer: 'cus_1',
+            status: 'canceled',
+            metadata: { tenantId: TENANT },
+          },
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const tenant = store.tenants.get(TENANT)!;
+    expect(tenant.subscriptionPlan).toBe('enterprise');
+    expect(tenant.mode).toBe('pro');
+  });
+
+  // 署名ヘッダが無いリクエストは 400 で拒否する (なりすまし対策)
+  it('stripe-signature ヘッダが無ければ 400 を返す', async () => {
+    const { POST } = await import('@/app/api/webhooks/stripe/route');
+    const req = new Request('http://localhost/api/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'customer.subscription.deleted', data: { object: {} } }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/line-push.test.ts
+++ b/tests/line-push.test.ts
@@ -6,6 +6,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // テスト対象: 本文組み立て / push 送信
 import { buildTicketReplyLineMessage, pushLineMessage } from '@/lib/line-push';
 
+// src/lib/webhook-fetch.ts は SSRF 対策の DNS 検証用 Dispatcher (Agent) を使うため
+// undici の fetch を直接 import している。vi.stubGlobal('fetch', ...) だけでは差し替わらない
+// ため、undici の fetch を globalThis.fetch (下の beforeEach で差し替える) へ委譲するモックにする
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: ((...args: Parameters<typeof globalThis.fetch>) =>
+      globalThis.fetch(...args)) as unknown as typeof actual.fetch,
+  };
+});
+
 // テスト用の有効な LINE ユーザー ID (正規形式: 'U' + 32 桁 16 進数)
 const VALID_LINE_USER_ID = `U${'a'.repeat(32)}`;
 
@@ -44,14 +56,12 @@ describe('pushLineMessage', () => {
 
   beforeEach(() => {
     // 既定は成功レスポンス
-    fetchMock = vi
-      .fn()
-      .mockResolvedValue({
-        ok: true,
-        status: 200,
-        type: 'basic',
-        text: () => Promise.resolve('{}'),
-      });
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      type: 'basic',
+      text: () => Promise.resolve('{}'),
+    });
     vi.stubGlobal('fetch', fetchMock);
   });
 

--- a/tests/ssrf-guard.test.ts
+++ b/tests/ssrf-guard.test.ts
@@ -131,4 +131,42 @@ describe('ssrfSafeLookup (DNS リバインディング対策)', () => {
 
     expect(result).toBe(dnsError);
   });
+
+  // 呼び出し元 (undici/Node) が options.all を指定しない場合、dns.lookup は単一アドレス
+  // (配列でない) 形式で応答することがある。この形式でも解決先の検証が効くこと、
+  // かつ呼び出し元が要求した「単一アドレス」の形式のままコールバックへ返すことを確認する
+  // (誤って配列形式に変換してしまうと、呼び出し元が形式の食い違いで壊れる恐れがあるため)。
+  it('単一アドレス形式 (options.all 未指定) でも内部 IP を検出してブロックする', async () => {
+    dnsLookupMock.mockImplementation((hostname, options, callback) => {
+      // dns.lookup は options.all が無いとき (err, address: string, family: number) で返す
+      callback(null, '169.254.169.254', 4);
+    });
+
+    const result = await new Promise((resolve) => {
+      ssrfSafeLookup('rebind-attacker.example.com', {}, (err, address, family) => {
+        resolve({ err, address, family });
+      });
+    });
+
+    expect((result as { err: Error | null }).err).toBeInstanceOf(Error);
+    expect((result as { err: Error }).err.message).toMatch(/SSRFガード/);
+  });
+
+  // 単一アドレス形式でパブリック IP なら許可し、かつ単一アドレスのまま (配列に変換せず) 返す
+  it('単一アドレス形式でパブリック IP なら許可し、形式もそのまま維持する', async () => {
+    dnsLookupMock.mockImplementation((hostname, options, callback) => {
+      callback(null, '203.0.113.10', 4);
+    });
+
+    const result = await new Promise((resolve) => {
+      ssrfSafeLookup('hooks.slack.com', {}, (err, address, family) => {
+        resolve({ err, address, family });
+      });
+    });
+
+    expect((result as { err: Error | null }).err).toBeNull();
+    // 呼び出し元が単一アドレス形式で受け取った場合、コールバックにも単一アドレス形式で返す
+    expect((result as { address: unknown }).address).toBe('203.0.113.10');
+    expect((result as { family: unknown }).family).toBe(4);
+  });
 });

--- a/tests/ssrf-guard.test.ts
+++ b/tests/ssrf-guard.test.ts
@@ -1,0 +1,134 @@
+// SSRF ガード (src/lib/ssrf-guard.ts) の単体テスト。
+// isPrivateHost / isUnsafeUrl (ホスト名文字列の検証) に加え、
+// ssrfSafeLookup (DNS リバインディング対策: 実際に解決された IP を検証する) を確認する。
+
+// Vitest の DSL とフック
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// node:dns の lookup をモックし、実際の DNS には問い合わせない
+const dnsLookupMock = vi.fn();
+vi.mock('node:dns', () => ({
+  default: {
+    lookup: (...args: unknown[]) => dnsLookupMock(...args),
+  },
+}));
+
+// モック設定後に読み込む (vi.mock はホイストされるため import 順は問題ない)
+import { isPrivateHost, isUnsafeUrl, ssrfSafeLookup } from '@/lib/ssrf-guard';
+
+describe('isPrivateHost', () => {
+  // ループバック・リンクローカル・プライベートアドレス帯を一括で検証する
+  it.each([
+    ['127.0.0.1', true],
+    ['169.254.169.254', true], // クラウドメタデータ (AWS IMDS)
+    ['10.0.0.5', true],
+    ['172.16.0.1', true],
+    ['192.168.1.1', true],
+    ['localhost', true],
+    ['::1', true],
+    ['[::1]', true], // URL 由来の括弧付き表記
+    ['0.0.0.0', true],
+    ['100.64.0.1', true], // CGNAT
+    ['::ffff:127.0.0.1', true], // IPv6-mapped IPv4
+    ['example.com', false],
+    ['203.0.113.10', false], // パブリック IP (TEST-NET-3)
+  ])('%s は %s と判定される', (host, expected) => {
+    expect(isPrivateHost(host)).toBe(expected);
+  });
+});
+
+describe('isUnsafeUrl', () => {
+  // http (非 TLS) は拒否する
+  it('https 以外のスキームは危険と判定する', () => {
+    expect(isUnsafeUrl('http://example.com/webhook')).toBe(true);
+  });
+
+  // パースできない文字列は fail-closed で危険と判定する
+  it('URL としてパースできない文字列は危険と判定する', () => {
+    expect(isUnsafeUrl('not a url')).toBe(true);
+  });
+
+  // パブリックホストの https は安全と判定する
+  it('パブリックホストの https は安全と判定する', () => {
+    expect(isUnsafeUrl('https://hooks.slack.com/services/x')).toBe(false);
+  });
+});
+
+describe('ssrfSafeLookup (DNS リバインディング対策)', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // DNS リバインディング攻撃を模擬する: 保存時・送信直前のホスト名検証は通過する
+  // パブリックなホスト名が、実際に接続する瞬間には内部 IP (クラウドメタデータ) に
+  // 解決されるケース。ホスト名文字列だけの検証では検知できないため、
+  // ssrfSafeLookup が「解決された IP そのもの」を見て拒否できることを確認する。
+  it('解決先が内部 IP (クラウドメタデータ) なら接続をブロックする', async () => {
+    dnsLookupMock.mockImplementation((hostname, options, callback) => {
+      callback(null, [{ address: '169.254.169.254', family: 4 }]);
+    });
+
+    const result = await new Promise((resolve) => {
+      ssrfSafeLookup('rebind-attacker.example.com', {}, (err, address) => {
+        resolve({ err, address });
+      });
+    });
+
+    // 接続前にブロックされ、エラーとして伝播する
+    expect((result as { err: Error | null }).err).toBeInstanceOf(Error);
+    expect((result as { err: Error }).err.message).toMatch(/SSRFガード/);
+  });
+
+  // 複数解決先のうち 1 つでも内部アドレスなら、DNS ラウンドロビン経由の迂回を
+  // 防ぐため一括で拒否する (fail-closed)
+  it('複数解決先の一部が内部 IP でも一括でブロックする', async () => {
+    dnsLookupMock.mockImplementation((hostname, options, callback) => {
+      callback(null, [
+        { address: '203.0.113.10', family: 4 },
+        { address: '127.0.0.1', family: 4 },
+      ]);
+    });
+
+    const result = await new Promise((resolve) => {
+      ssrfSafeLookup('mixed.example.com', {}, (err, address) => {
+        resolve({ err, address });
+      });
+    });
+
+    expect((result as { err: Error | null }).err).toBeInstanceOf(Error);
+  });
+
+  // 正常系: すべてパブリック IP ならそのまま解決結果を返す
+  it('解決先がすべてパブリック IP なら許可する', async () => {
+    dnsLookupMock.mockImplementation((hostname, options, callback) => {
+      callback(null, [{ address: '203.0.113.10', family: 4 }]);
+    });
+
+    const result = await new Promise((resolve) => {
+      ssrfSafeLookup('hooks.slack.com', {}, (err, address) => {
+        resolve({ err, address });
+      });
+    });
+
+    expect((result as { err: Error | null }).err).toBeNull();
+    expect((result as { address: unknown }).address).toEqual([
+      { address: '203.0.113.10', family: 4 },
+    ]);
+  });
+
+  // DNS 解決自体が失敗した場合は、そのままエラーとして伝播する (握りつぶさない)
+  it('DNS 解決の失敗はそのままエラーとして伝播する', async () => {
+    const dnsError = new Error('ENOTFOUND');
+    dnsLookupMock.mockImplementation((hostname, options, callback) => {
+      callback(dnsError, []);
+    });
+
+    const result = await new Promise((resolve) => {
+      ssrfSafeLookup('nonexistent.example.com', {}, (err) => {
+        resolve(err);
+      });
+    });
+
+    expect(result).toBe(dnsError);
+  });
+});

--- a/tests/webhook-fetch.test.ts
+++ b/tests/webhook-fetch.test.ts
@@ -7,6 +7,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // テスト対象: Webhook POST 共通ユーティリティ
 import { postWebhook } from '@/lib/webhook-fetch';
 
+// webhook-fetch.ts は SSRF 対策の DNS 検証用 Dispatcher (Agent) を使うため undici の fetch を
+// 直接 import している。vi.stubGlobal('fetch', ...) だけでは差し替わらないため、undici の
+// fetch を globalThis.fetch (下の beforeEach で差し替える) へ委譲するモックにする
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: ((...args: Parameters<typeof globalThis.fetch>) =>
+      globalThis.fetch(...args)) as unknown as typeof actual.fetch,
+  };
+});
+
 // fetch のモック関数 (各テストで差し替える)
 let fetchMock: ReturnType<typeof vi.fn>;
 


### PR DESCRIPTION
## Context

`docs/smb-dx-pivot-plan.md` の Phase 0〜4 と `docs/issue-backlog.md` は全項目が実装済みで、未実装のバックログ項目が見つからなかったため（`docs/smb-dx-pivot-plan.md` §5.6・§9・§6.1 のセキュリティ・整合性要件に照らして）既存コードベースの徹底監査を実施し、実際に悪用可能/機能破綻を招く3件の不備を発見・修正しました。さらに `/code-review ultra` で追加の4件の不備（依存バージョン不整合・DRY違反・追加のTOCTOU）を発見し修正しています。

## 変更内容

### 1. SSRF ガードの DNS リバインディング対策 (`docs/smb-dx-pivot-plan.md` §9)
`src/lib/ssrf-guard.ts` の `isUnsafeUrl` はホスト名文字列を「保存時」「送信直前」に検証するのみで、検証後に DNS レコードを内部 IP (`169.254.169.254` 等) へ差し替える DNS リバインディング攻撃には無防備でした。実際に接続する直前に DNS 解決結果そのものを検証する undici Dispatcher (`ssrfSafeLookup`/`ssrfSafeDispatcher`) を追加し、`src/lib/webhook-fetch.ts` の `postWebhook` をこの Dispatcher 経由の undici fetch に切り替えました。

### 2. LINE/メール取り込みの冪等化に残る TOCTOU 競合 (`docs/smb-dx-pivot-plan.md` §5.3)
「対応表を SELECT → 無ければ起票 → 対応表へ INSERT」を別々の呼び出しで行っており、Webhook の at-least-once 再送が完全に同時に届くと二重チケットが作られ得ました（既存コードのコメントで「既知の制約」と明記されていた窓）。`UnitOfWork` に `isolationLevel` オプションと `isTransactionConflict` 判定を追加し、Serializable トランザクションで「確認→起票→登録」を原子的に行うよう修正しました。

### 3. プランダウングレード時に Pro モードが残る不備 (`docs/smb-dx-pivot-plan.md` §6.1)
Stripe でプランを解約/ダウングレードしても `tenant.mode` は変更されず、エスカレーションや 7 ステータスワークフローなど Pro 専用機能が降格後も使い続けられる状態でした。Stripe Webhook でプラン変更を適用する際、新プランが Pro モードを許可しなくなった場合は同一トランザクションで `mode` を `lite` に強制することにしました。

### 4. コードレビューで発見した追加の不備
- **依存バージョン不整合**: SSRF 対策で追加した `undici@8.7.0` が Node `>=22.19.0` を要求し、本リポジトリの Dockerfile/CI (Node 20) と矛盾していたため `7.28.0` に固定 (Node `>=20.18.1` で動作、挙動を再検証済み)。
- **DRY 違反**: LINE/メール取り込みの冪等起票ロジックがほぼ同一のまま重複していたため `src/lib/idempotent-ticket-creation.ts` に共通化。
- **`ssrfSafeLookup` の形式不一致**: 呼び出し元の `options.all` を無視して常に配列形式で応答していた不備を修正 (将来の undici/Node バージョンでの破損を予防)。
- **Stripe ダウングレード判定の TOCTOU**: `applyPlanChange` が `tenant.mode` をトランザクション開始前に読んでいた不備を修正し、トランザクション内で読み直すよう変更。

## レビュー

- `/code-review ultra` (ローカル最大効力レビュー): 5 角度の発見エージェント → 検証 → 上記 4 件の追加修正を実施。
- `/security-review ultra`: SSRF/TOCTOU/認可の観点で専門レビューを実施し、悪用可能な脆弱性は検出されませんでした（テナントスコープの一貫性、DNS リバインディング対策の閉塞性、Stripe 認可境界を個別に確認済み）。

## 検証方法

- `npm run typecheck` / `npm run lint` / `npm run format` (Prettier) — いずれも通過
- `npx vitest run` — 490 件通過
- `RUN_PRISMA_CONTRACT=1` の契約テスト — ローカルに一時的に立てた PostgreSQL 16 に対して実行し、Serializable 分離レベルでの書き込み競合検知（2トランザクション完全同時実行）を含む38件すべて通過を確認
- CI (GitHub Actions): Lint/Typecheck/Unit tests・Prisma adapter contract tests・Playwright E2E・Shellcheck の全 4 ジョブが green

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format` (Prettier チェック)
- [x] `npx vitest run` (ユニットテスト)
- [x] `RUN_PRISMA_CONTRACT=1 npm run test:contract` (実 PostgreSQL に対する契約テスト)
- [x] `/code-review ultra`
- [x] `/security-review ultra`
- [x] CI 全ジョブ green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjjFEpgKcCFAuxfkBGjywp
