### PR TITLE
fix(tickets): コメント外部通知・メール/LINE月間上限・LINE連携コード再送誤起票の3件を修正

### DIFF
--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -58,6 +58,8 @@ import { formatTicketRef } from '@/lib/ticket-ref';
 import { isEmailInboundAllowed } from '@/lib/plan-guard';
 // Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (Web フォーム・LINE 取り込み・CSV インポートと共有)
 import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
+// Phase 4 課金: 月間チケット上限チェック (Web フォーム・CSV インポートと共有)
+import { getMonthlyTicketQuota } from '@/lib/tenant-plan';
 
 // このルートは Node ランタイムで動かす (node:crypto / Prisma を使うため Edge では動かない)
 export const runtime = 'nodejs';
@@ -529,6 +531,20 @@ export async function POST(req: Request) {
     }
     // 参照先チケットが見つからない (削除済み等) 場合は、下の新規起票へフォールスルーする
     console.warn('[POST /api/inbound/email] referenced ticket not found; creating a new one');
+  }
+
+  // Phase 4 課金: 月間チケット上限チェック (Web フォーム・CSV インポートと共有)。
+  // tenant-plan.ts のコメントで「全ての起票入口で共有する」と明記されているにもかかわらず、
+  // メール取り込みだけこのチェックを呼んでいなかった。現状メール取り込みが使えるプラン
+  // (Standard 以上) は月間上限が無制限のため実害は無いが、将来 Standard に有限上限が付いた
+  // 瞬間にこの入口だけ無制限の抜け道になる SSOT 違反を防ぐため、他入口と揃えておく。
+  // 上限到達時は未知送信者と同じ「隔離 202」にして、プロバイダの再送ループを避ける。
+  const quota = await getMonthlyTicketQuota(tenant.id, tenant.subscriptionPlan);
+  if (quota.limited && quota.remaining <= 0) {
+    console.warn('[POST /api/inbound/email] quarantined: monthly ticket quota reached', {
+      plan: tenant.subscriptionPlan,
+    });
+    return NextResponse.json({ status: 'quarantined' }, { status: 202 });
   }
 
   // 起票時刻 (SLA 期限の計算基準)

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -91,7 +91,11 @@ const LINK_CODE_DEDUP_TTL_MS = 10 * 60 * 1000;
 // invalid になり、コード文字列そのものが本文の問い合わせとして誤起票され得た。
 // このメモリ上の Map で「直近に連携コードとして処理済みの messageId」を記憶し、再送時は
 // 連携ロジックへ進まず即座にスキップする。sse-subscribers.ts / rate-limit.ts と同じ
-// 「インプロセス Map」の制約 (水平スケール未対応) を受け入れる。
+// 「インプロセス Map」の制約 (水平スケール未対応・複数インスタンス間で共有されない) を受け入れる。
+// キーは messageId のみで tenantId を含まない: LINE のメッセージ ID はプラットフォーム全体で
+// 一意な値であり (lineMessages 対応表の DB 冪等化と異なりテナント間でキーが衝突しないため)、
+// §9 のクロステナント漏洩対策としての tenantId スコープは元々不要 (メッセージの中身は一切
+// 保持しないため漏洩し得る情報も無い)。
 const recentlyLinkedMessageIds = new Map<string, number>(); // messageId -> 処理時刻 (ms)
 
 // messageId が直近 (TTL 以内) に連携コードとして処理済みかを判定する。期限切れエントリは掃除する
@@ -110,14 +114,37 @@ function wasRecentlyProcessedAsLinkCode(messageId: string): boolean {
 
 // messageId を「連携コードとして処理済み」として記録する
 function markProcessedAsLinkCode(messageId: string): void {
+  // 現在時刻を記録する (TTL 判定の基準)
   recentlyLinkedMessageIds.set(messageId, Date.now());
+  // このキー以外のエントリも含めて、既に TTL を過ぎたものを掃除する (rate-limit.ts の
+  // sweepStaleBuckets と同じ「ながら掃除」)。wasRecentlyProcessedAsLinkCode は「同じ
+  // messageId が再度問い合わせられたとき」しか掃除しないため、二度と再送されない
+  // (= 大多数の) messageId はここで掃除しない限り Map に残り続けてしまう
+  sweepStaleLinkCodeEntries(Date.now());
+}
+
+// recentlyLinkedMessageIds 全体を走査し、TTL を過ぎたエントリを削除する
+function sweepStaleLinkCodeEntries(now: number): void {
+  // Map の全エントリを走査する
+  for (const [messageId, processedAt] of recentlyLinkedMessageIds) {
+    // TTL を過ぎていれば削除する
+    if (now - processedAt > LINK_CODE_DEDUP_TTL_MS) {
+      recentlyLinkedMessageIds.delete(messageId);
+    }
+  }
 }
 
 // テスト専用: recentlyLinkedMessageIds をクリアする (src/lib/rate-limit.ts の
 // __resetRateLimits と同じ理由。この route モジュールはテスト間で import キャッシュが
 // 共有されるため、固定の messageId ('m1' 等) を使う別テストの記録が漏れ込むのを防ぐ)
 export function __resetLineLinkCodeDedup(): void {
+  // Map を空にする (次のテストへ記録を持ち越さない)
   recentlyLinkedMessageIds.clear();
+}
+
+// テスト専用: recentlyLinkedMessageIds の現在のエントリ数を返す (無制限増加しないことの検証用)
+export function __getLineLinkCodeDedupSize(): number {
+  return recentlyLinkedMessageIds.size;
 }
 
 // レート制限を適用し、超過していれば 429 レスポンスを返す共通ヘルパー。
@@ -486,7 +513,12 @@ async function processLineEvent(
         return null;
       }
       // invalid (コードの形だが有効な発行行が無い) は通常の問い合わせとして下の起票へ進む
-      // (typo 等の本来の invalid はメッセージ ID 冪等化の対象になるため再送で二重起票しない)
+      // (typo 等の本来の invalid はメッセージ ID 冪等化の対象になるため再送で二重起票しない)。
+      // 残存する既知の制約: recentlyLinkedMessageIds はインプロセス Map のため、
+      // (a) 連携成功直後の再送が別インスタンスに振られる水平スケール環境、
+      // (b) 連携成功直後 (TTL 10分以内) にプロセス再起動/デプロイが挟まる場合は、
+      // この冪等化が効かず本コメント冒頭の誤起票が再現し得る (水平スケール前提の解決には
+      // sse-subscribers.ts と同様 Redis 等の共有ストアへの置き換えが必要)。
     }
   }
 

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -63,6 +63,8 @@ import { broadcastUnreadCountToMany } from '@/features/notifications/notify';
 import { isLineIntegrationAllowed } from '@/lib/plan-guard';
 // Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (Web フォーム・メール取り込み・CSV インポートと共有)
 import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
