### PR TITLE
プラン降格後の設定削除・添付累計サイズ上限・優先度変更通知の3件を修正

### DIFF
--- a/prisma/migrations/20260707000000_add_notification_type_priority_changed/migration.sql
+++ b/prisma/migrations/20260707000000_add_notification_type_priority_changed/migration.sql
@@ -1,0 +1,8 @@
+-- Migration: NotificationType enum に 'priorityChanged' 値を追加する
+-- updateTicketPriority (優先度変更) が発行する通知種別として使用する。
+--
+-- PostgreSQL では ALTER TYPE ... ADD VALUE は DDL トランザクション外でのみ実行できる。
+-- Prisma はデフォルトでトランザクションを使うため、このファイルには pragma: notx を設定する必要はなく、
+-- Prisma が自動的にトランザクション外で実行する。
+-- IF NOT EXISTS を付けることでべき等性を保ち、再実行しても安全にする。
+ALTER TYPE "NotificationType" ADD VALUE IF NOT EXISTS 'priorityChanged';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,6 +65,7 @@ enum NotificationType {
   escalated // エスカレーション通知
   commented // コメント追加通知
   statusChanged // ステータス変更通知
+  priorityChanged // 優先度変更通知
   imported // CSV・メール一括取り込みによる複数チケット追加通知
 }
 

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -60,16 +60,19 @@ export default async function SettingsPage() {
   ]);
 
   // Phase 4 Enterprise: SSO は Enterprise プランのみ、Phase 2 フォローアップ: LINE 連携は
-  // Pro / Enterprise プランのみ表示・設定可能。それぞれ独立したクエリなので Promise.all で
-  // 並列に取得する (非対象テナントには Promise.resolve(null) で余計なクエリを投げない)。
+  // Pro / Enterprise プランのみ新規設定・再設定が可能。ただし既存設定はプラン降格後も
+  // 削除だけはできる必要があるため (プラン不問の削除ゲート。line-config-context.ts /
+  // sso-context.ts 参照)、設定の有無自体はプランに関わらず常に取得する。
   const ssoAllowed = isSsoAllowed(tenant?.subscriptionPlan ?? 'free');
   const lineAllowed = isLineIntegrationAllowed(tenant?.subscriptionPlan ?? 'free');
   const [ssoConfig, lineConfig] = await Promise.all([
-    ssoAllowed ? repos.ssoConfigs.findByTenant(session.user.tenantId) : Promise.resolve(null),
-    lineAllowed ? repos.lineConfigs.findByTenant(session.user.tenantId) : Promise.resolve(null),
+    repos.ssoConfigs.findByTenant(session.user.tenantId),
+    repos.lineConfigs.findByTenant(session.user.tenantId),
   ]);
-  // SP の各 URL を組み立てる (Enterprise のときだけ使う)
-  const spUrls = ssoAllowed ? buildSpUrls(resolveAppBaseUrl(), session.user.tenantId) : null;
+  // SP の各 URL を組み立てる (Enterprise のとき、またはプラン降格後も既存設定の削除
+  // 画面を出すために ssoConfig が残っているときに使う)
+  const spUrls =
+    ssoAllowed || ssoConfig ? buildSpUrls(resolveAppBaseUrl(), session.user.tenantId) : null;
   // Webhook 受信 URL (LINE Developers コンソールに登録する値)
   const lineWebhookUrl = `${resolveAppBaseUrl()}/api/inbound/line`;
 
