### PR TITLE
feat(inbound-line): LINE 連携をテナント単位のマルチチャネル設定に対応

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,16 +42,10 @@ INBOUND_EMAIL_DOMAIN=""
 # (送信者が偽装ヘッダを混入しても、プロバイダの結果が先頭に来て優先されることを期待する)。
 INBOUND_EMAIL_AUTH=""
 
-# LINE 公式アカウント連携 (Phase 2 β / docs/smb-dx-pivot-plan.md §4 Phase 2)。
-# Webhook (POST /api/inbound/line) の署名検証に使うチャネルシークレット。
-# 未設定の間は LINE Webhook 取り込みは無効 (fail-closed で 500 を返す)。
-LINE_CHANNEL_SECRET=""
-# LINE Webhook からの取り込み先テナント ID (β は 1 テナント / 1 LINE チャネル構成)。
-# 未設定の間は LINE Webhook 取り込みは無効 (fail-closed で 500 を返す)。
-LINE_TARGET_TENANT_ID=""
-# Messaging API の長期アクセストークン。担当者の返信を LINE 連携済みの依頼者へ push する際に使う。
-# 未設定の間は LINE への返信送信だけがスキップされる (メール返信は届く。任意機能のため起動は失敗しない)。
-LINE_CHANNEL_ACCESS_TOKEN=""
+# LINE 公式アカウント連携 (Phase 2 β / docs/smb-dx-pivot-plan.md §4 Phase 2.1)。
+# チャネルシークレット・アクセストークン・Bot User ID はテナント単位の DB 設定
+# (TenantLineConfig) で管理する。テナント管理者が /settings 画面から登録する
+# (グローバルな環境変数ではなく、テナントごとに異なる LINE チャネルを登録できる)。
 
 # チュートリアル動画リンク (Phase 3 オンボーディング / docs/smb-dx-pivot-plan.md §4)。
 # ダッシュボードの「はじめかた」とヘルプセンターの「30 分で運用開始する」ページに動画リンクを出す。

--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -131,6 +131,31 @@
 - [x] メール通知テンプレートの整備（HTML、日本語、件名規約）
 - [x] 「対応すると依頼者にメールで返信が届く」を既定動作に（依頼者がアプリにログインしなくても完結）
 
+#### 2.1 フォローアップ（2026-07-06）: LINE 連携のマルチテナント化
+
+初回実装（PR #170 系列）では 1 デプロイ環境につき 1 テナント / 1 LINE チャネルを
+`LINE_CHANNEL_SECRET` / `LINE_TARGET_TENANT_ID` / `LINE_CHANNEL_ACCESS_TOKEN` の環境変数で
+決め打ちする β 制約付きで実装した（`src/app/api/inbound/line/route.ts` のコメント参照）。
+本アプリはマルチテナント SaaS が前提（§3.3・§5.6）であり、他の全チャネル（メール取り込み・
+Slack/Teams/Chatwork 通知・SSO）は既にテナント単位の設定として実装済みのため、LINE 連携だけが
+グローバル単一チャネルのままなのは設計上の整合性を欠く。よって本計画を更新し、以下を追加実装する:
+
+- テナント単位の `TenantLineConfig`（channelSecret / channelAccessToken / botUserId）を Prisma
+  モデルとして追加し、Port/Adapter（Prisma + メモリ）で管理する。
+- Webhook 受信時は LINE が送ってくる `destination`（チャネルの Bot User ID。秘密情報ではない
+  公開識別子）で `TenantLineConfig` を引き、そのテナント専用の `channelSecret` で署名検証する
+  （メール取り込みの `inboundToken` と同じ「公開識別子でテナントを特定 → 秘密鍵で認証」の設計）。
+  署名検証前に `destination` を信用してはいけないため、検証成功までは「該当チャネル設定が
+  存在するかどうか」を含め詳細を外部に漏らさない（未設定・不一致のどちらも同一の 401 を返す）。
+- 担当者からの LINE 返信 push（`src/lib/line-push.ts`）もテナントの `channelAccessToken` を
+  使うよう変更し、環境変数 `LINE_CHANNEL_ACCESS_TOKEN` への依存を廃止する。
+- 設定画面（`/settings`、admin 専用・Pro/Enterprise プランのみ）でテナントごとに
+  チャネルシークレット・アクセストークン・Bot User ID を登録できるようにする。
+
+この変更により、複数テナントが同時に別々の LINE 公式アカウントを連携できるようになる
+（β の「1 テナント 1 チャネル」制約そのものは変わらないが、それがテナントごとに独立して
+設定可能になる）。
+
 ### Phase 3 — オンボーディング & 業種テンプレ（3 週間）
 
 - [x] テナント作成時に **業種テンプレ**（製造業 / 飲食 / 介護 / 不動産 / 士業 / 卸売 など）でカテゴリと「よくある質問」を初期投入

--- a/prisma/migrations/20260706000000_add_tenant_line_config/migration.sql
+++ b/prisma/migrations/20260706000000_add_tenant_line_config/migration.sql
@@ -1,0 +1,28 @@
+-- Phase 2 フォローアップ (docs/smb-dx-pivot-plan.md §4 Phase 2.1): テナント単位の LINE 公式アカウント
+-- 連携設定テーブルを追加する。従来は環境変数で 1 デプロイ環境 / 1 テナントに決め打ちしていた
+-- LINE Webhook 署名検証・Messaging API push の認証情報を、テナントごとの DB 設定に切り替える。
+
+-- LINE チャネル設定テーブル本体
+CREATE TABLE "TenantLineConfig" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "channelSecret" TEXT NOT NULL,
+    "channelAccessToken" TEXT NOT NULL,
+    "botUserId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TenantLineConfig_pkey" PRIMARY KEY ("id")
+);
+
+-- 1 テナント 1 設定 (1:1) を担保する一意インデックス
+CREATE UNIQUE INDEX "TenantLineConfig_tenantId_key" ON "TenantLineConfig"("tenantId");
+
+-- 1 LINE チャネル (Bot User ID) につき 1 テナントだけが名乗れるようにする一意インデックス
+-- (クロステナント混線防止: 同じチャネルを 2 テナントが同時に登録できない)
+CREATE UNIQUE INDEX "TenantLineConfig_botUserId_key" ON "TenantLineConfig"("botUserId");
+
+-- テナント削除時に LINE 連携設定も連鎖削除する外部キー制約
+ALTER TABLE "TenantLineConfig"
+    ADD CONSTRAINT "TenantLineConfig_tenantId_fkey"
+    FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -141,6 +141,7 @@ model Tenant {
   lineMessageRefs LineMessageRef[] // LINE メッセージ ID → チケット 対応表 (取り込みの冪等化 / Phase 2)
   locations       Location[] // Phase 4 多拠点: テナント内の店舗・拠点
   ssoConfig       TenantSsoConfig? // Phase 4 Enterprise: SAML SSO 設定 (1 テナント 1 件・未設定なら null)
+  lineConfig      TenantLineConfig? // Phase 2 フォローアップ: LINE 公式アカウント連携設定 (1 テナント 1 件・未設定なら null)
 }
 
 // Phase 4 Enterprise: テナント単位の SAML シングルサインオン (SSO) 設定。
@@ -156,6 +157,30 @@ model TenantSsoConfig {
   idpX509Cert String // IdP の署名検証用 X.509 証明書 (PEM またはその base64 本体)
   createdAt   DateTime @default(now()) // 作成日時
   updatedAt   DateTime @updatedAt // 更新日時 (Prisma が自動更新)
+
+  // 所属テナント (テナント削除で連鎖削除)
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+}
+
+// Phase 2 フォローアップ (docs/smb-dx-pivot-plan.md §4 Phase 2.1): テナント単位の LINE 公式アカウント
+// 連携設定。従来は 1 デプロイ環境 / 1 テナント / 1 LINE チャネルを環境変数で決め打ちしていたが、
+// マルチテナント SaaS の他チャネル (メール取り込み・SSO・外部通知) と同様にテナントごとの
+// DB 設定へ切り替える。Webhook 受信時は botUserId (LINE の destination フィールド。秘密情報ではない
+// 公開識別子) でこの行を引き、その行の channelSecret で署名を検証する (メール取り込みの inboundToken
+// と同じ「公開識別子でテナントを特定 → 秘密鍵で認証」の設計)。
+model TenantLineConfig {
+  id                 String   @id @default(cuid()) // 主キー (cuid)
+  tenantId           String   @unique // 所属テナント (1 テナント 1 設定。@unique で 1:1 を担保)
+  // Webhook 署名 (X-Line-Signature) の HMAC-SHA256 検証に使うチャネルシークレット (秘匿情報)
+  channelSecret      String
+  // Messaging API push (担当者の返信を LINE へ返す) に使う長期アクセストークン (秘匿情報)
+  channelAccessToken String
+  // LINE が Webhook の destination フィールドで送ってくる、このチャネル自身の Bot User ID。
+  // 秘密情報ではない公開識別子だが、複数テナントで同じ値を登録できないよう @unique にする
+  // (同じ LINE チャネルを 2 テナントが同時に名乗るクロステナント混線を防ぐ)。
+  botUserId          String   @unique
+  createdAt          DateTime @default(now()) // 作成日時
+  updatedAt          DateTime @updatedAt // 更新日時 (Prisma が自動更新)
 
   // 所属テナント (テナント削除で連鎖削除)
   tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -59,19 +59,17 @@ export default async function SettingsPage() {
     repos.users.countByTenant(session.user.tenantId),
   ]);
 
-  // Phase 4 Enterprise: SSO は Enterprise プランのみ表示・設定可能。
-  // プランが許可する場合のみ SSO 設定を取得する (非対象テナントに余計なクエリを投げない)。
+  // Phase 4 Enterprise: SSO は Enterprise プランのみ、Phase 2 フォローアップ: LINE 連携は
+  // Pro / Enterprise プランのみ表示・設定可能。それぞれ独立したクエリなので Promise.all で
+  // 並列に取得する (非対象テナントには Promise.resolve(null) で余計なクエリを投げない)。
   const ssoAllowed = isSsoAllowed(tenant?.subscriptionPlan ?? 'free');
-  const ssoConfig = ssoAllowed ? await repos.ssoConfigs.findByTenant(session.user.tenantId) : null;
+  const lineAllowed = isLineIntegrationAllowed(tenant?.subscriptionPlan ?? 'free');
+  const [ssoConfig, lineConfig] = await Promise.all([
+    ssoAllowed ? repos.ssoConfigs.findByTenant(session.user.tenantId) : Promise.resolve(null),
+    lineAllowed ? repos.lineConfigs.findByTenant(session.user.tenantId) : Promise.resolve(null),
+  ]);
   // SP の各 URL を組み立てる (Enterprise のときだけ使う)
   const spUrls = ssoAllowed ? buildSpUrls(resolveAppBaseUrl(), session.user.tenantId) : null;
-
-  // Phase 2 フォローアップ: LINE 連携は Pro / Enterprise プランのみ表示・設定可能。
-  // プランが許可する場合のみ設定を取得する (非対象テナントに余計なクエリを投げない)。
-  const lineAllowed = isLineIntegrationAllowed(tenant?.subscriptionPlan ?? 'free');
-  const lineConfig = lineAllowed
-    ? await repos.lineConfigs.findByTenant(session.user.tenantId)
-    : null;
   // Webhook 受信 URL (LINE Developers コンソールに登録する値)
   const lineWebhookUrl = `${resolveAppBaseUrl()}/api/inbound/line`;
 
@@ -212,8 +210,11 @@ export default async function SettingsPage() {
               へ届けます。LINE Developers コンソールで発行したチャネル情報を設定してください。
             </p>
           </div>
-          {/* LINE 連携設定フォーム (現在の設定と Webhook URL を渡す) */}
-          <LineConfigSection config={lineConfig} webhookUrl={lineWebhookUrl} />
+          {/* LINE 連携設定フォーム (秘密情報は渡さず botUserId のみ渡す。§9 参照) */}
+          <LineConfigSection
+            config={lineConfig ? { botUserId: lineConfig.botUserId } : null}
+            webhookUrl={lineWebhookUrl}
+          />
         </section>
       )}
 

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -18,10 +18,12 @@ import { LocationsSection } from '@/features/settings/components/LocationsSectio
 import { BillingSection } from '@/features/settings/components/BillingSection';
 // Phase 4 Enterprise: SAML SSO 設定セクション (Client Component)
 import { SsoConfigSection } from '@/features/settings/components/SsoConfigSection';
+// Phase 2 フォローアップ: テナント単位の LINE 連携設定セクション (Client Component)
+import { LineConfigSection } from '@/features/settings/components/LineConfigSection';
 // テナント情報取得 (slackWebhookUrl / 拠点一覧 / プラン情報の初期値を渡すため)
 import { repos } from '@/data';
-// Enterprise プランのみ SSO を表示するためのプランゲート
-import { isSsoAllowed } from '@/lib/plan-guard';
+// プランゲート: Enterprise のみ SSO、Pro/Enterprise のみ LINE 連携を表示する
+import { isLineIntegrationAllowed, isSsoAllowed } from '@/lib/plan-guard';
 // SSO の SP エンドポイント URL を組み立てるヘルパー
 import { buildSpUrls } from '@/lib/saml';
 // アプリの公開ベース URL を解決するヘルパー (SP URL の組み立てに使う)