+// Phase 4 課金: 月間チケット上限チェック (Web フォーム・CSV インポートと共有)
+import { getMonthlyTicketQuota, type MonthlyTicketQuota } from '@/lib/tenant-plan';
 
 // このルートは Node ランタイムで動かす (node:crypto / Prisma を使うため Edge では動かない)
 export const runtime = 'nodejs';
@@ -79,6 +81,44 @@ const LINE_UNAUTHENTICATED_RATE_LIMIT = { limit: 600, windowMs: 60_000 } as cons
 // (シークレット漏洩時のスパムを抑える)。lineConfig.tenantId は DB 由来の信頼できる値
 // (botUserId の @unique 制約でテナントと 1:1) なので、これをキーにする。
 const LINE_RATE_LIMIT = { limit: 120, windowMs: 60_000 } as const;
+
+// 連携コード処理 (紐付け成功/競合) の冪等化用 TTL。LINE の再送窓 (5 分) に余裕を持たせる
+const LINK_CODE_DEDUP_TTL_MS = 10 * 60 * 1000;
+// 直近「連携コードとして処理済み」の LINE メッセージ ID を憶えておく、インプロセスの Map。
+// 既知の制約 (docs/smb-dx-pivot-plan.md §5.3 コメント参照): 連携成功時は起票を伴わないため
+// lineMessages 対応表 (createTicketIdempotent が使う DB 冪等化) の対象外になる。連携成功直後に
+// Webhook 応答が遅延して LINE が同一メッセージを再送すると、2 回目はコードが既に消費済みで
+// invalid になり、コード文字列そのものが本文の問い合わせとして誤起票され得た。
+// このメモリ上の Map で「直近に連携コードとして処理済みの messageId」を記憶し、再送時は
+// 連携ロジックへ進まず即座にスキップする。sse-subscribers.ts / rate-limit.ts と同じ
+// 「インプロセス Map」の制約 (水平スケール未対応) を受け入れる。
+const recentlyLinkedMessageIds = new Map<string, number>(); // messageId -> 処理時刻 (ms)
+
+// messageId が直近 (TTL 以内) に連携コードとして処理済みかを判定する。期限切れエントリは掃除する
+function wasRecentlyProcessedAsLinkCode(messageId: string): boolean {
+  // 記録が無ければ未処理
+  const processedAt = recentlyLinkedMessageIds.get(messageId);
+  if (processedAt === undefined) return false;
+  // TTL を過ぎていれば期限切れとして削除し、未処理扱いにする (Map の無限増加を防ぐ)
+  if (Date.now() - processedAt > LINK_CODE_DEDUP_TTL_MS) {
+    recentlyLinkedMessageIds.delete(messageId);
+    return false;
+  }
+  // TTL 内なので処理済み
+  return true;
+}
+
+// messageId を「連携コードとして処理済み」として記録する
+function markProcessedAsLinkCode(messageId: string): void {
+  recentlyLinkedMessageIds.set(messageId, Date.now());
+}
+
+// テスト専用: recentlyLinkedMessageIds をクリアする (src/lib/rate-limit.ts の
+// __resetRateLimits と同じ理由。この route モジュールはテスト間で import キャッシュが
+// 共有されるため、固定の messageId ('m1' 等) を使う別テストの記録が漏れ込むのを防ぐ)
+export function __resetLineLinkCodeDedup(): void {
+  recentlyLinkedMessageIds.clear();
+}
 
 // レート制限を適用し、超過していれば 429 レスポンスを返す共通ヘルパー。
 // 超過なしなら null を返し、呼び出し側はそのまま処理を続行する。
@@ -158,6 +198,7 @@ interface LineEventContext {
   now: Date; // 起票時刻 (SLA 期限計算の基準)
   initialStatus: ReturnType<typeof initialStatusForMode>; // 初期ステータス (mode 依存)
   resolutionDueAt: ReturnType<typeof calculateResolutionDueAt>; // 優先度 Medium ベースの解決期限
+  quota: MonthlyTicketQuota; // 月間チケット上限の残枠 (イベントごとに消費するミュータブルなカウンタ)
 }
 
 // LINE Webhook の署名を検証する関数 (LINE Developers ドキュメント準拠)