@@ -155,8 +158,8 @@ export default async function SettingsPage() {
           <h2 className="text-base font-semibold text-slate-900">課金プラン</h2>
           {/* 説明: 現在プランの確認とアップグレードを案内する */}
           <p className="mt-1 text-sm text-slate-500">
-            現在の料金プランを確認し、アップグレードや解約の管理ができます。
-            Standard・Pro へのアップグレードは Stripe の安全な決済ページに移動します。
+            現在の料金プランを確認し、アップグレードや解約の管理ができます。 Standard・Pro
+            へのアップグレードは Stripe の安全な決済ページに移動します。
           </p>
         </div>
         {/* プラン情報と操作ボタン */}
@@ -168,12 +171,15 @@ export default async function SettingsPage() {
         />
       </section>
 
-      {/* Phase 4 Enterprise: SAML SSO 設定カード (Enterprise プランのみ表示) */}
-      {ssoAllowed && spUrls && (
+      {/* Phase 4 Enterprise: SAML SSO 設定カード (Enterprise プランで表示。プラン降格後も
+          既存設定が残っていれば削除だけできるよう表示を続ける) */}
+      {(ssoAllowed || ssoConfig) && spUrls && (
         <section className="space-y-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
           <div>
             {/* セクション見出し */}
-            <h2 className="text-base font-semibold text-slate-900">シングルサインオン (SAML SSO)</h2>
+            <h2 className="text-base font-semibold text-slate-900">
+              シングルサインオン (SAML SSO)
+            </h2>
             {/* 説明: Enterprise 向けの SSO 設定であることを伝える */}
             <p className="mt-1 text-sm text-slate-500">
               社内の IdP (Okta・Microsoft Entra ID・Google Workspace など) と SAML 連携し、
@@ -181,7 +187,8 @@ export default async function SettingsPage() {
               ログインできるのは、組織に既に登録済みのメンバーのみです。
             </p>
           </div>
-          {/* SSO 設定フォームと SP 情報 (現在の設定と SP URL を渡す) */}
+          {/* SSO 設定フォームと SP 情報 (現在の設定と SP URL を渡す)。プラン降格後は
+              planAllowed=false を渡し、再設定フォームを隠して削除だけ可能にする */}
           <SsoConfigSection
             config={
               ssoConfig
@@ -194,12 +201,14 @@ export default async function SettingsPage() {
                 : null
             }
             sp={spUrls}
+            planAllowed={ssoAllowed}
           />
         </section>
       )}
 
-      {/* Phase 2 フォローアップ: LINE 公式アカウント連携設定カード (Pro/Enterprise プランのみ表示) */}
-      {lineAllowed && (
+      {/* Phase 2 フォローアップ: LINE 公式アカウント連携設定カード (Pro/Enterprise プランで表示。
+          プラン降格後も既存設定が残っていれば削除だけできるよう表示を続ける) */}
+      {(lineAllowed || lineConfig) && (
         <section className="space-y-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
           <div>
             {/* セクション見出し */}
@@ -210,10 +219,12 @@ export default async function SettingsPage() {
               へ届けます。LINE Developers コンソールで発行したチャネル情報を設定してください。
             </p>
           </div>
-          {/* LINE 連携設定フォーム (秘密情報は渡さず botUserId のみ渡す。§9 参照) */}
+          {/* LINE 連携設定フォーム (秘密情報は渡さず botUserId のみ渡す。§9 参照)。プラン降格後は
+              planAllowed=false を渡し、再設定フォームを隠して削除だけ可能にする */}
           <LineConfigSection
             config={lineConfig ? { botUserId: lineConfig.botUserId } : null}
             webhookUrl={lineWebhookUrl}
+            planAllowed={lineAllowed}
           />
         </section>
       )}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -173,7 +173,7 @@ export default async function SettingsPage() {
 
       {/* Phase 4 Enterprise: SAML SSO 設定カード (Enterprise プランで表示。プラン降格後も
           既存設定が残っていれば削除だけできるよう表示を続ける) */}
-      {(ssoAllowed || ssoConfig) && spUrls && (
+      {spUrls && (
         <section className="space-y-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
           <div>
             {/* セクション見出し */}

--- a/src/app/api/tickets/[id]/comments/route.ts
+++ b/src/app/api/tickets/[id]/comments/route.ts
@@ -32,10 +32,12 @@ import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
 import { commentBodySchema } from '@/lib/validations/ticket';
 // 添付ファイル検証ヘルパー
 import { validateUploadedFiles } from '@/lib/validations/attachment';
-// MIME → 拡張子の対応表 (storageKey の組み立てで使う)
-import { MIME_TO_EXTENSION } from '@/domain/attachment';
+// MIME → 拡張子の対応表 (storageKey の組み立てで使う)、バイト数を GB 表示に丸めるヘルパー
+import { MIME_TO_EXTENSION, formatBytesAsGb } from '@/domain/attachment';
 // LINE 連携機能のプランゲート (§6.1 料金プラン: Pro / Enterprise のみ利用可能)
 import { isLineIntegrationAllowed } from '@/lib/plan-guard';
+// Phase 4 課金: 添付累計サイズ上限チェック (チケット作成時添付と共有)
+import { getAttachmentQuota } from '@/lib/tenant-plan';
 // Phase 4: Slack/Teams/Chatwork 外部通知のベストエフォート送信共通ヘルパー
 import { notifyOutboundBestEffort } from '@/lib/outbound-notify';
 
@@ -112,6 +114,19 @@ export async function POST(req: Request, { params }: Params) {
   const attachmentValidation = await validateUploadedFiles(files);
   if (!attachmentValidation.ok) {
     return validationError(attachmentValidation.message, ['files']);
+  }
+
+  // Phase 4 課金: 添付ファイルがある場合、テナントの累計サイズ上限 (§6.1 Standard「添付1GB」) を
+  // 超えないか確認する。0 件アップロードなら DB 集計を行わずスキップする
+  if (attachmentValidation.files.length > 0) {
+    const newBytes = attachmentValidation.files.reduce((sum, f) => sum + f.size, 0);
+    const attachmentQuota = await getAttachmentQuota(tenantId);
+    if (attachmentQuota.limited && newBytes > attachmentQuota.remainingBytes) {
+      return validationError(
+        `添付ファイルの合計サイズがプランの上限 (${formatBytesAsGb(attachmentQuota.limitBytes)}GB) を超えています`,
+        ['files'],
+      );
+    }
   }
 
   // 対象チケットを tenantId スコープで取得 (他テナントは null になる)

--- a/src/app/api/tickets/[id]/comments/route.ts
+++ b/src/app/api/tickets/[id]/comments/route.ts
@@ -32,12 +32,12 @@ import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
 import { commentBodySchema } from '@/lib/validations/ticket';
 // 添付ファイル検証ヘルパー
 import { validateUploadedFiles } from '@/lib/validations/attachment';
-// MIME → 拡張子の対応表 (storageKey の組み立てで使う)、バイト数を GB 表示に丸めるヘルパー
-import { MIME_TO_EXTENSION, formatBytesAsGb } from '@/domain/attachment';
+// MIME → 拡張子の対応表 (storageKey の組み立てで使う)
+import { MIME_TO_EXTENSION } from '@/domain/attachment';
 // LINE 連携機能のプランゲート (§6.1 料金プラン: Pro / Enterprise のみ利用可能)
 import { isLineIntegrationAllowed } from '@/lib/plan-guard';
 // Phase 4 課金: 添付累計サイズ上限チェック (チケット作成時添付と共有)
-import { getAttachmentQuota } from '@/lib/tenant-plan';
+import { checkAttachmentQuota } from '@/lib/tenant-plan';
 // Phase 4: Slack/Teams/Chatwork 外部通知のベストエフォート送信共通ヘルパー
 import { notifyOutboundBestEffort } from '@/lib/outbound-notify';
 
@@ -117,16 +117,11 @@ export async function POST(req: Request, { params }: Params) {
   }
 
   // Phase 4 課金: 添付ファイルがある場合、テナントの累計サイズ上限 (§6.1 Standard「添付1GB」) を
-  // 超えないか確認する。0 件アップロードなら DB 集計を行わずスキップする
-  if (attachmentValidation.files.length > 0) {
-    const newBytes = attachmentValidation.files.reduce((sum, f) => sum + f.size, 0);
-    const attachmentQuota = await getAttachmentQuota(tenantId);
-    if (attachmentQuota.limited && newBytes > attachmentQuota.remainingBytes) {
-      return validationError(
-        `添付ファイルの合計サイズがプランの上限 (${formatBytesAsGb(attachmentQuota.limitBytes)}GB) を超えています`,
-        ['files'],
-      );
-    }
+  // 超えないか確認する。チケット作成時添付と同じ判定ヘルパーを共有する (tenant-plan.ts)
+  const newAttachmentBytes = attachmentValidation.files.reduce((sum, f) => sum + f.size, 0);
+  const attachmentQuotaCheck = await checkAttachmentQuota(tenantId, newAttachmentBytes);
+  if (!attachmentQuotaCheck.ok) {
+    return validationError(attachmentQuotaCheck.message, ['files']);
   }
 
   // 対象チケットを tenantId スコープで取得 (他テナントは null になる)

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -24,9 +24,7 @@ import { getCurrentTenantMode } from '@/lib/tenant';
 import { endOfDayJST } from '@/lib/format-date';
 // Phase 4 課金: プランごとの月間チケット上限・添付累計サイズ上限チェック
 // (月間上限は CSV インポート・メール/LINE 取り込みと共有、添付上限はコメント投稿と共有)
-import { getAttachmentQuota, getMonthlyTicketQuota } from '@/lib/tenant-plan';
-// バイト数を GB 表示に丸めるヘルパー (添付上限エラーメッセージ用)
-import { formatBytesAsGb } from '@/domain/attachment';
+import { checkAttachmentQuota, getMonthlyTicketQuota, resolveTenantPlan } from '@/lib/tenant-plan';
 // Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (失敗してもチケット作成は止めない。
 // メール取り込み・LINE 取り込み・CSV インポートと共有する)
 import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
@@ -123,17 +121,16 @@ export async function POST(req: Request) {
     return validationError(attachmentValidation.message, ['files']);
   }
 
-  // Phase 4 課金: 添付ファイルがある場合、テナントの累計サイズ上限 (§6.1 Standard「添付1GB」) を
-  // 超えないか確認する。0 件アップロードなら DB 集計を行わずスキップする
-  if (attachmentValidation.files.length > 0) {
-    const newBytes = attachmentValidation.files.reduce((sum, f) => sum + f.size, 0);
-    const attachmentQuota = await getAttachmentQuota(tenantId);
-    if (attachmentQuota.limited && newBytes > attachmentQuota.remainingBytes) {
-      return validationError(
-        `添付ファイルの合計サイズがプランの上限 (${formatBytesAsGb(attachmentQuota.limitBytes)}GB) を超えています`,
-        ['files'],
-      );
-    }
+  // Phase 4 課金: このリクエスト内で月間チケット上限・添付累計サイズ上限の両方を確認するため、
+  // プランを 1 度だけ解決して使い回す (それぞれが個別にテナントを取得する二重フェッチを避ける)
+  const plan = await resolveTenantPlan(tenantId);
+
+  // 添付ファイルがある場合、テナントの累計サイズ上限 (§6.1 Standard「添付1GB」) を超えないか確認する。
+  // チケット作成・コメント投稿の両方の添付アップロード経路が共有するヘルパー (tenant-plan.ts)
+  const newAttachmentBytes = attachmentValidation.files.reduce((sum, f) => sum + f.size, 0);
+  const attachmentQuotaCheck = await checkAttachmentQuota(tenantId, newAttachmentBytes, plan);
+  if (!attachmentQuotaCheck.ok) {
+    return validationError(attachmentQuotaCheck.message, ['files']);
   }
 
   // 検証済みの値を分解 (body は変数名衝突を避けてリネーム)
@@ -165,8 +162,9 @@ export async function POST(req: Request) {
     }
   }
 
-  // Phase 4 課金: テナントの当月チケット起票の残枠を確認する (§6.1 料金プランの月間上限)
-  const quota = await getMonthlyTicketQuota(tenantId);
+  // Phase 4 課金: テナントの当月チケット起票の残枠を確認する (§6.1 料金プランの月間上限)。
+  // plan は上の添付上限チェックで既に解決済みのものを渡し、テナントの二重取得を避ける
+  const quota = await getMonthlyTicketQuota(tenantId, plan);
   // 残枠が無い (上限のあるプランで使い切った) 場合は 429 でプランアップグレードを促す
   if (quota.limited && quota.remaining <= 0) {
     return NextResponse.json(

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -22,8 +22,11 @@ import { initialStatusForMode } from '@/domain/ticket-status';
 import { getCurrentTenantMode } from '@/lib/tenant';
 // 'YYYY-MM-DD' を JST 終端 Date に変換するヘルパー (サーバ TZ 非依存)
 import { endOfDayJST } from '@/lib/format-date';
-// Phase 4 課金: プランごとの月間チケット上限チェック (CSV インポート・メール/LINE 取り込みと共有)
-import { getMonthlyTicketQuota } from '@/lib/tenant-plan';
+// Phase 4 課金: プランごとの月間チケット上限・添付累計サイズ上限チェック
+// (月間上限は CSV インポート・メール/LINE 取り込みと共有、添付上限はコメント投稿と共有)
+import { getAttachmentQuota, getMonthlyTicketQuota } from '@/lib/tenant-plan';
+// バイト数を GB 表示に丸めるヘルパー (添付上限エラーメッセージ用)
+import { formatBytesAsGb } from '@/domain/attachment';
 // Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (失敗してもチケット作成は止めない。
 // メール取り込み・LINE 取り込み・CSV インポートと共有する)
 import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
@@ -118,6 +121,19 @@ export async function POST(req: Request) {
   // 1 件でも違反があれば 422 で返す
   if (!attachmentValidation.ok) {
     return validationError(attachmentValidation.message, ['files']);
+  }
+
+  // Phase 4 課金: 添付ファイルがある場合、テナントの累計サイズ上限 (§6.1 Standard「添付1GB」) を
+  // 超えないか確認する。0 件アップロードなら DB 集計を行わずスキップする
+  if (attachmentValidation.files.length > 0) {
+    const newBytes = attachmentValidation.files.reduce((sum, f) => sum + f.size, 0);
+    const attachmentQuota = await getAttachmentQuota(tenantId);
+    if (attachmentQuota.limited && newBytes > attachmentQuota.remainingBytes) {
+      return validationError(
+        `添付ファイルの合計サイズがプランの上限 (${formatBytesAsGb(attachmentQuota.limitBytes)}GB) を超えています`,
+        ['files'],
+      );
+    }
   }
 
   // 検証済みの値を分解 (body は変数名衝突を避けてリネーム)

--- a/src/data/adapters/memory/attachment-repository.memory.ts
+++ b/src/data/adapters/memory/attachment-repository.memory.ts
@@ -69,6 +69,17 @@ export function makeAttachmentRepo(store: Store): AttachmentRepository {
       return count;
     },
 
+    // テナント全体の添付サイズ合計 (バイト) を返す (添付累計サイズ上限チェック用)
+    async sumSizeByTenant(tenantId) {
+      // 走査してサイズを積算する
+      let total = 0;
+      for (const row of store.attachments.values()) {
+        if (row.tenantId !== tenantId) continue;
+        total += row.size;
+      }
+      return total;
+    },
+
     // ID + tenantId で 1 件削除 (他テナントの ID は no-op)
     async delete(id, tenantId) {
       // 取り出してテナント一致のみ削除する

--- a/src/data/adapters/prisma/attachment-repository.prisma.ts
+++ b/src/data/adapters/prisma/attachment-repository.prisma.ts
@@ -82,6 +82,17 @@ export function makeAttachmentRepo(db: PrismaLike): AttachmentRepository {
       return db.attachment.count({ where: { ticketId, tenantId } });
     },
 
+    // テナント全体の添付サイズ合計 (バイト) を返す (添付累計サイズ上限チェック用)
+    async sumSizeByTenant(tenantId) {
+      // aggregate の SUM を使い、行を取得せず集計だけ DB 側で行う
+      const result = await db.attachment.aggregate({
+        where: { tenantId },
+        _sum: { size: true },
+      });
+      // 該当行が無い場合 _sum.size は null になるため 0 にフォールバックする
+      return result._sum.size ?? 0;
+    },
+
     // ID + tenantId で 1 件削除 (他テナントの ID は 0 件削除となり no-op)
     async delete(id, tenantId) {
       // updateMany と同じく deleteMany で AND 一致のみ削除する

--- a/src/data/ports/attachment-repository.ts
+++ b/src/data/ports/attachment-repository.ts
@@ -35,6 +35,8 @@ export interface AttachmentRepository {
   listByTicket(ticketId: string, tenantId: string): Promise<Attachment[]>;
   // チケットに紐づく添付の件数を返す (5 枚上限チェック用)
   countByTicket(ticketId: string, tenantId: string): Promise<number>;
+  // テナント全体の添付サイズ合計 (バイト) を返す (Phase 4 課金: 添付累計サイズ上限チェック用)
+  sumSizeByTenant(tenantId: string): Promise<number>;
   // ID + tenantId で 1 件削除 (StoragePort.delete のロールバック相互運用に使う)。
   // 物理ファイルは別途 storage.delete を呼ぶこと
   delete(id: string, tenantId: string): Promise<void>;

--- a/src/domain/attachment.ts
+++ b/src/domain/attachment.ts
@@ -35,6 +35,12 @@ export function isAllowedImageMimeType(mime: string): mime is AllowedImageMimeTy
   return (ALLOWED_IMAGE_MIME_TYPES as readonly string[]).includes(mime);
 }
 
+// バイト数を GB に丸めて文字列化する (プランの添付累計上限を UI/エラーメッセージへ出す用途)
+export function formatBytesAsGb(bytes: number): string {
+  // 小数第 2 位までに丸める (例: 1.00GB)
+  return (bytes / (1024 * 1024 * 1024)).toFixed(2);
+}
+
 // 添付ファイル 1 件分のドメイン表現 (画面表示・API 配信で使う最小情報)
 export interface Attachment {
   id: string; // 添付 ID (主キー)

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -36,6 +36,7 @@ export type NotificationType =
   | 'escalated' // エスカレーション通知
   | 'commented' // コメント追加通知
   | 'statusChanged' // ステータス変更通知
+  | 'priorityChanged' // 優先度変更通知
   | 'imported'; // CSV・メール一括取り込みで複数チケットが追加された通知
 
 // テナントの動作モード (Lite=SMB 既定 / Pro=現行フル機能)

--- a/src/features/settings/actions/delete-line-config.ts
+++ b/src/features/settings/actions/delete-line-config.ts
@@ -1,15 +1,17 @@
 'use server';
 
 // Phase 2 フォローアップ: テナント単位の LINE 公式アカウント連携設定を削除する Server Action。
-// Pro / Enterprise プランの管理者のみ実行可能。削除すると LINE Webhook 取り込み・push が無効化される。
+// 自テナントの admin であれば実行可能 (プラン不問)。削除すると LINE Webhook 取り込み・push が
+// 無効化される。プラン降格後に既存設定を削除できなくなる不具合を避けるため、削除はプラン非依存の
+// 軽量ゲートで検証する (作成/更新の assertLineConfigAdmin とは異なる。line-config-context.ts 参照)。
 // docs/smb-dx-pivot-plan.md §4 Phase 2.1。
 
 // Next.js のキャッシュ無効化
 import { revalidatePath } from 'next/cache';
 // データリポジトリ
 import { repos } from '@/data';
-// LINE 連携設定変更の共有認可ゲート (ログイン済み・admin・Pro/Enterprise)
-import { assertLineConfigAdmin } from '@/lib/line-config-context';
+// LINE 連携設定削除の共有認可ゲート (ログイン済み・admin・自テナント。プラン不問)
+import { assertLineConfigOwner } from '@/lib/line-config-context';
 
 // 削除結果型 (useActionState 互換)
 export interface DeleteLineConfigState {
@@ -22,8 +24,8 @@ export async function deleteLineConfig(
   _prevState: DeleteLineConfigState,
   _formData: FormData,
 ): Promise<DeleteLineConfigState> {
-  // 共有ゲートで「ログイン済み・admin・Pro/Enterprise」をまとめて検証する
-  const gate = await assertLineConfigAdmin();
+  // 共有ゲートで「ログイン済み・admin・自テナント」をまとめて検証する (プラン不問)
+  const gate = await assertLineConfigOwner();
   // ゲート不通過ならその理由をそのまま返す
   if (!gate.ok) return { error: gate.error };
   // 検証済みの tenantId (セッション由来)

--- a/src/features/settings/actions/delete-sso-config.ts
+++ b/src/features/settings/actions/delete-sso-config.ts
@@ -1,15 +1,17 @@
 'use server';
 
 // Phase 4 Enterprise: SAML SSO 設定を削除する Server Action。
-// Enterprise プランの管理者のみ実行可能。削除すると SSO ログインが無効化される。
+// 自テナントの admin であれば実行可能 (プラン不問)。削除すると SSO ログインが無効化される。
+// プラン降格後に既存設定を削除できなくなる不具合を避けるため、削除はプラン非依存の軽量ゲートで
+// 検証する (作成/更新の assertSsoConfigAdmin とは異なる。sso-context.ts 参照)。
 // docs/smb-dx-pivot-plan.md §6.1 Enterprise「SSO(SAML)」。
 
 // Next.js のキャッシュ無効化
 import { revalidatePath } from 'next/cache';
 // データリポジトリ
 import { repos } from '@/data';
-// SSO 設定変更の共有認可ゲート (ログイン済み・admin・Enterprise)
-import { assertSsoConfigAdmin } from '@/lib/sso-context';
+// SSO 設定削除の共有認可ゲート (ログイン済み・admin・自テナント。プラン不問)
+import { assertSsoConfigOwner } from '@/lib/sso-context';
 
 // 削除結果型 (useActionState 互換)
 export interface DeleteSsoConfigState {
@@ -22,8 +24,8 @@ export async function deleteSsoConfig(
   _prevState: DeleteSsoConfigState,
   _formData: FormData,
 ): Promise<DeleteSsoConfigState> {
-  // 共有ゲートで「ログイン済み・admin・Enterprise」をまとめて検証する
-  const gate = await assertSsoConfigAdmin();
+  // 共有ゲートで「ログイン済み・admin・自テナント」をまとめて検証する (プラン不問)
+  const gate = await assertSsoConfigOwner();
   // ゲート不通過ならその理由をそのまま返す
   if (!gate.ok) return { error: gate.error };
   // 検証済みの tenantId (セッション由来)

--- a/src/features/settings/components/LineConfigSection.tsx
+++ b/src/features/settings/components/LineConfigSection.tsx
@@ -22,6 +22,7 @@ interface LineConfigView {
 interface Props {
   config: LineConfigView | null; // 現在の LINE 連携設定 (botUserId のみ)
   webhookUrl: string; // Webhook 受信 URL
+  planAllowed: boolean; // 現在のプランが LINE 連携を許可するか (false ならプラン降格後で削除のみ可能)
 }
 
 // 入力フィールド共通の Tailwind クラス
@@ -33,7 +34,7 @@ const labelClass = 'block text-sm font-medium text-slate-700';
 const helpClass = 'mt-1 text-xs text-slate-500';
 
 // LINE 連携設定セクション本体
-export function LineConfigSection({ config, webhookUrl }: Props) {
+export function LineConfigSection({ config, webhookUrl, planAllowed }: Props) {
   // 設定保存アクションの状態
   const [saveState, saveAction] = useActionState(updateLineConfig, {});
   // 設定削除アクションの状態
@@ -61,6 +62,42 @@ export function LineConfigSection({ config, webhookUrl }: Props) {
     }
     // 空の FormData でアクションを呼ぶ
     startTransition(() => deleteAction(new FormData()));
+  }
+
+  // プラン降格後 (現在のプランでは LINE 連携を利用できない) は、既存設定の削除だけを
+  // 案内する簡易表示にする。再設定フォームを出すと「保存」時にサーバー側のプランゲートで
+  // 弾かれてしまい紛らわしいため、削除ボタンのみ表示する
+  if (!planAllowed) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-slate-600">
+          現在のプランでは LINE 連携をご利用いただけません。既存の設定を削除できます
+          （再設定するにはプランのアップグレードが必要です）。
+        </p>
+        {/* 削除結果メッセージ */}
+        {deleteState.error && (
+          <p role="alert" className="text-sm text-rose-700">
+            {deleteState.error}
+          </p>
+        )}
+        {deleteState.success && (
+          <p role="status" aria-live="polite" className="text-sm text-teal-700">
+            LINE 連携設定を削除しました。
+          </p>
+        )}
+        {/* 削除ボタン (設定が存在する場合のみ表示) */}
+        {config && (
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={isPending}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-rose-600 transition hover:bg-rose-50 disabled:opacity-50"
+          >
+            設定を削除
+          </button>
+        )}
+      </div>
+    );
   }
 
   return (

--- a/src/features/settings/components/SsoConfigSection.tsx
+++ b/src/features/settings/components/SsoConfigSection.tsx
@@ -30,6 +30,7 @@ interface SpUrls {
 interface Props {
   config: SsoConfigView | null; // 現在の SSO 設定
   sp: SpUrls; // SP 側の URL 群
+  planAllowed: boolean; // 現在のプランが SSO を許可するか (false ならプラン降格後で削除のみ可能)
 }
 
 // 入力フィールド共通の Tailwind クラス
@@ -47,7 +48,7 @@ function SpField({ label, value }: { label: string; value: string }) {
       {/* 項目名 */}
       <p className="text-xs font-semibold text-slate-500">{label}</p>
       {/* 値 (折り返し可能・等幅でコピーしやすく) */}
-      <p className="break-all rounded bg-slate-50 px-2 py-1 font-mono text-xs text-slate-700 ring-1 ring-slate-200">
+      <p className="rounded bg-slate-50 px-2 py-1 font-mono text-xs break-all text-slate-700 ring-1 ring-slate-200">
         {value}
       </p>
     </div>
@@ -55,7 +56,7 @@ function SpField({ label, value }: { label: string; value: string }) {
 }
 
 // SSO 設定セクション本体
-export function SsoConfigSection({ config, sp }: Props) {
+export function SsoConfigSection({ config, sp, planAllowed }: Props) {
   // 設定保存アクションの状態
   const [saveState, saveAction] = useActionState(updateSsoConfig, {});
   // 設定削除アクションの状態
@@ -81,6 +82,42 @@ export function SsoConfigSection({ config, sp }: Props) {
     startTransition(() => deleteAction(new FormData()));
   }
 
+  // プラン降格後 (現在のプランでは SSO を利用できない) は、既存設定の削除だけを案内する
+  // 簡易表示にする。再設定フォームを出すと「保存」時にサーバー側のプランゲートで弾かれてしまい
+  // 紛らわしいため、削除ボタンのみ表示する
+  if (!planAllowed) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-slate-600">
+          現在のプランでは SSO をご利用いただけません。既存の設定を削除できます
+          （再設定するにはプランのアップグレードが必要です）。
+        </p>
+        {/* 削除結果メッセージ */}
+        {deleteState.error && (
+          <p role="alert" className="text-sm text-rose-700">
+            {deleteState.error}
+          </p>
+        )}
+        {deleteState.success && (
+          <p role="status" aria-live="polite" className="text-sm text-teal-700">
+            SSO 設定を削除しました。
+          </p>
+        )}
+        {/* 削除ボタン (設定が存在する場合のみ表示) */}
+        {config && (
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={isPending}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-rose-600 transition hover:bg-rose-50 disabled:opacity-50"
+          >
+            設定を削除
+          </button>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6">
       {/* ── SP 情報 (IdP 側に登録する値) ─────────────────────────── */}
@@ -104,7 +141,9 @@ export function SsoConfigSection({ config, sp }: Props) {
           <label htmlFor="idp-entity-id" className={labelClass}>
             IdP EntityID (Issuer)
           </label>
-          <p className={helpClass}>IdP が発行する識別子。受信したログイン応答の発行元検証に使います。</p>
+          <p className={helpClass}>
+            IdP が発行する識別子。受信したログイン応答の発行元検証に使います。
+          </p>
           <input
             id="idp-entity-id"
             name="idpEntityId"
@@ -141,8 +180,8 @@ export function SsoConfigSection({ config, sp }: Props) {
             IdP X.509 証明書
           </label>
           <p className={helpClass}>
-            IdP の署名検証用の公開証明書。PEM 形式（-----BEGIN CERTIFICATE-----）または
-            その base64 本体を貼り付けてください。
+            IdP の署名検証用の公開証明書。PEM 形式（-----BEGIN CERTIFICATE-----）または その base64
+            本体を貼り付けてください。
           </p>
           <textarea
             id="idp-cert"

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -232,26 +232,17 @@ export async function updateTicketPriority(ticketId: string, newPriority: Priori
     windowMs: 10_000,
   });
 
-  // コミット後の broadcastUnreadCount に渡す「通知を実際に書き込んだ起票者 ID」を保持する
-  // (updateTicketStatus と同じパターン。自己更新では通知を作らないため null のままにする)
-  let notifiedCreatorId: string | null = null;
-  // メール送信・Slack 通知に必要なチケット情報を uow.run 外で参照するために宣言する
-  // null のままなら送らない (自己更新 or チケット未取得 or 変更なし)
-  let ticketSnapshot: { creatorId: string; title: string } | null = null;
-  // 優先度変更前の値 (メール本文でラベルを出すために外側で保持する)
-  let oldPriority: Priority | null = null;
-
-  // 1 トランザクションで更新と履歴記録・通知作成を実行
-  await uow.run(async (r) => {
+  // 1 トランザクションで更新と履歴記録・通知作成を実行し、トランザクション外の後続処理
+  // (SSE配信・メール・Slack) に必要な情報を戻り値としてそのまま受け取る。
+  // (updateTicketStatus は外側 let 変数 + as キャストでクロージャの外へ持ち出しているが、
+  // async 関数の戻り値は TSC が通常どおり narrow できるため、こちらはキャスト不要にできる)
+  const result = await uow.run(async (r) => {
     // チケットを tenantId スコープで取得
     const ticket = await r.tickets.findById(ticketId, tenantId);
     // 無ければエラー
     if (!ticket) throw new Error('チケットが見つかりません');
-    // 変更無しならスキップ
-    if (ticket.priority === newPriority) return;
-    // 変更前の優先度と件名/起票者をトランザクション外の通知処理に伝えるため外側変数に保存する
-    oldPriority = ticket.priority;
-    ticketSnapshot = { creatorId: ticket.creatorId, title: ticket.title };
+    // 変更無しなら何もせず null を返す (冪等)
+    if (ticket.priority === newPriority) return null;
 
     // 優先度を更新 (tenantId スコープで where に注入)
     await r.tickets.updatePriority(ticketId, newPriority, tenantId);
@@ -263,56 +254,69 @@ export async function updateTicketPriority(ticketId: string, newPriority: Priori
       oldValue: ticket.priority,
       newValue: newPriority,
     });
+    // 自分以外の起票者にのみ通知を送るため、まず未通知 (null) で用意しておく
+    let notifiedCreatorId: string | null = null;
     // 自分以外の起票者にのみ通知を送る (updateTicketStatus と同じく自己操作では自己通知しない)
     if (ticket.creatorId !== session.user.id) {
+      // 起票者に優先度変更通知を DB に書き込む
       await r.notifications.create({
         userId: ticket.creatorId, // 通知の受信者は起票者
-        type: 'priorityChanged',
-        message: `チケット「${ticket.title}」の優先度が「${PRIORITY_LABELS[newPriority] ?? newPriority}」に変更されました`,
-        ticketId,
+        type: 'priorityChanged', // 通知の種類: 優先度変更
+        // getStatusLabel と同じく、優先度も日本語ラベルに変換して表示文言に埋め込む
+        message: `チケット「${ticket.title}」の優先度が「${PRIORITY_LABELS[newPriority] ?? newPriority}」に変更されました`, // 表示文言
+        ticketId, // 関連チケット ID
         tenantId: ticket.tenantId, // テナントスコープ (クロステナント漏洩防止)
       });
-      // 通知を書き込んだ起票者 ID を外側変数に渡す (コミット後の SSE 配信に使う)
+      // 通知を書き込んだ起票者 ID を記録する (コミット後の SSE 配信に使う)
       notifiedCreatorId = ticket.creatorId;
     }
+    // トランザクション外の後続処理に必要な情報をまとめて返す
+    return {
+      creatorId: ticket.creatorId, // 起票者 ID (メール宛先取得・自己操作判定に使う)
+      title: ticket.title, // 件名 (メール・Slack 本文に使う)
+      oldPriority: ticket.priority, // 変更前の優先度 (メールのラベル変換に使う)
+      notifiedCreatorId, // 通知を書き込んだ起票者 ID (null なら自己操作で未通知)
+    };
   });
 
-  // 通知を実際に書き込んだ場合のみ、起票者の未読件数を SSE でリアルタイム配信する
-  if (notifiedCreatorId) await broadcastUnreadCount(notifiedCreatorId, tenantId);
-
-  // Phase 2: 優先度変更を依頼者へメールで通知する (ベストエフォート)。
-  // let 変数は async クロージャを跨ぐと TSC の CFA が never に絞り込むため、
-  // updateTicketStatus と同じく宣言型アサーションで const に取り出してから null チェックする
-  const snapForMail = ticketSnapshot as { creatorId: string; title: string } | null;
-  const oldPriorityForMail = oldPriority as Priority | null;
-  if (
-    snapForMail !== null &&
-    oldPriorityForMail !== null &&
-    snapForMail.creatorId !== session.user.id
-  ) {
-    await sendPriorityChangedEmailToRequester({
-      ticketId,
-      ticketTitle: snapForMail.title,
-      creatorId: snapForMail.creatorId,
-      oldPriority: oldPriorityForMail,
-      newPriority,
-    });
+  // 変更が無かった (冪等スキップ) 場合はキャッシュ無効化だけ行って終了する
+  if (!result) {
+    revalidatePath(`/tickets/${ticketId}`);
+    return;
   }
 
-  // Phase 4: Slack/Teams/Chatwork 外部通知 (updateTicketStatus と同じパターン)。
-  // チームの共有チャネル宛の「見える化」目的なので、自己更新でも送る。
-  const snapForSlack = ticketSnapshot as { creatorId: string; title: string } | null;
-  if (snapForSlack !== null) {
-    await notifyOutboundBestEffort(
+  // 通知を実際に書き込んだ場合のみ、起票者の未読件数を SSE でリアルタイム配信する
+  if (result.notifiedCreatorId) await broadcastUnreadCount(result.notifiedCreatorId, tenantId);
+
+  // 優先度の日本語ラベル (メール・Slack 本文の両方で使うため 1 度だけ変換する)
+  const newPriorityLabel = PRIORITY_LABELS[newPriority] ?? newPriority;
+
+  // Phase 2 メール通知 + Phase 4 Slack/Teams/Chatwork 外部通知: この 2 経路は互いに依存しない
+  // 独立した I/O なので、escalateTicket と同じく Promise.allSettled で並行実行し、片方の遅延/失敗が
+  // 他方に波及しないようにする。メールは自分以外の起票者にのみ送るが (個人宛の通知のため)、
+  // Slack はチームの共有チャネル宛の「見える化」目的なので自己更新でも送る。
+  await Promise.allSettled([
+    // 経路 1: 起票者へメール送信 (自己操作なら送らない)
+    result.creatorId !== session.user.id
+      ? sendPriorityChangedEmailToRequester({
+          ticketId,
+          ticketTitle: result.title,
+          creatorId: result.creatorId,
+          oldPriority: result.oldPriority,
+          newPriority,
+        })
+      : Promise.resolve(),
+    // 経路 2: Slack/Teams/Chatwork へ優先度変更を通知する
+    notifyOutboundBestEffort(
       tenantId,
       (baseUrl) => ({
-        subject: `優先度が変更されました: ${snapForSlack.title}`,
-        body: `「${snapForSlack.title}」の優先度が「${PRIORITY_LABELS[newPriority] ?? newPriority}」に変更されました。`,
+        subject: `優先度が変更されました: ${result.title}`,
+        body: `「${result.title}」の優先度が「${newPriorityLabel}」に変更されました。`,
         ticketUrl: buildTicketUrl(baseUrl, ticketId),
       }),
       '[updateTicketPriority]',
-    );
-  }
+    ),
+  ]);
 
   // 詳細ページのキャッシュ無効化
   revalidatePath(`/tickets/${ticketId}`);

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -20,8 +20,8 @@ import {
 } from '@/domain/ticket-status';
 // セッションの tenantId からテナント mode (lite | pro) を取得するヘルパー
 import { getCurrentTenantMode } from '@/lib/tenant';
-// ステータス・優先度などの一元管理ラベル取得関数
-import { getStatusLabel } from '@/lib/constants';
+// ステータス・優先度などの一元管理ラベル取得関数/定数
+import { getStatusLabel, PRIORITY_LABELS } from '@/lib/constants';
 // 型のみインポート (優先度/ステータス)
 import type { Priority, TicketStatus } from '@/domain/types';
 // レート制限 (連打防止) の共通ヘルパー
@@ -33,6 +33,7 @@ import type { Session } from 'next-auth';
 // ステータス変更・担当者割当・エスカレーションのメール本文を生成する純粋ヘルパー (Phase 2)
 import {
   renderTicketStatusChangedEmail,
+  renderPriorityChangedEmail,
   renderAssignedEmail,
   renderEscalatedEmail,
   buildTicketUrl,
@@ -231,7 +232,16 @@ export async function updateTicketPriority(ticketId: string, newPriority: Priori
     windowMs: 10_000,
   });
 
-  // 1 トランザクションで更新と履歴記録
+  // コミット後の broadcastUnreadCount に渡す「通知を実際に書き込んだ起票者 ID」を保持する
+  // (updateTicketStatus と同じパターン。自己更新では通知を作らないため null のままにする)
+  let notifiedCreatorId: string | null = null;
+  // メール送信・Slack 通知に必要なチケット情報を uow.run 外で参照するために宣言する
+  // null のままなら送らない (自己更新 or チケット未取得 or 変更なし)
+  let ticketSnapshot: { creatorId: string; title: string } | null = null;
+  // 優先度変更前の値 (メール本文でラベルを出すために外側で保持する)
+  let oldPriority: Priority | null = null;
+
+  // 1 トランザクションで更新と履歴記録・通知作成を実行
   await uow.run(async (r) => {
     // チケットを tenantId スコープで取得
     const ticket = await r.tickets.findById(ticketId, tenantId);
@@ -239,6 +249,9 @@ export async function updateTicketPriority(ticketId: string, newPriority: Priori
     if (!ticket) throw new Error('チケットが見つかりません');
     // 変更無しならスキップ
     if (ticket.priority === newPriority) return;
+    // 変更前の優先度と件名/起票者をトランザクション外の通知処理に伝えるため外側変数に保存する
+    oldPriority = ticket.priority;
+    ticketSnapshot = { creatorId: ticket.creatorId, title: ticket.title };
 
     // 優先度を更新 (tenantId スコープで where に注入)
     await r.tickets.updatePriority(ticketId, newPriority, tenantId);
@@ -250,10 +263,93 @@ export async function updateTicketPriority(ticketId: string, newPriority: Priori
       oldValue: ticket.priority,
       newValue: newPriority,
     });
+    // 自分以外の起票者にのみ通知を送る (updateTicketStatus と同じく自己操作では自己通知しない)
+    if (ticket.creatorId !== session.user.id) {
+      await r.notifications.create({
+        userId: ticket.creatorId, // 通知の受信者は起票者
+        type: 'priorityChanged',
+        message: `チケット「${ticket.title}」の優先度が「${PRIORITY_LABELS[newPriority] ?? newPriority}」に変更されました`,
+        ticketId,
+        tenantId: ticket.tenantId, // テナントスコープ (クロステナント漏洩防止)
+      });
+      // 通知を書き込んだ起票者 ID を外側変数に渡す (コミット後の SSE 配信に使う)
+      notifiedCreatorId = ticket.creatorId;
+    }
   });
+
+  // 通知を実際に書き込んだ場合のみ、起票者の未読件数を SSE でリアルタイム配信する
+  if (notifiedCreatorId) await broadcastUnreadCount(notifiedCreatorId, tenantId);
+
+  // Phase 2: 優先度変更を依頼者へメールで通知する (ベストエフォート)。
+  // let 変数は async クロージャを跨ぐと TSC の CFA が never に絞り込むため、
+  // updateTicketStatus と同じく宣言型アサーションで const に取り出してから null チェックする
+  const snapForMail = ticketSnapshot as { creatorId: string; title: string } | null;
+  const oldPriorityForMail = oldPriority as Priority | null;
+  if (
+    snapForMail !== null &&
+    oldPriorityForMail !== null &&
+    snapForMail.creatorId !== session.user.id
+  ) {
+    await sendPriorityChangedEmailToRequester({
+      ticketId,
+      ticketTitle: snapForMail.title,
+      creatorId: snapForMail.creatorId,
+      oldPriority: oldPriorityForMail,
+      newPriority,
+    });
+  }
+
+  // Phase 4: Slack/Teams/Chatwork 外部通知 (updateTicketStatus と同じパターン)。
+  // チームの共有チャネル宛の「見える化」目的なので、自己更新でも送る。
+  const snapForSlack = ticketSnapshot as { creatorId: string; title: string } | null;
+  if (snapForSlack !== null) {
+    await notifyOutboundBestEffort(
+      tenantId,
+      (baseUrl) => ({
+        subject: `優先度が変更されました: ${snapForSlack.title}`,
+        body: `「${snapForSlack.title}」の優先度が「${PRIORITY_LABELS[newPriority] ?? newPriority}」に変更されました。`,
+        ticketUrl: buildTicketUrl(baseUrl, ticketId),
+      }),
+      '[updateTicketPriority]',
+    );
+  }
 
   // 詳細ページのキャッシュ無効化
   revalidatePath(`/tickets/${ticketId}`);
+}
+
+// 優先度変更を依頼者へメールで通知する内部ヘルパー (ベストエフォート / 副作用は send のみ)。
+// sendStatusChangedEmailToRequester と同じく、例外は呼び出し側に伝播させずログに残して握り潰す。
+async function sendPriorityChangedEmailToRequester(args: {
+  ticketId: string; // 対象チケット ID (URL 構築用)
+  ticketTitle: string; // チケット件名 (メール本文用)
+  creatorId: string; // 起票者ユーザー ID (メールアドレス取得用)
+  oldPriority: Priority; // 変更前の優先度 (ラベル変換用)
+  newPriority: Priority; // 変更後の優先度 (ラベル変換用)
+}): Promise<void> {
+  const { ticketId, ticketTitle, creatorId, oldPriority, newPriority } = args;
+  try {
+    // 起票者 (依頼者) のメールアドレスをユーザーリポジトリから引く
+    const creator = await repos.users.findById(creatorId);
+    // 依頼者が見つからない / メール未設定なら送りようがないのでスキップ
+    if (!creator?.email) return;
+    // ベース URL を解決する (production で NEXTAUTH_URL 未設定なら throw → 下で握る)
+    const baseUrl = resolveAppBaseUrl();
+    // チケット詳細ページへの導線 URL を組み立てる
+    const ticketUrl = buildTicketUrl(baseUrl, ticketId);
+    // 優先度変更メールの件名 / テキスト / HTML を純粋ヘルパーで生成する
+    const { subject, text, html } = renderPriorityChangedEmail({
+      ticketTitle,
+      ticketUrl,
+      oldPriorityLabel: PRIORITY_LABELS[oldPriority] ?? oldPriority,
+      newPriorityLabel: PRIORITY_LABELS[newPriority] ?? newPriority,
+    });
+    // 設定された EmailSender (console / smtp) 経由でメール送信
+    await getEmailSender().send({ to: creator.email, subject, text, html });
+  } catch (err) {
+    // 送信失敗はサーバログに残すだけ (アプリ内通知は既に成立している)
+    console.error('[updateTicketPriority] 依頼者宛優先度変更メール送信に失敗しました', err);
+  }
 }
 
 // チケットの担当者を割当/解除するサーバーアクション

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -124,6 +124,7 @@ export const NOTIFICATION_TYPE_LABELS: Record<string, string> = {
   escalated: 'エスカレーション',
   commented: 'コメント',
   statusChanged: 'ステータス変更',
+  priorityChanged: '優先度変更',
   imported: '一括取り込み', // CSV・メール一括インポートで複数チケットが追加されたことを通知する
 };
 

--- a/src/lib/line-config-context.ts
+++ b/src/lib/line-config-context.ts
@@ -35,3 +35,22 @@ export async function assertLineConfigAdmin(): Promise<LineConfigAdminGate> {
   // すべて満たしたので tenantId を返す
   return { ok: true, tenantId };
 }
+
+// LINE 連携設定の削除専用ゲート: 「ログイン済み・admin・自テナント」のみを検証し、
+// プランチェックは行わない。プラン降格後に既存設定が削除できなくなる不具合を防ぐため
+// (assertLineConfigAdmin は新規作成/更新など「これから LINE 連携を使う」操作向けのゲートで、
+// 「もう使わない設定を消す」削除操作には本来不要なプラン要件まで課してしまっていた)。
+export async function assertLineConfigOwner(): Promise<LineConfigAdminGate> {
+  // セッション取得と認証チェック
+  const session = await auth();
+  // 未ログインまたは tenantId 不在は拒否
+  if (!session?.user?.id || !session.user.tenantId) {
+    return { ok: false, error: '認証が必要です' };
+  }
+  // 管理者以外は設定削除不可 (UI 非表示に頼らずサーバー側で強制)
+  if (session.user.role !== 'admin') {
+    return { ok: false, error: 'この操作は管理者のみ実行できます' };
+  }
+  // セッション由来の tenantId のみ使う (クロステナント設定防止)。プランは問わない
+  return { ok: true, tenantId: session.user.tenantId };
+}

--- a/src/lib/line-config-context.ts
+++ b/src/lib/line-config-context.ts
@@ -2,38 +2,30 @@
 // docs/smb-dx-pivot-plan.md §4 Phase 2.1。SsoConfig の assertSsoConfigAdmin と同じ設計
 // (「ログイン済み・admin・対象プラン」をまとめて検証し、実装ドリフトを防ぐ)。
 
-// 現在のセッション取得
-import { auth } from '@/lib/auth';
 // データ層の Composition Root (テナントのプラン確認に使う)
 import { repos } from '@/data';
 // LINE 連携機能のプランゲート (Pro / Enterprise のみ)
 import { isLineIntegrationAllowed } from '@/lib/plan-guard';
+// 「ログイン済み・admin・自テナント」の共通プリミティブ (sso-context.ts と共有)
+import { assertTenantAdmin } from '@/lib/tenant-admin-gate';
 
 // LINE 連携設定変更の前提検証結果
 export type LineConfigAdminGate = { ok: true; tenantId: string } | { ok: false; error: string };
 
 // LINE 連携設定変更の前提 (ログイン済み・admin・Pro/Enterprise プラン) をまとめて検証する。
 export async function assertLineConfigAdmin(): Promise<LineConfigAdminGate> {
-  // セッション取得と認証チェック
-  const session = await auth();
-  // 未ログインまたは tenantId 不在は拒否
-  if (!session?.user?.id || !session.user.tenantId) {
-    return { ok: false, error: '認証が必要です' };
-  }
-  // 管理者以外は設定変更不可 (UI 非表示に頼らずサーバー側で強制)
-  if (session.user.role !== 'admin') {
-    return { ok: false, error: 'この操作は管理者のみ実行できます' };
-  }
-  // セッション由来の tenantId のみ使う (クロステナント設定防止)
-  const tenantId = session.user.tenantId;
+  // 共通プリミティブで「ログイン済み・admin・自テナント」を検証する
+  const gate = await assertTenantAdmin();
+  // 不通過ならその理由をそのまま返す
+  if (!gate.ok) return gate;
   // テナントを取得してプランが LINE 連携を許可するか確認する (Pro / Enterprise のみ)
-  const tenant = await repos.tenants.findById(tenantId);
+  const tenant = await repos.tenants.findById(gate.tenantId);
   if (!tenant) return { ok: false, error: 'テナント情報の取得に失敗しました' };
   if (!isLineIntegrationAllowed(tenant.subscriptionPlan)) {
     return { ok: false, error: 'LINE 連携は Pro / Enterprise プランでのみ利用できます。' };
   }
   // すべて満たしたので tenantId を返す
-  return { ok: true, tenantId };
+  return { ok: true, tenantId: gate.tenantId };
 }
 
 // LINE 連携設定の削除専用ゲート: 「ログイン済み・admin・自テナント」のみを検証し、
@@ -41,16 +33,6 @@ export async function assertLineConfigAdmin(): Promise<LineConfigAdminGate> {
 // (assertLineConfigAdmin は新規作成/更新など「これから LINE 連携を使う」操作向けのゲートで、
 // 「もう使わない設定を消す」削除操作には本来不要なプラン要件まで課してしまっていた)。
 export async function assertLineConfigOwner(): Promise<LineConfigAdminGate> {
-  // セッション取得と認証チェック
-  const session = await auth();
-  // 未ログインまたは tenantId 不在は拒否
-  if (!session?.user?.id || !session.user.tenantId) {
-    return { ok: false, error: '認証が必要です' };
-  }
-  // 管理者以外は設定削除不可 (UI 非表示に頼らずサーバー側で強制)
-  if (session.user.role !== 'admin') {
-    return { ok: false, error: 'この操作は管理者のみ実行できます' };
-  }
-  // セッション由来の tenantId のみ使う (クロステナント設定防止)。プランは問わない
-  return { ok: true, tenantId: session.user.tenantId };
+  // プランチェックが不要な分、共通プリミティブの結果をそのまま返す
+  return assertTenantAdmin();
 }

--- a/src/lib/plan-guard.ts
+++ b/src/lib/plan-guard.ts
@@ -28,6 +28,16 @@ export const MONTHLY_TICKET_LIMIT: Record<SubscriptionPlan, number> = {
   enterprise: Infinity, // Enterprise: 無制限
 };
 
+// 添付ファイルの累計サイズ上限 (バイト、プランごと)。docs/smb-dx-pivot-plan.md §6.1 で明記されて
+// いるのは Standard の「添付1GB」のみで、他プランに数値の定めは無い。MONTHLY_TICKET_LIMIT と同じ
+// 規約 (明記されたプランだけ有限値、それ以外は無制限) に揃える
+export const ATTACHMENT_TOTAL_SIZE_LIMIT_BYTES: Record<SubscriptionPlan, number> = {
+  free: Infinity, // Free: 計画書に上限の定めなし (無制限)
+  standard: 1024 * 1024 * 1024, // Standard: 1GB (§6.1 に明記)
+  pro: Infinity, // Pro: 計画書に上限の定めなし (無制限)
+  enterprise: Infinity, // Enterprise: 無制限
+};
+
 // ─────────────────────────────────────────────────────────────────────────────
 // プラン機能可用性フラグ
 // ─────────────────────────────────────────────────────────────────────────────
@@ -88,5 +98,12 @@ export function getUserLimit(plan: SubscriptionPlan): number {
 // プランの月間チケット上限値を返す (UI 表示用)。Infinity の場合は -1 を返す
 export function getMonthlyTicketLimit(plan: SubscriptionPlan): number {
   const limit = MONTHLY_TICKET_LIMIT[plan];
+  return Number.isFinite(limit) ? limit : -1;
+}
+
+// プランの添付累計サイズ上限 (バイト) を返す (UI 表示用)。Infinity の場合は -1 を返す
+// (getUserLimit / getMonthlyTicketLimit と同じ規約)
+export function getAttachmentSizeLimit(plan: SubscriptionPlan): number {
+  const limit = ATTACHMENT_TOTAL_SIZE_LIMIT_BYTES[plan];
   return Number.isFinite(limit) ? limit : -1;
 }

--- a/src/lib/sso-context.ts
+++ b/src/lib/sso-context.ts
@@ -38,9 +38,7 @@ export async function loadEnabledSsoContext(tenantId: string): Promise<SsoContex
 }
 
 // SSO 設定の作成/更新/削除 Server Action が共有する認可ゲートの結果
-export type SsoAdminGate =
-  | { ok: true; tenantId: string }
-  | { ok: false; error: string };
+export type SsoAdminGate = { ok: true; tenantId: string } | { ok: false; error: string };
 
 // SSO 設定変更の前提 (ログイン済み・admin・Enterprise プラン) をまとめて検証する。
 // update/delete-sso-config の両 Server Action で重複していた認可チェックを 1 か所に集約し、
@@ -66,4 +64,24 @@ export async function assertSsoConfigAdmin(): Promise<SsoAdminGate> {
   }
   // すべて満たしたので tenantId を返す
   return { ok: true, tenantId };
+}
+
+// SSO 設定の削除専用ゲート: 「ログイン済み・admin・自テナント」のみを検証し、プランチェックは
+// 行わない。プラン降格後に既存設定が削除できなくなる不具合を防ぐため (assertSsoConfigAdmin は
+// 新規作成/更新など「これから SSO を使う」操作向けのゲートで、「もう使わない設定を消す」削除
+// 操作には本来不要なプラン要件まで課してしまっていた)。loadEnabledSsoContext がログイン時に
+// 独立してプランを検証しているため、削除ゲートを緩めても SSO ログインの fail-closed には影響しない。
+export async function assertSsoConfigOwner(): Promise<SsoAdminGate> {
+  // セッション取得と認証チェック
+  const session = await auth();
+  // 未ログインまたは tenantId 不在は拒否
+  if (!session?.user?.id || !session.user.tenantId) {
+    return { ok: false, error: '認証が必要です' };
+  }
+  // 管理者以外は設定削除不可 (UI 非表示に頼らずサーバー側で強制)
+  if (session.user.role !== 'admin') {
+    return { ok: false, error: 'この操作は管理者のみ実行できます' };
+  }
+  // セッション由来の tenantId のみ使う (クロステナント設定防止)。プランは問わない
+  return { ok: true, tenantId: session.user.tenantId };
 }

--- a/src/lib/sso-context.ts
+++ b/src/lib/sso-context.ts
@@ -5,14 +5,14 @@
 // すべて満たすときだけ SAML SP 構築に必要な情報を返す (fail-closed)。
 // いずれかの条件を欠く場合は理由付きで失敗を返し、呼び出し側がエラーリダイレクトに変換する。
 
-// 現在のセッション取得
-import { auth } from '@/lib/auth';
 // データ層の Composition Root
 import { repos } from '@/data';
 // プラン別の SSO 可否ゲート (Enterprise のみ)
 import { isSsoAllowed } from '@/lib/plan-guard';
 // アプリの公開ベース URL を解決するヘルパー
 import { resolveAppBaseUrl } from '@/lib/app-url';
+// 「ログイン済み・admin・自テナント」の共通プリミティブ (line-config-context.ts と共有)
+import { assertTenantAdmin } from '@/lib/tenant-admin-gate';
 // ドメイン型
 import type { Tenant, TenantSsoConfig } from '@/domain/types';
 
@@ -44,26 +44,18 @@ export type SsoAdminGate = { ok: true; tenantId: string } | { ok: false; error: 
 // update/delete-sso-config の両 Server Action で重複していた認可チェックを 1 か所に集約し、
 // セキュリティ上重要な「admin かつ Enterprise」ゲートの実装ドリフトを防ぐ。
 export async function assertSsoConfigAdmin(): Promise<SsoAdminGate> {
-  // セッション取得と認証チェック
-  const session = await auth();
-  // 未ログインまたは tenantId 不在は拒否
-  if (!session?.user?.id || !session.user.tenantId) {
-    return { ok: false, error: '認証が必要です' };
-  }
-  // 管理者以外は設定変更不可 (UI 非表示に頼らずサーバー側で強制)
-  if (session.user.role !== 'admin') {
-    return { ok: false, error: 'この操作は管理者のみ実行できます' };
-  }
-  // セッション由来の tenantId のみ使う (クロステナント設定防止)
-  const tenantId = session.user.tenantId;
+  // 共通プリミティブで「ログイン済み・admin・自テナント」を検証する
+  const gate = await assertTenantAdmin();
+  // 不通過ならその理由をそのまま返す
+  if (!gate.ok) return gate;
   // テナントを取得してプランが SSO を許可するか確認する (Enterprise のみ)
-  const tenant = await repos.tenants.findById(tenantId);
+  const tenant = await repos.tenants.findById(gate.tenantId);
   if (!tenant) return { ok: false, error: 'テナント情報の取得に失敗しました' };
   if (!isSsoAllowed(tenant.subscriptionPlan)) {
     return { ok: false, error: 'SSO は Enterprise プランでのみ利用できます。' };
   }
   // すべて満たしたので tenantId を返す
-  return { ok: true, tenantId };
+  return { ok: true, tenantId: gate.tenantId };
 }
 
 // SSO 設定の削除専用ゲート: 「ログイン済み・admin・自テナント」のみを検証し、プランチェックは
@@ -72,16 +64,6 @@ export async function assertSsoConfigAdmin(): Promise<SsoAdminGate> {
 // 操作には本来不要なプラン要件まで課してしまっていた)。loadEnabledSsoContext がログイン時に
 // 独立してプランを検証しているため、削除ゲートを緩めても SSO ログインの fail-closed には影響しない。
 export async function assertSsoConfigOwner(): Promise<SsoAdminGate> {
-  // セッション取得と認証チェック
-  const session = await auth();
-  // 未ログインまたは tenantId 不在は拒否
-  if (!session?.user?.id || !session.user.tenantId) {
-    return { ok: false, error: '認証が必要です' };
-  }
-  // 管理者以外は設定削除不可 (UI 非表示に頼らずサーバー側で強制)
-  if (session.user.role !== 'admin') {
-    return { ok: false, error: 'この操作は管理者のみ実行できます' };
-  }
-  // セッション由来の tenantId のみ使う (クロステナント設定防止)。プランは問わない
-  return { ok: true, tenantId: session.user.tenantId };
+  // プランチェックが不要な分、共通プリミティブの結果をそのまま返す
+  return assertTenantAdmin();
 }

--- a/src/lib/tenant-admin-gate.ts
+++ b/src/lib/tenant-admin-gate.ts
@@ -1,0 +1,27 @@
+// 「ログイン済み・admin・自テナント」だけを検証する共通プリミティブ。
+// LINE/SSO 連携設定の各種認可ゲート (line-config-context.ts / sso-context.ts) が、
+// 機能固有のプランチェック (isLineIntegrationAllowed 等) を足す/足さないかだけが異なる
+// 同じ「認証+ロール」ブロックを個別に複製していたため、その共通部分だけを 1 か所に集約する。
+// プランチェックは機能ごとに異なる (あるいは削除ゲートのように不要な) ため、ここでは行わない。
+
+// 現在のセッション取得
+import { auth } from '@/lib/auth';
+
+// テナント管理者ゲートの検証結果
+export type TenantAdminGate = { ok: true; tenantId: string } | { ok: false; error: string };
+
+// 「ログイン済み・admin・自テナント」をまとめて検証する。プランは問わない
+export async function assertTenantAdmin(): Promise<TenantAdminGate> {
+  // セッション取得と認証チェック
+  const session = await auth();
+  // 未ログインまたは tenantId 不在は拒否
+  if (!session?.user?.id || !session.user.tenantId) {
+    return { ok: false, error: '認証が必要です' };
+  }
+  // 管理者以外は操作不可 (UI 非表示に頼らずサーバー側で強制)
+  if (session.user.role !== 'admin') {
+    return { ok: false, error: 'この操作は管理者のみ実行できます' };
+  }
+  // セッション由来の tenantId を返す (クロステナント操作防止)
+  return { ok: true, tenantId: session.user.tenantId };
+}

--- a/src/lib/tenant-plan.ts
+++ b/src/lib/tenant-plan.ts
@@ -13,8 +13,14 @@ import { repos } from '@/data';
 import type { Repos } from '@/data/ports/unit-of-work';
 // 課金プランの型
 import type { SubscriptionPlan } from '@/domain/types';
-// 月間チケット上限・スタッフ上限の判定ヘルパー (プランごとの上限値は plan-guard.ts が単一の源)
-import { getMonthlyTicketLimit, getUserLimit, isUserLimitReached } from '@/lib/plan-guard';
+// 月間チケット上限・スタッフ上限・添付累計サイズ上限の判定ヘルパー
+// (プランごとの上限値は plan-guard.ts が単一の源)
+import {
+  getAttachmentSizeLimit,
+  getMonthlyTicketLimit,
+  getUserLimit,
+  isUserLimitReached,
+} from '@/lib/plan-guard';
 // JST (日本時間) 基準の月初を計算する共通ヘルパー (endOfDayJST と同じファイルに集約)
 import { startOfMonthJST } from '@/lib/format-date';
 
@@ -99,5 +105,43 @@ export async function checkSeatAvailability(
   return {
     available: !isUserLimitReached(tenant.subscriptionPlan, currentUserCount),
     limit: getUserLimit(tenant.subscriptionPlan),
+  };
+}
+
+// 添付ファイルの累計サイズの残枠を表す (Web フォーム・コメント投稿の添付アップロードが共有する)
+export interface AttachmentQuota {
+  limited: boolean; // 上限のあるプランか (無制限プランなら false)
+  limitBytes: number; // 上限バイト数 (無制限なら -1。plan-guard.ts の規約をそのまま流用)
+  usedBytes: number; // 現在の累計バイト数 (無制限プランでは DB 集計をスキップし 0 固定)
+  remainingBytes: number; // 今すぐアップロードできる残りバイト数 (無制限なら Infinity)
+}
+
+// 指定テナントの添付ファイル累計サイズの残枠を取得する。
+// POST /api/tickets (チケット作成時添付) と POST /api/tickets/[id]/comments (コメント添付) の
+// 両方が同じ判定を使うための共通ヘルパー (§6.1 料金プラン Standard「添付1GB」)。
+// plan を既に把握している呼び出し側は渡せる (二重の tenant 取得を避ける)。
+//
+// getMonthlyTicketQuota と同じく best-effort な上限であり、DB レベルの原子性は持たない
+// (check-then-act。同時並行アップロードでは合計が上限をわずかに超えうる)。
+export async function getAttachmentQuota(
+  tenantId: string,
+  plan?: SubscriptionPlan,
+): Promise<AttachmentQuota> {
+  // プラン未指定なら解決する
+  const resolvedPlan = plan ?? (await resolveTenantPlan(tenantId));
+  // このプランの添付累計サイズ上限を取得する (-1 = 無制限)
+  const limitBytes = getAttachmentSizeLimit(resolvedPlan);
+  // 無制限プランは DB 集計を行わず即座に返す (不要なクエリを避ける)
+  if (limitBytes === -1) {
+    return { limited: false, limitBytes: -1, usedBytes: 0, remainingBytes: Infinity };
+  }
+  // 現在の累計サイズをテナントスコープで集計する
+  const usedBytes = await repos.attachments.sumSizeByTenant(tenantId);
+  // 残枠は 0 未満にならないようクランプする
+  return {
+    limited: true,
+    limitBytes,
+    usedBytes,
+    remainingBytes: Math.max(0, limitBytes - usedBytes),
   };
 }

--- a/src/lib/tenant-plan.ts
+++ b/src/lib/tenant-plan.ts
@@ -23,6 +23,8 @@ import {
 } from '@/lib/plan-guard';
 // JST (日本時間) 基準の月初を計算する共通ヘルパー (endOfDayJST と同じファイルに集約)
 import { startOfMonthJST } from '@/lib/format-date';
+// バイト数を GB 表示に丸めるヘルパー (添付上限エラーメッセージ用)
+import { formatBytesAsGb } from '@/domain/attachment';
 
 // 指定テナントの現在の課金プランを返す。テナントが見つからない場合は 'free' として扱う
 // (fail-closed: 存在しない/取得できないテナントに Pro/Enterprise 限定機能を渡さない)。
@@ -144,4 +146,31 @@ export async function getAttachmentQuota(
     usedBytes,
     remainingBytes: Math.max(0, limitBytes - usedBytes),
   };
+}
+
+// 添付アップロードの残枠チェック結果 (超過時のみ日本語メッセージを持つ)
+export type AttachmentQuotaCheck = { ok: true } | { ok: false; message: string };
+
+// アップロードしようとしているファイル群の合計サイズが、テナントの添付累計上限を
+// 超えないかを判定する。POST /api/tickets と POST /api/tickets/[id]/comments の
+// 両方が同じ判定 + 同じエラーメッセージを使うための共通ヘルパー (§6 DRY)。
+// newBytesTotal が 0 (添付なし) なら DB 集計を行わず即座に許可する。
+export async function checkAttachmentQuota(
+  tenantId: string,
+  newBytesTotal: number,
+  plan?: SubscriptionPlan,
+): Promise<AttachmentQuotaCheck> {
+  // 添付が無いアップロードは常に許可 (不要なクエリを避ける)
+  if (newBytesTotal <= 0) return { ok: true };
+  // 現在の残枠を取得する
+  const quota = await getAttachmentQuota(tenantId, plan);
+  // 上限のあるプランで、今回の合計サイズが残枠を超えるなら拒否メッセージを返す
+  if (quota.limited && newBytesTotal > quota.remainingBytes) {
+    return {
+      ok: false,
+      message: `添付ファイルの合計サイズがプランの上限 (${formatBytesAsGb(quota.limitBytes)}GB) を超えています`,
+    };
+  }
+  // 残枠内なので許可
+  return { ok: true };
 }

--- a/src/lib/ticket-email.ts
+++ b/src/lib/ticket-email.ts
@@ -179,6 +179,55 @@ export function renderTicketStatusChangedEmail(input: {
   return { subject, text, html };
 }
 
+// 優先度変更を依頼者に知らせるメール本文を生成する純粋関数 (副作用なし)
+// Phase 2 メール通知テンプレート整備 (docs/smb-dx-pivot-plan.md §4 Phase 2)。
+// renderTicketStatusChangedEmail と同じ「変更前後を並べる」構成に揃える
+export function renderPriorityChangedEmail(input: {
+  ticketTitle: string; // 問い合わせの件名
+  ticketUrl: string; // チケット詳細ページの URL
+  oldPriorityLabel: string; // 変更前優先度の日本語ラベル (例: 「中」)
+  newPriorityLabel: string; // 変更後優先度の日本語ラベル (例: 「高」)
+}): { subject: string; text: string; html: string } {
+  // 件名: 接頭辞 + 変更前後の優先度を明示する。ヘッダインジェクション防止のためサニタイズする
+  const subject = sanitizeSubject(
+    `${SUBJECT_PREFIX} 問い合わせ「${input.ticketTitle}」の優先度が「${input.oldPriorityLabel}」から「${input.newPriorityLabel}」に変わりました`,
+  );
+
+  // テキスト本文 (HTML 非対応クライアント向けフォールバック)
+  const text = [
+    `お問い合わせ「${input.ticketTitle}」の優先度が変更されました。`,
+    '',
+    `変更前: ${input.oldPriorityLabel}`,
+    `変更後: ${input.newPriorityLabel}`,
+    '',
+    '詳細の確認は、下のリンクから行えます。',
+    `${input.ticketUrl}`,
+    '',
+    'このメールに心当たりがない場合は破棄してください。',
+  ].join('\n');
+
+  // HTML 本文に差し込む外部由来文字列を個別にエスケープする (XSS / 文面崩れ防止)
+  const escapedTitle = escapeHtml(input.ticketTitle);
+  const escapedOld = escapeHtml(input.oldPriorityLabel);
+  const escapedNew = escapeHtml(input.newPriorityLabel);
+  const escapedUrl = escapeHtml(input.ticketUrl);
+
+  // HTML 本文 (変更前後を並べて表示し、続きはボタンでアプリへ誘導する)
+  const html = `
+    <p>お問い合わせ「${escapedTitle}」の優先度が変更されました。</p>
+    <blockquote style="margin:0 0 16px;padding:12px 16px;border-left:4px solid #0f766e;background:#f1f5f9;color:#0f172a;">
+      変更前: <strong>${escapedOld}</strong><br>
+      変更後: <strong>${escapedNew}</strong>
+    </blockquote>
+    <p><a href="${escapedUrl}" style="display:inline-block;padding:10px 16px;background:#0f766e;color:#ffffff;border-radius:6px;text-decoration:none;font-weight:600;">問い合わせを開く</a></p>
+    <p style="font-size:13px;color:#475569;">うまく開けない場合はこちらの URL をブラウザに貼り付けてください:<br><span style="word-break:break-all;">${escapedUrl}</span></p>
+    <p style="font-size:13px;color:#64748b;">このメールに心当たりがない場合は破棄してください。</p>
+  `.trim();
+
+  // 3 点セットを返す
+  return { subject, text, html };
+}
+
 // 担当者割当を担当者に知らせるメール本文を生成する純粋関数 (副作用なし)
 // Phase 2 メール通知テンプレート整備 (docs/smb-dx-pivot-plan.md §4 Phase 2)
 export function renderAssignedEmail(input: {

--- a/tests/data/attachment-repository.memory.test.ts
+++ b/tests/data/attachment-repository.memory.test.ts
@@ -12,7 +12,11 @@ const TENANT_A = 'tenant-a';
 const TENANT_B = 'tenant-b';
 
 // 添付作成の最低限な雛形 (個別テストで一部を上書きする)
-function makeInput(overrides: Partial<Parameters<ReturnType<typeof createMemoryContext>['repos']['attachments']['create']>[0]> = {}) {
+function makeInput(
+  overrides: Partial<
+    Parameters<ReturnType<typeof createMemoryContext>['repos']['attachments']['create']>[0]
+  > = {},
+) {
   // テナント A・チケット t-1・ユーザー u-1 を既定値とする
   return {
     ticketId: 't-1',
@@ -58,9 +62,7 @@ describe('AttachmentRepository (memory adapter)', () => {
     // 時系列を確実に分けるため 2ms 待つ (Date.now の分解能対策)
     await new Promise((r) => setTimeout(r, 2));
     const a2 = await repos.attachments.create(makeInput({ originalName: 'a2.jpg' }));
-    await repos.attachments.create(
-      makeInput({ tenantId: TENANT_B, originalName: 'b1.jpg' }),
-    );
+    await repos.attachments.create(makeInput({ tenantId: TENANT_B, originalName: 'b1.jpg' }));
 
     // テナント A から見ると 2 件 (a1, a2) のみ、古い順
     const listA = await repos.attachments.listByTicket('t-1', TENANT_A);
@@ -82,6 +84,25 @@ describe('AttachmentRepository (memory adapter)', () => {
     expect(await repos.attachments.countByTicket('t-1', TENANT_A)).toBe(2);
     // B から見ると 1 件
     expect(await repos.attachments.countByTicket('t-1', TENANT_B)).toBe(1);
+  });
+
+  // sumSizeByTenant は同テナントの添付サイズのみ合算する (添付累計サイズ上限チェック用)
+  it('sumSizeByTenant sums only same-tenant rows', async () => {
+    const { repos } = createMemoryContext();
+    // テナント A に 1000 + 2000 バイト、B に 500 バイト
+    await repos.attachments.create(makeInput({ size: 1000 }));
+    await repos.attachments.create(makeInput({ size: 2000 }));
+    await repos.attachments.create(makeInput({ tenantId: TENANT_B, size: 500 }));
+    // A から見ると 3000 バイト
+    expect(await repos.attachments.sumSizeByTenant(TENANT_A)).toBe(3000);
+    // B から見ると 500 バイト
+    expect(await repos.attachments.sumSizeByTenant(TENANT_B)).toBe(500);
+  });
+
+  // テナントに添付が 1 件も無ければ 0 を返す
+  it('sumSizeByTenant returns 0 when the tenant has no attachments', async () => {
+    const { repos } = createMemoryContext();
+    expect(await repos.attachments.sumSizeByTenant(TENANT_A)).toBe(0);
   });
 
   // delete は他テナントの ID を渡しても元行を残す

--- a/tests/features/attachments/create-ticket-with-files.test.ts
+++ b/tests/features/attachments/create-ticket-with-files.test.ts
@@ -57,7 +57,14 @@ async function seed() {
     mode: 'lite',
     industry: null,
     inboundToken: null, // メール取り込み未発行 (テスト用フィクスチャ)
-      slackWebhookUrl: null, subscriptionPlan: 'free' as const, stripeCustomerId: null, stripeSubscriptionId: null, stripeSubscriptionStatus: null, teamsWebhookUrl: null, chatworkApiToken: null, chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
+    slackWebhookUrl: null,
+    subscriptionPlan: 'free' as const,
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+    stripeSubscriptionStatus: null,
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
     createdAt: now,
   });
   // 依頼者ユーザーを投入
@@ -151,10 +158,7 @@ describe('POST /api/tickets (multipart with attachments)', () => {
         body: '紙詰まりエラーが出る',
         priority: 'Medium',
       },
-      [
-        makeFile('a.jpg', 'image/jpeg', 'jpeg-bytes'),
-        makeFile('b.png', 'image/png', 'png-bytes'),
-      ],
+      [makeFile('a.jpg', 'image/jpeg', 'jpeg-bytes'), makeFile('b.png', 'image/png', 'png-bytes')],
     );
 
     // POST 実行
@@ -179,10 +183,9 @@ describe('POST /api/tickets (multipart with attachments)', () => {
   it('rejects disallowed MIME and creates nothing', async () => {
     const { POST } = await import('@/app/api/tickets/route');
 
-    const req = buildMultipartRequest(
-      { title: 't', body: 'b', priority: 'Medium' },
-      [makeFile('doc.pdf', 'application/pdf', 'pdf-bytes')],
-    );
+    const req = buildMultipartRequest({ title: 't', body: 'b', priority: 'Medium' }, [
+      makeFile('doc.pdf', 'application/pdf', 'pdf-bytes'),
+    ]);
 
     const res = await POST(req);
     expect(res.status).toBe(422);
@@ -206,13 +209,10 @@ describe('POST /api/tickets (multipart with attachments)', () => {
     });
 
     const { POST } = await import('@/app/api/tickets/route');
-    const req = buildMultipartRequest(
-      { title: 't', body: 'b', priority: 'Medium' },
-      [
-        makeFile('a.jpg', 'image/jpeg', 'jpeg-a'),
-        makeFile('b.jpg', 'image/jpeg', 'jpeg-b'),
-      ],
-    );
+    const req = buildMultipartRequest({ title: 't', body: 'b', priority: 'Medium' }, [
+      makeFile('a.jpg', 'image/jpeg', 'jpeg-a'),
+      makeFile('b.jpg', 'image/jpeg', 'jpeg-b'),
+    ]);
 
     const res = await POST(req);
     // 500 で失敗を伝える
@@ -230,10 +230,38 @@ describe('POST /api/tickets (multipart with attachments)', () => {
     const files = Array.from({ length: 6 }, (_, i) =>
       makeFile(`a${i}.jpg`, 'image/jpeg', `jpeg-${i}`),
     );
-    const req = buildMultipartRequest(
-      { title: 't', body: 'b', priority: 'Medium' },
-      files,
-    );
+    const req = buildMultipartRequest({ title: 't', body: 'b', priority: 'Medium' }, files);
+
+    const res = await POST(req);
+    expect(res.status).toBe(422);
+    expect(store.tickets.size).toBe(0);
+    expect(storage.entries.size).toBe(0);
+  });
+
+  // 回帰防止: 添付累計サイズがプラン上限 (Standard = 1GB) に達しているテナントは
+  // 新規チケット作成時の添付も 422 で拒否する (§6.1 料金プラン「添付1GB」)
+  it('rejects new attachments when the tenant already reached the Standard plan attachment quota', async () => {
+    const tenant = store.tenants.get(TENANT)!;
+    // Standard プランへ変更 (添付累計 1GB 上限)
+    store.tenants.set(TENANT, { ...tenant, subscriptionPlan: 'standard' as const });
+    // 既存の別チケットへ、上限ギリギリ (残り 100 バイト) まで積み上げておく
+    const ONE_GB = 1024 * 1024 * 1024;
+    await repos.attachments.create({
+      ticketId: 'other-ticket',
+      commentId: null,
+      uploaderId: REQUESTER,
+      tenantId: TENANT,
+      mimeType: 'image/jpeg',
+      size: ONE_GB - 100,
+      originalName: 'existing.jpg',
+      storageKey: `${TENANT}/other-ticket/existing.jpg`,
+      storage: 'local',
+    });
+
+    const { POST } = await import('@/app/api/tickets/route');
+    const req = buildMultipartRequest({ title: 't', body: 'b', priority: 'Medium' }, [
+      makeFile('big.jpg', 'image/jpeg', 'x'.repeat(200)),
+    ]);
 
     const res = await POST(req);
     expect(res.status).toBe(422);

--- a/tests/features/attachments/post-comment-route.test.ts
+++ b/tests/features/attachments/post-comment-route.test.ts
@@ -586,4 +586,57 @@ describe('POST /api/tickets/[id]/comments', () => {
       }
     });
   });
+
+  // 回帰防止: 添付累計サイズがプラン上限 (Standard = 1GB) に達しているテナントは
+  // コメントへの追加添付を 422 で拒否する (§6.1 料金プラン「添付1GB」)
+  describe('添付累計サイズ上限 (Standard)', () => {
+    it('累計サイズが上限に達している Standard テナントは追加添付を 422 で拒否する', async () => {
+      const { ticketId } = await seed();
+      const tenant = store.tenants.get(TENANT)!;
+      // Standard プランへ変更 (添付累計 1GB 上限)
+      store.tenants.set(TENANT, { ...tenant, subscriptionPlan: 'standard' as const });
+      // 既存添付で上限ギリギリ (残り 100 バイト) まで積み上げておく
+      const ONE_GB = 1024 * 1024 * 1024;
+      await repos.attachments.create({
+        ticketId,
+        commentId: null,
+        uploaderId: REQUESTER,
+        tenantId: TENANT,
+        mimeType: 'image/jpeg',
+        size: ONE_GB - 100,
+        originalName: 'existing.jpg',
+        storageKey: `${TENANT}/${ticketId}/existing.jpg`,
+        storage: 'local',
+      });
+
+      mockSession = buildSession(REQUESTER, 'requester', TENANT);
+      const { POST } = await import('@/app/api/tickets/[id]/comments/route');
+      // 残り 100 バイトしかないところへ、それより大きいファイルを添付しようとする
+      const res = await POST(
+        buildRequest('容量オーバーの写真です', [
+          makeFile('big.jpg', 'image/jpeg', 'x'.repeat(200)),
+        ]),
+        makeParams(ticketId),
+      );
+      expect(res.status).toBe(422);
+      // コメントも新規添付も保存されていない
+      const comments = [...store.comments.values()].filter((c) => c.ticketId === ticketId);
+      expect(comments).toHaveLength(0);
+      expect(storage.entries.size).toBe(0);
+    });
+
+    it('残枠内に収まる添付は Standard テナントでも成功する', async () => {
+      const { ticketId } = await seed();
+      const tenant = store.tenants.get(TENANT)!;
+      store.tenants.set(TENANT, { ...tenant, subscriptionPlan: 'standard' as const });
+
+      mockSession = buildSession(REQUESTER, 'requester', TENANT);
+      const { POST } = await import('@/app/api/tickets/[id]/comments/route');
+      const res = await POST(
+        buildRequest('小さな写真です', [makeFile('small.jpg', 'image/jpeg', 'jpeg-data')]),
+        makeParams(ticketId),
+      );
+      expect(res.status).toBe(201);
+    });
+  });
 });

--- a/tests/features/delete-line-config.test.ts
+++ b/tests/features/delete-line-config.test.ts
@@ -1,0 +1,117 @@
+// deleteLineConfig (Server Action) のテスト。
+// プラン降格後 (Standard 以下) でも、既存の LINE 連携設定は削除できることを中心に検証する
+// (assertLineConfigOwner はプラン不問。line-config-context.ts 参照)。
+
+// Vitest の DSL とモック機能
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// メモリ実装の context (store/repos)
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// リポジトリ束の型
+import type { Repos } from '@/data/ports/unit-of-work';
+// 課金プランの型 (フィクスチャ切替に使う)
+import type { SubscriptionPlan } from '@/domain/types';
+
+const TENANT_ID = 'tenant-1';
+const ADMIN_ID = 'u-admin-1';
+const BOT_USER_ID = 'Uaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+// 各テストで差し替える可変な依存 (Action import 前に値を入れる)
+let store: Store;
+let repos: Repos;
+// 認証モックが返すセッション (テストごとに差し替える)
+let sessionUser: { id: string; role: string; tenantId: string } | null;
+
+// @/data を差し替え (getter で beforeEach の上書きを反映)
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+}));
+
+// 認証はテストごとに差し替え可能なセッションを返すモックに置換
+vi.mock('@/lib/auth', () => ({
+  auth: async () => (sessionUser ? { user: sessionUser } : null),
+}));
+
+// next/cache の副作用 (revalidatePath) はテストでは不要
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// 指定プランのテナントをシードする
+function seedTenant(plan: SubscriptionPlan) {
+  store.tenants.set(TENANT_ID, {
+    id: TENANT_ID,
+    name: 'テスト組織',
+    mode: 'lite',
+    industry: null,
+    inboundToken: null,
+    slackWebhookUrl: null,
+    subscriptionPlan: plan,
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+    stripeSubscriptionStatus: null,
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null,
+    createdAt: new Date(),
+  });
+}
+
+describe('deleteLineConfig', () => {
+  beforeEach(() => {
+    const ctx = createMemoryContext();
+    store = ctx.store;
+    repos = ctx.repos;
+    sessionUser = { id: ADMIN_ID, role: 'admin', tenantId: TENANT_ID };
+  });
+
+  // 本 PR の主眼: Pro 在籍中に作った設定を Standard へ降格した後でも削除できる
+  // (assertLineConfigAdmin を使った旧実装では、プラン不許可を理由に削除自体が拒否されていた)
+  it('プラン降格後 (Standard) でも既存の LINE 連携設定を削除できる', async () => {
+    seedTenant('pro');
+    await repos.lineConfigs.upsert({
+      tenantId: TENANT_ID,
+      channelSecret: 's1',
+      channelAccessToken: 't1',
+      botUserId: BOT_USER_ID,
+    });
+    // Standard へ降格 (LINE 連携は Pro/Enterprise 限定)
+    seedTenant('standard');
+
+    const { deleteLineConfig } = await import('@/features/settings/actions/delete-line-config');
+    const result = await deleteLineConfig({}, new FormData());
+
+    expect(result.success).toBe(true);
+    expect(await repos.lineConfigs.findByTenant(TENANT_ID)).toBeNull();
+  });
+
+  // admin 以外は削除できない (プラン不問ゲートでも RBAC は維持する)
+  it('admin 以外は削除できない', async () => {
+    seedTenant('pro');
+    await repos.lineConfigs.upsert({
+      tenantId: TENANT_ID,
+      channelSecret: 's1',
+      channelAccessToken: 't1',
+      botUserId: BOT_USER_ID,
+    });
+    sessionUser = { id: 'u-agent-1', role: 'agent', tenantId: TENANT_ID };
+
+    const { deleteLineConfig } = await import('@/features/settings/actions/delete-line-config');
+    const result = await deleteLineConfig({}, new FormData());
+
+    expect(result.error).toBe('この操作は管理者のみ実行できます');
+    expect(await repos.lineConfigs.findByTenant(TENANT_ID)).not.toBeNull();
+  });
+
+  // 未ログインは拒否される
+  it('未ログインでは削除できない', async () => {
+    seedTenant('pro');
+    sessionUser = null;
+
+    const { deleteLineConfig } = await import('@/features/settings/actions/delete-line-config');
+    const result = await deleteLineConfig({}, new FormData());
+
+    expect(result.error).toBe('認証が必要です');
+  });
+});

--- a/tests/features/delete-sso-config.test.ts
+++ b/tests/features/delete-sso-config.test.ts
@@ -1,0 +1,118 @@
+// deleteSsoConfig (Server Action) のテスト。
+// プラン降格後 (Enterprise 以外) でも、既存の SSO 設定は削除できることを中心に検証する
+// (assertSsoConfigOwner はプラン不問。sso-context.ts 参照)。
+
+// Vitest の DSL とモック機能
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// メモリ実装の context (store/repos)
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// リポジトリ束の型
+import type { Repos } from '@/data/ports/unit-of-work';
+// 課金プランの型 (フィクスチャ切替に使う)
+import type { SubscriptionPlan } from '@/domain/types';
+
+const TENANT_ID = 'tenant-1';
+const ADMIN_ID = 'u-admin-1';
+
+// 各テストで差し替える可変な依存 (Action import 前に値を入れる)
+let store: Store;
+let repos: Repos;
+// 認証モックが返すセッション (テストごとに差し替える)
+let sessionUser: { id: string; role: string; tenantId: string } | null;
+
+// @/data を差し替え (getter で beforeEach の上書きを反映)
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+}));
+
+// 認証はテストごとに差し替え可能なセッションを返すモックに置換
+vi.mock('@/lib/auth', () => ({
+  auth: async () => (sessionUser ? { user: sessionUser } : null),
+}));
+
+// next/cache の副作用 (revalidatePath) はテストでは不要
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// 指定プランのテナントをシードする
+function seedTenant(plan: SubscriptionPlan) {
+  store.tenants.set(TENANT_ID, {
+    id: TENANT_ID,
+    name: 'テスト組織',
+    mode: 'lite',
+    industry: null,
+    inboundToken: null,
+    slackWebhookUrl: null,
+    subscriptionPlan: plan,
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+    stripeSubscriptionStatus: null,
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null,
+    createdAt: new Date(),
+  });
+}
+
+describe('deleteSsoConfig', () => {
+  beforeEach(() => {
+    const ctx = createMemoryContext();
+    store = ctx.store;
+    repos = ctx.repos;
+    sessionUser = { id: ADMIN_ID, role: 'admin', tenantId: TENANT_ID };
+  });
+
+  // 本 PR の主眼: Enterprise 在籍中に作った設定を Pro へ降格した後でも削除できる
+  // (assertSsoConfigAdmin を使った旧実装では、プラン不許可を理由に削除自体が拒否されていた)
+  it('プラン降格後 (Pro) でも既存の SSO 設定を削除できる', async () => {
+    seedTenant('enterprise');
+    await repos.ssoConfigs.upsert({
+      tenantId: TENANT_ID,
+      enabled: true,
+      idpEntityId: 'https://idp.example.com/entity',
+      idpSsoUrl: 'https://idp.example.com/sso',
+      idpX509Cert: '-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----',
+    });
+    // Pro へ降格 (SSO は Enterprise 限定)
+    seedTenant('pro');
+
+    const { deleteSsoConfig } = await import('@/features/settings/actions/delete-sso-config');
+    const result = await deleteSsoConfig({}, new FormData());
+
+    expect(result.success).toBe(true);
+    expect(await repos.ssoConfigs.findByTenant(TENANT_ID)).toBeNull();
+  });
+
+  // admin 以外は削除できない (プラン不問ゲートでも RBAC は維持する)
+  it('admin 以外は削除できない', async () => {
+    seedTenant('enterprise');
+    await repos.ssoConfigs.upsert({
+      tenantId: TENANT_ID,
+      enabled: true,
+      idpEntityId: 'https://idp.example.com/entity',
+      idpSsoUrl: 'https://idp.example.com/sso',
+      idpX509Cert: '-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----',
+    });
+    sessionUser = { id: 'u-agent-1', role: 'agent', tenantId: TENANT_ID };
+
+    const { deleteSsoConfig } = await import('@/features/settings/actions/delete-sso-config');
+    const result = await deleteSsoConfig({}, new FormData());
+
+    expect(result.error).toBe('この操作は管理者のみ実行できます');
+    expect(await repos.ssoConfigs.findByTenant(TENANT_ID)).not.toBeNull();
+  });
+
+  // 未ログインは拒否される
+  it('未ログインでは削除できない', async () => {
+    seedTenant('enterprise');
+    sessionUser = null;
+
+    const { deleteSsoConfig } = await import('@/features/settings/actions/delete-sso-config');
+    const result = await deleteSsoConfig({}, new FormData());
+
+    expect(result.error).toBe('認証が必要です');
+  });
+});

--- a/tests/features/update-ticket.test.ts
+++ b/tests/features/update-ticket.test.ts
@@ -234,6 +234,86 @@ describe('updateTicketStatus (provider-agnostic)', () => {
   });
 });
 
+// 回帰防止: updateTicketPriority は以前 DB/SSE/メール通知を一切発行しない「完全に無音」の
+// アクションだった (updateTicketStatus / updateTicketAssignee 等の兄弟アクションと不整合)。
+// ここでは「起票者への通知が作られる」「自己操作では通知しない」「メールが送られる」を検証する。
+describe('updateTicketPriority (provider-agnostic)', () => {
+  // 正常系: 優先度が更新され、履歴が 1 件残り、起票者以外が操作すると通知とメールが発生する
+  it('updates priority, records history, notifies the creator, and sends an email', async () => {
+    const { ticketId } = await seed();
+    const { updateTicketPriority } = await import('@/features/tickets/actions/update-ticket');
+
+    await updateTicketPriority(ticketId, 'High');
+
+    // 優先度が反映されている
+    const t = await repos.tickets.findById(ticketId, TENANT);
+    expect(t?.priority).toBe('High');
+    // 履歴が 1 件残る (priority / Medium → High)
+    const histories = [...store.histories.values()].filter((h) => h.ticketId === ticketId);
+    expect(histories).toHaveLength(1);
+    expect(histories[0].field).toBe('priority');
+    expect(histories[0].oldValue).toBe('Medium');
+    expect(histories[0].newValue).toBe('High');
+    // 起票者 (u-req-1) 宛に通知が 1 件作られている
+    const notifications = [...store.notifications.values()].filter((n) => n.ticketId === ticketId);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].userId).toBe('u-req-1');
+    expect(notifications[0].type).toBe('priorityChanged');
+    expect(notifications[0].message).toContain('高');
+    // 起票者宛にメールが送られている
+    expect(sentEmails).toHaveLength(1);
+    expect(sentEmails[0].to).toBe('u-req-1@example.com');
+  });
+
+  // 変更なし (同じ優先度) なら履歴も通知も作られない (冪等)
+  it('does nothing when the priority is unchanged', async () => {
+    const { ticketId } = await seed();
+    const { updateTicketPriority } = await import('@/features/tickets/actions/update-ticket');
+
+    await updateTicketPriority(ticketId, 'Medium');
+
+    const histories = [...store.histories.values()].filter((h) => h.ticketId === ticketId);
+    expect(histories).toHaveLength(0);
+    const notifications = [...store.notifications.values()].filter((n) => n.ticketId === ticketId);
+    expect(notifications).toHaveLength(0);
+    expect(sentEmails).toHaveLength(0);
+  });
+
+  // 起票者自身 (エージェントが自分で起票したチケット) が操作した場合は自己通知しない
+  // (updateTicketStatus の「自己更新ではメールを送らない」と同じ方針)
+  it('does not notify or email the creator when they change the priority themselves', async () => {
+    await seed();
+    // 起票者が操作者 (u-agt-1) 自身のチケットを作る
+    const own = await repos.tickets.create({
+      title: '自分で起票した件',
+      body: 'x',
+      priority: 'Medium',
+      creatorId: 'u-agt-1',
+      categoryId: 'cat-1',
+      tenantId: TENANT,
+    });
+    const { updateTicketPriority } = await import('@/features/tickets/actions/update-ticket');
+
+    await updateTicketPriority(own.id, 'High');
+
+    const notifications = [...store.notifications.values()].filter((n) => n.ticketId === own.id);
+    expect(notifications).toHaveLength(0);
+    expect(sentEmails).toHaveLength(0);
+  });
+
+  // requester (エージェント以外) は実行できない
+  it('refuses when caller is not an agent', async () => {
+    const { ticketId } = await seed();
+    sessionUserId = 'u-req-1';
+    sessionRole = 'requester';
+    const { updateTicketPriority } = await import('@/features/tickets/actions/update-ticket');
+
+    await expect(updateTicketPriority(ticketId, 'High')).rejects.toThrow(
+      /エージェントまたは管理者/,
+    );
+  });
+});
+
 // Lite モード (mode: 'lite') のテナントから呼び出した場合の遷移検証
 // (UI の StatusSelect が見せる選択肢とサーバ側検証が一致することを確認)
 describe('updateTicketStatus (Lite mode)', () => {

--- a/tests/plan-guard.test.ts
+++ b/tests/plan-guard.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   USER_LIMIT,
   MONTHLY_TICKET_LIMIT,
+  ATTACHMENT_TOTAL_SIZE_LIMIT_BYTES,
   isEmailInboundAllowed,
   isAuditLogAllowed,
   isLineIntegrationAllowed,
@@ -13,6 +14,7 @@ import {
   isUserLimitReached,
   getUserLimit,
   getMonthlyTicketLimit,
+  getAttachmentSizeLimit,
 } from '../src/lib/plan-guard';
 // プラン型 (網羅性の担保に使う)
 import type { SubscriptionPlan } from '../src/domain/types';
@@ -23,13 +25,15 @@ const ALL_PLANS: SubscriptionPlan[] = ['free', 'standard', 'pro', 'enterprise'];
 // プランごとの上限・機能フラグが仕様 (smb-dx-pivot-plan.md §6.1) どおりかを検証する
 describe('plan-guard: プランごとの上限と機能フラグ', () => {
   // 全プランが上限テーブルに登録されていること (網羅漏れ検知)
-  it('全プランが USER_LIMIT / MONTHLY_TICKET_LIMIT に存在する', () => {
+  it('全プランが USER_LIMIT / MONTHLY_TICKET_LIMIT / ATTACHMENT_TOTAL_SIZE_LIMIT_BYTES に存在する', () => {
     // すべてのプランについてキーが定義されているか確認する
     for (const plan of ALL_PLANS) {
       // ユーザー上限が定義されている
       expect(USER_LIMIT[plan]).toBeDefined();
       // 月間チケット上限が定義されている
       expect(MONTHLY_TICKET_LIMIT[plan]).toBeDefined();
+      // 添付累計サイズ上限が定義されている
+      expect(ATTACHMENT_TOTAL_SIZE_LIMIT_BYTES[plan]).toBeDefined();
     }
   });
 
@@ -47,6 +51,15 @@ describe('plan-guard: プランごとの上限と機能フラグ', () => {
     expect(MONTHLY_TICKET_LIMIT.standard).toBe(Infinity); // Standard 無制限
     expect(MONTHLY_TICKET_LIMIT.pro).toBe(Infinity); // Pro 無制限
     expect(MONTHLY_TICKET_LIMIT.enterprise).toBe(Infinity); // Enterprise 無制限
+  });
+
+  // 添付累計サイズ上限は Standard のみ有限 (1GB)、他は無制限 (§6.1 に明記されているのが
+  // Standard のみのため。MONTHLY_TICKET_LIMIT と同じ「明記プランだけ有限」規約)
+  it('添付累計サイズ上限は Standard のみ 1GB、他は無制限', () => {
+    expect(ATTACHMENT_TOTAL_SIZE_LIMIT_BYTES.free).toBe(Infinity); // Free 無制限
+    expect(ATTACHMENT_TOTAL_SIZE_LIMIT_BYTES.standard).toBe(1024 * 1024 * 1024); // Standard 1GB
+    expect(ATTACHMENT_TOTAL_SIZE_LIMIT_BYTES.pro).toBe(Infinity); // Pro 無制限
+    expect(ATTACHMENT_TOTAL_SIZE_LIMIT_BYTES.enterprise).toBe(Infinity); // Enterprise 無制限
   });
 
   // メール取り込みは Free 以外で有効
@@ -104,10 +117,12 @@ describe('plan-guard: 上限到達判定と表示ヘルパー', () => {
   });
 
   // 表示用ヘルパーは無制限を -1 で返す (UI は -1 を「無制限」と解釈する規約)
-  it('getUserLimit / getMonthlyTicketLimit は無制限を -1 で返す', () => {
+  it('getUserLimit / getMonthlyTicketLimit / getAttachmentSizeLimit は無制限を -1 で返す', () => {
     expect(getUserLimit('pro')).toBe(30); // 有限はそのまま
     expect(getUserLimit('enterprise')).toBe(-1); // 無制限は -1
     expect(getMonthlyTicketLimit('free')).toBe(50); // 有限はそのまま
     expect(getMonthlyTicketLimit('enterprise')).toBe(-1); // 無制限は -1
+    expect(getAttachmentSizeLimit('standard')).toBe(1024 * 1024 * 1024); // 有限はそのまま
+    expect(getAttachmentSizeLimit('free')).toBe(-1); // 無制限は -1
   });
 });


### PR DESCRIPTION
## Summary

`docs/smb-dx-pivot-plan.md` のギャップ監査 (4巡目) で見つかった未実装項目のうち、上位3件を実装。

1. **fix(settings): プラン降格後もLINE/SSO連携設定を削除できるようにする**
   - LINE/SSO連携設定の削除アクションが、作成/更新と同じ「プラン許可」ゲート (`assertLineConfigAdmin` / `assertSsoConfigAdmin`) を使っていたため、プラン降格後 (Pro→Standard 等) に既存設定を二度と削除できなくなっていた。
   - 削除専用の軽量ゲート (`assertLineConfigOwner` / `assertSsoConfigOwner`) を追加し、「ログイン済み・admin・自テナント」のみを検証してプランは問わないようにした。
   - `loadEnabledSsoContext` (SSOログイン時の実際のenforcement) は独立してプランを検証し続けるため、この変更でSSOログインのfail-closedには影響しない。
   - 設定ページも、プラン非対象でも既存設定があれば表示を続け、再設定フォームを隠して削除ボタンのみ案内するようにした (`planAllowed` prop)。

2. **feat(attachments): 添付ファイルの累計サイズ上限をプランごとに強制する**
   - `docs/smb-dx-pivot-plan.md` §6.1「Standard: 添付1GB」が未実装だった。
   - `MONTHLY_TICKET_LIMIT` と同じ規約 (計画書に明記されたプランだけ有限値、他は無制限) で `ATTACHMENT_TOTAL_SIZE_LIMIT_BYTES` を追加。
   - `AttachmentRepository` port に `sumSizeByTenant` を追加 (Prisma/メモリ両アダプタ)、`getMonthlyTicketQuota` と同型の `getAttachmentQuota` を追加。
   - `POST /api/tickets` と `POST /api/tickets/[id]/comments` の両添付アップロード経路から共有して呼び出し、上限超過時は既存の422バリデーションエラー形式で拒否する。

3. **fix(tickets): 優先度変更が通知チャネルを一切発行していなかった不備を修正**
   - `updateTicketPriority` が兄弟アクション (`updateTicketStatus` 等) と異なり、DB通知・SSE・メール・Slack/Teams/Chatwork のいずれも発行しない「完全に無音」な実装だった。
   - 新しい `NotificationType` `'priorityChanged'` を追加 (schema.prisma + 専用マイグレーション)。
   - `updateTicketStatus` と同じパターンで、起票者以外が操作したときのみDB通知+SSE配信、依頼者へメール送信 (`renderPriorityChangedEmail` 新設)、Slack/Teams/Chatworkへは自己操作でも送信する。

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (557 passed)
- [x] `npm run build` (route export制約含め確認済み)
- [x] `npm run db:generate` (NotificationType enum追加を反映)
- [ ] CI (lint / typecheck / unit / Prisma契約テスト / Playwright E2E) がグリーンであることを確認

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015a7mk7TDJdiL6MsDifaoYF


---
_Generated by [Claude Code](https://claude.ai/code/session_015a7mk7TDJdiL6MsDifaoYF)_