### PR TITLE
feat(tickets): 外部通知の起票チャネル横展開・担当者アサイン通知・LINEプランガード修正

### DIFF
--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -56,6 +56,8 @@ import { buildReplyMessageId, resolveMessageIdDomain } from '@/lib/email-message
 import { formatTicketRef } from '@/lib/ticket-ref';
 // メール取り込み機能のプランゲート (§6.1 料金プラン: Free では利用不可)
 import { isEmailInboundAllowed } from '@/lib/plan-guard';
+// Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (Web フォーム・LINE 取り込み・CSV インポートと共有)
+import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
 
 // このルートは Node ランタイムで動かす (node:crypto / Prisma を使うため Edge では動かない)
 export const runtime = 'nodejs';
@@ -559,6 +561,15 @@ export async function POST(req: Request) {
     console.info('[POST /api/inbound/email] resolved write conflict as duplicate', ticketId);
     return NextResponse.json({ status: 'duplicate', ticketId }, { status: 200 });
   }
+
+  // Phase 4: 新規起票を Slack/Teams/Chatwork へ通知する (Web フォーム・LINE・CSV と同じ経路)。
+  // メール取り込みは担当者が画面を開かなくても起票された事実に気づけることが重要なため、
+  // 受領自動返信と同様にベストエフォートで送る (失敗してもチケット作成のレスポンスには影響しない)
+  await notifyNewTicketOutbound(tenant.id, {
+    id: ticketId,
+    title: email.subject,
+    priority: 'Medium',
+  });
 
   // 初回メール起票の受領自動返信 (メンバー改善 #1): 送信元へ「受け付けました」を 1 通返す。
   // Web フォーム起票は送信後すぐ画面に出るが、メール起票は受領確認が無いと「届いたか不明」になる穴を埋める。

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -61,6 +61,8 @@ import {
 import { broadcastUnreadCountToMany } from '@/features/notifications/notify';
 // LINE 連携機能のプランゲート (§6.1 料金プラン: Pro / Enterprise のみ利用可能)
 import { isLineIntegrationAllowed } from '@/lib/plan-guard';
+// Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (Web フォーム・メール取り込み・CSV インポートと共有)
+import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
 
 // このルートは Node ランタイムで動かす (node:crypto / Prisma を使うため Edge では動かない)
 export const runtime = 'nodejs';
@@ -539,6 +541,9 @@ async function processLineEvent(
         notifyErr,
       );
     }