@@ -325,6 +366,9 @@ export async function POST(req: Request) {
   const initialStatus = initialStatusForMode(tenant.mode);
   // メッセージには期限指定が無いため優先度 Medium ベースで解決期限を算出する
   const resolutionDueAt = calculateResolutionDueAt('Medium', now);
+  // Phase 4 課金: 月間チケット上限の残枠を 1 度だけ取得する (Web フォーム・CSV インポートと共有)。
+  // 1 リクエストに複数イベントが含まれうるため、イベントごとに ctx.quota.remaining を消費する
+  const quota = await getMonthlyTicketQuota(targetTenantId, tenant.subscriptionPlan);
 
   // 1 リクエストに含まれる複数イベントを順に処理してチケットを起票する。
   // 1 件ずつの詳細処理は processLineEvent に委譲し、ここでは結果 (チケット ID) の収集に専念する。
@@ -335,6 +379,7 @@ export async function POST(req: Request) {
     now, // 起票時刻 (SLA 期限計算の基準)
     initialStatus, // 初期ステータス (mode 依存)
     resolutionDueAt, // 優先度 Medium ベースの解決期限
+    quota, // 月間チケット上限の残枠
   };
   const ticketIds: string[] = [];
   for (const event of body.events) {
@@ -344,9 +389,9 @@ export async function POST(req: Request) {
   }
 
   // LINE サーバーはレスポンスを所定時間内に受信しないと再送するため、必ず 200 を返す。
-  // 冪等化 (メッセージ ID による重複排除) は createTicketIdempotent の Serializable
-  // トランザクションで、起票を伴う通常メッセージについて実施済み (連携コード分岐の既知の制約は
-  // 上のコメント参照)。
+  // 冪等化 (メッセージ ID による重複排除) は、起票を伴う通常メッセージは createTicketIdempotent
+  // の Serializable トランザクションで、連携コード処理 (起票を伴わない) は上の
+  // recentlyLinkedMessageIds によるインプロセス Map でそれぞれ担保している。
   return NextResponse.json({ ticketIds }, { status: 200 });
 }
 
@@ -412,6 +457,15 @@ async function processLineEvent(
     // 受信テキストを正規化 (ハイフン・空白除去 + 大文字化) してコードの形か軽く判定する
     const normalizedCode = normalizeLineLinkCode(trimmedText);
     if (looksLikeLineLinkCode(normalizedCode)) {
+      // 連携コード処理は起票を伴わないため lineMessages 対応表の冪等化対象外になる。
+      // 直近この messageId を連携コードとして処理済みなら、再度 linkLineUserByCode を
+      // 呼ばずに即座にスキップする (再送で「コードは消費済み → invalid → 誤起票」になるのを防ぐ)
+      if (messageId && wasRecentlyProcessedAsLinkCode(messageId)) {
+        console.info(
+          `[POST /api/inbound/line] duplicate link-code message, skipping: ${messageId}`,
+        );
+        return null;
+      }
       // 形が一致したらハッシュ化し、有効な発行行があれば原子的に紐付ける
       const codeHash = await hashLineLinkCode(normalizedCode);
       const link = await repos.users.linkLineUserByCode({
@@ -427,13 +481,12 @@ async function processLineEvent(
           `[POST /api/inbound/line] line link ${link.status} for tenant`,
           targetTenantId,
         );
+        // この messageId を「連携コードとして処理済み」に記録する (再送時の誤起票防止)
+        if (messageId) markProcessedAsLinkCode(messageId);
         return null;
       }
-      // invalid (コードの形だが有効な発行行が無い) は通常の問い合わせとして下の起票へ進む。
-      // 既知の制約: この分岐は起票を伴わないため、上のメッセージ ID 冪等化 (register) の対象外。
-      // 連携成功直後に応答が遅延して LINE が同一メッセージを再送すると、2 回目はコードが
-      // 消費済みで invalid になり、コード文字列を本文とする問い合わせが起票され得る
-      // (Webhook 応答の高速化で再送自体を減らすのが現実的な対策。将来課題)
+      // invalid (コードの形だが有効な発行行が無い) は通常の問い合わせとして下の起票へ進む
+      // (typo 等の本来の invalid はメッセージ ID 冪等化の対象になるため再送で二重起票しない)
     }
   }
 
@@ -460,6 +513,17 @@ async function processLineEvent(
 
   // チケット本文: LINE ユーザー ID と全メッセージテキストを含める (担当者が手動連絡できるよう)
   const ticketBody = `[LINE 経由の問い合わせ]\nLINE ユーザー ID: ${lineUserId}\n\n${safeText}`;
+
+  // Phase 4 課金: 月間チケット上限チェック (Web フォーム・CSV インポート・メール取り込みと共有)。
+  // tenant-plan.ts のコメントで「全ての起票入口で共有する」と明記されているにもかかわらず、
+  // LINE 取り込みだけこのチェックを呼んでいなかった。現状 LINE 連携が使えるプラン (Pro 以上) は
+  // 月間上限が無制限のため実害は無いが、将来上限が付いた瞬間にこの入口だけ無制限の抜け道に
+  // なる SSOT 違反を防ぐため、他入口と揃えておく。1 リクエストに複数イベントが含まれうるため、
+  // ctx.quota (POST 側で 1 度だけ取得) の残枠をイベントごとに消費する簡易カウンタとして扱う。
+  if (ctx.quota.limited && ctx.quota.remaining <= 0) {
+    console.warn(`[POST /api/inbound/line] ignored: monthly ticket quota reached: ${messageId}`);
+    return null;
+  }
 
   // 新規チケットを起票する (Web フォーム・メール取り込みと同じ PORT 経由)。
   // 1 件の起票失敗で全体を 500 にすると LINE がバッチ全体を再送し、既に起票済みのチケットが
@@ -490,6 +554,9 @@ async function processLineEvent(
       console.info(`[POST /api/inbound/line] resolved write conflict as duplicate: ${messageId}`);
       return ticketId;
     }
+    // 上限のあるプランでは残枠を消費する (無制限プランは remaining が Infinity のため減算不要だが、
+    // 明示的にガードして意図を示す。CSV インポートと同じパターン)
+    if (ctx.quota.limited) ctx.quota.remaining -= 1;
     // 起票成功後に担当者全員へ「新しい問い合わせが届きました」通知を送る (ベストエフォート)。
     // 失敗してもチケット起票自体は確定済みのため、ログを残して続行する (§9 fail-safe)。
     try {

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -65,6 +65,12 @@ import { isLineIntegrationAllowed } from '@/lib/plan-guard';
 import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
 // Phase 4 課金: 月間チケット上限チェック (Web フォーム・CSV インポートと共有)
 import { getMonthlyTicketQuota, type MonthlyTicketQuota } from '@/lib/tenant-plan';
+// 連携コード処理 (紐付け成功/競合) の冪等化ヘルパー。route.ts は Next.js の Route Handler
+// 制約により GET/POST/config/runtime 以外の export を持てないため、状態を別モジュールに分離している
+import {
+  markProcessedAsLinkCode,
+  wasRecentlyProcessedAsLinkCode,
+} from '@/lib/line-link-code-dedup';
 
 // このルートは Node ランタイムで動かす (node:crypto / Prisma を使うため Edge では動かない)
 export const runtime = 'nodejs';
@@ -81,71 +87,6 @@ const LINE_UNAUTHENTICATED_RATE_LIMIT = { limit: 600, windowMs: 60_000 } as cons
 // (シークレット漏洩時のスパムを抑える)。lineConfig.tenantId は DB 由来の信頼できる値
 // (botUserId の @unique 制約でテナントと 1:1) なので、これをキーにする。
 const LINE_RATE_LIMIT = { limit: 120, windowMs: 60_000 } as const;
-
-// 連携コード処理 (紐付け成功/競合) の冪等化用 TTL。LINE の再送窓 (5 分) に余裕を持たせる
-const LINK_CODE_DEDUP_TTL_MS = 10 * 60 * 1000;
-// 直近「連携コードとして処理済み」の LINE メッセージ ID を憶えておく、インプロセスの Map。
-// 既知の制約 (docs/smb-dx-pivot-plan.md §5.3 コメント参照): 連携成功時は起票を伴わないため
-// lineMessages 対応表 (createTicketIdempotent が使う DB 冪等化) の対象外になる。連携成功直後に
-// Webhook 応答が遅延して LINE が同一メッセージを再送すると、2 回目はコードが既に消費済みで
-// invalid になり、コード文字列そのものが本文の問い合わせとして誤起票され得た。
-// このメモリ上の Map で「直近に連携コードとして処理済みの messageId」を記憶し、再送時は
-// 連携ロジックへ進まず即座にスキップする。sse-subscribers.ts / rate-limit.ts と同じ
-// 「インプロセス Map」の制約 (水平スケール未対応・複数インスタンス間で共有されない) を受け入れる。
-// キーは messageId のみで tenantId を含まない: LINE のメッセージ ID はプラットフォーム全体で
-// 一意な値であり (lineMessages 対応表の DB 冪等化と異なりテナント間でキーが衝突しないため)、
-// §9 のクロステナント漏洩対策としての tenantId スコープは元々不要 (メッセージの中身は一切
-// 保持しないため漏洩し得る情報も無い)。
-const recentlyLinkedMessageIds = new Map<string, number>(); // messageId -> 処理時刻 (ms)
-
-// messageId が直近 (TTL 以内) に連携コードとして処理済みかを判定する。期限切れエントリは掃除する
-function wasRecentlyProcessedAsLinkCode(messageId: string): boolean {
-  // 記録が無ければ未処理
-  const processedAt = recentlyLinkedMessageIds.get(messageId);
-  if (processedAt === undefined) return false;
-  // TTL を過ぎていれば期限切れとして削除し、未処理扱いにする (Map の無限増加を防ぐ)
-  if (Date.now() - processedAt > LINK_CODE_DEDUP_TTL_MS) {
-    recentlyLinkedMessageIds.delete(messageId);
-    return false;
-  }
-  // TTL 内なので処理済み
-  return true;
-}
-
-// messageId を「連携コードとして処理済み」として記録する
-function markProcessedAsLinkCode(messageId: string): void {
-  // 現在時刻を記録する (TTL 判定の基準)
-  recentlyLinkedMessageIds.set(messageId, Date.now());
-  // このキー以外のエントリも含めて、既に TTL を過ぎたものを掃除する (rate-limit.ts の
-  // sweepStaleBuckets と同じ「ながら掃除」)。wasRecentlyProcessedAsLinkCode は「同じ
-  // messageId が再度問い合わせられたとき」しか掃除しないため、二度と再送されない
-  // (= 大多数の) messageId はここで掃除しない限り Map に残り続けてしまう
-  sweepStaleLinkCodeEntries(Date.now());
-}
-
-// recentlyLinkedMessageIds 全体を走査し、TTL を過ぎたエントリを削除する
-function sweepStaleLinkCodeEntries(now: number): void {
-  // Map の全エントリを走査する
-  for (const [messageId, processedAt] of recentlyLinkedMessageIds) {
-    // TTL を過ぎていれば削除する
-    if (now - processedAt > LINK_CODE_DEDUP_TTL_MS) {
-      recentlyLinkedMessageIds.delete(messageId);
-    }
-  }
-}
-
-// テスト専用: recentlyLinkedMessageIds をクリアする (src/lib/rate-limit.ts の
-// __resetRateLimits と同じ理由。この route モジュールはテスト間で import キャッシュが
-// 共有されるため、固定の messageId ('m1' 等) を使う別テストの記録が漏れ込むのを防ぐ)
-export function __resetLineLinkCodeDedup(): void {
-  // Map を空にする (次のテストへ記録を持ち越さない)
-  recentlyLinkedMessageIds.clear();
-}
-
-// テスト専用: recentlyLinkedMessageIds の現在のエントリ数を返す (無制限増加しないことの検証用)
-export function __getLineLinkCodeDedupSize(): number {
-  return recentlyLinkedMessageIds.size;
-}
 
 // レート制限を適用し、超過していれば 429 レスポンスを返す共通ヘルパー。
 // 超過なしなら null を返し、呼び出し側はそのまま処理を続行する。

--- a/src/app/api/tickets/[id]/comments/route.ts
+++ b/src/app/api/tickets/[id]/comments/route.ts
@@ -36,6 +36,8 @@ import { validateUploadedFiles } from '@/lib/validations/attachment';
 import { MIME_TO_EXTENSION } from '@/domain/attachment';
 // LINE 連携機能のプランゲート (§6.1 料金プラン: Pro / Enterprise のみ利用可能)
 import { isLineIntegrationAllowed } from '@/lib/plan-guard';
+// Phase 4: Slack/Teams/Chatwork 外部通知のベストエフォート送信共通ヘルパー
+import { notifyOutboundBestEffort } from '@/lib/outbound-notify';
 
 // /api/tickets/[id]/comments の動的セグメント
 type Params = { params: Promise<{ id: string }> };
@@ -196,6 +198,21 @@ export async function POST(req: Request, { params }: Params) {
 
   // 通知対象が 1 名以上いれば未読件数を一斉配信
   if (recipientIds.length > 0) await broadcastUnreadCountToMany(recipientIds, tenantId);
+
+  // Phase 4: Slack/Teams/Chatwork 外部通知 (updateTicketStatus / escalateTicket /
+  // updateTicketAssignee と同じパターン)。ステータス変更・エスカレーション・担当者割当は
+  // 外部チャネルに通知されるのに、コメント (依頼者からの新着質問・担当者の返信) だけ
+  // チーム共有チャネルに一切届かず「対応漏れに気づける」という Phase 4 の目的から抜けていた。
+  // アプリ内通知/メール/LINE と同じくベストエフォートで送る (失敗してもコメント投稿は成功扱い)。
+  await notifyOutboundBestEffort(
+    tenantId,
+    (baseUrl) => ({
+      subject: `新しいコメントが投稿されました: ${ticket.title}`,
+      body: `投稿者: ${session.user.name ?? (authorIsAgent ? '担当者' : '依頼者')}`,
+      ticketUrl: buildTicketUrl(baseUrl, ticketId),
+    }),
+    '[POST /api/tickets/[id]/comments]',
+  );
 
   // Phase 2「対応すると依頼者にメールで返信が届く」「担当者の返信が LINE に返る」
   // (docs/smb-dx-pivot-plan.md §4 Phase 2): 担当者がコメント (返信) した場合は、依頼者が

--- a/src/lib/line-link-code-dedup.ts
+++ b/src/lib/line-link-code-dedup.ts
@@ -1,0 +1,75 @@
+// LINE Webhook の連携コード処理 (紐付け成功/競合) 専用の冪等化ヘルパー。
+// src/app/api/inbound/line/route.ts から使う。
+//
+// なぜ別ファイルに分離しているか: Next.js の Route Handler (route.ts) は
+// GET/POST/config/runtime 等の決められた export しか許可しない (それ以外の named
+// export があると `next build` の型検査が "not a valid Route export field" で失敗する)。
+// テスト専用のリセット/検査用ヘルパーを route.ts に直接 export できないため、
+// この状態と関数群を独立した lib モジュールに切り出し、route.ts からは通常の
+// import として使う。
+//
+// 背景: 連携コード送信での紐付け成立は起票を伴わないため、lineMessages 対応表
+// (createTicketIdempotent が使う DB 冪等化) の対象外になる。連携成功直後に Webhook
+// 応答が遅延して LINE が同一メッセージを再送すると、2 回目はコードが既に消費済みで
+// invalid になり、コード文字列そのものが本文の問い合わせとして誤起票され得た。
+// このメモリ上の Map で「直近に連携コードとして処理済みの messageId」を記憶し、再送時は
+// 連携ロジックへ進まず即座にスキップする。sse-subscribers.ts / rate-limit.ts と同じ
+// 「インプロセス Map」の制約 (水平スケール未対応・複数インスタンス間で共有されない) を受け入れる。
+// キーは messageId のみで tenantId を含まない: LINE のメッセージ ID はプラットフォーム全体で
+// 一意な値であり (lineMessages 対応表の DB 冪等化と異なりテナント間でキーが衝突しないため)、
+// §9 のクロステナント漏洩対策としての tenantId スコープは元々不要 (メッセージの中身は一切
+// 保持しないため漏洩し得る情報も無い)。
+
+// 連携コード処理 (紐付け成功/競合) の冪等化用 TTL。LINE の再送窓 (5 分) に余裕を持たせる
+const LINK_CODE_DEDUP_TTL_MS = 10 * 60 * 1000;
+// 直近「連携コードとして処理済み」の LINE メッセージ ID を憶えておく、インプロセスの Map
+const recentlyLinkedMessageIds = new Map<string, number>(); // messageId -> 処理時刻 (ms)
+
+// messageId が直近 (TTL 以内) に連携コードとして処理済みかを判定する。期限切れエントリは掃除する
+export function wasRecentlyProcessedAsLinkCode(messageId: string): boolean {
+  // 記録が無ければ未処理
+  const processedAt = recentlyLinkedMessageIds.get(messageId);
+  if (processedAt === undefined) return false;
+  // TTL を過ぎていれば期限切れとして削除し、未処理扱いにする (Map の無限増加を防ぐ)
+  if (Date.now() - processedAt > LINK_CODE_DEDUP_TTL_MS) {
+    recentlyLinkedMessageIds.delete(messageId);
+    return false;
+  }
+  // TTL 内なので処理済み
+  return true;
+}
+
+// messageId を「連携コードとして処理済み」として記録する
+export function markProcessedAsLinkCode(messageId: string): void {
+  // 現在時刻を記録する (TTL 判定の基準)
+  recentlyLinkedMessageIds.set(messageId, Date.now());
+  // このキー以外のエントリも含めて、既に TTL を過ぎたものを掃除する (rate-limit.ts の
+  // sweepStaleBuckets と同じ「ながら掃除」)。wasRecentlyProcessedAsLinkCode は「同じ
+  // messageId が再度問い合わせられたとき」しか掃除しないため、二度と再送されない
+  // (= 大多数の) messageId はここで掃除しない限り Map に残り続けてしまう
+  sweepStaleLinkCodeEntries(Date.now());
+}
+
+// recentlyLinkedMessageIds 全体を走査し、TTL を過ぎたエントリを削除する
+function sweepStaleLinkCodeEntries(now: number): void {
+  // Map の全エントリを走査する
+  for (const [messageId, processedAt] of recentlyLinkedMessageIds) {
+    // TTL を過ぎていれば削除する
+    if (now - processedAt > LINK_CODE_DEDUP_TTL_MS) {
+      recentlyLinkedMessageIds.delete(messageId);
+    }
+  }
+}
+
+// テスト専用: recentlyLinkedMessageIds をクリアする (src/lib/rate-limit.ts の
+// __resetRateLimits と同じ理由。route モジュールはテスト間で import キャッシュが
+// 共有されるため、固定の messageId ('m1' 等) を使う別テストの記録が漏れ込むのを防ぐ)
+export function __resetLineLinkCodeDedup(): void {
+  // Map を空にする (次のテストへ記録を持ち越さない)
+  recentlyLinkedMessageIds.clear();
+}
+
+// テスト専用: recentlyLinkedMessageIds の現在のエントリ数を返す (無制限増加しないことの検証用)
+export function __getLineLinkCodeDedupSize(): number {
+  return recentlyLinkedMessageIds.size;
+}

--- a/tests/features/attachments/post-comment-route.test.ts
+++ b/tests/features/attachments/post-comment-route.test.ts
@@ -539,4 +539,51 @@ describe('POST /api/tickets/[id]/comments', () => {
       repos.users.findById = originalFindById;
     }
   });
+
+  // 回帰防止: コメント投稿を Slack/Teams/Chatwork の外部チャネルへ通知する
+  // (updateTicketStatus/escalateTicket/updateTicketAssignee と同じパターン)。
+  // 従来はアプリ内通知・メール・LINE はあるのに、外部チャネルにだけ一切届かなかった。
+  describe('外部通知 (Slack/Teams/Chatwork)', () => {
+    const SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/xxx';
+    let fetchMock: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+      fetchMock = vi
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve('ok') });
+      vi.stubGlobal('fetch', fetchMock);
+    });
+
+    it('Slack Webhook 設定済みテナントでコメント投稿すると Slack へ通知される', async () => {
+      const { ticketId } = await seed();
+      const tenant = store.tenants.get(TENANT)!;
+      store.tenants.set(TENANT, { ...tenant, slackWebhookUrl: SLACK_WEBHOOK_URL });
+
+      try {
+        mockSession = buildSession(AGENT, 'agent', TENANT);
+        const { POST } = await import('@/app/api/tickets/[id]/comments/route');
+        const res = await POST(buildRequest('対応しました', []), makeParams(ticketId));
+        expect(res.status).toBe(201);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toBe(SLACK_WEBHOOK_URL);
+        expect(JSON.stringify(JSON.parse(init.body))).toContain('プリンタ');
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
+    it('外部通知が未設定のテナントでコメント投稿しても fetch は呼ばれない', async () => {
+      const { ticketId } = await seed();
+      try {
+        mockSession = buildSession(AGENT, 'agent', TENANT);
+        const { POST } = await import('@/app/api/tickets/[id]/comments/route');
+        const res = await POST(buildRequest('対応しました', []), makeParams(ticketId));
+        expect(res.status).toBe(201);
+        expect(fetchMock).not.toHaveBeenCalled();
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+  });
 });

--- a/tests/features/inbound-email-route.test.ts
+++ b/tests/features/inbound-email-route.test.ts
@@ -34,6 +34,18 @@ vi.mock('undici', async (importOriginal) => {
   };
 });
 
+// getMonthlyTicketQuota だけ差し替え可能にする (実装は既定で本物を使い、上限到達テストでのみ
+// 上書きする)。Standard/Pro プランは現状無制限 (Infinity) のため、実際のプラン設定だけでは
+// 上限到達を再現できず、この関数の呼び出し配線自体を検証する必要があるため
+const { getMonthlyTicketQuotaMock } = vi.hoisted(() => ({
+  getMonthlyTicketQuotaMock: vi.fn(),
+}));
+vi.mock('@/lib/tenant-plan', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/tenant-plan')>();
+  getMonthlyTicketQuotaMock.mockImplementation(actual.getMonthlyTicketQuota);
+  return { ...actual, getMonthlyTicketQuota: getMonthlyTicketQuotaMock };
+});
+
 // 各テストで差し替える可変な依存 (Route import 前に値を入れる)
 let store: Store;
 let repos: Repos;
@@ -631,6 +643,28 @@ describe('POST /api/inbound/email', () => {
       expect(reply.status).toBe(200);
       // スレッド追記では「新規起票」通知を重複して送らない
       expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // 回帰防止: 月間チケット上限 (§6.1 料金プラン)。Web フォーム・CSV インポートと共有する
+  // getMonthlyTicketQuota が、メール取り込みからも呼ばれることを確認する。
+  // Standard プランは現状無制限のため、この関数自体をモックして上限到達を再現する。
+  describe('月間チケット上限 (§6.1 料金プラン)', () => {
+    it('上限到達済みなら隔離して 202 を返し、起票しない', async () => {
+      // 残枠 0 の状態を再現する
+      getMonthlyTicketQuotaMock.mockResolvedValueOnce({ limited: true, limit: 10, remaining: 0 });
+      const { POST } = await import('@/app/api/inbound/email/route');
+      const res = await POST(makeRequest(VALID_EMAIL));
+      expect(res.status).toBe(202);
+      expect(store.tickets.size).toBe(0);
+    });
+
+    it('残枠があれば通常どおり起票する', async () => {
+      getMonthlyTicketQuotaMock.mockResolvedValueOnce({ limited: true, limit: 10, remaining: 3 });
+      const { POST } = await import('@/app/api/inbound/email/route');
+      const res = await POST(makeRequest(VALID_EMAIL));
+      expect(res.status).toBe(201);
+      expect(store.tickets.size).toBe(1);
     });
   });
 });

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -25,6 +25,18 @@ vi.mock('undici', async (importOriginal) => {
   };
 });
 
+// getMonthlyTicketQuota だけ差し替え可能にする (実装は既定で本物を使い、上限到達テストでのみ
+// 上書きする)。Pro プランは現状無制限 (Infinity) のため、実際のプラン設定だけでは
+// 上限到達を再現できず、この関数の呼び出し配線自体を検証する必要があるため
+const { getMonthlyTicketQuotaMock } = vi.hoisted(() => ({
+  getMonthlyTicketQuotaMock: vi.fn(),
+}));
+vi.mock('@/lib/tenant-plan', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/tenant-plan')>();
+  getMonthlyTicketQuotaMock.mockImplementation(actual.getMonthlyTicketQuota);
+  return { ...actual, getMonthlyTicketQuota: getMonthlyTicketQuotaMock };
+});
+
 const SECRET = 'test-line-channel-secret';
 const TENANT = 'default-tenant';
 const AGENT_ID = 'u-agent-1';