@@ -63,6 +65,15 @@ export default async function SettingsPage() {
   const ssoConfig = ssoAllowed ? await repos.ssoConfigs.findByTenant(session.user.tenantId) : null;
   // SP の各 URL を組み立てる (Enterprise のときだけ使う)
   const spUrls = ssoAllowed ? buildSpUrls(resolveAppBaseUrl(), session.user.tenantId) : null;
+
+  // Phase 2 フォローアップ: LINE 連携は Pro / Enterprise プランのみ表示・設定可能。
+  // プランが許可する場合のみ設定を取得する (非対象テナントに余計なクエリを投げない)。
+  const lineAllowed = isLineIntegrationAllowed(tenant?.subscriptionPlan ?? 'free');
+  const lineConfig = lineAllowed
+    ? await repos.lineConfigs.findByTenant(session.user.tenantId)
+    : null;
+  // Webhook 受信 URL (LINE Developers コンソールに登録する値)
+  const lineWebhookUrl = `${resolveAppBaseUrl()}/api/inbound/line`;
 
   return (
     <div className="mx-auto max-w-2xl space-y-6">
@@ -186,6 +197,23 @@ export default async function SettingsPage() {
             }
             sp={spUrls}
           />
+        </section>
+      )}
+
+      {/* Phase 2 フォローアップ: LINE 公式アカウント連携設定カード (Pro/Enterprise プランのみ表示) */}
+      {lineAllowed && (
+        <section className="space-y-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+          <div>
+            {/* セクション見出し */}
+            <h2 className="text-base font-semibold text-slate-900">LINE 公式アカウント連携</h2>
+            {/* 説明: テナント単位の LINE チャネル設定であることを伝える */}
+            <p className="mt-1 text-sm text-slate-500">
+              LINE 公式アカウントに送られたメッセージを問い合わせとして取り込み、担当者の返信を LINE
+              へ届けます。LINE Developers コンソールで発行したチャネル情報を設定してください。
+            </p>
+          </div>
+          {/* LINE 連携設定フォーム (現在の設定と Webhook URL を渡す) */}
+          <LineConfigSection config={lineConfig} webhookUrl={lineWebhookUrl} />
         </section>
       )}
 

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -1,14 +1,20 @@
 /**
- * LINE 公式アカウント Webhook (Phase 2 β / docs/smb-dx-pivot-plan.md §4 / §5.3)
+ * LINE 公式アカウント Webhook (Phase 2 β / docs/smb-dx-pivot-plan.md §4 Phase 2 / §4 Phase 2.1 / §5.3)
  *
  * LINE 公式アカウントに送られたテキストメッセージを受信し、テナントの問い合わせ (Ticket) として
  * 取り込む。複数イベントを 1 リクエストで受け取ることがあるため、テキストメッセージ以外は無視して
  * 全イベントを処理してから 200 を返す (LINE は 200 未受信で 5 分以内に再送するため必ず 200 を返す)。
  *
- * β 制約 (本計画書 §8 リスク表):
- *  - 1 テナント / 1 LINE チャネル構成を env var で決め打ち (マルチチャネルは将来課題)。
- *    LINE_CHANNEL_SECRET: Webhook 署名の検証に使うチャネルシークレット
- *    LINE_TARGET_TENANT_ID: メッセージを受け付けるテナント ID
+ * マルチテナント化 (§4 Phase 2.1 / 2026-07-06 フォローアップ):
+ *  - チャネルごとの認証情報 (channelSecret / channelAccessToken) はテナント単位の
+ *    `TenantLineConfig` (DB) で管理する (旧: 環境変数 LINE_CHANNEL_SECRET / LINE_TARGET_TENANT_ID
+ *    による 1 デプロイ環境 = 1 テナント決め打ちの β 制約を解消)。
+ *  - テナント解決: LINE Webhook が送ってくる `destination` (このチャネル自身の Bot User ID。
+ *    署名鍵ではない公開識別子) で `TenantLineConfig.botUserId` を引く。署名検証前の値なので、
+ *    これ単体では「どのテナント宛か」の手がかりに過ぎず、実際の認証は次の署名検証が担う
+ *    (メール取り込みの `inboundToken` と同じ「公開識別子でテナントを特定 → 秘密鍵で認証」設計)。
+ *  - チャネル未登録・署名不一致のどちらも同一の 401 を返す (どちらが原因かを外部に漏らさない)。
+ *  - 1 テナント / 1 LINE チャネルの制約自体は β のまま (マルチチャネル/1 テナントは将来課題)。
  *  - LINE ユーザーとテナントメンバーの紐付け: メンバーが Web 設定画面で発行したワンタイムコードを
  *    LINE に送ると、その送信元 LINE ユーザー ID をメンバーへ紐付ける。紐付け済みなら起票者は本人になり
  *    自己解決 UI が開通する。未紐付けの LINE ユーザーは従来どおりテナント内担当者をプロキシ起票者とする
@@ -20,8 +26,8 @@
  *
  * セキュリティ要点 (§9):
  *  - X-Line-Signature ヘッダの HMAC-SHA256 を定数時間比較で検証する (LINE Docs 準拠)。
- *  - シークレット・テナント ID 未設定は fail-closed (500 で取り込み口を閉じる)。
- *  - テナント単位のレート制限でバーストに備える。
+ *  - 未登録チャネル・シークレット不一致は fail-closed (401 で取り込み口を閉じ、理由は漏らさない)。
+ *  - チャネル (destination) 単位のレート制限でバーストに備える。
  */
 
 // JSON レスポンスヘルパー
@@ -57,7 +63,9 @@ import { isLineIntegrationAllowed } from '@/lib/plan-guard';
 // このルートは Node ランタイムで動かす (node:crypto / Prisma を使うため Edge では動かない)
 export const runtime = 'nodejs';
 
-// テナント単位の取り込み流量上限 (シークレット漏洩時のスパムを抑える)
+// LINE チャネル (destination) 単位の取り込み流量上限 (シークレット漏洩時のスパムを抑える)。
+// テナント解決 (DB 参照) より前にチェックするため、まだ認証していない destination 値を
+// キーに使う (botUserId は @unique でテナントと 1:1 なので、実質テナント単位の制限と同じ)。
 const LINE_RATE_LIMIT = { limit: 120, windowMs: 60_000 } as const;
 
 // チケットタイトルとして使うテキストの最大文字数 (長すぎる場合は末尾を省略する)
@@ -102,7 +110,7 @@ interface LineMessageEvent {
 
 // LINE が POST してくる Webhook ボディの型 (パース直後は信用せず events が配列かを実行時に検証する)
 interface LineWebhookBody {
-  destination?: string; // LINE チャネルのユーザー ID (受信先の特定に使えるが β では env var を使う)
+  destination?: string; // このチャネル自身の Bot User ID (テナント解決キー。署名検証前は未信用の値)
   events?: LineMessageEvent[]; // 1 リクエストに複数イベントが含まれることがある
 }
 
@@ -142,22 +150,6 @@ function verifyLineSignature(rawBody: string, signature: string, channelSecret: 
 
 // POST /api/inbound/line : LINE Webhook を受信してチケットを作成する
 export async function POST(req: Request) {
-  // LINE チャネルシークレットを環境変数から取得する (未設定なら fail-closed)
-  const channelSecret = process.env.LINE_CHANNEL_SECRET?.trim();
-  if (!channelSecret) {
-    // 設定漏れはサーバーログに残し、外部には詳細を出さない 500 を返す (§9 fail-closed)
-    console.error('[POST /api/inbound/line] LINE_CHANNEL_SECRET is not configured');
-    return NextResponse.json({ error: 'LINE 連携は利用できません' }, { status: 500 });
-  }
-
-  // 取り込み先テナント ID を環境変数から取得する (未設定なら fail-closed)
-  const targetTenantId = process.env.LINE_TARGET_TENANT_ID?.trim();
-  if (!targetTenantId) {
-    // テナント ID が設定されていない場合はメッセージを起票する先がないため拒否する
-    console.error('[POST /api/inbound/line] LINE_TARGET_TENANT_ID is not configured');
-    return NextResponse.json({ error: 'LINE 連携の送信先が設定されていません' }, { status: 500 });
-  }
-
   // 署名ヘッダの存在を最初に確認する。未認証リクエストにサイズ情報を漏らさないため、
   // Content-Length チェックより前に行う (存在しなければ 401 を返して終了)。
   // trim() でプロキシが付加した余分な空白を除去してから比較する
@@ -192,16 +184,10 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'リクエストが大きすぎます' }, { status: 413 });
   }
 
-  // 署名を検証する (不正なら 401)
-  if (!verifyLineSignature(rawBody, signature, channelSecret)) {
-    // 署名不一致は LINE サーバからのものではないため拒否する (なりすまし POST の防止)
-    return NextResponse.json({ error: '署名の検証に失敗しました' }, { status: 401 });
-  }
-
-  // 検証済みの生ボディを JSON としてパースする
+  // ボディを JSON としてパースする。この時点では署名未検証なので中身は一切信用しない。
+  // 唯一の目的は「どのチャネル (テナント) 宛かを示す公開識別子 (destination)」を取り出すことだけ。
   let body: LineWebhookBody;
   try {
-    // 署名は検証済みだが JSON の中身は信用しない (構造は下で実行時チェックする)
     body = JSON.parse(rawBody) as LineWebhookBody;
   } catch (err) {
     // パース失敗は 400 (内容を外部に出さずログに記録する)
@@ -209,7 +195,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'リクエストの形式が正しくありません' }, { status: 400 });
   }
 