+    // Phase 4: 新規起票を Slack/Teams/Chatwork へ通知する (Web フォーム・メール・CSV と同じ経路)。
+    // アプリ内通知とは独立したベストエフォート処理なので、失敗してもここまでの成功を巻き戻さない
+    await notifyNewTicketOutbound(targetTenantId, { id: ticketId, title, priority: 'Medium' });
     return ticketId;
   } catch (err) {
     // 起票失敗は握り潰さずログに残す。再送による重複起票を避けるため呼び出し側は 200 で受領する

--- a/src/app/api/tickets/[id]/comments/route.ts
+++ b/src/app/api/tickets/[id]/comments/route.ts
@@ -34,6 +34,8 @@ import { commentBodySchema } from '@/lib/validations/ticket';
 import { validateUploadedFiles } from '@/lib/validations/attachment';
 // MIME → 拡張子の対応表 (storageKey の組み立てで使う)
 import { MIME_TO_EXTENSION } from '@/domain/attachment';
+// LINE 連携機能のプランゲート (§6.1 料金プラン: Pro / Enterprise のみ利用可能)
+import { isLineIntegrationAllowed } from '@/lib/plan-guard';
 
 // /api/tickets/[id]/comments の動的セグメント
 type Params = { params: Promise<{ id: string }> };
@@ -324,6 +326,14 @@ async function sendReplyLineToRequester(args: {
     // LINE push を使わないので何もしない (Pro/Enterprise 限定機能の任意設定)
     const lineConfig = await repos.lineConfigs.findByTenant(tenantId);
     if (!lineConfig) return;
+
+    // プランゲート: LINE 連携は Pro/Enterprise 限定機能 (§6.1 料金プラン)。受信側 Webhook
+    // (POST /api/inbound/line) は isLineIntegrationAllowed で強制しているが、この返信 push は
+    // TenantLineConfig の存在チェックのみで、プランダウングレード後も設定行が残っていれば
+    // 送信され続けてしまっていた (Stripe Webhook はプラン変更のみで LineConfig を削除しない)。
+    // UI 非表示に頼らずここでもサーバー側で強制する (§9)。
+    const tenant = await repos.tenants.findById(tenantId);
+    if (!tenant || !isLineIntegrationAllowed(tenant.subscriptionPlan)) return;
 
     // メール内リンクと同じベース URL 解決ロジックを再利用する (single source)
     const baseUrl = resolveAppBaseUrl();

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -24,12 +24,9 @@ import { getCurrentTenantMode } from '@/lib/tenant';
 import { endOfDayJST } from '@/lib/format-date';
 // Phase 4 課金: プランごとの月間チケット上限チェック (CSV インポート・メール/LINE 取り込みと共有)
 import { getMonthlyTicketQuota } from '@/lib/tenant-plan';
-// Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (失敗してもチケット作成は止めない)
-import { sendOutboundNotification } from '@/lib/outbound-notify';
-// メール/通知本文に載せるチケット詳細ページの絶対 URL を組み立てるためのベース URL 解決ヘルパー
-import { resolveAppBaseUrl } from '@/lib/app-url';
-// 優先度の日本語ラベル (外部通知本文に使う)
-import { PRIORITY_LABELS } from '@/lib/constants';
+// Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (失敗してもチケット作成は止めない。
+// メール取り込み・LINE 取り込み・CSV インポートと共有する)
+import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
 // 新規作成されたチケットの型 (通知本文の組み立てに使う最小限のフィールドのみ参照)
 import type { Ticket } from '@/domain/types';
 
@@ -43,27 +40,6 @@ function validationError(message: string, path: (string | number)[]) {
     },
     { status: 422 },
   );
-}
-
-// 新規チケット作成を Slack/Teams/Chatwork の外部チャネルへ通知するヘルパー。
-// Phase 4「Slack / Chatwork / Microsoft Teams 通知 Adapter」の主目的である
-// 「新しい問い合わせが届いたことにすぐ気づける」を満たすため、起票直後に呼ぶ。
-// 送信失敗はログに残すだけでチケット作成のレスポンスには影響させない (非クリティカルな副作用)。
-async function notifyNewTicketOutbound(tenantId: string, ticket: Ticket): Promise<void> {
-  try {
-    // ベース URL を取得してチケットリンクを組み立てる (NEXTAUTH_URL 未設定時に例外が出る可能性があるため内側に置く)
-    const baseUrl = resolveAppBaseUrl();
-    // 外部チャネル (Slack/Teams/Chatwork) に通知を送る
-    await sendOutboundNotification(tenantId, {
-      subject: `新しい問い合わせが届きました: ${ticket.title}`,
-      body: `優先度: ${PRIORITY_LABELS[ticket.priority] ?? ticket.priority}`,
-      ticketUrl: `${baseUrl}/tickets/${ticket.id}`,
-    });
-  } catch (err) {
-    // 外部通知の失敗はログに記録するが、チケット作成自体は成功扱いにする
-    // (ネットワーク障害・Webhook 設定ミスでチケット起票が失敗に見えるのを防ぐ)
-    console.error('[POST /api/tickets] 外部通知の送信に失敗しました (チケット作成は完了):', err);
-  }
 }
 
 // POST /api/tickets : 新規チケットを作成する HTTP エンドポイント

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -25,6 +25,10 @@ import { initialStatusForMode } from '@/domain/ticket-status';
 import { broadcastUnreadCountToMany } from '@/features/notifications/notify';
 // Phase 4 課金: 月間チケット上限チェック (Web フォーム・メール/LINE 取り込みと共有)
 import { getMonthlyTicketQuota } from '@/lib/tenant-plan';
+// Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (Web フォーム・メール・LINE 取り込みと共有)
+import { sendOutboundNotification } from '@/lib/outbound-notify';
+// メール/通知本文に載せる一覧ページの絶対 URL を組み立てるためのベース URL 解決ヘルパー
+import { resolveAppBaseUrl } from '@/lib/app-url';
 
 // 1 インポートあたりの最大行数 (これを超えたらエラー)
 const MAX_ROWS = 200;
@@ -384,6 +388,21 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     // /dashboard も対象にしないと、インポート後もカウントが旧値のまま最大 60 秒間表示され続ける
     revalidatePath('/tickets');
     revalidatePath('/dashboard');
+
+    // Phase 4: 新規起票を Slack/Teams/Chatwork へ通知する (Web フォーム・メール・LINE と同じ経路)。
+    // CSV は 1 回で最大 MAX_ROWS 件を作成しうるため、他チャネルと違いチケットごとには送らず、
+    // 件数をまとめた 1 通にする (アプリ内通知と同じ「まとめて 1 通」方針。200 件でも通知は 1 通)。
+    // 失敗してもインポート結果には影響させないベストエフォート。
+    try {
+      const baseUrl = resolveAppBaseUrl();
+      await sendOutboundNotification(tenantId, {
+        subject: `CSV インポートで${imported}件の問い合わせが追加されました`,
+        body: `一覧から内容を確認してください。`,
+        ticketUrl: `${baseUrl}/tickets`,
+      });
+    } catch (err) {
+      console.error('[importTickets] 外部通知の送信に失敗しました (インポートは完了):', err);
+    }
 
     // 同テナントの他エージェント (インポート実行者を除く) に一括追加を通知する。
     // 個別チケットごとではなく 1 通にまとめることで通知の過多を防ぐ (200 件追加でも通知は 1 通)。

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -26,9 +26,7 @@ import { broadcastUnreadCountToMany } from '@/features/notifications/notify';
 // Phase 4 課金: 月間チケット上限チェック (Web フォーム・メール/LINE 取り込みと共有)
 import { getMonthlyTicketQuota } from '@/lib/tenant-plan';
 // Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (Web フォーム・メール・LINE 取り込みと共有)
-import { sendOutboundNotification } from '@/lib/outbound-notify';
-// メール/通知本文に載せる一覧ページの絶対 URL を組み立てるためのベース URL 解決ヘルパー
-import { resolveAppBaseUrl } from '@/lib/app-url';
+import { notifyOutboundBestEffort } from '@/lib/outbound-notify';
 
 // 1 インポートあたりの最大行数 (これを超えたらエラー)
 const MAX_ROWS = 200;
@@ -392,17 +390,16 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     // Phase 4: 新規起票を Slack/Teams/Chatwork へ通知する (Web フォーム・メール・LINE と同じ経路)。
     // CSV は 1 回で最大 MAX_ROWS 件を作成しうるため、他チャネルと違いチケットごとには送らず、
     // 件数をまとめた 1 通にする (アプリ内通知と同じ「まとめて 1 通」方針。200 件でも通知は 1 通)。
-    // 失敗してもインポート結果には影響させないベストエフォート。
-    try {
-      const baseUrl = resolveAppBaseUrl();
-      await sendOutboundNotification(tenantId, {
-        subject: `CSV インポートで${imported}件の問い合わせが追加されました`,
-        body: `一覧から内容を確認してください。`,
-        ticketUrl: `${baseUrl}/tickets`,
-      });
-    } catch (err) {
-      console.error('[importTickets] 外部通知の送信に失敗しました (インポートは完了):', err);
-    }
+    // ベース URL 解決・送信・失敗時のベストエフォートログは共通ヘルパーに集約する (§6 DRY)
+    await notifyOutboundBestEffort(
+      tenantId,
+      (baseUrl) => ({
+        subject: `CSV インポートで${imported}件の問い合わせが追加されました`, // 通知の見出し (件数を含める)
+        body: `一覧から内容を確認してください。`, // 個々のチケット内容は含めず一覧への導線のみ示す
+        ticketUrl: `${baseUrl}/tickets`, // 単一チケットに紐づかないため一覧ページへリンクする
+      }),
+      '[importTickets]',
+    );
 
     // 同テナントの他エージェント (インポート実行者を除く) に一括追加を通知する。
     // 個別チケットごとではなく 1 通にまとめることで通知の過多を防ぐ (200 件追加でも通知は 1 通)。

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -42,7 +42,7 @@ import { getEmailSender } from '@/lib/email';
 // メールに埋め込むリンクのベース URL を解決するヘルパー
 import { resolveAppBaseUrl } from '@/lib/app-url';
 // Phase 4: Slack/Teams 外部通知ヘルパー (失敗してもチケット操作を止めない)
-import { sendOutboundNotification } from '@/lib/outbound-notify';
+import { sendOutboundNotification, notifyOutboundBestEffort } from '@/lib/outbound-notify';
 
 // セッションがログイン済みであることを保証するアサーション関数
 function assertAuthenticatedUser(session: Session | null): asserts session is Session {
@@ -354,23 +354,19 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
   // 担当者アサインもステータス変更・エスカレーションと同格の重要イベントであり、
   // チーム共有チャネルで「誰が対応することになったか」に気づけることが望ましい。
   // 担当解除 (null) はチームの注意を引く必要が薄いため対象外にする。
+  // 自己割当でも送る (上の個人宛メールとは異なる意図): Slack はチームの共有チャネル宛の
+  // 「見える化」目的なので、updateTicketStatus の Slack 通知と同じく自己操作でも除外しない。
   if (newAssigneeId) {
-    try {
-      // ベース URL を解決してチケットリンクを組み立てる (NEXTAUTH_URL 未設定時は例外 → 下の catch で握る)
-      const baseUrl = resolveAppBaseUrl();
-      // 外部チャネル (Slack/Teams/Chatwork) に担当者アサインを通知する
-      await sendOutboundNotification(tenantId, {
+    // ベース URL 解決・送信・ログ処理は共通ヘルパーに集約する (§6 DRY)
+    await notifyOutboundBestEffort(
+      tenantId,
+      (baseUrl) => ({
         subject: `担当者が割り当てられました: ${ticket.title}`,
         body: `担当: ${newName ?? '(不明)'}`,
         ticketUrl: buildTicketUrl(baseUrl, ticketId),
-      });
-    } catch (err) {
-      // 外部通知の失敗はログに記録するが、チケット更新自体は成功扱いにする
-      console.error(
-        '[updateTicketAssignee] 外部通知の送信に失敗しました (チケット更新は完了):',
-        err,
-      );
-    }
+      }),
+      '[updateTicketAssignee]',
+    );
   }
 
   // 詳細ページのキャッシュを無効化

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -350,6 +350,29 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
     }
   }
 