@@ -121,7 +133,7 @@ function makeRequest(text: string, userId: string, destination: string = BOT_USE
 }
 
 describe('POST /api/inbound/line', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     const ctx = createMemoryContext();
     store = ctx.store;
     repos = ctx.repos;
@@ -129,6 +141,10 @@ describe('POST /api/inbound/line', () => {
     seed();
     // レート制限バケットはモジュールグローバルなので、他ファイルのテストの影響を受けないよう初期化する
     __resetRateLimits();
+    // 連携コード冪等化 Map もモジュールグローバルなので、固定 messageId ('m1') を使う
+    // 他テストの記録が残らないよう初期化する (route モジュールはテスト間でキャッシュされる)
+    const { __resetLineLinkCodeDedup } = await import('@/app/api/inbound/line/route');
+    __resetLineLinkCodeDedup();
   });
 
   afterEach(() => {
@@ -238,6 +254,42 @@ describe('POST /api/inbound/line', () => {
     expect(store.users.get(MEMBER_ID)?.lineUserId).toBe(LINE_ID_NEW);
     // 発行中コードは消費済み
     expect(store.users.get(MEMBER_ID)?.lineLinkCodeHash).toBeNull();
+  });
+
+  // 回帰防止: 連携成功直後に Webhook 応答が遅延して LINE が同一メッセージを再送すると、
+  // 2 回目はコードが既に消費済み (invalid) になり、コード文字列そのものが本文の問い合わせ
+  // として誤起票され得た (既知の制約として明記されていたエッジケース)。
+  // 同一 messageId の連携コード処理は冪等化され、再送では起票されないことを確認する。
+  it('連携コード成功後の同一メッセージ ID 再送では誤起票しない', async () => {
+    const now = new Date();
+    const rawCode = 'AB7K-9QF2';
+    const codeHash = await hashLineLinkCode(normalizeLineLinkCode(rawCode));
+    store.users.set(MEMBER_ID, {
+      id: MEMBER_ID,
+      email: 'member@example.com',
+      name: '依頼 花子',
+      passwordHash: 'x',
+      role: 'requester',
+      tenantId: TENANT,
+      createdAt: now,
+      updatedAt: now,
+      lineLinkCodeHash: codeHash,
+      lineLinkCodeExpiresAt: new Date(Date.now() + 60_000),
+    });
+    const { POST } = await import('@/app/api/inbound/line/route');
+    // 1 回目: 連携が成立し、コードが消費される (チケットは作られない)
+    const req = () => makeRequest('ab7k9qf2', LINE_ID_NEW);
+    const first = await POST(req());
+    expect(first.status).toBe(200);
+    expect(store.tickets.size).toBe(0);
+    expect(store.users.get(MEMBER_ID)?.lineUserId).toBe(LINE_ID_NEW);
+
+    // 2 回目: 同一 messageId ('m1') の再送 (LINE の at-least-once 再送を模す)。
+    // 冪等化が無ければコードが消費済みで invalid 判定になり、"ab7k9qf2" が本文の問い合わせとして
+    // 誤起票されてしまう。冪等化により再送はスキップされ、チケットは作られない。
+    const second = await POST(req());
+    expect(second.status).toBe(200);
+    expect(store.tickets.size).toBe(0);
   });
 
   // コードの形だが発行行が無いテキストは通常の問い合わせとして起票する
@@ -423,6 +475,27 @@ describe('POST /api/inbound/line', () => {
       expect(res.status).toBe(200);
       expect(store.tickets.size).toBe(0);
       expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // 回帰防止: 月間チケット上限 (§6.1 料金プラン)。Web フォーム・CSV インポート・メール取り込みと
+  // 共有する getMonthlyTicketQuota が、LINE 取り込みからも呼ばれることを確認する。
+  // Pro プランは現状無制限のため、この関数自体をモックして上限到達を再現する。
+  describe('月間チケット上限 (§6.1 料金プラン)', () => {
+    it('上限到達済みなら起票せず 200 を返す', async () => {
+      getMonthlyTicketQuotaMock.mockResolvedValueOnce({ limited: true, limit: 10, remaining: 0 });
+      const { POST } = await import('@/app/api/inbound/line/route');
+      const res = await POST(makeRequest('プリンターが動きません', LINE_ID_UNLINKED));
+      expect(res.status).toBe(200);
+      expect(store.tickets.size).toBe(0);
+    });
+
+    it('残枠があれば通常どおり起票する', async () => {
+      getMonthlyTicketQuotaMock.mockResolvedValueOnce({ limited: true, limit: 10, remaining: 3 });
+      const { POST } = await import('@/app/api/inbound/line/route');
+      const res = await POST(makeRequest('プリンターが動きません', LINE_ID_UNLINKED));
+      expect(res.status).toBe(200);
+      expect(store.tickets.size).toBe(1);
     });
   });
 });

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -9,6 +9,8 @@ import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
 import { hashLineLinkCode, normalizeLineLinkCode } from '@/lib/line-link';
 // レート制限バケットをテスト間で初期化するためのヘルパー (グローバル Map の汚染を防ぐ)
 import { __resetRateLimits } from '@/lib/rate-limit';
+// 連携コード冪等化 Map をテスト間で初期化・検査するためのヘルパー
+import { __resetLineLinkCodeDedup, __getLineLinkCodeDedupSize } from '@/lib/line-link-code-dedup';
 
 // 外部通知 (Slack/Teams/Chatwork) テスト用の Slack Webhook URL (実際には送信されない)
 const SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/xxx';
@@ -138,7 +140,7 @@ function makeRequest(
 }
 
 describe('POST /api/inbound/line', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     const ctx = createMemoryContext();
     store = ctx.store;
     repos = ctx.repos;
@@ -148,7 +150,6 @@ describe('POST /api/inbound/line', () => {
     __resetRateLimits();
     // 連携コード冪等化 Map もモジュールグローバルなので、固定 messageId ('m1') を使う
     // 他テストの記録が残らないよう初期化する (route モジュールはテスト間でキャッシュされる)
-    const { __resetLineLinkCodeDedup } = await import('@/app/api/inbound/line/route');
     __resetLineLinkCodeDedup();
   });
 
@@ -322,7 +323,7 @@ describe('POST /api/inbound/line', () => {
           lineLinkCodeExpiresAt: new Date(Date.now() + 3_600_000),
         });
       }
-      const { POST, __getLineLinkCodeDedupSize } = await import('@/app/api/inbound/line/route');
+      const { POST } = await import('@/app/api/inbound/line/route');
       // 3 件、それぞれ異なる messageId で連携成功させる (二度と再送されない想定の messageId)
       for (let i = 0; i < rawCodes.length; i += 1) {
         const res = await POST(

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -114,14 +114,19 @@ function sign(body: string): string {
 
 // 1 件のテキストメッセージイベントを含む署名付きリクエストを組み立てる。
 // destination はチャネル解決に使う値で、既定はシード済みテナントの BOT_USER_ID
-function makeRequest(text: string, userId: string, destination: string = BOT_USER_ID): Request {
+function makeRequest(
+  text: string,
+  userId: string,
+  destination: string = BOT_USER_ID,
+  messageId: string = 'm1',
+): Request {
   const body = JSON.stringify({
     destination,
     events: [
       {
         type: 'message',
         source: { type: 'user', userId },
-        message: { type: 'text', id: 'm1', text },
+        message: { type: 'text', id: messageId, text },
       },
     ],
   });
@@ -290,6 +295,69 @@ describe('POST /api/inbound/line', () => {
     const second = await POST(req());
     expect(second.status).toBe(200);
     expect(store.tickets.size).toBe(0);
+  });
+
+  // 回帰防止: 連携コード冪等化 Map (recentlyLinkedMessageIds) が無制限に増加しないこと。
+  // 二度と再送されない (= 大多数の) messageId も、TTL 経過後の別呼び出しに便乗した
+  // 「ながら掃除」で削除されることを検証する (src/lib/rate-limit.ts の sweepStaleBuckets と同じ)。
+  it('連携コード冪等化 Map は TTL 超過エントリを掃除し無制限に増加しない', async () => {
+    vi.useFakeTimers();
+    try {
+      const now = new Date();
+      // LINE_LINK_CODE_LENGTH(8) かつ CODE_ALPHABET (0-9, I/L/O/U を除く A-Z) に収まる
+      // ユニークなコードを 3 件用意する (それぞれ別の messageId で連携させるため)
+      const rawCodes = ['A1B2C3D0', 'A1B2C3D1', 'A1B2C3D2'];
+      for (let i = 0; i < rawCodes.length; i += 1) {
+        const codeHash = await hashLineLinkCode(normalizeLineLinkCode(rawCodes[i]!));
+        store.users.set(`u-member-${i}`, {
+          id: `u-member-${i}`,
+          email: `member${i}@example.com`,
+          name: `会員${i}`,
+          passwordHash: 'x',
+          role: 'requester',
+          tenantId: TENANT,
+          createdAt: now,
+          updatedAt: now,
+          lineLinkCodeHash: codeHash,
+          lineLinkCodeExpiresAt: new Date(Date.now() + 3_600_000),
+        });
+      }
+      const { POST, __getLineLinkCodeDedupSize } = await import('@/app/api/inbound/line/route');
+      // 3 件、それぞれ異なる messageId で連携成功させる (二度と再送されない想定の messageId)
+      for (let i = 0; i < rawCodes.length; i += 1) {
+        const res = await POST(
+          makeRequest(rawCodes[i]!, `U${'1'.repeat(31)}${i}`, BOT_USER_ID, `link-${i}`),
+        );
+        expect(res.status).toBe(200);
+      }
+      expect(__getLineLinkCodeDedupSize()).toBe(3);
+
+      // TTL (10分) を超えて時計を進める
+      vi.setSystemTime(new Date(Date.now() + 11 * 60 * 1000));
+
+      // 4 件目の連携成功イベント (新しい messageId) がながら掃除のトリガーになる
+      const rawCode4 = 'A1B2C3D4';
+      const codeHash4 = await hashLineLinkCode(normalizeLineLinkCode(rawCode4));
+      store.users.set('u-member-4', {
+        id: 'u-member-4',
+        email: 'member4@example.com',
+        name: '会員4',
+        passwordHash: 'x',
+        role: 'requester',
+        tenantId: TENANT,
+        createdAt: now,
+        updatedAt: now,
+        lineLinkCodeHash: codeHash4,
+        lineLinkCodeExpiresAt: new Date(Date.now() + 3_600_000),
+      });
+      const res4 = await POST(makeRequest(rawCode4, `U${'2'.repeat(32)}`, BOT_USER_ID, 'link-4'));
+      expect(res4.status).toBe(200);
+
+      // 期限切れの 3 件は掃除され、直近の 1 件だけが残る (4 件のまま溜まり続けない)
+      expect(__getLineLinkCodeDedupSize()).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // コードの形だが発行行が無いテキストは通常の問い合わせとして起票する


### PR DESCRIPTION
## Context

`docs/smb-dx-pivot-plan.md` の Phase 0〜4 は全項目 `[x]` 済みだったため、着手前に監査を行い「計画書ではチェック済みだが、実際には一部の入口だけ配線されていない」実装漏れを3件発見・修正した（PR #174, #175 と同種のパターン）。

対応フェーズ: `docs/smb-dx-pivot-plan.md` §4 Phase 4「Slack / Chatwork / Microsoft Teams 通知 Adapter」、§6.1「料金プラン」、Phase 2「LINE Bot（β）」。

## 変更内容 (1 コミット = 1 論理変更)

### 1. `feat(tickets)`: コメント投稿時も Slack/Teams/Chatwork へ通知する

新規起票・ステータス変更・エスカレーション・担当者アサインは外部通知されるが、コメント追加（依頼者からの新着質問・担当者の返信）だけチーム共有チャネルに一切通知されず「対応漏れに気づける」という Phase 4 の目的から抜けていた。`notifyOutboundBestEffort` を呼ぶだけの小さな追加。

### 2. `fix(inbound-email)`: メール取り込みが月間チケット上限をチェックしていなかった不備を修正

`src/lib/tenant-plan.ts` のコメントで「全ての起票入口で共有する」と明記されているにもかかわらず、メール取り込みだけ `getMonthlyTicketQuota` を呼んでいなかった。現状無害（メール取り込みが使えるプランは月間無制限）だが、将来上限が付いた瞬間に無制限の抜け道になる SSOT 違反。

### 3. `fix(inbound-line)`: LINE 取り込みの月間上限未チェックと連携コード再送誤起票を修正

上記と同じ SSOT 違反に加え、コード内に「既知の制約」「将来課題」と明記済みだった未修正エッジケースも修正: 連携コード送信での紐付け成立は起票を伴わないため、メッセージ ID 冪等化の対象外になっていた。連携成功直後に Webhook 応答が遅延して LINE が同一メッセージを再送すると、2 回目はコードが消費済みで invalid になり、コード文字列そのものが本文の問い合わせとして誤起票され得た。インプロセスの Map（TTL 10分）で直近処理済みの messageId を記憶し、再送時は連携ロジックへ進まず即座にスキップするようにした。

## 再利用した既存実装

- `notifyOutboundBestEffort` (`src/lib/outbound-notify.ts`, PR #175 で追加) — コメント通知に再利用。
- `getMonthlyTicketQuota` (`src/lib/tenant-plan.ts`) — Web フォーム・CSV インポートと同じ判定関数をメール/LINE にも適用。
- `sse-subscribers.ts` / `rate-limit.ts` と同じ「インプロセス Map + TTL」パターン — LINE 連携コード冪等化に流用。

## 検証方法

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test` ✅ (540 passed / 43 skipped — skipped は `RUN_PRISMA_CONTRACT=1` 専用の契約テスト)
- `npx prettier --check` ✅ (該当ファイルすべて)
- 新規/更新テスト:
  - `tests/features/attachments/post-comment-route.test.ts` に「外部通知」ブロックを追加
  - `tests/features/inbound-email-route.test.ts` / `inbound-line-route.test.ts` に「月間チケット上限」ブロックを追加（`getMonthlyTicketQuota` を部分モックして配線を検証）
  - `tests/features/inbound-line-route.test.ts` に連携コード再送の誤起票回帰テストを追加

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_015a7mk7TDJdiL6MsDifaoYF)_