-  // 署名検証済みでも JSON の構造は信用しない (§9 入力は信用しない)。events が配列でなければ
+  // 署名検証前でも JSON の構造は信用しない (§9 入力は信用しない)。events が配列でなければ
   // 以降の body.events.length / for-of が TypeError になるため、ここで 400 を返して握り潰さない
   if (!Array.isArray(body.events)) {
     console.warn('[POST /api/inbound/line] webhook body has no events array');
@@ -226,10 +212,21 @@ export async function POST(req: Request) {
     return NextResponse.json({ status: 'ignored', reason: 'too_many_events' }, { status: 200 });
   }
 
-  // テナント単位のレート制限を適用する (シークレット漏洩時のバーストを防ぐ)
+  // destination (このチャネル自身の Bot User ID) を取り出す。署名鍵ではない公開識別子だが、
+  // 正規の LINE ユーザー ID と同じ 'U' + 32 桁 16 進数の形式に必ず従うため、ここで形式を検証する
+  // (形式外の値をそのまま DB 検索・レート制限キーに使わない §9)。欠落・形式不正はテナントを
+  // 特定できないため、以降の「チャネル未登録」「署名不一致」と同一の 401 で拒否する
+  // (どの理由で失敗したかを外部に区別させない fail-closed)。
+  const destination = typeof body.destination === 'string' ? body.destination : '';
+  if (!LINE_USER_ID_PATTERN.test(destination)) {
+    return NextResponse.json({ error: '署名の検証に失敗しました' }, { status: 401 });
+  }
+
+  // チャネル (destination) 単位のレート制限を適用する (DB 参照より前に置き、
+  // シークレット漏洩やチャネル総当たりによるバースト・DB 負荷を抑える)
   try {
     // 同期の流量制限チェック (超過時は RateLimitError を throw する)
-    enforceRateLimit(`inbound-line:${targetTenantId}`, LINE_RATE_LIMIT);
+    enforceRateLimit(`inbound-line:${destination}`, LINE_RATE_LIMIT);
   } catch (err) {
     // 流量超過専用エラーだけを 429 にマップ。それ以外は想定外なので上位へ再 throw する
     if (err instanceof RateLimitError) {
@@ -241,10 +238,28 @@ export async function POST(req: Request) {
     throw err;
   }
 
-  // 取り込み先テナントを ID で引く
+  // destination からテナントの LINE 連携設定 (チャネルシークレット等) を引く。
+  // 未登録チャネルは「どのテナントの鍵で検証すべきか」が分からないため、この時点で拒否する
+  // (署名不一致と同一メッセージ・ステータスにして、チャネル登録の有無を外部に漏らさない)。
+  const lineConfig = await repos.lineConfigs.findByBotUserId(destination);
+  if (!lineConfig) {
+    return NextResponse.json({ error: '署名の検証に失敗しました' }, { status: 401 });
+  }
+
+  // このチャネル (テナント) 専用のシークレットで署名を検証する (不正なら 401)
+  if (!verifyLineSignature(rawBody, signature, lineConfig.channelSecret)) {
+    // 署名不一致は LINE サーバからのものではないため拒否する (なりすまし POST の防止)
+    return NextResponse.json({ error: '署名の検証に失敗しました' }, { status: 401 });
+  }
+
+  // ここまでで署名検証済み: 以降は body の中身を信用してよい
+  const targetTenantId = lineConfig.tenantId;
+
+  // 取り込み先テナントを ID で引く (botUserId の @unique 制約により通常は必ず見つかるが、
+  // データ不整合に備えた防御的チェック)
   const tenant = await repos.tenants.findById(targetTenantId);
   if (!tenant) {
-    // env var に設定したテナント ID が存在しない場合はサーバー設定エラーとして 404 を返す
+    // 署名検証済みのチャネルなのにテナントが見つからない場合はデータ不整合としてログに残す
     console.error('[POST /api/inbound/line] target tenant not found:', targetTenantId);
     return NextResponse.json({ error: '送信先テナントが見つかりません' }, { status: 404 });
   }

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -27,7 +27,9 @@
  * セキュリティ要点 (§9):
  *  - X-Line-Signature ヘッダの HMAC-SHA256 を定数時間比較で検証する (LINE Docs 準拠)。
  *  - 未登録チャネル・シークレット不一致は fail-closed (401 で取り込み口を閉じ、理由は漏らさない)。
- *  - チャネル (destination) 単位のレート制限でバーストに備える。
+ *  - レート制限は 2 段構え: テナント解決 (DB 参照) 前は攻撃者が操作できない固定キーで
+ *    全体の上限を設け (destination を変え続けるレート制限回避を防ぐ)、解決後は信頼できる
+ *    tenantId をキーにしたチャネル単位の上限で個別テナントのバーストに備える。
  */
 
 // JSON レスポンスヘルパー
@@ -63,10 +65,38 @@ import { isLineIntegrationAllowed } from '@/lib/plan-guard';
 // このルートは Node ランタイムで動かす (node:crypto / Prisma を使うため Edge では動かない)
 export const runtime = 'nodejs';
 
-// LINE チャネル (destination) 単位の取り込み流量上限 (シークレット漏洩時のスパムを抑える)。
-// テナント解決 (DB 参照) より前にチェックするため、まだ認証していない destination 値を
-// キーに使う (botUserId は @unique でテナントと 1:1 なので、実質テナント単位の制限と同じ)。
+// テナント解決 (DB 参照) より前に適用する、固定キーの全体レート制限。
+// destination は署名検証前の値で攻撃者が自由に生成できるため、これをレート制限のキーに
+// 使うと値を毎回変えるだけで無制限に新しいバケットが作られ、事実上レート制限を回避されて
+// しまう (バケット数の際限ない増加は enforceRateLimit 内の全体掃除処理の負荷も増やす)。
+// そのため DB 参照 (findByBotUserId) の前段では固定キーで「未認証リクエスト全体」の上限を
+// 設け、destination をどれだけ変えても DB 参照の総量が頭打ちになるようにする。
+const LINE_UNAUTHENTICATED_RATE_LIMIT = { limit: 600, windowMs: 60_000 } as const;
+
+// テナント解決後に適用する、チャネル (テナント) 単位の取り込み流量上限
+// (シークレット漏洩時のスパムを抑える)。lineConfig.tenantId は DB 由来の信頼できる値
+// (botUserId の @unique 制約でテナントと 1:1) なので、これをキーにする。
 const LINE_RATE_LIMIT = { limit: 120, windowMs: 60_000 } as const;
+
+// レート制限を適用し、超過していれば 429 レスポンスを返す共通ヘルパー。
+// 超過なしなら null を返し、呼び出し側はそのまま処理を続行する。
+function checkRateLimit(key: string, options: { limit: number; windowMs: number }) {
+  try {
+    // 同期の流量制限チェック (超過時は RateLimitError を throw する)
+    enforceRateLimit(key, options);
+    // 超過なし: 呼び出し側へ処理続行を伝える
+    return null;
+  } catch (err) {
+    // 流量超過専用エラーだけを 429 にマップ。それ以外は想定外なので上位へ再 throw する
+    if (err instanceof RateLimitError) {
+      return NextResponse.json(
+        { error: '取り込みが混み合っています' },
+        { status: 429, headers: { 'Retry-After': String(err.retryAfterSec) } },
+      );
+    }
+    throw err;
+  }
+}
 
 // チケットタイトルとして使うテキストの最大文字数 (長すぎる場合は末尾を省略する)
 const MAX_TITLE_LENGTH = 100;
@@ -214,7 +244,7 @@ export async function POST(req: Request) {
 
   // destination (このチャネル自身の Bot User ID) を取り出す。署名鍵ではない公開識別子だが、
   // 正規の LINE ユーザー ID と同じ 'U' + 32 桁 16 進数の形式に必ず従うため、ここで形式を検証する
-  // (形式外の値をそのまま DB 検索・レート制限キーに使わない §9)。欠落・形式不正はテナントを
+  // (形式外の値をそのまま DB 検索に使わない §9)。欠落・形式不正はテナントを
   // 特定できないため、以降の「チャネル未登録」「署名不一致」と同一の 401 で拒否する
   // (どの理由で失敗したかを外部に区別させない fail-closed)。
   const destination = typeof body.destination === 'string' ? body.destination : '';
@@ -222,21 +252,13 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: '署名の検証に失敗しました' }, { status: 401 });
   }
 
-  // チャネル (destination) 単位のレート制限を適用する (DB 参照より前に置き、
-  // シークレット漏洩やチャネル総当たりによるバースト・DB 負荷を抑える)
-  try {
-    // 同期の流量制限チェック (超過時は RateLimitError を throw する)
-    enforceRateLimit(`inbound-line:${destination}`, LINE_RATE_LIMIT);
-  } catch (err) {
-    // 流量超過専用エラーだけを 429 にマップ。それ以外は想定外なので上位へ再 throw する
-    if (err instanceof RateLimitError) {
-      return NextResponse.json(
-        { error: '取り込みが混み合っています' },
-        { status: 429, headers: { 'Retry-After': String(err.retryAfterSec) } },
-      );
-    }
-    throw err;
-  }
+  // 固定キーの全体レート制限を適用する (DB 参照より前に置き、destination を変え続ける
+  // ことでのレート制限回避・DB 負荷増大を防ぐ。詳細は定数の定義コメント参照)
+  const unauthLimitResponse = checkRateLimit(
+    'inbound-line:unauthenticated',
+    LINE_UNAUTHENTICATED_RATE_LIMIT,
+  );
+  if (unauthLimitResponse) return unauthLimitResponse;
 
   // destination からテナントの LINE 連携設定 (チャネルシークレット等) を引く。
   // 未登録チャネルは「どのテナントの鍵で検証すべきか」が分からないため、この時点で拒否する
@@ -245,6 +267,14 @@ export async function POST(req: Request) {
   if (!lineConfig) {
     return NextResponse.json({ error: '署名の検証に失敗しました' }, { status: 401 });
   }
+
+  // テナントが解決できたので、ここからは信頼できる tenantId をキーにしたチャネル単位の
+  // レート制限を適用する (destination のような攻撃者が操作可能な値はキーに使わない)。
+  const tenantLimitResponse = checkRateLimit(
+    `inbound-line:${lineConfig.tenantId}`,
+    LINE_RATE_LIMIT,
+  );
+  if (tenantLimitResponse) return tenantLimitResponse;
 
   // このチャネル (テナント) 専用のシークレットで署名を検証する (不正なら 401)
   if (!verifyLineSignature(rawBody, signature, lineConfig.channelSecret)) {

--- a/src/app/api/tickets/[id]/comments/route.ts
+++ b/src/app/api/tickets/[id]/comments/route.ts
@@ -249,7 +249,7 @@ async function notifyRequesterOfReply(args: {
 
   await Promise.all([
     sendReplyEmailToRequester({ creator, ticket, authorName, commentBody, ticketId, tenantId }),
-    sendReplyLineToRequester({ creator, ticket, authorName, commentBody, ticketId }),
+    sendReplyLineToRequester({ creator, ticket, authorName, commentBody, ticketId, tenantId }),
   ]);
 }
 
@@ -305,20 +305,26 @@ async function sendReplyEmailToRequester(args: {
 }
 
 // 担当者の返信を依頼者へ LINE で届ける内部ヘルパー (ベストエフォート / 副作用は push のみ)。
-// LINE_CHANNEL_ACCESS_TOKEN 未設定、または依頼者が LINE 未連携 (lineUserId なし) の環境では
-// pushLineMessage 側 / ここでの早期 return により何もしない (機能オプトインの正常系)。
+// テナントの LINE 連携が未設定、または依頼者が LINE 未連携 (lineUserId なし) の場合は
+// 早期 return により何もしない (機能オプトインの正常系)。
 async function sendReplyLineToRequester(args: {
   creator: { lineUserId?: string | null };
   ticket: { title: string };
   authorName: string;
   commentBody: string;
   ticketId: string;
+  tenantId: string;
 }): Promise<void> {
-  const { creator, ticket, authorName, commentBody, ticketId } = args;
+  const { creator, ticket, authorName, commentBody, ticketId, tenantId } = args;
   // LINE 未連携なら送りようがないのでスキップ
   if (!creator.lineUserId) return;
 
   try {
+    // テナントの LINE 連携設定 (アクセストークン) を引く。未設定ならこのテナントは
+    // LINE push を使わないので何もしない (Pro/Enterprise 限定機能の任意設定)
+    const lineConfig = await repos.lineConfigs.findByTenant(tenantId);
+    if (!lineConfig) return;
+
     // メール内リンクと同じベース URL 解決ロジックを再利用する (single source)
     const baseUrl = resolveAppBaseUrl();
     const ticketUrl = buildTicketUrl(baseUrl, ticketId);
@@ -329,8 +335,8 @@ async function sendReplyLineToRequester(args: {
       commentBody,
       agentName: authorName,
     });
-    // Messaging API へ push する (アクセストークン未設定時は内部で何もしない)
-    await pushLineMessage(creator.lineUserId, text);
+    // Messaging API へ push する (このテナント専用のアクセストークンを使う)
+    await pushLineMessage(lineConfig.channelAccessToken, creator.lineUserId, text);
   } catch (err) {
     // 送信失敗はサーバログに残すだけ (依頼者への通知はアプリ内にも残っている)
     console.error('[POST /api/tickets/[id]/comments] 依頼者宛 LINE 送信に失敗しました', err);

--- a/src/data/adapters/memory/index.ts
+++ b/src/data/adapters/memory/index.ts
@@ -6,6 +6,7 @@ import { makeCategoryRepo } from './category-repository.memory';
 import { makeEmailThreadRepo } from './email-thread-repository.memory';
 import { makeFaqRepo } from './faq-repository.memory';
 import { makeInvitationRepo } from './invitation-repository.memory';
+import { makeLineConfigRepo } from './line-config-repository.memory';
 import { makeLineMessageRepo } from './line-message-repository.memory';
 import { makeLocationRepo } from './location-repository.memory';
 import { makeMagicLinkRepo } from './magic-link-repository.memory';
@@ -41,6 +42,7 @@ export function buildMemoryRepos(store: Store): Repos {
     lineMessages: makeLineMessageRepo(store), // LINE 取り込みの冪等化 (Phase 2)
     locations: makeLocationRepo(store), // Phase 4 多拠点
     ssoConfigs: makeSsoConfigRepo(store), // Phase 4 Enterprise: SAML SSO 設定
+    lineConfigs: makeLineConfigRepo(store), // Phase 2 フォローアップ: テナント単位の LINE 連携設定
   };
 }
 

--- a/src/data/adapters/memory/line-config-repository.memory.ts
+++ b/src/data/adapters/memory/line-config-repository.memory.ts
@@ -21,8 +21,10 @@ export function makeLineConfigRepo(store: Store): LineConfigRepository {
     async findByBotUserId(botUserId) {
       // ストアの値から botUserId が一致する設定を線形探索する
       for (const cfg of store.lineConfigs.values()) {
+        // 一致したらその設定を返す (botUserId は @unique)
         if (cfg.botUserId === botUserId) return cfg;
       }
+      // 見つからなければ null
       return null;
     },
 
@@ -49,10 +51,10 @@ export function makeLineConfigRepo(store: Store): LineConfigRepository {
         // 更新後の設定オブジェクトを組み立てる (createdAt は維持、updatedAt を更新)
         const updated = {
           ...cfg,
-          channelSecret: input.channelSecret,
-          channelAccessToken: input.channelAccessToken,
-          botUserId: input.botUserId,
-          updatedAt: now,
+          channelSecret: input.channelSecret, // Webhook 署名検証用シークレット
+          channelAccessToken: input.channelAccessToken, // Messaging API push 用アクセストークン
+          botUserId: input.botUserId, // このチャネルの Bot User ID
+          updatedAt: now, // 更新日時を現在時刻に差し替え
         };
         // ストアへ書き戻す
         store.lineConfigs.set(existing, updated);
@@ -63,13 +65,13 @@ export function makeLineConfigRepo(store: Store): LineConfigRepository {
       const id = `line_cfg_${++store.idSeq.value}`;
       // 新規設定オブジェクトを組み立てる
       const created = {
-        id,
-        tenantId: input.tenantId,
-        channelSecret: input.channelSecret,
-        channelAccessToken: input.channelAccessToken,
-        botUserId: input.botUserId,
-        createdAt: now,
-        updatedAt: now,
+        id, // 払い出した ID
+        tenantId: input.tenantId, // 所属テナント (セッション由来のみ)
+        channelSecret: input.channelSecret, // Webhook 署名検証用シークレット
+        channelAccessToken: input.channelAccessToken, // Messaging API push 用アクセストークン
+        botUserId: input.botUserId, // このチャネルの Bot User ID
+        createdAt: now, // 作成日時
+        updatedAt: now, // 更新日時 (作成時は作成日時と同じ)
       };
       // ストアへ保存する
       store.lineConfigs.set(id, created);

--- a/src/data/adapters/memory/line-config-repository.memory.ts
+++ b/src/data/adapters/memory/line-config-repository.memory.ts
@@ -1,0 +1,89 @@
+// LINE 連携設定リポジトリの契約 (port)
+import type { LineConfigRepository } from '@/data/ports/line-config-repository';
+// テスト用メモリストア
+import type { Store } from './store';
+
+// メモリストアを使った LINE 連携設定リポジトリを生成するファクトリ関数 (テスト用)
+export function makeLineConfigRepo(store: Store): LineConfigRepository {
+  return {
+    // テナントの LINE 連携設定を取得する (未設定なら null)
+    async findByTenant(tenantId) {
+      // ストアの値から tenantId が一致する設定を線形探索する
+      for (const cfg of store.lineConfigs.values()) {
+        // 一致したらその設定を返す (1 テナント 1 設定)
+        if (cfg.tenantId === tenantId) return cfg;
+      }
+      // 見つからなければ null
+      return null;
+    },
+
+    // destination (Bot User ID) からテナントの LINE 連携設定を取得する (未登録なら null)
+    async findByBotUserId(botUserId) {
+      // ストアの値から botUserId が一致する設定を線形探索する
+      for (const cfg of store.lineConfigs.values()) {
+        if (cfg.botUserId === botUserId) return cfg;
+      }
+      return null;
+    },
+
+    // LINE 連携設定を作成または更新する (tenantId をキーに upsert)
+    async upsert(input) {
+      // botUserId の一意性を確認する (他テナントが既に同じチャネルを登録していないか)
+      for (const cfg of store.lineConfigs.values()) {
+        if (cfg.botUserId === input.botUserId && cfg.tenantId !== input.tenantId) {
+          // Prisma の P2002 (unique 制約違反) 相当のエラーを投げて呼び出し側に重複を伝える
+          throw new Error('Unique constraint failed on the fields: (`botUserId`) (P2002)');
+        }
+      }
+      // 既存設定を探す
+      let existing = null as null | string;
+      for (const [id, cfg] of store.lineConfigs.entries()) {
+        // tenantId が一致する設定の Map キー (id) を控える
+        if (cfg.tenantId === input.tenantId) existing = id;
+      }
+      // 現在時刻 (作成/更新日時に使う)
+      const now = new Date();
+      if (existing) {
+        // 既存設定を取り出して値を更新する
+        const cfg = store.lineConfigs.get(existing)!;
+        // 更新後の設定オブジェクトを組み立てる (createdAt は維持、updatedAt を更新)
+        const updated = {
+          ...cfg,
+          channelSecret: input.channelSecret,
+          channelAccessToken: input.channelAccessToken,
+          botUserId: input.botUserId,
+          updatedAt: now,
+        };
+        // ストアへ書き戻す
+        store.lineConfigs.set(existing, updated);
+        // 更新後の設定を返す
+        return updated;
+      }
+      // 新規作成: 連番から ID を払い出す
+      const id = `line_cfg_${++store.idSeq.value}`;
+      // 新規設定オブジェクトを組み立てる
+      const created = {
+        id,
+        tenantId: input.tenantId,
+        channelSecret: input.channelSecret,
+        channelAccessToken: input.channelAccessToken,
+        botUserId: input.botUserId,
+        createdAt: now,
+        updatedAt: now,
+      };
+      // ストアへ保存する
+      store.lineConfigs.set(id, created);
+      // 作成した設定を返す
+      return created;
+    },
+
+    // テナントの LINE 連携設定を削除する (tenantId スコープ)
+    async delete(tenantId) {
+      // tenantId が一致する設定を探して削除する
+      for (const [id, cfg] of store.lineConfigs.entries()) {
+        // 一致したら Map から削除する
+        if (cfg.tenantId === tenantId) store.lineConfigs.delete(id);
+      }
+    },
+  };
+}

--- a/src/data/adapters/memory/store.ts
+++ b/src/data/adapters/memory/store.ts
@@ -6,6 +6,7 @@ import type {
   MagicLinkToken,
   Notification,
   Tenant,
+  TenantLineConfig,
   TenantSsoConfig,
   Ticket,
   TicketComment,
@@ -61,6 +62,7 @@ export interface Store {
   lineMessageRefs: Map<string, LineMessageRefRow>; // LINE メッセージ ID → チケット 対応表 (Phase 2 冪等化)
   locations: Map<string, Location>; // Phase 4 多拠点: テナント内の店舗・拠点
   ssoConfigs: Map<string, TenantSsoConfig>; // Phase 4 Enterprise: テナント単位の SAML SSO 設定
+  lineConfigs: Map<string, TenantLineConfig>; // Phase 2 フォローアップ: テナント単位の LINE 連携設定
   idSeq: { value: number }; // 連番生成用のカウンタ (オブジェクトに包んで参照共有)
 }
 
@@ -83,6 +85,7 @@ export function createEmptyStore(): Store {
     lineMessageRefs: new Map(),
     locations: new Map(), // Phase 4 多拠点: テナント内の店舗・拠点
     ssoConfigs: new Map(), // Phase 4 Enterprise: SAML SSO 設定
+    lineConfigs: new Map(), // Phase 2 フォローアップ: テナント単位の LINE 連携設定
     idSeq: { value: 0 },
   };
 }
@@ -106,6 +109,7 @@ export function cloneStore(src: Store): Store {
     lineMessageRefs: new Map(src.lineMessageRefs),
     locations: new Map(src.locations), // Phase 4 多拠点
     ssoConfigs: new Map(src.ssoConfigs), // Phase 4 Enterprise: SAML SSO 設定
+    lineConfigs: new Map(src.lineConfigs), // Phase 2 フォローアップ: テナント単位の LINE 連携設定
     idSeq: { value: src.idSeq.value },
   };
 }
@@ -128,6 +132,7 @@ export function overwriteStore(dst: Store, src: Store): void {
   dst.lineMessageRefs = new Map(src.lineMessageRefs);
   dst.locations = new Map(src.locations); // Phase 4 多拠点
   dst.ssoConfigs = new Map(src.ssoConfigs); // Phase 4 Enterprise: SAML SSO 設定
+  dst.lineConfigs = new Map(src.lineConfigs); // Phase 2 フォローアップ: テナント単位の LINE 連携設定
   // 連番も元に戻す
   dst.idSeq.value = src.idSeq.value;
 }

--- a/src/data/adapters/prisma/index.ts
+++ b/src/data/adapters/prisma/index.ts
@@ -7,6 +7,7 @@ import { makeCategoryRepo } from './category-repository.prisma';
 import { makeEmailThreadRepo } from './email-thread-repository.prisma';
 import { makeFaqRepo } from './faq-repository.prisma';
 import { makeInvitationRepo } from './invitation-repository.prisma';
+import { makeLineConfigRepo } from './line-config-repository.prisma';
 import { makeLineMessageRepo } from './line-message-repository.prisma';
 import { makeLocationRepo } from './location-repository.prisma';
 import { makeMagicLinkRepo } from './magic-link-repository.prisma';
@@ -42,6 +43,7 @@ export function buildPrismaRepos(db: PrismaLike): Repos {
     lineMessages: makeLineMessageRepo(db), // LINE 取り込みの冪等化 (Phase 2)
     locations: makeLocationRepo(db), // Phase 4 多拠点
     ssoConfigs: makeSsoConfigRepo(db), // Phase 4 Enterprise: SAML SSO 設定
+    lineConfigs: makeLineConfigRepo(db), // Phase 2 フォローアップ: テナント単位の LINE 連携設定
   };
 }
 

--- a/src/data/adapters/prisma/line-config-repository.prisma.ts
+++ b/src/data/adapters/prisma/line-config-repository.prisma.ts
@@ -58,9 +58,9 @@ export function makeLineConfigRepo(db: PrismaLike): LineConfigRepository {
         },
         // 既存更新時の値 (tenantId は変更しない)
         update: {
-          channelSecret: input.channelSecret,
-          channelAccessToken: input.channelAccessToken,
-          botUserId: input.botUserId,
+          channelSecret: input.channelSecret, // Webhook 署名検証用シークレット
+          channelAccessToken: input.channelAccessToken, // Messaging API push 用アクセストークン
+          botUserId: input.botUserId, // このチャネルの Bot User ID
         },
       });
       // 作成/更新後の行をドメイン型に変換して返す

--- a/src/data/adapters/prisma/line-config-repository.prisma.ts
+++ b/src/data/adapters/prisma/line-config-repository.prisma.ts
@@ -1,0 +1,76 @@
+// LINE 連携設定リポジトリの契約 (port)
+import type { LineConfigRepository } from '@/data/ports/line-config-repository';
+// ドメイン型
+import type { TenantLineConfig } from '@/domain/types';
+// Prisma の行型
+import type { Prisma } from '@/generated/prisma';
+// Prisma クライアント/トランザクション共通型
+import type { PrismaLike } from './types';
+
+// Prisma の TenantLineConfig 行 (include なし) の型エイリアス
+type LineConfigRow = Prisma.TenantLineConfigGetPayload<Record<string, never>>;
+
+// Prisma の行をドメイン型に変換する関数
+function toLineConfig(row: LineConfigRow): TenantLineConfig {
+  // 必要なフィールドだけ詰め替えて返す
+  return {
+    id: row.id, // 設定 ID
+    tenantId: row.tenantId, // 所属テナント (マルチテナント化のキー)
+    channelSecret: row.channelSecret, // Webhook 署名検証用シークレット
+    channelAccessToken: row.channelAccessToken, // Messaging API push 用アクセストークン
+    botUserId: row.botUserId, // このチャネルの Bot User ID (テナント解決キー)
+    createdAt: row.createdAt, // 作成日時
+    updatedAt: row.updatedAt, // 更新日時
+  };
+}
+
+// Prisma クライアントを使った LINE 連携設定リポジトリを生成するファクトリ関数
+export function makeLineConfigRepo(db: PrismaLike): LineConfigRepository {
+  return {
+    // テナントの LINE 連携設定を取得する (未設定なら null)
+    async findByTenant(tenantId) {
+      // tenantId は @unique なので findUnique で 1 件取得する
+      const row = await db.tenantLineConfig.findUnique({ where: { tenantId } });
+      // 見つからなければ null、見つかればドメイン型に変換して返す
+      return row ? toLineConfig(row) : null;
+    },
+
+    // destination (Bot User ID) からテナントの LINE 連携設定を取得する (未登録なら null)
+    async findByBotUserId(botUserId) {
+      // botUserId も @unique なので findUnique で 1 件取得する
+      const row = await db.tenantLineConfig.findUnique({ where: { botUserId } });
+      return row ? toLineConfig(row) : null;
+    },
+
+    // LINE 連携設定を作成または更新する (tenantId をキーに upsert)
+    async upsert(input) {
+      // tenantId が既存なら update、なければ create される。botUserId の @unique 制約に
+      // 反する場合 (他テナントが同じチャネルを既に登録済み) は Prisma が P2002 を投げる
+      // (呼び出し側の Server Action がユーザー向けメッセージへ変換する)
+      const row = await db.tenantLineConfig.upsert({
+        where: { tenantId: input.tenantId },
+        // 新規作成時の値
+        create: {
+          tenantId: input.tenantId, // 所属テナント (セッション由来のみ)
+          channelSecret: input.channelSecret, // Webhook 署名検証用シークレット
+          channelAccessToken: input.channelAccessToken, // Messaging API push 用アクセストークン
+          botUserId: input.botUserId, // このチャネルの Bot User ID
+        },
+        // 既存更新時の値 (tenantId は変更しない)
+        update: {
+          channelSecret: input.channelSecret,
+          channelAccessToken: input.channelAccessToken,
+          botUserId: input.botUserId,
+        },
+      });
+      // 作成/更新後の行をドメイン型に変換して返す
+      return toLineConfig(row);
+    },
+
+    // テナントの LINE 連携設定を削除する (tenantId スコープ)
+    async delete(tenantId) {
+      // deleteMany は該当行が無くてもエラーにならない (冪等)。tenantId スコープでクロステナント防止
+      await db.tenantLineConfig.deleteMany({ where: { tenantId } });
+    },
+  };
+}

--- a/src/data/ports/line-config-repository.ts
+++ b/src/data/ports/line-config-repository.ts
@@ -1,0 +1,24 @@
+// Phase 2 フォローアップ: テナント単位の LINE 公式アカウント連携設定リポジトリの契約 (port)
+// docs/smb-dx-pivot-plan.md §4 Phase 2.1
+
+// LINE 連携設定ドメイン型
+import type { TenantLineConfig } from '@/domain/types';
+
+// LINE 連携設定リポジトリの契約 (port)。1 テナント 1 設定をテナントスコープで操作する
+export interface LineConfigRepository {
+  // テナントの LINE 連携設定を取得する (未設定なら null)
+  findByTenant(tenantId: string): Promise<TenantLineConfig | null>;
+  // LINE の destination (Bot User ID) からテナントの LINE 連携設定を取得する (未登録なら null)。
+  // Webhook 受信時に「署名検証前の公開識別子からテナントを特定する」ために使う
+  // (メール取り込みの inboundToken と同じ設計。botUserId 自体は秘密情報ではない)。
+  findByBotUserId(botUserId: string): Promise<TenantLineConfig | null>;
+  // LINE 連携設定を作成または更新する (1 テナント 1 設定なので tenantId で upsert)
+  upsert(input: {
+    tenantId: string; // 所属テナント (セッション由来のみ許可。クロステナント設定防止)
+    channelSecret: string; // Webhook 署名検証用シークレット
+    channelAccessToken: string; // Messaging API push 用の長期アクセストークン
+    botUserId: string; // このチャネルの Bot User ID (destination 値)
+  }): Promise<TenantLineConfig>;
+  // テナントの LINE 連携設定を削除する (tenantId スコープで他テナントは no-op)
+  delete(tenantId: string): Promise<void>;
+}

--- a/src/data/ports/unit-of-work.ts
+++ b/src/data/ports/unit-of-work.ts
@@ -4,6 +4,7 @@ import type { CategoryRepository } from './category-repository';
 import type { EmailThreadRepository } from './email-thread-repository';
 import type { FaqRepository } from './faq-repository';
 import type { InvitationRepository } from './invitation-repository';
+import type { LineConfigRepository } from './line-config-repository';
 import type { LineMessageRepository } from './line-message-repository';
 import type { LocationRepository } from './location-repository';
 import type { MagicLinkRepository } from './magic-link-repository';
@@ -32,6 +33,7 @@ export interface Repos {
   lineMessages: LineMessageRepository; // LINE メッセージ ID → チケット 対応表 (取り込みの冪等化 / Phase 2)
   locations: LocationRepository; // Phase 4 多拠点: テナント内の店舗・拠点
   ssoConfigs: SsoConfigRepository; // Phase 4 Enterprise: テナント単位の SAML SSO 設定
+  lineConfigs: LineConfigRepository; // Phase 2 フォローアップ: テナント単位の LINE 連携設定
 }
 
 // run() のオプション

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -82,6 +82,18 @@ export interface TenantSsoConfig {
   updatedAt: Date; // 更新日時
 }
 
+// Phase 2 フォローアップ: テナント単位の LINE 公式アカウント連携設定 1 件分。
+// docs/smb-dx-pivot-plan.md §4 Phase 2.1。Webhook 署名検証・Messaging API push の認証情報を保持する。
+export interface TenantLineConfig {
+  id: string; // 設定 ID (主キー)
+  tenantId: string; // 所属テナント ID (1 テナント 1 設定)
+  channelSecret: string; // Webhook 署名 (X-Line-Signature) の HMAC-SHA256 検証用シークレット
+  channelAccessToken: string; // Messaging API push (担当者の返信を LINE へ返す) 用の長期アクセストークン
+  botUserId: string; // LINE の destination フィールドと一致するこのチャネルの Bot User ID (テナント解決キー)
+  createdAt: Date; // 作成日時
+  updatedAt: Date; // 更新日時
+}
+
 // Phase 4 多拠点: テナント内の店舗・拠点 1 件分
 export interface Location {
   id: string; // 拠点 ID (主キー)

--- a/src/features/settings/actions/delete-line-config.ts
+++ b/src/features/settings/actions/delete-line-config.ts
@@ -1,0 +1,44 @@
+'use server';
+
+// Phase 2 フォローアップ: テナント単位の LINE 公式アカウント連携設定を削除する Server Action。
+// Pro / Enterprise プランの管理者のみ実行可能。削除すると LINE Webhook 取り込み・push が無効化される。
+// docs/smb-dx-pivot-plan.md §4 Phase 2.1。
+
+// Next.js のキャッシュ無効化
+import { revalidatePath } from 'next/cache';
+// データリポジトリ
+import { repos } from '@/data';
+// LINE 連携設定変更の共有認可ゲート (ログイン済み・admin・Pro/Enterprise)
+import { assertLineConfigAdmin } from '@/lib/line-config-context';
+
+// 削除結果型 (useActionState 互換)
+export interface DeleteLineConfigState {
+  error?: string; // エラーメッセージ
+  success?: boolean; // 成功フラグ
+}
+
+// LINE 連携設定を削除するサーバーアクション
+export async function deleteLineConfig(
+  _prevState: DeleteLineConfigState,
+  _formData: FormData,
+): Promise<DeleteLineConfigState> {
+  // 共有ゲートで「ログイン済み・admin・Pro/Enterprise」をまとめて検証する
+  const gate = await assertLineConfigAdmin();
+  // ゲート不通過ならその理由をそのまま返す
+  if (!gate.ok) return { error: gate.error };
+  // 検証済みの tenantId (セッション由来)
+  const tenantId = gate.tenantId;
+
+  try {
+    // LINE 連携設定を削除する (tenantId スコープ)
+    await repos.lineConfigs.delete(tenantId);
+    // 設定ページのキャッシュを無効化する
+    revalidatePath('/settings');
+    // 成功を返す
+    return { success: true };
+  } catch (err) {
+    // 失敗はログに残して汎用メッセージを返す
+    console.error('[delete-line-config] LINE 連携設定の削除に失敗しました:', err);
+    return { error: 'LINE 連携設定の削除に失敗しました' };
+  }
+}

--- a/src/features/settings/actions/update-line-config.ts
+++ b/src/features/settings/actions/update-line-config.ts
@@ -1,0 +1,84 @@
+'use server';
+
+// Phase 2 フォローアップ: テナント単位の LINE 公式アカウント連携設定を作成/更新する Server Action。
+// Pro / Enterprise プランの管理者のみ実行可能。docs/smb-dx-pivot-plan.md §4 Phase 2.1。
+
+// Next.js のキャッシュ無効化 (設定ページの再レンダリングに使う)
+import { revalidatePath } from 'next/cache';
+// データリポジトリ (LINE 連携設定 upsert)
+import { repos } from '@/data';
+// LINE 連携設定変更の共有認可ゲート (ログイン済み・admin・Pro/Enterprise)
+import { assertLineConfigAdmin } from '@/lib/line-config-context';
+// LINE ユーザー ID / Bot User ID の正規形式 (Webhook 受信側と共有する単一の源)
+import { LINE_USER_ID_PATTERN } from '@/lib/line-link';
+
+// 入力長の上限 (DoS・異常入力対策)
+const CHANNEL_SECRET_MAX = 256; // チャネルシークレットの最大長
+const CHANNEL_ACCESS_TOKEN_MAX = 1024; // アクセストークンの最大長 (LINE の長期トークンは十分収まる)
+
+// LINE 連携設定の更新結果型 (useActionState 互換)
+export interface UpdateLineConfigState {
+  error?: string; // エラーメッセージ
+  success?: boolean; // 成功フラグ
+}
+
+// LINE 連携設定を作成/更新するサーバーアクション (useActionState 互換シグネチャ)
+export async function updateLineConfig(
+  _prevState: UpdateLineConfigState,
+  formData: FormData,
+): Promise<UpdateLineConfigState> {
+  // 共有ゲートで「ログイン済み・admin・Pro/Enterprise」をまとめて検証する
+  const gate = await assertLineConfigAdmin();
+  // ゲート不通過ならその理由をそのまま返す
+  if (!gate.ok) return { error: gate.error };
+  // 検証済みの tenantId (セッション由来)
+  const tenantId = gate.tenantId;
+
+  // フォームから各値を取り出して前後空白を除去する
+  const channelSecret = String(formData.get('channelSecret') ?? '').trim();
+  const channelAccessToken = String(formData.get('channelAccessToken') ?? '').trim();
+  const botUserId = String(formData.get('botUserId') ?? '').trim();
+
+  // チャネルシークレットの検証 (必須・長さ上限)
+  if (!channelSecret) return { error: 'チャネルシークレットは必須です' };
+  if (channelSecret.length > CHANNEL_SECRET_MAX) {
+    return { error: 'チャネルシークレットが長すぎます' };
+  }
+
+  // アクセストークンの検証 (必須・長さ上限)
+  if (!channelAccessToken) return { error: 'チャネルアクセストークンは必須です' };
+  if (channelAccessToken.length > CHANNEL_ACCESS_TOKEN_MAX) {
+    return { error: 'チャネルアクセストークンが長すぎます' };
+  }
+
+  // Bot User ID の検証 (必須・LINE ユーザー ID と同じ 'U' + 32 桁 16 進数の形式)。
+  // Webhook 受信 (/api/inbound/line) はこの値と destination の一致でテナントを解決するため、
+  // 形式外の値を登録させると絶対に一致せず連携が機能しなくなる (事前に弾いて設定ミスを防ぐ)。
+  if (!botUserId) return { error: 'Bot User ID は必須です' };
+  if (!LINE_USER_ID_PATTERN.test(botUserId)) {
+    return { error: 'Bot User ID の形式が正しくありません ("U" + 32桁の16進数)' };
+  }
+
+  try {
+    // LINE 連携設定を upsert する (tenantId スコープで他テナントに影響しない)
+    await repos.lineConfigs.upsert({
+      tenantId,
+      channelSecret,
+      channelAccessToken,
+      botUserId,
+    });
+    // 設定ページのキャッシュを無効化して結果をすぐ反映する
+    revalidatePath('/settings');
+    // 成功を返す
+    return { success: true };
+  } catch (err) {
+    // botUserId の重複 (他テナントが既に同じチャネルを登録済み) をユーザー向けメッセージに変換する
+    const message = err instanceof Error ? err.message : '';
+    if (message.includes('Unique constraint') || message.includes('P2002')) {
+      return { error: 'この Bot User ID は既に別のテナントで登録されています' };
+    }
+    // その他の失敗はログに残して汎用メッセージを返す (内部詳細を漏らさない)
+    console.error('[update-line-config] LINE 連携設定の保存に失敗しました:', err);
+    return { error: 'LINE 連携設定の保存に失敗しました' };
+  }
+}

--- a/src/features/settings/actions/update-line-config.ts
+++ b/src/features/settings/actions/update-line-config.ts
@@ -34,18 +34,28 @@ export async function updateLineConfig(
   // 検証済みの tenantId (セッション由来)
   const tenantId = gate.tenantId;
 
-  // フォームから各値を取り出して前後空白を除去する
-  const channelSecret = String(formData.get('channelSecret') ?? '').trim();
-  const channelAccessToken = String(formData.get('channelAccessToken') ?? '').trim();
+  // フォームから各値を取り出して前後空白を除去する。
+  // channelSecret / channelAccessToken は書き込み専用フィールド (§9 秘密情報をフロントに
+  // 露出させない): 設定画面はこれらの現在値を表示しない。空欄で送信された場合は
+  // 「変更しない」ことを意味し、既存の値をそのまま維持する (新規設定時は必須)。
+  const channelSecretInput = String(formData.get('channelSecret') ?? '').trim();
+  const channelAccessTokenInput = String(formData.get('channelAccessToken') ?? '').trim();
   const botUserId = String(formData.get('botUserId') ?? '').trim();
 
-  // チャネルシークレットの検証 (必須・長さ上限)
+  // 既存設定を取得する (空欄フィールドを既存値で補うため、および必須判定のため)
+  const existing = await repos.lineConfigs.findByTenant(tenantId);
+
+  // 空欄なら既存値を維持し、入力があればそれを採用する
+  const channelSecret = channelSecretInput || existing?.channelSecret || '';
+  const channelAccessToken = channelAccessTokenInput || existing?.channelAccessToken || '';
+
+  // チャネルシークレットの検証 (新規設定時は必須・長さ上限)
   if (!channelSecret) return { error: 'チャネルシークレットは必須です' };
   if (channelSecret.length > CHANNEL_SECRET_MAX) {
     return { error: 'チャネルシークレットが長すぎます' };
   }
 
-  // アクセストークンの検証 (必須・長さ上限)
+  // アクセストークンの検証 (新規設定時は必須・長さ上限)
   if (!channelAccessToken) return { error: 'チャネルアクセストークンは必須です' };
   if (channelAccessToken.length > CHANNEL_ACCESS_TOKEN_MAX) {
     return { error: 'チャネルアクセストークンが長すぎます' };
@@ -54,6 +64,7 @@ export async function updateLineConfig(
   // Bot User ID の検証 (必須・LINE ユーザー ID と同じ 'U' + 32 桁 16 進数の形式)。
   // Webhook 受信 (/api/inbound/line) はこの値と destination の一致でテナントを解決するため、
   // 形式外の値を登録させると絶対に一致せず連携が機能しなくなる (事前に弾いて設定ミスを防ぐ)。
+  // Bot User ID 自体は秘密情報ではないため、既存値の表示・再送信は問題ない。
   if (!botUserId) return { error: 'Bot User ID は必須です' };
   if (!LINE_USER_ID_PATTERN.test(botUserId)) {
     return { error: 'Bot User ID の形式が正しくありません ("U" + 32桁の16進数)' };

--- a/src/features/settings/components/LineConfigSection.tsx
+++ b/src/features/settings/components/LineConfigSection.tsx
@@ -10,17 +10,17 @@ import { useActionState, useTransition } from 'react';
 import { updateLineConfig } from '@/features/settings/actions/update-line-config';
 import { deleteLineConfig } from '@/features/settings/actions/delete-line-config';
 
-// 現在の LINE 連携設定 (未設定なら null)。秘匿情報 (シークレット/トークン) も
-// 既存の Chatwork API トークン欄と同じ運用で type="password" 欄にそのまま表示する。
+// 現在の LINE 連携設定の「安全に表示できる部分」だけを受け取る (未設定なら null)。
+// channelSecret / channelAccessToken は秘密情報のため §9 に従いフロントへ渡さない
+// (書き込み専用: 空欄で保存すると既存値を維持する。update-line-config.ts 参照)。
+// botUserId は秘密情報ではないので現在値をそのまま表示・再編集できる。
 interface LineConfigView {
-  channelSecret: string; // Webhook 署名検証用シークレット
-  channelAccessToken: string; // Messaging API push 用アクセストークン
   botUserId: string; // このチャネルの Bot User ID
 }
 
 // Webhook 受信 URL (LINE Developers コンソールに登録する値。秘密情報ではない)
 interface Props {
-  config: LineConfigView | null; // 現在の LINE 連携設定
+  config: LineConfigView | null; // 現在の LINE 連携設定 (botUserId のみ)
   webhookUrl: string; // Webhook 受信 URL
 }
 
@@ -102,40 +102,46 @@ export function LineConfigSection({ config, webhookUrl }: Props) {
           />
         </div>
 
-        {/* チャネルシークレット */}
+        {/* チャネルシークレット (書き込み専用: 現在値は表示しない。空欄保存で維持) */}
         <div className="space-y-1">
           <label htmlFor="line-channel-secret" className={labelClass}>
             チャネルシークレット
           </label>
-          <p className={helpClass}>Webhook の署名検証に使う秘匿情報です。</p>
+          <p className={helpClass}>
+            Webhook の署名検証に使う秘匿情報です。
+            {config
+              ? '設定済みのため画面には表示されません。変更する場合のみ新しい値を入力してください（空欄なら現在の値を維持します）。'
+              : ''}
+          </p>
           <input
             id="line-channel-secret"
             name="channelSecret"
             type="password"
-            defaultValue={config?.channelSecret ?? ''}
-            placeholder="チャネルシークレット"
+            placeholder={config ? '変更する場合のみ入力' : 'チャネルシークレット'}
             autoComplete="off"
-            required
+            required={!config}
             className={fieldClass}
           />
         </div>
 
-        {/* チャネルアクセストークン */}
+        {/* チャネルアクセストークン (書き込み専用: 現在値は表示しない。空欄保存で維持) */}
         <div className="space-y-1">
           <label htmlFor="line-channel-access-token" className={labelClass}>
             チャネルアクセストークン
           </label>
           <p className={helpClass}>
             担当者の返信を LINE へ push する Messaging API の長期アクセストークンです。
+            {config
+              ? '設定済みのため画面には表示されません。変更する場合のみ新しい値を入力してください（空欄なら現在の値を維持します）。'
+              : ''}
           </p>
           <input
             id="line-channel-access-token"
             name="channelAccessToken"
             type="password"
-            defaultValue={config?.channelAccessToken ?? ''}
-            placeholder="チャネルアクセストークン"
+            placeholder={config ? '変更する場合のみ入力' : 'チャネルアクセストークン'}
             autoComplete="off"
-            required
+            required={!config}
             className={fieldClass}
           />
         </div>

--- a/src/features/settings/components/LineConfigSection.tsx
+++ b/src/features/settings/components/LineConfigSection.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+// Phase 2 フォローアップ: テナント単位の LINE 公式アカウント連携設定セクション
+// (Pro / Enterprise プランの管理者向け)。docs/smb-dx-pivot-plan.md §4 Phase 2.1。
+// LINE Developers コンソールで確認できる値を入力して保存する。
+
+// React の Server Action 状態管理フックと送信中フラグ管理フック
+import { useActionState, useTransition } from 'react';
+// LINE 連携設定の作成/更新・削除サーバーアクション
+import { updateLineConfig } from '@/features/settings/actions/update-line-config';
+import { deleteLineConfig } from '@/features/settings/actions/delete-line-config';
+
+// 現在の LINE 連携設定 (未設定なら null)。秘匿情報 (シークレット/トークン) も
+// 既存の Chatwork API トークン欄と同じ運用で type="password" 欄にそのまま表示する。
+interface LineConfigView {
+  channelSecret: string; // Webhook 署名検証用シークレット
+  channelAccessToken: string; // Messaging API push 用アクセストークン
+  botUserId: string; // このチャネルの Bot User ID
+}
+
+// Webhook 受信 URL (LINE Developers コンソールに登録する値。秘密情報ではない)
+interface Props {
+  config: LineConfigView | null; // 現在の LINE 連携設定
+  webhookUrl: string; // Webhook 受信 URL
+}
+
+// 入力フィールド共通の Tailwind クラス
+const fieldClass =
+  'w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500';
+// ラベル共通の Tailwind クラス
+const labelClass = 'block text-sm font-medium text-slate-700';
+// 補足説明共通の Tailwind クラス
+const helpClass = 'mt-1 text-xs text-slate-500';
+
+// LINE 連携設定セクション本体
+export function LineConfigSection({ config, webhookUrl }: Props) {
+  // 設定保存アクションの状態
+  const [saveState, saveAction] = useActionState(updateLineConfig, {});
+  // 設定削除アクションの状態
+  const [deleteState, deleteAction] = useActionState(deleteLineConfig, {});
+  // 送信中フラグ (保存・削除で共有)
+  const [isPending, startTransition] = useTransition();
+
+  // 保存フォーム送信ハンドラ
+  function handleSave(e: React.FormEvent<HTMLFormElement>) {
+    // ブラウザ既定の送信を抑止する
+    e.preventDefault();
+    // フォームデータを取り出してアクションに渡す
+    const formData = new FormData(e.currentTarget);
+    // トランジション内で実行して isPending を立てる
+    startTransition(() => saveAction(formData));
+  }
+
+  // 削除ボタンハンドラ
+  function handleDelete() {
+    // 誤操作防止の確認 (削除すると LINE 取り込み・返信 push が無効になる)
+    if (
+      !window.confirm('LINE 連携設定を削除しますか？ LINE からの取り込みと返信が無効になります。')
+    ) {
+      return;
+    }
+    // 空の FormData でアクションを呼ぶ
+    startTransition(() => deleteAction(new FormData()));
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* ── Webhook 受信 URL (LINE Developers 側に登録する値) ─────────── */}
+      <div className="space-y-3 rounded-xl bg-slate-50/60 p-4 ring-1 ring-slate-200">
+        <p className="text-sm font-semibold text-slate-700">
+          LINE Developers に登録する Webhook URL
+        </p>
+        <p className={helpClass}>
+          LINE Developers コンソールの Messaging API 設定画面で、この URL を Webhook URL
+          として登録してください。
+        </p>
+        <p className="rounded bg-slate-50 px-2 py-1 font-mono text-xs break-all text-slate-700 ring-1 ring-slate-200">
+          {webhookUrl}
+        </p>
+      </div>
+
+      {/* ── チャネル情報の入力フォーム ───────────────────────────────── */}
+      <form onSubmit={handleSave} className="space-y-4">
+        {/* Bot User ID */}
+        <div className="space-y-1">
+          <label htmlFor="line-bot-user-id" className={labelClass}>
+            Bot User ID
+          </label>
+          <p className={helpClass}>
+            LINE Developers コンソールの「あなたのユーザー
+            ID」欄に表示される値。受信メッセージの宛先確認に使います。
+          </p>
+          <input
+            id="line-bot-user-id"
+            name="botUserId"
+            type="text"
+            defaultValue={config?.botUserId ?? ''}
+            placeholder="U0123456789abcdef0123456789abcdef"
+            autoComplete="off"
+            required
+            className={`${fieldClass} font-mono`}
+          />
+        </div>
+
+        {/* チャネルシークレット */}
+        <div className="space-y-1">
+          <label htmlFor="line-channel-secret" className={labelClass}>
+            チャネルシークレット
+          </label>
+          <p className={helpClass}>Webhook の署名検証に使う秘匿情報です。</p>
+          <input
+            id="line-channel-secret"
+            name="channelSecret"
+            type="password"
+            defaultValue={config?.channelSecret ?? ''}
+            placeholder="チャネルシークレット"
+            autoComplete="off"
+            required
+            className={fieldClass}
+          />
+        </div>
+
+        {/* チャネルアクセストークン */}
+        <div className="space-y-1">
+          <label htmlFor="line-channel-access-token" className={labelClass}>
+            チャネルアクセストークン
+          </label>
+          <p className={helpClass}>
+            担当者の返信を LINE へ push する Messaging API の長期アクセストークンです。
+          </p>
+          <input
+            id="line-channel-access-token"
+            name="channelAccessToken"
+            type="password"
+            defaultValue={config?.channelAccessToken ?? ''}
+            placeholder="チャネルアクセストークン"
+            autoComplete="off"
+            required
+            className={fieldClass}
+          />
+        </div>
+
+        {/* エラーメッセージ (保存) */}
+        {saveState.error && (
+          <p role="alert" className="text-sm text-rose-700">
+            {saveState.error}
+          </p>
+        )}
+        {/* 成功メッセージ (保存) */}
+        {saveState.success && (
+          <p role="status" aria-live="polite" className="text-sm text-teal-700">
+            LINE 連携設定を保存しました。
+          </p>
+        )}
+        {/* 削除結果メッセージ */}
+        {deleteState.error && (
+          <p role="alert" className="text-sm text-rose-700">
+            {deleteState.error}
+          </p>
+        )}
+        {deleteState.success && (
+          <p role="status" aria-live="polite" className="text-sm text-teal-700">
+            LINE 連携設定を削除しました。
+          </p>
+        )}
+
+        {/* 操作ボタン群 */}
+        <div className="flex flex-wrap items-center gap-3">
+          {/* 保存ボタン */}
+          <button
+            type="submit"
+            disabled={isPending}
+            className="rounded-lg bg-teal-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-teal-800 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isPending ? '保存中…' : 'LINE 連携設定を保存'}
+          </button>
+          {/* 削除ボタン (設定が存在する場合のみ表示) */}
+          {config && (
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={isPending}
+              className="rounded-lg px-4 py-2 text-sm font-medium text-rose-600 transition hover:bg-rose-50 disabled:opacity-50"
+            >
+              設定を削除
+            </button>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/lib/line-config-context.ts
+++ b/src/lib/line-config-context.ts
@@ -1,0 +1,37 @@
+// Phase 2 フォローアップ: LINE 連携設定 (テナント単位) の変更 Server Action が共有する認可ゲート。
+// docs/smb-dx-pivot-plan.md §4 Phase 2.1。SsoConfig の assertSsoConfigAdmin と同じ設計
+// (「ログイン済み・admin・対象プラン」をまとめて検証し、実装ドリフトを防ぐ)。
+
+// 現在のセッション取得
+import { auth } from '@/lib/auth';
+// データ層の Composition Root (テナントのプラン確認に使う)
+import { repos } from '@/data';
+// LINE 連携機能のプランゲート (Pro / Enterprise のみ)
+import { isLineIntegrationAllowed } from '@/lib/plan-guard';
+
+// LINE 連携設定変更の前提検証結果
+export type LineConfigAdminGate = { ok: true; tenantId: string } | { ok: false; error: string };
+
+// LINE 連携設定変更の前提 (ログイン済み・admin・Pro/Enterprise プラン) をまとめて検証する。
+export async function assertLineConfigAdmin(): Promise<LineConfigAdminGate> {
+  // セッション取得と認証チェック
+  const session = await auth();
+  // 未ログインまたは tenantId 不在は拒否
+  if (!session?.user?.id || !session.user.tenantId) {
+    return { ok: false, error: '認証が必要です' };
+  }
+  // 管理者以外は設定変更不可 (UI 非表示に頼らずサーバー側で強制)
+  if (session.user.role !== 'admin') {
+    return { ok: false, error: 'この操作は管理者のみ実行できます' };
+  }
+  // セッション由来の tenantId のみ使う (クロステナント設定防止)
+  const tenantId = session.user.tenantId;
+  // テナントを取得してプランが LINE 連携を許可するか確認する (Pro / Enterprise のみ)
+  const tenant = await repos.tenants.findById(tenantId);
+  if (!tenant) return { ok: false, error: 'テナント情報の取得に失敗しました' };
+  if (!isLineIntegrationAllowed(tenant.subscriptionPlan)) {
+    return { ok: false, error: 'LINE 連携は Pro / Enterprise プランでのみ利用できます。' };
+  }
+  // すべて満たしたので tenantId を返す
+  return { ok: true, tenantId };
+}

--- a/src/lib/line-push.ts
+++ b/src/lib/line-push.ts
@@ -5,9 +5,9 @@
  * コメント (返信) すると、依頼者がアプリにログインしなくても内容を確認できるよう LINE へ push する。
  * 既存のメール返信 (src/lib/ticket-email.ts) と同じ「何を送るか (純粋関数) / 送る (副作用)」の分離方針。
  *
- * 必要な環境変数: LINE_CHANNEL_ACCESS_TOKEN (Messaging API の長期アクセストークン)。
- * 未設定の間は push をスキップする (LINE 連携自体が任意機能のため、メール送信のような起動失敗には
- * しない。メール取り込み用シークレット等の必須セキュリティ設定とは性質が異なる)。
+ * アクセストークン (Messaging API の長期アクセストークン) はテナント単位の `TenantLineConfig`
+ * (§4 Phase 2.1 フォローアップ) から呼び出し側が解決して渡す。この関数自体は環境変数を読まない
+ * (呼び出し側でテナントの LINE 連携が未設定なら、そもそも呼び出されない想定)。
  */
 
 // Webhook POST 共通ユーティリティ (タイムアウト・本文上限・リダイレクト非追従) を再利用する
@@ -53,12 +53,17 @@ export function buildTicketReplyLineMessage(input: {
 }
 
 // 指定した LINE ユーザーへテキストメッセージを push する。
-// LINE_CHANNEL_ACCESS_TOKEN 未設定時は何もしない (任意機能のためサイレントにスキップする)。
+// accessToken が空文字ならこのテナントで LINE 連携が未設定 (または未対応プラン) であることを
+// 意味し、何もしない (任意機能のためサイレントにスキップする)。
 // HTTP エラー時は例外を投げる (呼び出し側がベストエフォートとして catch する設計)。
-export async function pushLineMessage(lineUserId: string, text: string): Promise<void> {
-  // アクセストークン未設定はこの環境で LINE push が無効であることを意味する (フィーチャーフラグ的に扱う)
-  const accessToken = process.env.LINE_CHANNEL_ACCESS_TOKEN?.trim();
-  if (!accessToken) return;
+export async function pushLineMessage(
+  accessToken: string,
+  lineUserId: string,
+  text: string,
+): Promise<void> {
+  // アクセストークン未設定はこのテナントで LINE push が無効であることを意味する (フィーチャーフラグ的に扱う)
+  const trimmedToken = accessToken.trim();
+  if (!trimmedToken) return;
 
   // 紐付け済み lineUserId は DB 由来だが、JSON ボディに載せる前に形式を再検証する (防御的多層化)。
   // 形式外の値を送っても LINE 側で 400 になるだけだが、外部 API へ無駄なリクエストを送らずに済む。
@@ -72,7 +77,7 @@ export async function pushLineMessage(lineUserId: string, text: string): Promise
     headers: {
       'Content-Type': 'application/json',
       // 長期アクセストークンを Bearer 認証で渡す (LINE Messaging API 仕様)
-      Authorization: `Bearer ${accessToken}`,
+      Authorization: `Bearer ${trimmedToken}`,
     },
     body: JSON.stringify({
       to: lineUserId,

--- a/tests/data/line-config-repository.contract.prisma.test.ts
+++ b/tests/data/line-config-repository.contract.prisma.test.ts
@@ -1,0 +1,112 @@
+// LINE 連携設定リポジトリ (Prisma アダプタ) の契約テスト。
+// クロステナント分離など、本番 Prisma 実装が満たすべき性質を実 DB に対して検証する。
+// docs/smb-dx-pivot-plan.md §4 Phase 2.1。
+//
+// この DB 依存テストは RUN_PRISMA_CONTRACT=1 のときだけ走り、beforeEach で全テーブルを
+// TRUNCATE するため **開発 DB を指さない** こと (CLAUDE.md §テスト)。
+
+// Vitest の DSL (describe=グループ, beforeAll/afterAll/beforeEach=前後処理, it/expect)
+import { describe, beforeAll, afterAll, beforeEach, expect, it } from 'vitest';
+// Prisma クライアント本体 (生成物。DB へ実際に接続して操作する SDK)
+import { PrismaClient } from '@/generated/prisma';
+// 本番 Prisma 実装の repos 束を組み立てる関数
+import { buildPrismaRepos } from '@/data/adapters/prisma';
+
+// テナント A / B の ID
+const TENANT_A = 'default-tenant';
+const TENANT_B = 'tenant-b';
+
+// この DB 依存テストを実行してよいかどうかの明示フラグ (CI の専用ジョブだけが '1' を立てる)
+const SHOULD_RUN = process.env.RUN_PRISMA_CONTRACT === '1';
+
+// Prisma 実装が LineConfigRepository 契約を満たすか検証する (フラグが立っているときだけ走る)
+describe.runIf(SHOULD_RUN)('LineConfigRepository (prisma adapter)', () => {
+  // 後続のテストから参照する PrismaClient
+  let prisma: PrismaClient;
+
+  // スイート開始時に 1 度だけ DB へ接続する
+  beforeAll(async () => {
+    prisma = new PrismaClient();
+    await prisma.$connect();
+  });
+
+  // スイート終了時に接続を確実に閉じる
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  // 各テスト前に全テーブルを空にし、テナント A / B を作成する
+  beforeEach(async () => {
+    // LINE 連携設定 → Tenant の順に依存するが CASCADE が吸収する。TenantLineConfig も明示的に含める
+    await prisma.$executeRawUnsafe(
+      'TRUNCATE TABLE "TenantLineConfig","TenantSsoConfig","Attachment","TicketHistory","TicketComment","Notification","FaqCandidate","Ticket","Category","MagicLinkToken","User","Tenant" RESTART IDENTITY CASCADE',
+    );
+    // テナント A / B を作成する
+    await prisma.tenant.create({ data: { id: TENANT_A, name: 'デフォルト組織', mode: 'lite' } });
+    await prisma.tenant.create({ data: { id: TENANT_B, name: '別組織', mode: 'lite' } });
+  });
+
+  // テスト用の LINE 連携設定入力を作るヘルパー
+  function input(tenantId: string, botUserId: string) {
+    return {
+      tenantId,
+      channelSecret: `secret-${tenantId}`,
+      channelAccessToken: `token-${tenantId}`,
+      botUserId,
+    };
+  }
+
+  // upsert で作成し findByTenant / findByBotUserId で取得できる
+  it('upsert で作成し findByTenant / findByBotUserId で取得できる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const botUserId = 'Ubbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const created = await repos.lineConfigs.upsert(input(TENANT_A, botUserId));
+    expect(created.tenantId).toBe(TENANT_A);
+    const byTenant = await repos.lineConfigs.findByTenant(TENANT_A);
+    expect(byTenant?.channelSecret).toBe(`secret-${TENANT_A}`);
+    const byBotUserId = await repos.lineConfigs.findByBotUserId(botUserId);
+    expect(byBotUserId?.tenantId).toBe(TENANT_A);
+  });
+
+  // 同一テナントへの upsert は更新になる (1 テナント 1 設定 = @unique tenantId)
+  it('同一テナントへの upsert は重複作成せず更新になる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const first = await repos.lineConfigs.upsert(
+      input(TENANT_A, 'Uaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+    );
+    const second = await repos.lineConfigs.upsert(
+      input(TENANT_A, 'Ucccccccccccccccccccccccccccccccc'),
+    );
+    // 同一レコードの更新なので ID は不変、値だけ変わる
+    expect(second.id).toBe(first.id);
+    expect(second.botUserId).toBe('Ucccccccccccccccccccccccccccccccc');
+  });
+
+  // 他テナントが既に使用している botUserId への upsert は一意制約違反でエラーになる
+  it('他テナントが使用中の botUserId への upsert はエラーになる (クロステナント混線防止)', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const sharedBotUserId = 'Uddddddddddddddddddddddddddddddd1';
+    await repos.lineConfigs.upsert(input(TENANT_A, sharedBotUserId));
+    await expect(repos.lineConfigs.upsert(input(TENANT_B, sharedBotUserId))).rejects.toThrow();
+  });
+
+  // クロステナント分離: A の設定は B から取得・削除できない
+  it('テナント A の設定はテナント B から取得・削除できない (クロステナント分離)', async () => {
+    const repos = buildPrismaRepos(prisma);
+    // A にだけ設定を作る
+    await repos.lineConfigs.upsert(input(TENANT_A, 'Ueeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'));
+    // B からは取得できない
+    expect(await repos.lineConfigs.findByTenant(TENANT_B)).toBeNull();
+    // B の delete は A に影響しない
+    await repos.lineConfigs.delete(TENANT_B);
+    expect(await repos.lineConfigs.findByTenant(TENANT_A)).not.toBeNull();
+  });
+
+  // delete で自テナントの設定を削除できる
+  it('delete で自テナントの設定を削除できる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await repos.lineConfigs.upsert(input(TENANT_A, 'Uffffffffffffffffffffffffffffffff'));
+    await repos.lineConfigs.delete(TENANT_A);
+    expect(await repos.lineConfigs.findByTenant(TENANT_A)).toBeNull();
+  });
+});

--- a/tests/data/line-config-repository.memory.test.ts
+++ b/tests/data/line-config-repository.memory.test.ts
@@ -1,0 +1,109 @@
+// LINE 連携設定リポジトリ (メモリアダプタ) の単体テスト。
+// upsert / findByTenant / findByBotUserId / delete が正しく動き、テナント境界を越えないことを確認する。
+// docs/smb-dx-pivot-plan.md §4 Phase 2.1。
+
+// Vitest の DSL とフック
+import { beforeEach, describe, expect, it } from 'vitest';
+// メモリ context (store/repos)
+import { createMemoryContext } from '@/data/adapters/memory';
+// 型のみ
+import type { Repos } from '@/data/ports/unit-of-work';
+
+// テスト用テナント識別子
+const TENANT_A = 'tenant-a';
+const TENANT_B = 'tenant-b';
+
+// テストごとに作り直す repos
+let repos: Repos;
+
+// LINE 連携設定の入力サンプルを作るヘルパー
+function sampleInput(tenantId: string, botUserId: string) {
+  return {
+    tenantId, // 所属テナント
+    channelSecret: `secret-${tenantId}`, // Webhook 署名検証用シークレット
+    channelAccessToken: `token-${tenantId}`, // Messaging API push 用アクセストークン
+    botUserId, // このチャネルの Bot User ID
+  };
+}
+
+// LINE 連携設定リポジトリの仕様確認テスト群
+describe('LineConfigRepository (memory)', () => {
+  // 各テストの前にメモリ context を作り直す
+  beforeEach(() => {
+    repos = createMemoryContext().repos;
+  });
+
+  // 未設定なら null を返す
+  it('未設定のテナントは findByTenant が null を返す', async () => {
+    expect(await repos.lineConfigs.findByTenant(TENANT_A)).toBeNull();
+  });
+
+  // 未登録の botUserId は findByBotUserId が null を返す
+  it('未登録の botUserId は findByBotUserId が null を返す', async () => {
+    expect(await repos.lineConfigs.findByBotUserId('Uaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toBeNull();
+  });
+
+  // upsert が新規作成し、findByTenant / findByBotUserId 両方で取得できる
+  it('upsert で新規作成し findByTenant / findByBotUserId で取得できる', async () => {
+    const botUserId = 'Ubbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const created = await repos.lineConfigs.upsert(sampleInput(TENANT_A, botUserId));
+    // 作成結果が入力どおりであること
+    expect(created.tenantId).toBe(TENANT_A);
+    expect(created.botUserId).toBe(botUserId);
+    // tenantId からも botUserId からも同じ設定を取得できる
+    const byTenant = await repos.lineConfigs.findByTenant(TENANT_A);
+    expect(byTenant?.channelSecret).toBe(`secret-${TENANT_A}`);
+    const byBotUserId = await repos.lineConfigs.findByBotUserId(botUserId);
+    expect(byBotUserId?.tenantId).toBe(TENANT_A);
+  });
+
+  // 同一テナントへの upsert は新規作成ではなく更新になる (1 テナント 1 設定)
+  it('同一テナントへの upsert は更新になる (重複作成しない)', async () => {
+    const botUserId1 = 'Uaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const botUserId2 = 'Uddddddddddddddddddddddddddddddd1';
+    // 1 回目: 作成
+    const first = await repos.lineConfigs.upsert(sampleInput(TENANT_A, botUserId1));
+    // 2 回目: botUserId 変更で更新
+    const second = await repos.lineConfigs.upsert({
+      ...sampleInput(TENANT_A, botUserId2),
+      channelSecret: 'new-secret',
+    });
+    // ID は維持され (同一レコードの更新)、値だけ変わる
+    expect(second.id).toBe(first.id);
+    expect(second.botUserId).toBe(botUserId2);
+    expect(second.channelSecret).toBe('new-secret');
+    // 旧 botUserId ではもう引けない
+    expect(await repos.lineConfigs.findByBotUserId(botUserId1)).toBeNull();
+  });
+
+  // 他テナントが既に使用している botUserId への upsert はエラーになる (クロステナント混線防止)
+  it('他テナントが使用中の botUserId への upsert はエラーになる', async () => {
+    const sharedBotUserId = 'Ueeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+    await repos.lineConfigs.upsert(sampleInput(TENANT_A, sharedBotUserId));
+    await expect(
+      repos.lineConfigs.upsert(sampleInput(TENANT_B, sharedBotUserId)),
+    ).rejects.toThrow();
+  });
+
+  // delete で設定が消える
+  it('delete で設定を削除できる', async () => {
+    const botUserId = 'Uffffffffffffffffffffffffffffffff';
+    await repos.lineConfigs.upsert(sampleInput(TENANT_A, botUserId));
+    await repos.lineConfigs.delete(TENANT_A);
+    // 削除後は tenantId からも botUserId からも取得できない
+    expect(await repos.lineConfigs.findByTenant(TENANT_A)).toBeNull();
+    expect(await repos.lineConfigs.findByBotUserId(botUserId)).toBeNull();
+  });
+
+  // クロステナント分離: テナント A の設定はテナント B から見えない
+  it('テナント A の設定はテナント B から取得できない (クロステナント分離)', async () => {
+    const botUserId = 'Uaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab';
+    // A にだけ設定を作る
+    await repos.lineConfigs.upsert(sampleInput(TENANT_A, botUserId));
+    // B からは取得できない
+    expect(await repos.lineConfigs.findByTenant(TENANT_B)).toBeNull();
+    // B の delete は A に影響しない
+    await repos.lineConfigs.delete(TENANT_B);
+    expect(await repos.lineConfigs.findByTenant(TENANT_A)).not.toBeNull();
+  });
+});

--- a/tests/features/attachments/post-comment-route.test.ts
+++ b/tests/features/attachments/post-comment-route.test.ts
@@ -429,9 +429,20 @@ describe('POST /api/tickets/[id]/comments', () => {
     // 依頼者を LINE 連携済みにする
     const requester = store.users.get(REQUESTER)!;
     store.users.set(REQUESTER, { ...requester, lineUserId: REQUESTER_LINE_USER_ID });
+    // テナントの LINE 連携設定 (アクセストークン) をシードする
+    // (Phase 2 フォローアップ: グローバル環境変数ではなくテナント単位の DB 設定から解決する)
+    const now = new Date();
+    store.lineConfigs.set('line_cfg_test', {
+      id: 'line_cfg_test',
+      tenantId: TENANT,
+      channelSecret: 'irrelevant-for-push',
+      channelAccessToken: 'test-access-token',
+      botUserId: `U${'b'.repeat(32)}`,
+      createdAt: now,
+      updatedAt: now,
+    });
 
-    // LINE push を有効化し、fetch をモックして実際の外部送信は行わない
-    vi.stubEnv('LINE_CHANNEL_ACCESS_TOKEN', 'test-access-token');
+    // fetch をモックして実際の外部送信は行わない
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -454,8 +465,7 @@ describe('POST /api/tickets/[id]/comments', () => {
       expect(body.to).toBe(REQUESTER_LINE_USER_ID);
       expect(body.messages[0].text).toContain('対応しました');
     } finally {
-      // 他テストへ影響しないよう env / fetch のスタブを必ず元に戻す
-      vi.unstubAllEnvs();
+      // 他テストへ影響しないよう fetch のスタブを必ず元に戻す
       vi.unstubAllGlobals();
     }
   });

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -2,7 +2,7 @@
 // 署名検証済みの本文を渡し、(a) ワンタイムコード送信での連携 (起票しない)、
 // (b) 連携済みユーザーの起票者が本人になる、(c) 未連携はプロキシ担当者、を検証する (DB は持ち込まない)。
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createHmac } from 'node:crypto';
 import { createMemoryContext, type Store } from '@/data/adapters/memory';
 import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
@@ -12,6 +12,8 @@ const SECRET = 'test-line-channel-secret';
 const TENANT = 'default-tenant';
 const AGENT_ID = 'u-agent-1';
 const MEMBER_ID = 'u-member-1';
+// このテナントのチャネルを表す Bot User ID (LINE の destination フィールドと一致させる値)
+const BOT_USER_ID = 'Ubbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 // LINE ユーザー ID のテスト用固定値。LINE の実形式 (U + 32桁小文字 hex) に合わせる。
 // ルートが userId フォーマットを検証するようになったため、形式外の値は '不明' 扱いになる
 const LINE_ID_UNLINKED = 'U00000000000000000000000000000001'; // テナントメンバーに未紐付け
@@ -64,6 +66,16 @@ function seed() {
     createdAt: now,
     updatedAt: now,
   });
+  // テナント単位の LINE 連携設定 (destination=BOT_USER_ID からこのテナントを解決する)
+  store.lineConfigs.set('line_cfg_1', {
+    id: 'line_cfg_1',
+    tenantId: TENANT,
+    channelSecret: SECRET,
+    channelAccessToken: 'test-access-token',
+    botUserId: BOT_USER_ID,
+    createdAt: now,
+    updatedAt: now,
+  });
 }
 
 // LINE 署名を計算する (X-Line-Signature = Base64(HMAC-SHA256(body, secret)))
@@ -71,9 +83,11 @@ function sign(body: string): string {
   return createHmac('sha256', SECRET).update(body, 'utf8').digest('base64');
 }
 
-// 1 件のテキストメッセージイベントを含む署名付きリクエストを組み立てる
-function makeRequest(text: string, userId: string): Request {
+// 1 件のテキストメッセージイベントを含む署名付きリクエストを組み立てる。
+// destination はチャネル解決に使う値で、既定はシード済みテナントの BOT_USER_ID
+function makeRequest(text: string, userId: string, destination: string = BOT_USER_ID): Request {
   const body = JSON.stringify({
+    destination,
     events: [
       {
         type: 'message',
@@ -96,12 +110,6 @@ describe('POST /api/inbound/line', () => {
     repos = ctx.repos;
     uow = ctx.uow;
     seed();
-    vi.stubEnv('LINE_CHANNEL_SECRET', SECRET);
-    vi.stubEnv('LINE_TARGET_TENANT_ID', TENANT);
-  });
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
   });
 
   // Standard 以下のプランは LINE 連携不可 (§6.1 料金プラン)。署名は正しくても起票しない
@@ -260,12 +268,39 @@ describe('POST /api/inbound/line', () => {
     expect(findTicketIdByMessageId).toHaveBeenCalledTimes(2);
   });
 
-  // 署名が不正なリクエストは 401 で拒否する
+  // 署名が不正なリクエストは 401 で拒否する (destination は登録済みチャネルと一致させ、
+  // 「チャネル未登録」ではなく「署名不一致」の分岐を確実に踏む)
   it('署名が不正なら 401 を返す', async () => {
-    const body = JSON.stringify({ events: [] });
+    const body = JSON.stringify({ destination: BOT_USER_ID, events: [] });
     const req = new Request('http://localhost/api/inbound/line', {
       method: 'POST',
       headers: { 'content-type': 'application/json', 'x-line-signature': 'wrong' },
+      body,
+    });
+    const { POST } = await import('@/app/api/inbound/line/route');
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    expect(store.tickets.size).toBe(0);
+  });
+
+  // destination が未登録のチャネルを指す場合も 401 で拒否する (署名は正当な値で計算するが、
+  // どのテナントの鍵で検証すべきか分からないため署名検証まで到達しない)
+  it('destination が未登録のチャネルなら 401 を返す', async () => {
+    const unknownDestination = 'Uccccccccccccccccccccccccccccccc';
+    const body = JSON.stringify({
+      destination: unknownDestination,
+      events: [
+        {
+          type: 'message',
+          source: { type: 'user', userId: LINE_ID_UNLINKED },
+          message: { type: 'text', id: 'm1', text: 'プリンターが動きません' },
+        },
+      ],
+    });
+    // このチャネルの正しいシークレットが無いので、SECRET で署名しても一致しないテナントに届く想定
+    const req = new Request('http://localhost/api/inbound/line', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-line-signature': sign(body) },
       body,
     });
     const { POST } = await import('@/app/api/inbound/line/route');

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -2,11 +2,13 @@
 // 署名検証済みの本文を渡し、(a) ワンタイムコード送信での連携 (起票しない)、
 // (b) 連携済みユーザーの起票者が本人になる、(c) 未連携はプロキシ担当者、を検証する (DB は持ち込まない)。
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createHmac } from 'node:crypto';
 import { createMemoryContext, type Store } from '@/data/adapters/memory';
 import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
 import { hashLineLinkCode, normalizeLineLinkCode } from '@/lib/line-link';
+// レート制限バケットをテスト間で初期化するためのヘルパー (グローバル Map の汚染を防ぐ)
+import { __resetRateLimits } from '@/lib/rate-limit';
 
 const SECRET = 'test-line-channel-secret';
 const TENANT = 'default-tenant';
@@ -110,6 +112,39 @@ describe('POST /api/inbound/line', () => {
     repos = ctx.repos;
     uow = ctx.uow;
     seed();
+    // レート制限バケットはモジュールグローバルなので、他ファイルのテストの影響を受けないよう初期化する
+    __resetRateLimits();
+  });
+
+  afterEach(() => {
+    // 次のテストファイルに影響しないよう、このファイルで消費したバケットも初期化しておく
+    __resetRateLimits();
+  });
+
+  // セキュリティ回帰テスト: destination (署名検証前の値) をレート制限のキーに使うと、
+  // 攻撃者が destination を毎回変えるだけで無制限に新しいバケットを作れてしまい、
+  // レート制限が事実上機能しなくなる。固定キーの全体レート制限がこれを防いでいることを確認する。
+  it('destination を変え続けても固定キーの全体レート制限で頭打ちになる (レート制限回避の防止)', async () => {
+    const { POST } = await import('@/app/api/inbound/line/route');
+    // LINE_UNAUTHENTICATED_RATE_LIMIT の上限 (600件/分) に達するまで、
+    // 毎回異なる未登録 destination で送り続ける (署名は無効なので全て 401 になるはず)
+    let lastStatus = 0;
+    for (let i = 0; i < 601; i += 1) {
+      // 16進32桁のランダムな destination を都度生成する (登録済み BOT_USER_ID とは無関係)
+      const randomDestination = `U${i.toString(16).padStart(32, '0')}`;
+      const body = JSON.stringify({ destination: randomDestination, events: [] });
+      const req = new Request('http://localhost/api/inbound/line', {
+        method: 'POST',
+        // 署名はこの destination 用のチャネル設定が無いのでどうせ無効 (未登録チャネル判定になる)
+        headers: { 'content-type': 'application/json', 'x-line-signature': 'invalid-signature' },
+        body,
+      });
+      const res = await POST(req);
+      lastStatus = res.status;
+    }
+    // 601 回目 (上限 600 を超えた直後) は、destination が変わっていても固定キーの
+    // 全体レート制限に引っかかり 429 になる (401 のままなら回避が成立してしまっている)
+    expect(lastStatus).toBe(429);
   });
 
   // Standard 以下のプランは LINE 連携不可 (§6.1 料金プラン)。署名は正しくても起票しない

--- a/tests/features/update-line-config.test.ts
+++ b/tests/features/update-line-config.test.ts
@@ -1,0 +1,174 @@
+// updateLineConfig (Server Action) のテスト。
+// 書き込み専用フィールド (channelSecret / channelAccessToken) が §9 の方針どおり
+// 空欄送信で既存値を維持し、画面へ現在値を返さないことを中心に検証する。
+
+// Vitest の DSL とモック機能
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// メモリ実装の context (store/repos)
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// リポジトリ束の型
+import type { Repos } from '@/data/ports/unit-of-work';
+// 課金プランの型 (フィクスチャ切替に使う)
+import type { SubscriptionPlan } from '@/domain/types';
+
+const TENANT_ID = 'tenant-1';
+const ADMIN_ID = 'u-admin-1';
+const BOT_USER_ID_A = 'Uaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const BOT_USER_ID_B = 'Ubbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+// 各テストで差し替える可変な依存 (Action import 前に値を入れる)
+let store: Store;
+let repos: Repos;
+
+// @/data を差し替え (getter で beforeEach の上書きを反映)
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+}));
+
+// 認証は固定セッション (admin) を返すモックに置換
+vi.mock('@/lib/auth', () => ({
+  auth: async () => ({
+    user: { id: ADMIN_ID, role: 'admin', tenantId: TENANT_ID },
+  }),
+}));
+
+// next/cache の副作用 (revalidatePath) はテストでは不要
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// FormData を組み立てるヘルパー (空欄で送りたいフィールドは省略可能にする)
+function makeForm(input: {
+  channelSecret?: string;
+  channelAccessToken?: string;
+  botUserId?: string;
+}): FormData {
+  const fd = new FormData();
+  fd.set('channelSecret', input.channelSecret ?? '');
+  fd.set('channelAccessToken', input.channelAccessToken ?? '');
+  fd.set('botUserId', input.botUserId ?? '');
+  return fd;
+}
+
+// 指定プランのテナントをシードする (Pro/Enterprise のみ LINE 連携可)
+function seedTenant(plan: SubscriptionPlan) {
+  store.tenants.set(TENANT_ID, {
+    id: TENANT_ID,
+    name: 'テスト組織',
+    mode: 'lite',
+    industry: null,
+    inboundToken: null,
+    slackWebhookUrl: null,
+    subscriptionPlan: plan,
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+    stripeSubscriptionStatus: null,
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null,
+    createdAt: new Date(),
+  });
+}
+
+describe('updateLineConfig', () => {
+  beforeEach(() => {
+    const ctx = createMemoryContext();
+    store = ctx.store;
+    repos = ctx.repos;
+  });
+
+  // Standard プランでは LINE 連携自体が使えない (§6.1 料金プラン)
+  it('Standard プランでは保存が拒否される', async () => {
+    seedTenant('standard');
+    const { updateLineConfig } = await import('@/features/settings/actions/update-line-config');
+    const result = await updateLineConfig(
+      {},
+      makeForm({ channelSecret: 's1', channelAccessToken: 't1', botUserId: BOT_USER_ID_A }),
+    );
+    expect(result.error).toBe('LINE 連携は Pro / Enterprise プランでのみ利用できます。');
+    expect(store.lineConfigs.size).toBe(0);
+  });
+
+  // 新規作成時は channelSecret / channelAccessToken が空だとエラーになる (書き込み専用フィールドの必須化)
+  it('新規作成時に channelSecret が空だとエラーになる', async () => {
+    seedTenant('pro');
+    const { updateLineConfig } = await import('@/features/settings/actions/update-line-config');
+    const result = await updateLineConfig(
+      {},
+      makeForm({ channelAccessToken: 't1', botUserId: BOT_USER_ID_A }),
+    );
+    expect(result.error).toBe('チャネルシークレットは必須です');
+    expect(store.lineConfigs.size).toBe(0);
+  });
+
+  // 新規作成は全フィールドを入力すれば成功する
+  it('新規作成は全フィールド入力で成功する', async () => {
+    seedTenant('pro');
+    const { updateLineConfig } = await import('@/features/settings/actions/update-line-config');
+    const result = await updateLineConfig(
+      {},
+      makeForm({ channelSecret: 's1', channelAccessToken: 't1', botUserId: BOT_USER_ID_A }),
+    );
+    expect(result.success).toBe(true);
+    const saved = await repos.lineConfigs.findByTenant(TENANT_ID);
+    expect(saved?.channelSecret).toBe('s1');
+    expect(saved?.channelAccessToken).toBe('t1');
+    expect(saved?.botUserId).toBe(BOT_USER_ID_A);
+  });
+
+  // 書き込み専用フィールドの中核仕様: 既存設定がある状態で channelSecret / channelAccessToken を
+  // 空欄のまま送信すると、既存の値を上書きせずそのまま維持する (§9: 秘密情報を画面に出さない設計)
+  it('空欄で送信すると既存の channelSecret / channelAccessToken を維持する', async () => {
+    seedTenant('pro');
+    const { updateLineConfig } = await import('@/features/settings/actions/update-line-config');
+    // 1 回目: 通常どおり全項目を入力して作成
+    await updateLineConfig(
+      {},
+      makeForm({
+        channelSecret: 'original-secret',
+        channelAccessToken: 'original-token',
+        botUserId: BOT_USER_ID_A,
+      }),
+    );
+    // 2 回目: botUserId だけ変更し、シークレット/トークンは空欄のまま送信
+    const result = await updateLineConfig({}, makeForm({ botUserId: BOT_USER_ID_B }));
+    expect(result.success).toBe(true);
+    const saved = await repos.lineConfigs.findByTenant(TENANT_ID);
+    // シークレット・トークンは初回設定時の値のまま (空文字で上書きされていない)
+    expect(saved?.channelSecret).toBe('original-secret');
+    expect(saved?.channelAccessToken).toBe('original-token');
+    // botUserId だけ更新されている
+    expect(saved?.botUserId).toBe(BOT_USER_ID_B);
+  });
+
+  // botUserId の形式検証 (destination との一致に使うため 'U' + 32桁 hex 以外は拒否する)
+  it('botUserId の形式が不正だとエラーになる', async () => {
+    seedTenant('pro');
+    const { updateLineConfig } = await import('@/features/settings/actions/update-line-config');
+    const result = await updateLineConfig(
+      {},
+      makeForm({ channelSecret: 's1', channelAccessToken: 't1', botUserId: 'not-a-valid-id' }),
+    );
+    expect(result.error).toBe('Bot User ID の形式が正しくありません ("U" + 32桁の16進数)');
+  });
+
+  // 他テナントが既に使用中の botUserId は一意制約違反として拒否される
+  it('他テナントが使用中の botUserId は拒否される', async () => {
+    seedTenant('pro');
+    // 別テナントが同じ botUserId を既に登録済み
+    await repos.lineConfigs.upsert({
+      tenantId: 'other-tenant',
+      channelSecret: 's-other',
+      channelAccessToken: 't-other',
+      botUserId: BOT_USER_ID_A,
+    });
+    const { updateLineConfig } = await import('@/features/settings/actions/update-line-config');
+    const result = await updateLineConfig(
+      {},
+      makeForm({ channelSecret: 's1', channelAccessToken: 't1', botUserId: BOT_USER_ID_A }),
+    );
+    expect(result.error).toBe('この Bot User ID は既に別のテナントで登録されています');
+  });
+});

--- a/tests/line-push.test.ts
+++ b/tests/line-push.test.ts
@@ -67,20 +67,17 @@ describe('pushLineMessage', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
-    vi.unstubAllEnvs();
   });
 
-  // 未設定: LINE_CHANNEL_ACCESS_TOKEN が無ければ何もせず fetch を呼ばない (任意機能のスキップ)
-  it('LINE_CHANNEL_ACCESS_TOKEN 未設定なら fetch を呼ばない', async () => {
-    vi.stubEnv('LINE_CHANNEL_ACCESS_TOKEN', '');
-    await pushLineMessage(VALID_LINE_USER_ID, 'こんにちは');
+  // 未設定: accessToken が空文字なら何もせず fetch を呼ばない (テナント未設定のスキップ)
+  it('accessToken が空文字なら fetch を呼ばない', async () => {
+    await pushLineMessage('', VALID_LINE_USER_ID, 'こんにちは');
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   // 正常系: Messaging API の push エンドポイントへ Bearer 認証付きで POST する
   it('Messaging API へ Bearer 認証付きで POST する', async () => {
-    vi.stubEnv('LINE_CHANNEL_ACCESS_TOKEN', 'test-access-token');
-    await pushLineMessage(VALID_LINE_USER_ID, 'こんにちは');
+    await pushLineMessage('test-access-token', VALID_LINE_USER_ID, 'こんにちは');
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
@@ -93,22 +90,20 @@ describe('pushLineMessage', () => {
 
   // セキュリティ: 不正な形式の lineUserId は fetch を呼ばずにスキップする (防御的な多層チェック)
   it('不正な形式の lineUserId は fetch を呼ばない', async () => {
-    vi.stubEnv('LINE_CHANNEL_ACCESS_TOKEN', 'test-access-token');
-    await pushLineMessage('not-a-line-user-id', 'こんにちは');
+    await pushLineMessage('test-access-token', 'not-a-line-user-id', 'こんにちは');
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   // 異常系: HTTP エラー時は例外を投げる (呼び出し側がベストエフォートとして catch する)
   it('HTTP エラー時は例外を投げる', async () => {
-    vi.stubEnv('LINE_CHANNEL_ACCESS_TOKEN', 'test-access-token');
     fetchMock.mockResolvedValue({
       ok: false,
       status: 401,
       type: 'basic',
       text: () => Promise.resolve('Unauthorized'),
     });
-    await expect(pushLineMessage(VALID_LINE_USER_ID, 'こんにちは')).rejects.toThrow(
-      /LINE push 送信失敗/,
-    );
+    await expect(
+      pushLineMessage('test-access-token', VALID_LINE_USER_ID, 'こんにちは'),
+    ).rejects.toThrow(/LINE push 送信失敗/);
   });
 });


### PR DESCRIPTION
## 対応する計画項目

`docs/smb-dx-pivot-plan.md` §4 Phase 2.1（2026-07-06 フォローアップ、本 PR で追記）。

`docs/smb-dx-pivot-plan.md` の Phase 0〜4 は既に全項目がチェック済みでしたが、LINE 公式アカウント連携（Phase 2）だけは「1 デプロイ環境につき 1 テナント / 1 LINE チャネル」を環境変数（`LINE_CHANNEL_SECRET` / `LINE_TARGET_TENANT_ID` / `LINE_CHANNEL_ACCESS_TOKEN`）で決め打ちする β 制約付きの実装のままでした。本アプリはマルチテナント SaaS が前提（§3.3・§5.6）であり、他の全チャネル（メール取り込み・Slack/Teams/Chatwork 通知・SSO）は既にテナント単位の設定として実装済みのため、LINE 連携だけがグローバル単一チャネルのままなのは設計上の整合性を欠く状態でした。本 PR ではこのギャップを解消します。

## 変更内容

- `TenantLineConfig` Prisma モデル（`channelSecret` / `channelAccessToken` / `botUserId`）を追加し、Port/Adapter（Prisma + メモリ）で管理。
- `POST /api/inbound/line` は LINE が送ってくる `destination`（チャネルの Bot User ID。秘密情報ではない公開識別子）で `TenantLineConfig` を引いてテナントを解決し、そのテナント専用の `channelSecret` で署名検証するよう変更（メール取り込みの `inboundToken` と同じ「公開識別子でテナントを特定 → 秘密鍵で認証」の設計）。チャネル未登録・署名不一致はどちらも同一の 401 にして原因を外部に漏らさない。
- 担当者の LINE 返信 push（`src/lib/line-push.ts`）もテナントの `channelAccessToken` を使うよう変更し、グローバル環境変数への依存を廃止。
- `/settings` 画面に admin 専用・Pro/Enterprise プラン限定の LINE 連携設定セクション（チャネルシークレット・アクセストークン・Bot User ID の登録）を追加。
- `.env.example` からグローバル LINE 環境変数の記載を削除。

## 再利用した既存実装

- `TenantSsoConfig` / `SsoConfigRepository` の Port・Adapter・Server Action・設定画面パターンをそのまま踏襲。
- メール取り込み（`inboundToken`）の「公開識別子でテナント解決 → 秘密鍵で検証」という設計を LINE の `destination`/`botUserId` にも適用。

## 検証方法

- `npm run typecheck` / `npm run lint` / `npm run test`（504 件 pass、Prisma 契約テストはローカルに DB が無いため 43 件 skip）。
- 新規契約テスト `tests/data/line-config-repository.contract.prisma.test.ts` は CI の `prisma-contract` ジョブで実行される想定。
- 画面確認は本環境では未実施（Docker/Postgres が起動できないサンドボックス環境のため）。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01ByBGsmkkmaQ1SxPSyk2zeZ)_