+  // Phase 4: Slack/Teams/Chatwork 外部通知 (updateTicketStatus / escalateTicket と同じパターン)。
+  // 担当者アサインもステータス変更・エスカレーションと同格の重要イベントであり、
+  // チーム共有チャネルで「誰が対応することになったか」に気づけることが望ましい。
+  // 担当解除 (null) はチームの注意を引く必要が薄いため対象外にする。
+  if (newAssigneeId) {
+    try {
+      // ベース URL を解決してチケットリンクを組み立てる (NEXTAUTH_URL 未設定時は例外 → 下の catch で握る)
+      const baseUrl = resolveAppBaseUrl();
+      // 外部チャネル (Slack/Teams/Chatwork) に担当者アサインを通知する
+      await sendOutboundNotification(tenantId, {
+        subject: `担当者が割り当てられました: ${ticket.title}`,
+        body: `担当: ${newName ?? '(不明)'}`,
+        ticketUrl: buildTicketUrl(baseUrl, ticketId),
+      });
+    } catch (err) {
+      // 外部通知の失敗はログに記録するが、チケット更新自体は成功扱いにする
+      console.error(
+        '[updateTicketAssignee] 外部通知の送信に失敗しました (チケット更新は完了):',
+        err,
+      );
+    }
+  }
+
   // 詳細ページのキャッシュを無効化
   revalidatePath(`/tickets/${ticketId}`);
 }

--- a/src/lib/outbound-notify.ts
+++ b/src/lib/outbound-notify.ts
@@ -16,6 +16,17 @@ import type { OutboundMessage, OutboundNotifier } from '@/data/ports/outbound-no
 import { repos } from '@/data';
 // SSRF ガード: 送信直前に URL の安全性を再検証する (DNS リバインディング対策の二重防御)
 import { isUnsafeUrl } from '@/lib/ssrf-guard';
+// メール/通知本文に載せるチケット詳細ページの絶対 URL を組み立てるためのベース URL 解決ヘルパー
+import { resolveAppBaseUrl } from '@/lib/app-url';
+// 優先度の日本語ラベル (外部通知本文に使う)
+import { PRIORITY_LABELS } from '@/lib/constants';
+// 新規作成されたチケットの型 (通知本文の組み立てに使う最小限のフィールドのみ参照)
+import type { Ticket } from '@/domain/types';
+
+// notifyNewTicketOutbound が参照する最小限のチケット情報。
+// メール/LINE 取り込みは冪等化ヘルパーが { id, alreadyExisted } しか返さず、通知のためだけに
+// フル Ticket を再取得するのは無駄なため、呼び出し元が持つ最小限のフィールドだけ要求する。
+export type NewTicketNotifyInput = Pick<Ticket, 'id' | 'title' | 'priority'>;
 
 // 設定済みチャネルを表す内部型 (ログ用のチャネル名と送信実体をペアで持つ)
 interface ResolvedChannel {
@@ -37,7 +48,9 @@ function addWebhookChannel(
   // DNS リバインディング攻撃 (登録後に内部 IP へ変更) を緩和するため送信直前にも再検証する。
   if (isUnsafeUrl(url)) {
     // 安全でない URL が DB に残っている場合はスキップしてエラーログを残す
-    console.error(`[outbound-notify] SSRF ガード: 安全でない ${name} Webhook URL をスキップしました`);
+    console.error(
+      `[outbound-notify] SSRF ガード: 安全でない ${name} Webhook URL をスキップしました`,
+    );
     // 安全でない URL にはリクエストを送らずここで終わる
     return;
   }
@@ -100,4 +113,32 @@ export async function sendOutboundNotification(
       );
     }
   });
+}
+
+// 新規チケット作成を Slack/Teams/Chatwork の外部チャネルへ通知する共通ヘルパー。
+// Phase 4「Slack / Chatwork / Microsoft Teams 通知 Adapter」の主目的である
+// 「新しい問い合わせが届いたことにすぐ気づける」を、起票チャネル (Web フォーム / メール取り込み /
+// LINE 連携 / CSV インポート) を問わず満たすため、チケットを作成する全ての入口から呼ぶ。
+// 送信失敗はログに残すだけで呼び出し元のチケット作成処理には影響させない (非クリティカルな副作用)。
+export async function notifyNewTicketOutbound(
+  tenantId: string,
+  ticket: NewTicketNotifyInput,
+): Promise<void> {
+  try {
+    // ベース URL を取得してチケットリンクを組み立てる (NEXTAUTH_URL 未設定時に例外が出る可能性があるため内側に置く)
+    const baseUrl = resolveAppBaseUrl();
+    // 外部チャネル (Slack/Teams/Chatwork) に通知を送る
+    await sendOutboundNotification(tenantId, {
+      subject: `新しい問い合わせが届きました: ${ticket.title}`,
+      body: `優先度: ${PRIORITY_LABELS[ticket.priority] ?? ticket.priority}`,
+      ticketUrl: `${baseUrl}/tickets/${ticket.id}`,
+    });
+  } catch (err) {
+    // 外部通知の失敗はログに記録するが、呼び出し元のチケット作成自体は成功扱いにする
+    // (ネットワーク障害・Webhook 設定ミスでチケット起票が失敗に見えるのを防ぐ)
+    console.error(
+      '[notifyNewTicketOutbound] 外部通知の送信に失敗しました (チケット作成は完了):',
+      err,
+    );
+  }
 }

--- a/src/lib/outbound-notify.ts
+++ b/src/lib/outbound-notify.ts
@@ -115,6 +115,28 @@ export async function sendOutboundNotification(
   });
 }
 
+// tenantId + 呼び出し元コンテキストを受け取り、ベース URL 解決 + 送信 + ベストエフォート
+// エラーハンドリングをまとめる共通ヘルパー。担当者アサイン変更・CSV インポートのように
+// 「ベース URL を解決してメッセージを組み立て、失敗はログのみに留める」形が繰り返し
+// 現れる箇所で使う (§6 DRY)。メッセージ本文はベース URL 依存 (ticketUrl) のことが多いため、
+// buildMessage にベース URL を渡してその場で組み立ててもらう。
+export async function notifyOutboundBestEffort(
+  tenantId: string, // 送信先テナント
+  buildMessage: (baseUrl: string) => OutboundMessage, // ベース URL を使ってメッセージを組み立てる関数
+  logContext: string, // エラーログの接頭辞 (呼び出し元を識別するため。例: '[updateTicketAssignee]')
+): Promise<void> {
+  try {
+    // ベース URL を取得する (NEXTAUTH_URL 未設定時に例外が出る可能性があるため内側に置く)
+    const baseUrl = resolveAppBaseUrl();
+    // 呼び出し元が組み立てたメッセージを外部チャネルへ送る
+    await sendOutboundNotification(tenantId, buildMessage(baseUrl));
+  } catch (err) {
+    // 外部通知の失敗はログに記録するが、呼び出し元の処理自体は成功扱いにする
+    // (ネットワーク障害・Webhook 設定ミスで本来の操作が失敗に見えるのを防ぐ)
+    console.error(`${logContext} 外部通知の送信に失敗しました (処理自体は完了):`, err);
+  }
+}
+
 // 新規チケット作成を Slack/Teams/Chatwork の外部チャネルへ通知する共通ヘルパー。
 // Phase 4「Slack / Chatwork / Microsoft Teams 通知 Adapter」の主目的である
 // 「新しい問い合わせが届いたことにすぐ気づける」を、起票チャネル (Web フォーム / メール取り込み /

--- a/tests/features/assignee-outbound-notify.test.ts
+++ b/tests/features/assignee-outbound-notify.test.ts
@@ -1,0 +1,206 @@
+// updateTicketAssignee が Slack/Teams/Chatwork 外部通知 (sendOutboundNotification) を送ることを検証する。
+// 従来はステータス変更 (updateTicketStatus) とエスカレーション (escalateTicket) にしか
+// 外部通知が配線されておらず、同格に重要な「担当者が割り当てられた」イベントだけが
+// チーム共有チャネルに届かない不整合があった。
+// 主検証:
+//   1. Slack Webhook 設定済みテナントで担当者を割り当てると fetch が 1 回呼ばれる
+//   2. 担当解除 (null) では外部通知を送らない (注意を引く必要が薄いイベントのため対象外)
+//   3. 外部通知未設定テナントで割り当てても fetch は呼ばれない (無駄打ちしない)
+
+// Vitest の DSL とモック機能
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// メモリ実装の context (store/repos/uow)
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// 型のみ
+import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
+// レート制限の履歴をテスト間でクリアする内部用関数
+import { __resetRateLimits } from '@/lib/rate-limit';
+
+// 主に使うテナント / ユーザー ID
+const TENANT = 'default-tenant';
+const AGENT = 'u-agt-1';
+const NEW_ASSIGNEE = 'u-agt-2';
+// テスト用 Slack Webhook URL (実際には送信されない。SSRF ガードを通す公開ホスト)
+const SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/xxx';
+
+// 各テストで差し替える可変な依存 (Action import 前に値を入れる)
+let store: Store;
+let repos: Repos;
+let uow: UnitOfWork;
+// fetch のモック関数 (Slack Adapter が呼ぶ)
+let fetchMock: ReturnType<typeof vi.fn>;
+
+// src/lib/webhook-fetch.ts は SSRF 対策の DNS 検証用 Dispatcher (Agent) を使うため
+// undici の fetch を直接 import している。vi.stubGlobal('fetch', ...) だけでは差し替わらない
+// ため、undici の fetch を globalThis.fetch (下の beforeEach で差し替える) へ委譲するモックにする
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: ((...args: Parameters<typeof globalThis.fetch>) =>
+      globalThis.fetch(...args)) as unknown as typeof actual.fetch,
+  };
+});
+
+// @/data モジュールを差し替え (getter で参照することで beforeEach の上書きを反映)
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+  get uow() {
+    return uow;
+  },
+}));
+
+// セッションはエージェントで固定 (担当者割当はエージェント以上のみ実行可)
+vi.mock('@/lib/auth', () => ({
+  auth: async () => ({
+    user: { id: AGENT, role: 'agent' as const, tenantId: TENANT },
+  }),
+}));
+
+// next/cache の副作用は不要なので spy で潰す
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}));
+
+// SSE ブロードキャストもテストでは不要
+vi.mock('@/lib/sse-subscribers', () => ({
+  broadcast: vi.fn(),
+}));
+
+// 担当者割当メール送信 (別経路) はテストの主眼ではないため no-op にする
+vi.mock('@/lib/email', () => ({
+  getEmailSender: () => ({ send: async () => {} }),
+}));
+
+// テナント + 操作者エージェント + 割当候補エージェント + チケットを 1 件投入するヘルパー。
+// slackWebhookUrl だけを差し替えられるようにする
+async function seed(slackWebhookUrl: string | null): Promise<{ ticketId: string }> {
+  const now = new Date();
+  store.tenants.set(TENANT, {
+    id: TENANT,
+    name: 'デフォルト組織',
+    mode: 'pro',
+    industry: null,
+    inboundToken: null,
+    slackWebhookUrl,
+    subscriptionPlan: 'free' as const,
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+    stripeSubscriptionStatus: null,
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null,
+    createdAt: now,
+  });
+  // 操作者エージェント
+  store.users.set(AGENT, {
+    id: AGENT,
+    email: 'agent1@example.com',
+    name: '操作担当者',
+    passwordHash: 'x',
+    role: 'agent',
+    tenantId: TENANT,
+    createdAt: now,
+    updatedAt: now,
+  });
+  // 割当先候補の別エージェント
+  store.users.set(NEW_ASSIGNEE, {
+    id: NEW_ASSIGNEE,
+    email: 'agent2@example.com',
+    name: '新担当者',
+    passwordHash: 'x',
+    role: 'agent',
+    tenantId: TENANT,
+    createdAt: now,
+    updatedAt: now,
+  });
+  // 依頼者ユーザーを投入 (チケット起票者)
+  store.users.set('u-req-1', {
+    id: 'u-req-1',
+    email: 'requester@example.com',
+    name: '依頼者',
+    passwordHash: 'x',
+    role: 'requester',
+    tenantId: TENANT,
+    createdAt: now,
+    updatedAt: now,
+  });
+  // 検証対象チケットを作成する (未割当)
+  const ticket = await repos.tickets.create({
+    title: 'プリンタが動かない',
+    body: '朝から紙詰まりが続く',
+    priority: 'Medium',
+    creatorId: 'u-req-1',
+    categoryId: null,
+    tenantId: TENANT,
+  });
+  return { ticketId: ticket.id };
+}
+
+beforeEach(() => {
+  // 毎回新しい context を作って独立な状態にする
+  const ctx = createMemoryContext();
+  store = ctx.store;
+  repos = ctx.repos;
+  uow = ctx.uow;
+  // 動的 import の結果をリセット (mock 設定を反映させるため)
+  vi.resetModules();
+  // レート制限の履歴をクリア (前テストの呼び出し回数を引きずらない)
+  __resetRateLimits();
+  // fetch は常にモックし、成功レスポンスを返す (Slack Adapter が呼ぶ)
+  fetchMock = vi
+    .fn()
+    .mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve('ok') });
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('updateTicketAssignee (外部通知)', () => {
+  it('Slack Webhook 設定済みテナントで担当者を割り当てると Slack へ通知される', async () => {
+    const { ticketId } = await seed(SLACK_WEBHOOK_URL);
+    const { updateTicketAssignee } = await import('@/features/tickets/actions/update-ticket');
+
+    await updateTicketAssignee(ticketId, NEW_ASSIGNEE);
+
+    // 割当自体は成功する
+    const t = await repos.tickets.findById(ticketId, TENANT);
+    expect(t?.assigneeId).toBe(NEW_ASSIGNEE);
+    // Slack Webhook へ 1 回だけ POST される
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(SLACK_WEBHOOK_URL);
+    const texts = JSON.stringify(JSON.parse(init.body));
+    expect(texts).toContain('プリンタが動かない');
+    expect(texts).toContain('新担当者');
+  });
+
+  it('担当解除 (null) では外部通知を送らない', async () => {
+    const { ticketId } = await seed(SLACK_WEBHOOK_URL);
+    const { updateTicketAssignee } = await import('@/features/tickets/actions/update-ticket');
+    // 先に割り当ててから解除する
+    await updateTicketAssignee(ticketId, NEW_ASSIGNEE);
+    fetchMock.mockClear();
+
+    await updateTicketAssignee(ticketId, null);
+
+    const t = await repos.tickets.findById(ticketId, TENANT);
+    expect(t?.assigneeId).toBeNull();
+    // 解除では外部通知を送らない
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('外部通知が未設定のテナントで割り当てても fetch は呼ばれない', async () => {
+    const { ticketId } = await seed(null);
+    const { updateTicketAssignee } = await import('@/features/tickets/actions/update-ticket');
+
+    await updateTicketAssignee(ticketId, NEW_ASSIGNEE);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/features/attachments/post-comment-route.test.ts
+++ b/tests/features/attachments/post-comment-route.test.ts
@@ -426,6 +426,9 @@ describe('POST /api/tickets/[id]/comments', () => {
   // メールに加えて LINE Messaging API への push も行われる。
   it('pushes a LINE message to a linked requester when an agent replies', async () => {
     const { ticketId } = await seed();
+    // LINE 連携は Pro/Enterprise 限定機能 (§6.1 料金プラン) なので、seed() 既定の free から昇格させる
+    const tenant = store.tenants.get(TENANT)!;
+    store.tenants.set(TENANT, { ...tenant, subscriptionPlan: 'pro' as const });
     // 依頼者を LINE 連携済みにする
     const requester = store.users.get(REQUESTER)!;
     store.users.set(REQUESTER, { ...requester, lineUserId: REQUESTER_LINE_USER_ID });
@@ -464,6 +467,50 @@ describe('POST /api/tickets/[id]/comments', () => {
       const body = JSON.parse(init.body);
       expect(body.to).toBe(REQUESTER_LINE_USER_ID);
       expect(body.messages[0].text).toContain('対応しました');
+    } finally {
+      // 他テストへ影響しないよう fetch のスタブを必ず元に戻す
+      vi.unstubAllGlobals();
+    }
+  });
+
+  // 回帰防止: LINE 連携は Pro/Enterprise 限定機能 (§6.1 料金プラン)。TenantLineConfig 行が
+  // 残っていても、テナントがダウングレード (または未アップグレード) であれば push しないこと
+  // (受信側 Webhook の isLineIntegrationAllowed と対称のガードを返信 push 側にも掛けた回帰確認)。
+  it('does not push a LINE message when the tenant plan does not allow LINE integration', async () => {
+    const { ticketId } = await seed();
+    // seed() 既定の free プランのまま (LINE 連携を許可しないプラン)
+    // 依頼者を LINE 連携済みにする
+    const requester = store.users.get(REQUESTER)!;
+    store.users.set(REQUESTER, { ...requester, lineUserId: REQUESTER_LINE_USER_ID });
+    // テナントの LINE 連携設定自体は残っている状態を再現する (ダウングレード後も行は削除されない)
+    const now = new Date();
+    store.lineConfigs.set('line_cfg_test_free', {
+      id: 'line_cfg_test_free',
+      tenantId: TENANT,
+      channelSecret: 'irrelevant-for-push',
+      channelAccessToken: 'test-access-token',
+      botUserId: `U${'c'.repeat(32)}`,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // fetch をモックし、呼ばれないことを確認する
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      type: 'basic',
+      text: () => Promise.resolve('{}'),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      mockSession = buildSession(AGENT, 'agent', TENANT);
+      const { POST } = await import('@/app/api/tickets/[id]/comments/route');
+      const res = await POST(buildRequest('対応しました', []), makeParams(ticketId));
+      // コメント投稿自体は成功する (LINE 送信スキップはベストエフォート機能のオプトアウトに過ぎない)
+      expect(res.status).toBe(201);
+      // Free プランでは LINE push が送られない
+      expect(fetchMock).not.toHaveBeenCalled();
     } finally {
       // 他テストへ影響しないよう fetch のスタブを必ず元に戻す
       vi.unstubAllGlobals();

--- a/tests/features/import-tickets.test.ts
+++ b/tests/features/import-tickets.test.ts
@@ -3,13 +3,28 @@
 // 外部 DB・SSE・メール送信は一切行わず、メモリ Adapter とモックで完結する。
 
 // Vitest の DSL とモック
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // メモリ Adapter の context (store/repos)
 import { createMemoryContext, type Store } from '@/data/adapters/memory';
 // リポジトリ束の型
 import type { Repos } from '@/data/ports/unit-of-work';
 // レート制限をテスト間でクリアする内部用関数
 import { __resetRateLimits } from '@/lib/rate-limit';
+
+// 外部通知 (Slack/Teams/Chatwork) テスト用の Slack Webhook URL (実際には送信されない)
+const SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/xxx';
+
+// src/lib/webhook-fetch.ts は SSRF 対策の DNS 検証用 Dispatcher (Agent) を使うため
+// undici の fetch を直接 import している。vi.stubGlobal('fetch', ...) だけでは差し替わらない
+// ため、undici の fetch を globalThis.fetch へ委譲するモックにする (他テストへは影響しない)
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: ((...args: Parameters<typeof globalThis.fetch>) =>
+      globalThis.fetch(...args)) as unknown as typeof actual.fetch,
+  };
+});
 
 // 各テストで書き換える「可変な依存」 (Action import 前に値を入れる必要がある)
 let store: Store;
@@ -471,6 +486,58 @@ describe('importTickets', () => {
       expect([...store.notifications.values()]).toHaveLength(0); // 通知が一切作成されていないことを確認する
       // SSE ブロードキャストも呼ばれない
       expect(broadcastMock).not.toHaveBeenCalled(); // ブロードキャストが発生しないことを確認する
+    });
+  });
+
+  // 回帰防止: 新規起票を Slack/Teams/Chatwork の外部チャネルへ通知する (Web フォーム/メール/LINE と共有)。
+  // CSV は 1 回で最大 200 件を作成しうるため、他チャネルと違いチケットごとには送らず件数をまとめた
+  // 1 通にする方針 (アプリ内通知と同じ「まとめて 1 通」)。
+  describe('外部通知 (Slack/Teams/Chatwork)', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+      fetchMock = vi
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve('ok') });
+      vi.stubGlobal('fetch', fetchMock);
+    });
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('Slack Webhook 設定済みテナントでインポートすると件数をまとめて 1 通だけ通知される', async () => {
+      const tenant = store.tenants.get(TENANT)!;
+      store.tenants.set(TENANT, { ...tenant, slackWebhookUrl: SLACK_WEBHOOK_URL });
+
+      const importTickets = await loadAction();
+      // 3 件のチケットを含む CSV (200 件でも通知は 1 通であることの縮小版検証)
+      const csv = `件名\n問い合わせ1\n問い合わせ2\n問い合わせ3`;
+      const result = await importTickets(csv);
+      expect(result.imported).toBe(3);
+
+      // チケットごとではなく 1 回だけ通知される
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(SLACK_WEBHOOK_URL);
+      // 件数が本文に含まれる
+      expect(JSON.stringify(JSON.parse(init.body))).toContain('3件');
+    });
+
+    it('外部通知が未設定のテナントでインポートしても fetch は呼ばれない', async () => {
+      const importTickets = await loadAction();
+      const csv = `件名\nテスト件名`;
+      await importTickets(csv);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('0 件インポートのときは外部通知も送らない', async () => {
+      const tenant = store.tenants.get(TENANT)!;
+      store.tenants.set(TENANT, { ...tenant, slackWebhookUrl: SLACK_WEBHOOK_URL });
+
+      const importTickets = await loadAction();
+      const csv = `件名`; // ヘッダのみ (0 件)
+      const result = await importTickets(csv);
+      expect(result.imported).toBe(0);
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/features/inbound-email-route.test.ts
+++ b/tests/features/inbound-email-route.test.ts
@@ -19,6 +19,21 @@ const MEMBER_ID = 'u-member-1';
 // UnitOfWork 型 (スレッド継続のコメント追記でトランザクションを使う)
 import type { UnitOfWork } from '@/data/ports/unit-of-work';
 
+// 外部通知 (Slack/Teams/Chatwork) テスト用の Slack Webhook URL (実際には送信されない)
+const SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/xxx';
+
+// src/lib/webhook-fetch.ts は SSRF 対策の DNS 検証用 Dispatcher (Agent) を使うため
+// undici の fetch を直接 import している。vi.stubGlobal('fetch', ...) だけでは差し替わらない
+// ため、undici の fetch を globalThis.fetch へ委譲するモックにする (他テストへは影響しない)
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: ((...args: Parameters<typeof globalThis.fetch>) =>
+      globalThis.fetch(...args)) as unknown as typeof actual.fetch,
+  };
+});
+
 // 各テストで差し替える可変な依存 (Route import 前に値を入れる)
 let store: Store;
 let repos: Repos;
@@ -549,5 +564,73 @@ describe('POST /api/inbound/email', () => {
     expect(res.status).toBe(201);
     expect(store.tickets.size).toBe(1);
     expect(sentEmails).toHaveLength(0);
+  });
+
+  // 回帰防止: 新規起票を Slack/Teams/Chatwork の外部チャネルへ通知する (Web フォーム/LINE/CSV と共有)。
+  // 従来は Web フォーム (POST /api/tickets) にしか配線されておらず、メール取り込み経由の起票は
+  // 担当者チームの Slack に気づかれないまま埋もれてしまっていた。
+  describe('外部通知 (Slack/Teams/Chatwork)', () => {
+    // 各テストで fetch をモックする (Slack Adapter が呼ぶ)
+    let fetchMock: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+      fetchMock = vi
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve('ok') });
+      vi.stubGlobal('fetch', fetchMock);
+    });
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('Slack Webhook 設定済みテナントで新規起票すると Slack へ通知される', async () => {
+      // シード済みテナントに Slack Webhook を設定する
+      const tenant = store.tenants.get(TENANT)!;
+      store.tenants.set(TENANT, { ...tenant, slackWebhookUrl: SLACK_WEBHOOK_URL });
+
+      const { POST } = await import('@/app/api/inbound/email/route');
+      const res = await POST(makeRequest(VALID_EMAIL));
+      expect(res.status).toBe(201);
+
+      // Slack Webhook へ 1 回だけ POST される
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(SLACK_WEBHOOK_URL);
+      const payload = JSON.parse(init.body);
+      expect(JSON.stringify(payload)).toContain('プリンターが動きません');
+    });
+
+    it('外部通知が未設定のテナントで新規起票しても fetch は呼ばれない', async () => {
+      const { POST } = await import('@/app/api/inbound/email/route');
+      const res = await POST(makeRequest(VALID_EMAIL));
+      expect(res.status).toBe(201);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    // スレッド追記 (新規起票ではない) では新規チケット向けの外部通知を送らない
+    it('スレッド追記では外部通知を送らない', async () => {
+      const tenant = store.tenants.get(TENANT)!;
+      store.tenants.set(TENANT, { ...tenant, slackWebhookUrl: SLACK_WEBHOOK_URL });
+
+      // 1 通目: 新規起票 (ここで 1 回通知される)
+      const { POST } = await import('@/app/api/inbound/email/route');
+      const first = await POST(
+        makeRequest({ ...VALID_EMAIL, messageId: '<thread-1@example.com>' }),
+      );
+      expect(first.status).toBe(201);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // 2 通目: 1 通目への返信 (In-Reply-To で同じチケットへ追記)
+      fetchMock.mockClear();
+      const reply = await POST(
+        makeRequest({
+          ...VALID_EMAIL,
+          messageId: '<thread-2@example.com>',
+          inReplyTo: '<thread-1@example.com>',
+        }),
+      );
+      expect(reply.status).toBe(200);
+      // スレッド追記では「新規起票」通知を重複して送らない
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -10,6 +10,21 @@ import { hashLineLinkCode, normalizeLineLinkCode } from '@/lib/line-link';
 // レート制限バケットをテスト間で初期化するためのヘルパー (グローバル Map の汚染を防ぐ)
 import { __resetRateLimits } from '@/lib/rate-limit';
 
+// 外部通知 (Slack/Teams/Chatwork) テスト用の Slack Webhook URL (実際には送信されない)
+const SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/xxx';
+
+// src/lib/webhook-fetch.ts は SSRF 対策の DNS 検証用 Dispatcher (Agent) を使うため
+// undici の fetch を直接 import している。vi.stubGlobal('fetch', ...) だけでは差し替わらない
+// ため、undici の fetch を globalThis.fetch へ委譲するモックにする (他テストへは影響しない)
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: ((...args: Parameters<typeof globalThis.fetch>) =>
+      globalThis.fetch(...args)) as unknown as typeof actual.fetch,
+  };
+});
+
 const SECRET = 'test-line-channel-secret';
 const TENANT = 'default-tenant';
 const AGENT_ID = 'u-agent-1';
@@ -342,5 +357,72 @@ describe('POST /api/inbound/line', () => {
     const res = await POST(req);
     expect(res.status).toBe(401);
     expect(store.tickets.size).toBe(0);
+  });
+
+  // 回帰防止: 新規起票を Slack/Teams/Chatwork の外部チャネルへ通知する (Web フォーム/メール/CSV と共有)。
+  // 従来は Web フォーム (POST /api/tickets) にしか配線されておらず、LINE 経由の起票は
+  // 担当者チームの Slack に気づかれないまま埋もれてしまっていた。
+  describe('外部通知 (Slack/Teams/Chatwork)', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+      fetchMock = vi
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve('ok') });
+      vi.stubGlobal('fetch', fetchMock);
+    });
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('Slack Webhook 設定済みテナントで新規起票すると Slack へ通知される', async () => {
+      const tenant = store.tenants.get(TENANT)!;
+      store.tenants.set(TENANT, { ...tenant, slackWebhookUrl: SLACK_WEBHOOK_URL });
+
+      const { POST } = await import('@/app/api/inbound/line/route');
+      const res = await POST(makeRequest('プリンターが動きません', LINE_ID_UNLINKED));
+      expect(res.status).toBe(200);
+      expect(store.tickets.size).toBe(1);
+
+      // Slack Webhook へ 1 回だけ POST される
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(SLACK_WEBHOOK_URL);
+      expect(JSON.stringify(JSON.parse(init.body))).toContain('プリンターが動きません');
+    });
+
+    it('外部通知が未設定のテナントで新規起票しても fetch は呼ばれない', async () => {
+      const { POST } = await import('@/app/api/inbound/line/route');
+      const res = await POST(makeRequest('プリンターが動きません', LINE_ID_UNLINKED));
+      expect(res.status).toBe(200);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    // ワンタイムコードでの連携処理は起票を伴わないため、新規起票向け外部通知も送らない
+    it('ワンタイムコードでの連携処理では外部通知を送らない', async () => {
+      const tenant = store.tenants.get(TENANT)!;
+      store.tenants.set(TENANT, { ...tenant, slackWebhookUrl: SLACK_WEBHOOK_URL });
+      // 有効な連携コードを発行しておく
+      const now = new Date();
+      const rawCode = 'ABCD1234';
+      const codeHash = await hashLineLinkCode(normalizeLineLinkCode(rawCode));
+      store.users.set(MEMBER_ID, {
+        id: MEMBER_ID,
+        email: 'member@example.com',
+        name: '会員 花子',
+        passwordHash: 'x',
+        role: 'requester',
+        tenantId: TENANT,
+        createdAt: now,
+        updatedAt: now,
+        lineLinkCodeHash: codeHash,
+        lineLinkCodeExpiresAt: new Date(Date.now() + 60_000),
+      });
+
+      const { POST } = await import('@/app/api/inbound/line/route');
+      const res = await POST(makeRequest(rawCode, LINE_ID_NEW));
+      expect(res.status).toBe(200);
+      expect(store.tickets.size).toBe(0);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Context

`docs/smb-dx-pivot-plan.md` の Phase 0〜4 は全項目 `[x]` 済みだったため、着手前に監査を行い「計画書ではチェック済みだが、実際には一部の入口だけ配線されていない」実装漏れを3件発見・修正した（前PR #174 と同種のパターン）。

対応フェーズ: `docs/smb-dx-pivot-plan.md` §4 Phase 4「Slack / Chatwork / Microsoft Teams 通知 Adapter」、Phase 2.1「LINE 連携のマルチテナント化」、§6.1「料金プラン」。

## 変更内容 (1 コミット = 1 論理変更)

### 1. `feat(tickets)`: 新規起票を全チャネルから Slack/Teams/Chatwork へ通知する

PR #167 で「新規問い合わせ作成時に外部通知を送信」を実装したが、Web フォーム (`POST /api/tickets`) にしか配線されておらず、メール取り込み・LINE 連携・CSV インポート経由の起票は担当者チームの Slack/Teams/Chatwork に一切通知されていなかった。

`route.ts` のローカル関数を `src/lib/outbound-notify.ts` の共有ヘルパー `notifyNewTicketOutbound` へ切り出し（冪等化ヘルパーが返す `{ id, alreadyExisted }` だけの経路でもフル `Ticket` を再取得せずに呼べるよう、最小限のフィールドだけを要求する `NewTicketNotifyInput` 型にした）、メール取り込み・LINE 連携から呼ぶ。CSV インポートは 1 回で最大 200 件を作成しうるため、チケットごとではなくアプリ内通知と同じ「件数をまとめた 1 通」方式にした。

### 2. `feat(tickets)`: 担当者アサイン変更時も Slack/Teams/Chatwork へ通知する

ステータス変更・エスカレーションでは外部通知を送るが、同格に重要なイベントである担当者アサイン変更だけ外部チャネルに通知が届いていなかった。既存パターンと同じ try/catch でベストエフォート送信を追加（担当解除はチームの注意を引く必要が薄いため対象外）。

### 3. `fix(tickets)`: LINE プラン降格後も担当者返信 push が継続する不備を修正

受信側 Webhook は `isLineIntegrationAllowed` でプランゲートしているが、担当者の返信を依頼者へ届ける対称パス (`sendReplyLineToRequester`) は `TenantLineConfig` の存在チェックのみでプランを見ていなかった。Stripe Webhook はプラン変更時に `LineConfig` 行を削除しないため、Pro/Enterprise から Standard/Free へダウングレードしたテナントでも返信 push が送信され続けていた。受信側と同じガードを送信経路にも追加した。

## 再利用した既存実装

- `sendOutboundNotification` (`src/lib/outbound-notify.ts`) — 既存の Slack/Teams/Chatwork 送信基盤をそのまま再利用。
- `isLineIntegrationAllowed` (`src/lib/plan-guard.ts`) — 受信側 Webhook と同じプランゲート関数を送信側にも適用。

## 検証方法

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test` ✅ (533 passed / 43 skipped — skipped は `RUN_PRISMA_CONTRACT=1` 専用の契約テスト)
- `npx prettier --check` ✅ (該当ファイルすべて)
- 新規/更新テスト:
  - `tests/features/inbound-email-route.test.ts` / `inbound-line-route.test.ts` / `import-tickets.test.ts` に「外部通知」ブロックを追加
  - `tests/features/assignee-outbound-notify.test.ts` (新規)
  - `tests/features/attachments/post-comment-route.test.ts` に LINE プランガードの回帰テストを追加

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_015a7mk7TDJdiL6MsDifaoYF)_