### PR TITLE
初回応答期限の未配線とFree trial未実装を修正

### DIFF
--- a/prisma/migrations/20260707010000_add_tenant_trial_ends_at/migration.sql
+++ b/prisma/migrations/20260707010000_add_tenant_trial_ends_at/migration.sql
@@ -1,0 +1,3 @@
+-- §7.2「30日間の Free trial (Standard 相当)」用のトライアル終了日時カラムを追加する。
+-- null ならトライアル対象外/終了済み。既存テナントはすべて null (= トライアル無し) で補完される。
+ALTER TABLE "Tenant" ADD COLUMN "trialEndsAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -127,6 +127,13 @@ model Tenant {
   stripeSubscriptionId     String? // Stripe の Subscription ID (sub_xxx)
   // Stripe 側のサブスク状態 ("active" | "trialing" | "past_due" | "canceled" | "none")
   stripeSubscriptionStatus String? // Stripe の subscription.status をそのまま格納
+  // §7.2「30日間の Free trial (Standard 相当)」。テナント作成時に now+30日で設定する。
+  // Stripe 課金を伴わない社内トライアルのため subscriptionPlan 自体は free のまま据え置き、
+  // resolveEffectivePlan() がこの期限内だけ Standard 相当としてゲート判定する (§9: 判定は
+  // 常にサーバー側の現在時刻と突き合わせる)。期限切れ後は自動的に free の制限へ戻る
+  // (追加のバッチ処理は不要)。Stripe で正式にアップグレードされれば subscriptionPlan が
+  // 直接更新されるため、このフィールドの意味は失われる (無視してよい)
+  trialEndsAt              DateTime? // トライアル終了日時 (null = トライアル対象外/終了済み)
 
   createdAt DateTime @default(now()) // 作成日時
 

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -65,6 +65,13 @@ export default async function SettingsPage() {
   // sso-context.ts 参照)、設定の有無自体はプランに関わらず常に取得する。
   const ssoAllowed = isSsoAllowed(tenant?.subscriptionPlan ?? 'free');
   const lineAllowed = isLineIntegrationAllowed(tenant?.subscriptionPlan ?? 'free');
+  // §7.2 Free trial の残り日数 (対象外/終了済みなら null)。Date を Client Component へ直接
+  // 渡すのは避け、ここで日数に変換してから BillingSection に渡す
+  const now = new Date();
+  const trialDaysRemaining =
+    tenant?.subscriptionPlan === 'free' && tenant.trialEndsAt && tenant.trialEndsAt > now
+      ? Math.ceil((tenant.trialEndsAt.getTime() - now.getTime()) / (24 * 60 * 60 * 1000))
+      : null;
   const [ssoConfig, lineConfig] = await Promise.all([
     repos.ssoConfigs.findByTenant(session.user.tenantId),
     repos.lineConfigs.findByTenant(session.user.tenantId),
@@ -168,6 +175,7 @@ export default async function SettingsPage() {
           stripeStatus={tenant?.stripeSubscriptionStatus ?? null}
           hasStripeCustomer={!!tenant?.stripeCustomerId}
           currentUserCount={currentUserCount}
+          trialDaysRemaining={trialDaysRemaining}
         />
       </section>
 

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -22,8 +22,10 @@ import { SsoConfigSection } from '@/features/settings/components/SsoConfigSectio
 import { LineConfigSection } from '@/features/settings/components/LineConfigSection';
 // テナント情報取得 (slackWebhookUrl / 拠点一覧 / プラン情報の初期値を渡すため)
 import { repos } from '@/data';
-// プランゲート: Enterprise のみ SSO、Pro/Enterprise のみ LINE 連携を表示する
-import { isLineIntegrationAllowed, isSsoAllowed } from '@/lib/plan-guard';
+// プランゲート: Enterprise のみ SSO、Pro/Enterprise のみ LINE 連携を表示する。
+// resolveEffectivePlan は §7.2 Free trial 中の実効プラン (Standard 相当) を解決する
+// 唯一の判定ロジック (SSOT)。トライアル中かどうかの判定をここで再実装しない
+import { isLineIntegrationAllowed, isSsoAllowed, resolveEffectivePlan } from '@/lib/plan-guard';
 // SSO の SP エンドポイント URL を組み立てるヘルパー
 import { buildSpUrls } from '@/lib/saml';
 // アプリの公開ベース URL を解決するヘルパー (SP URL の組み立てに使う)
@@ -65,11 +67,23 @@ export default async function SettingsPage() {
   // sso-context.ts 参照)、設定の有無自体はプランに関わらず常に取得する。
   const ssoAllowed = isSsoAllowed(tenant?.subscriptionPlan ?? 'free');
   const lineAllowed = isLineIntegrationAllowed(tenant?.subscriptionPlan ?? 'free');
+  // §7.2 Free trial 中の実効プラン (Standard 相当への昇格を含む)。契約プラン自体は
+  // subscriptionPlan のままなので、スタッフ上限の超過判定など「今実際に適用されている上限」を
+  // 見る箇所は必ずこちらを使う (BillingSection の isOverUserLimit 等)
+  const now = new Date();
+  const effectivePlan = resolveEffectivePlan(
+    tenant?.subscriptionPlan ?? 'free',
+    tenant?.trialEndsAt ?? null,
+    now,
+  );
+  // トライアル中かどうかは「契約プランが free なのに実効プランがそれと異なる」ことで判定する
+  // (resolveEffectivePlan は free + トライアル有効期間中のみ 'standard' を返すため、
+  // trialEndsAt > now を再度ここで比較しない = SSOT を重複させない)
+  const isTrialActive = tenant?.subscriptionPlan === 'free' && effectivePlan !== 'free';
   // §7.2 Free trial の残り日数 (対象外/終了済みなら null)。Date を Client Component へ直接
   // 渡すのは避け、ここで日数に変換してから BillingSection に渡す
-  const now = new Date();
   const trialDaysRemaining =
-    tenant?.subscriptionPlan === 'free' && tenant.trialEndsAt && tenant.trialEndsAt > now
+    isTrialActive && tenant?.trialEndsAt
       ? Math.ceil((tenant.trialEndsAt.getTime() - now.getTime()) / (24 * 60 * 60 * 1000))
       : null;
   const [ssoConfig, lineConfig] = await Promise.all([
@@ -172,6 +186,7 @@ export default async function SettingsPage() {
         {/* プラン情報と操作ボタン */}
         <BillingSection
           currentPlan={tenant?.subscriptionPlan ?? 'free'}
+          effectivePlan={effectivePlan}
           stripeStatus={tenant?.stripeSubscriptionStatus ?? null}
           hasStripeCustomer={!!tenant?.stripeCustomerId}
           currentUserCount={currentUserCount}

--- a/src/app/(app)/tickets/[id]/page.tsx
+++ b/src/app/(app)/tickets/[id]/page.tsx
@@ -34,8 +34,10 @@ import { CommentForm } from '@/features/tickets/components/CommentForm';
 import { AttachmentList } from '@/features/tickets/components/AttachmentList';
 // エスカレーション操作フォーム
 import { EscalationForm } from '@/features/tickets/components/EscalationForm';
-// SLA 状態判定 + ラベル/カラー定義
-import { getSlaState, SLA_LABELS, SLA_COLORS } from '@/lib/sla';
+// SLA 状態判定 + ラベル/カラー定義。FIRST_RESPONSE_HOURS_BY_PRIORITY は初回応答 SLA の
+// 警告閾値を窓の長さに応じて計算するために使う (getSlaState の既定 24 時間閾値をそのまま
+// 使うと、4〜24 時間しかない初回応答期限では起票直後から常に warning になってしまうため)
+import { getSlaState, SLA_LABELS, SLA_COLORS, FIRST_RESPONSE_HOURS_BY_PRIORITY } from '@/lib/sla';
 // 現ステータスから許可される遷移先一覧を取得
 import { getAllowedTransitions } from '@/domain/ticket-status';
 // FAQ 候補登録フォーム
@@ -78,9 +80,18 @@ export default async function TicketDetailPage({ params }: Props) {
 
   // SLA 状態 (none/ok/warning/overdue) を計算
   const slaState = getSlaState(ticket.resolutionDueAt, ticket.resolvedAt);
-  // 初回応答 SLA 状態 (Pro モードのみ表示。Lite は「期限日」1 項目に統合する方針のため対象外)
+  // 初回応答 SLA 状態 (Pro モードのみ表示。Lite は「期限日」1 項目に統合する方針のため対象外)。
+  // 警告閾値は「窓 (優先度ごとの許容時間) の 25%」を渡す。解決期限向けの既定 24 時間閾値を
+  // そのまま使うと、High=4h/Medium=8h/Low=24h しかない初回応答期限では起票直後から
+  // ずっと warning になってしまう (回帰防止: /code-review ultra 指摘)
   const firstResponseSlaState =
-    mode === 'pro' ? getSlaState(ticket.firstResponseDueAt, ticket.firstRespondedAt) : 'none';
+    mode === 'pro'
+      ? getSlaState(
+          ticket.firstResponseDueAt,
+          ticket.firstRespondedAt,
+          FIRST_RESPONSE_HOURS_BY_PRIORITY[ticket.priority] * 0.25 * 60 * 60 * 1000,
+        )
+      : 'none';
   // エスカレーション可能か (エージェント && 現状から Escalated への遷移許可あり)
   // Pro モードの遷移表を参照する (Lite モードでは Escalated 自体が UI 上は存在しない)
   const canEscalate =

--- a/src/app/(app)/tickets/[id]/page.tsx
+++ b/src/app/(app)/tickets/[id]/page.tsx
@@ -78,6 +78,9 @@ export default async function TicketDetailPage({ params }: Props) {
 
   // SLA 状態 (none/ok/warning/overdue) を計算
   const slaState = getSlaState(ticket.resolutionDueAt, ticket.resolvedAt);
+  // 初回応答 SLA 状態 (Pro モードのみ表示。Lite は「期限日」1 項目に統合する方針のため対象外)
+  const firstResponseSlaState =
+    mode === 'pro' ? getSlaState(ticket.firstResponseDueAt, ticket.firstRespondedAt) : 'none';
   // エスカレーション可能か (エージェント && 現状から Escalated への遷移許可あり)
   // Pro モードの遷移表を参照する (Lite モードでは Escalated 自体が UI 上は存在しない)
   const canEscalate =
@@ -261,6 +264,34 @@ export default async function TicketDetailPage({ params }: Props) {
                   {formatDateJP(ticket.createdAt)}
                 </dd>
               </div>
+
+              {/* SLA: 初回応答期限 (Pro モード限定。Lite は「期限日」1 項目に統合する方針のため非表示) */}
+              {mode === 'pro' && ticket.firstResponseDueAt && (
+                <div>
+                  <dt className="font-medium text-gray-500">初回応答期限</dt>
+                  <dd className="mt-1 flex items-center gap-2">
+                    <span className="text-gray-700">
+                      {/* 初回応答期限を日本時間 (年月日) で表示する */}
+                      {formatDateJP(ticket.firstResponseDueAt)}
+                    </span>
+                    {/* 応答済みなら日時を、未応答なら警告/超過バッジを表示する */}
+                    {ticket.firstRespondedAt ? (
+                      <span className="text-xs text-gray-500">
+                        （{formatDateTimeJP(ticket.firstRespondedAt)} 応答済み）
+                      </span>
+                    ) : (
+                      firstResponseSlaState !== 'none' &&
+                      firstResponseSlaState !== 'ok' && (
+                        <span
+                          className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${SLA_COLORS[firstResponseSlaState]}`}
+                        >
+                          {SLA_LABELS[firstResponseSlaState]}
+                        </span>
+                      )
+                    )}
+                  </dd>
+                </div>
+              )}
 
               {/* SLA: 解決期限がある場合のみ表示 */}
               {ticket.resolutionDueAt && (

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -45,7 +45,7 @@ import { isAgent } from '@/lib/role';
 // 公開エンドポイントの流量制限 (§9: DoS / リソース枯渇防止)
 import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
 // 優先度から解決期限を計算する SLA ヘルパー (Web フォーム起票と同じ既定値に揃える)
-import { calculateResolutionDueAt } from '@/lib/sla';
+import { calculateFirstResponseDueAt, calculateResolutionDueAt } from '@/lib/sla';
 // 受領自動返信 (メンバー改善 #1) のための送信基盤・本文生成・リンク組み立てヘルパー
 import { getEmailSender } from '@/lib/email';
 import { renderTicketReceivedEmail, buildTicketUrl } from '@/lib/ticket-email';
@@ -553,6 +553,8 @@ export async function POST(req: Request) {
   const initialStatus = initialStatusForMode(tenant.mode);
   // メールには期限指定が無いため、Web フォーム起票と同じく優先度 Medium ベースで解決期限を算出する
   const resolutionDueAt = calculateResolutionDueAt('Medium', now);
+  // 初回応答期限も同じく優先度 Medium ベースで自動算出する
+  const firstResponseDueAt = calculateFirstResponseDueAt('Medium', now);
 
   // 受信メールを 1 件の問い合わせとして作成する (起票 + 対応表登録を原子的に行う)
   const { id: ticketId, alreadyExisted } = await createTicketIdempotent(
@@ -568,6 +570,7 @@ export async function POST(req: Request) {
       tenantId: tenant.id, // 取り込み先テナント
       status: initialStatus, // Lite は 'Open'、Pro は undefined (既定 New)
       resolutionDueAt, // 解決期限 (優先度ベース)
+      firstResponseDueAt, // 初回応答期限 (優先度ベース)
     },
   );
 

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -55,7 +55,7 @@ import { buildReplyMessageId, resolveMessageIdDomain } from '@/lib/email-message
 // 受付番号 (短縮 ID) の共有フォーマッタ (画面のチケット詳細ヘッダと同じ表記)
 import { formatTicketRef } from '@/lib/ticket-ref';
 // メール取り込み機能のプランゲート (§6.1 料金プラン: Free では利用不可)
-import { isEmailInboundAllowed } from '@/lib/plan-guard';
+import { isEmailInboundAllowed, resolveEffectivePlan } from '@/lib/plan-guard';
 // Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (Web フォーム・LINE 取り込み・CSV インポートと共有)
 import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
 // Phase 4 課金: 月間チケット上限チェック (Web フォーム・CSV インポートと共有)
@@ -369,12 +369,16 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: '取り込み先が見つかりません' }, { status: 404 });
   }
 
+  // §7.2 Free trial 中 (Standard 相当) ならメール取り込みも解禁する。以降のプラン依存判定
+  // (このゲートと月間チケット上限) は全てこの実効プランを使う
+  const effectivePlan = resolveEffectivePlan(tenant.subscriptionPlan, tenant.trialEndsAt);
+
   // プランゲート: メール取り込みは Standard 以上のみ (Free では利用不可 §6.1 料金プラン)。
   // UI 非表示に頼らずサーバー側 (Webhook 受信口) で強制する。未知送信者と同様に隔離扱いにして
   // 202 を返し、どのテナントが対象外かをレスポンスから推測されないようにする (§9)。
-  if (!isEmailInboundAllowed(tenant.subscriptionPlan)) {
+  if (!isEmailInboundAllowed(effectivePlan)) {
     console.warn('[POST /api/inbound/email] quarantined: email inbound not allowed for plan', {
-      plan: tenant.subscriptionPlan,
+      plan: effectivePlan,
     });
     return NextResponse.json({ status: 'quarantined' }, { status: 202 });
   }
@@ -539,10 +543,10 @@ export async function POST(req: Request) {
   // (Standard 以上) は月間上限が無制限のため実害は無いが、将来 Standard に有限上限が付いた
   // 瞬間にこの入口だけ無制限の抜け道になる SSOT 違反を防ぐため、他入口と揃えておく。
   // 上限到達時は未知送信者と同じ「隔離 202」にして、プロバイダの再送ループを避ける。
-  const quota = await getMonthlyTicketQuota(tenant.id, tenant.subscriptionPlan);
+  const quota = await getMonthlyTicketQuota(tenant.id, effectivePlan);
   if (quota.limited && quota.remaining <= 0) {
     console.warn('[POST /api/inbound/email] quarantined: monthly ticket quota reached', {
-      plan: tenant.subscriptionPlan,
+      plan: effectivePlan,
     });
     return NextResponse.json({ status: 'quarantined' }, { status: 202 });
   }

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -60,7 +60,7 @@ import {
 // 未読カウントを SSE で即時配信するヘルパー (新規起票後に担当者のバッジをリアルタイム更新する)
 import { broadcastUnreadCountToMany } from '@/features/notifications/notify';
 // LINE 連携機能のプランゲート (§6.1 料金プラン: Pro / Enterprise のみ利用可能)
-import { isLineIntegrationAllowed } from '@/lib/plan-guard';
+import { isLineIntegrationAllowed, resolveEffectivePlan } from '@/lib/plan-guard';
 // Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (Web フォーム・メール取り込み・CSV インポートと共有)
 import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
 // Phase 4 課金: 月間チケット上限チェック (Web フォーム・CSV インポートと共有)
@@ -337,9 +337,15 @@ export async function POST(req: Request) {
   const resolutionDueAt = calculateResolutionDueAt('Medium', now);
   // 初回応答期限も同じく優先度 Medium ベースで自動算出する
   const firstResponseDueAt = calculateFirstResponseDueAt('Medium', now);
+  // §7.2 Free trial 中の実効プラン (Standard 相当への昇格を含む)。LINE 連携自体は Pro 以上限定
+  // (トライアルで昇格しない。上の isLineIntegrationAllowed は契約プランのまま判定する) だが、
+  // 月間チケット上限は他の起票経路 (Web フォーム・メール取り込み) と同じくトライアル昇格を
+  // 適用するのが一貫している。ここに到達する時点で契約プランは pro/enterprise 確定のため
+  // resolveEffectivePlan は事実上の恒等関数だが、他経路との SSOT を揃えて将来の変更に備える
+  const effectivePlan = resolveEffectivePlan(tenant.subscriptionPlan, tenant.trialEndsAt, now);
   // Phase 4 課金: 月間チケット上限の残枠を 1 度だけ取得する (Web フォーム・CSV インポートと共有)。
   // 1 リクエストに複数イベントが含まれうるため、イベントごとに ctx.quota.remaining を消費する
-  const quota = await getMonthlyTicketQuota(targetTenantId, tenant.subscriptionPlan);
+  const quota = await getMonthlyTicketQuota(targetTenantId, effectivePlan);
 
   // 1 リクエストに含まれる複数イベントを順に処理してチケットを起票する。
   // 1 件ずつの詳細処理は processLineEvent に委譲し、ここでは結果 (チケット ID) の収集に専念する。

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -48,7 +48,7 @@ import { initialStatusForMode } from '@/domain/ticket-status';
 // 公開エンドポイントの流量制限 (§9: DoS / リソース枯渇防止)
 import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
 // 優先度から解決期限を計算する SLA ヘルパー (他の取り込みチャネルと同じ既定値に揃える)
-import { calculateResolutionDueAt } from '@/lib/sla';
+import { calculateFirstResponseDueAt, calculateResolutionDueAt } from '@/lib/sla';
 // LINE メンバー紐付け: 受信テキストの正規化・コード形判定・ハッシュ化 (発行は Web 設定画面側)
 // LINE ユーザー ID の正規形式 (line-push.ts と共有する単一の源)
 import {
@@ -166,6 +166,7 @@ interface LineEventContext {
   now: Date; // 起票時刻 (SLA 期限計算の基準)
   initialStatus: ReturnType<typeof initialStatusForMode>; // 初期ステータス (mode 依存)
   resolutionDueAt: ReturnType<typeof calculateResolutionDueAt>; // 優先度 Medium ベースの解決期限
+  firstResponseDueAt: ReturnType<typeof calculateFirstResponseDueAt>; // 優先度 Medium ベースの初回応答期限
   quota: MonthlyTicketQuota; // 月間チケット上限の残枠 (イベントごとに消費するミュータブルなカウンタ)
 }
 
@@ -334,6 +335,8 @@ export async function POST(req: Request) {
   const initialStatus = initialStatusForMode(tenant.mode);
   // メッセージには期限指定が無いため優先度 Medium ベースで解決期限を算出する
   const resolutionDueAt = calculateResolutionDueAt('Medium', now);
+  // 初回応答期限も同じく優先度 Medium ベースで自動算出する
+  const firstResponseDueAt = calculateFirstResponseDueAt('Medium', now);
   // Phase 4 課金: 月間チケット上限の残枠を 1 度だけ取得する (Web フォーム・CSV インポートと共有)。
   // 1 リクエストに複数イベントが含まれうるため、イベントごとに ctx.quota.remaining を消費する
   const quota = await getMonthlyTicketQuota(targetTenantId, tenant.subscriptionPlan);
@@ -347,6 +350,7 @@ export async function POST(req: Request) {
     now, // 起票時刻 (SLA 期限計算の基準)
     initialStatus, // 初期ステータス (mode 依存)
     resolutionDueAt, // 優先度 Medium ベースの解決期限
+    firstResponseDueAt, // 優先度 Medium ベースの初回応答期限
     quota, // 月間チケット上限の残枠
   };
   const ticketIds: string[] = [];
@@ -371,7 +375,15 @@ async function processLineEvent(
   ctx: LineEventContext,
 ): Promise<string | null> {
   // 文脈オブジェクトから各値を取り出す (POST 側で 1 度だけ解決済み)
-  const { targetTenantId, agents, proxyCreator, now, initialStatus, resolutionDueAt } = ctx;
+  const {
+    targetTenantId,
+    agents,
+    proxyCreator,
+    now,
+    initialStatus,
+    resolutionDueAt,
+    firstResponseDueAt,
+  } = ctx;
 
   // 配列要素が null / 非オブジェクトでも落ちないように、まず event の存在とメッセージ種別を確認する
   if (event?.type !== 'message') return null;
@@ -520,6 +532,7 @@ async function processLineEvent(
         tenantId: targetTenantId, // 取り込み先テナント
         status: initialStatus, // Lite は 'Open'、Pro は DB 既定 'New'
         resolutionDueAt, // 優先度 Medium ベースの解決期限
+        firstResponseDueAt, // 優先度 Medium ベースの初回応答期限
       },
     );
     if (alreadyExisted) {

--- a/src/app/api/tickets/[id]/comments/route.ts
+++ b/src/app/api/tickets/[id]/comments/route.ts
@@ -138,6 +138,8 @@ export async function POST(req: Request, { params }: Params) {
   // 通知の送信先を決定する (既存 addComment と同じロジック)
   const recipientIds = await resolveCommentRecipients(ticket, authorId, authorIsAgent, tenantId);
   const message = `チケット「${ticket.title}」に新しいコメントが追加されました`;
+  // 初回応答日時の記録に使う基準時刻
+  const now = new Date();
 
   // ストレージへ書き込んだキーをロールバック用に蓄える
   const writtenKeys: string[] = [];
@@ -151,6 +153,13 @@ export async function POST(req: Request, { params }: Params) {
         body: trimmedBody,
         tenantId, // 親チケットのテナント一致を Adapter 側でも検証する (issue #123)
       });
+
+      // SLA: エージェントの初回応答を記録する (SLA §初回応答期限)。
+      // 依頼者自身のコメントは「応答」ではないため対象外。既に記録済みなら上書きしない
+      // (2 回目以降のエージェントコメントで初回応答日時が後ろにズレるのを防ぐ)
+      if (authorIsAgent && !ticket.firstRespondedAt) {
+        await r.tickets.markFirstResponded(ticketId, now, tenantId);
+      }
 
       // 添付ファイルがあれば 1 件ずつ「ストレージ書き込み → メタ INSERT」の順に処理する
       for (const v of attachmentValidation.files) {

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -24,7 +24,11 @@ import { getCurrentTenantMode } from '@/lib/tenant';
 import { endOfDayJST } from '@/lib/format-date';
 // Phase 4 課金: プランごとの月間チケット上限・添付累計サイズ上限チェック
 // (月間上限は CSV インポート・メール/LINE 取り込みと共有、添付上限はコメント投稿と共有)
-import { checkAttachmentQuota, getMonthlyTicketQuota, resolveTenantPlan } from '@/lib/tenant-plan';
+import {
+  checkAttachmentQuota,
+  getMonthlyTicketQuota,
+  resolveTenantPlanDetail,
+} from '@/lib/tenant-plan';
 // Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (失敗してもチケット作成は止めない。
 // メール取り込み・LINE 取り込み・CSV インポートと共有する)
 import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
@@ -122,13 +126,16 @@ export async function POST(req: Request) {
   }
 
   // Phase 4 課金: このリクエスト内で月間チケット上限・添付累計サイズ上限の両方を確認するため、
-  // プランを 1 度だけ解決して使い回す (それぞれが個別にテナントを取得する二重フェッチを避ける)
-  const plan = await resolveTenantPlan(tenantId);
+  // プランを 1 度だけ解決して使い回す (それぞれが個別にテナントを取得する二重フェッチを避ける)。
+  // rawPlan (契約プランそのまま) と effectivePlan (Free trial 昇格後) の両方を受け取る
+  const { rawPlan, effectivePlan } = await resolveTenantPlanDetail(tenantId);
 
   // 添付ファイルがある場合、テナントの累計サイズ上限 (§6.1 Standard「添付1GB」) を超えないか確認する。
-  // チケット作成・コメント投稿の両方の添付アップロード経路が共有するヘルパー (tenant-plan.ts)
+  // チケット作成・コメント投稿の両方の添付アップロード経路が共有するヘルパー (tenant-plan.ts)。
+  // ここは必ず rawPlan を渡す (effectivePlan だと Free trial 中に Free=無制限 → Standard=1GB へ
+  // 上限が逆に厳しくなってしまう。tenant-plan.ts の TenantPlanResolution コメント参照)
   const newAttachmentBytes = attachmentValidation.files.reduce((sum, f) => sum + f.size, 0);
-  const attachmentQuotaCheck = await checkAttachmentQuota(tenantId, newAttachmentBytes, plan);
+  const attachmentQuotaCheck = await checkAttachmentQuota(tenantId, newAttachmentBytes, rawPlan);
   if (!attachmentQuotaCheck.ok) {
     return validationError(attachmentQuotaCheck.message, ['files']);
   }
@@ -163,8 +170,8 @@ export async function POST(req: Request) {
   }
 
   // Phase 4 課金: テナントの当月チケット起票の残枠を確認する (§6.1 料金プランの月間上限)。
-  // plan は上の添付上限チェックで既に解決済みのものを渡し、テナントの二重取得を避ける
-  const quota = await getMonthlyTicketQuota(tenantId, plan);
+  // effectivePlan (Free trial 中は Standard 相当) を渡し、テナントの二重取得を避ける
+  const quota = await getMonthlyTicketQuota(tenantId, effectivePlan);
   // 残枠が無い (上限のあるプランで使い切った) 場合は 429 でプランアップグレードを促す
   if (quota.limited && quota.remaining <= 0) {
     return NextResponse.json(

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -8,8 +8,8 @@ import { auth } from '@/lib/auth';
 import { repos, uow } from '@/data';
 // 添付ファイル本体の StoragePort (Edge runtime 汚染回避のため別モジュールから取り込む)
 import { storage } from '@/data/storage';
-// 優先度から解決期限を計算する SLA ヘルパー
-import { calculateResolutionDueAt } from '@/lib/sla';
+// 優先度から解決期限・初回応答期限を計算する SLA ヘルパー
+import { calculateFirstResponseDueAt, calculateResolutionDueAt } from '@/lib/sla';
 // 新規チケット入力の Zod スキーマ
 import { createTicketSchema } from '@/lib/validations/ticket';
 // 添付ファイル検証ヘルパー
@@ -192,6 +192,8 @@ export async function POST(req: Request) {
   const resolutionDueAt = dueDate
     ? (endOfDayJST(dueDate) ?? calculateResolutionDueAt(effectivePriority, now))
     : calculateResolutionDueAt(effectivePriority, now);
+  // 初回応答期限: 解決期限と同じく priority ベースで自動計算する (手動指定は無い)
+  const firstResponseDueAt = calculateFirstResponseDueAt(effectivePriority, now);
 
   // 添付なしの単純パス: 従来どおりトランザクション無しで作成して返す
   if (attachmentValidation.files.length === 0) {
@@ -206,6 +208,7 @@ export async function POST(req: Request) {
       tenantId,
       status: initialStatus, // Lite は 'Open'、Pro は undefined(既定 New)
       resolutionDueAt,
+      firstResponseDueAt,
     });
     // Phase 4: 外部チャネルへ新規問い合わせを通知する (ベストエフォート、失敗してもレスポンスには影響しない)
     await notifyNewTicketOutbound(tenantId, ticket);
@@ -238,6 +241,7 @@ export async function POST(req: Request) {
         tenantId,
         status: initialStatus, // Lite は 'Open'、Pro は undefined(既定 New)
         resolutionDueAt,
+        firstResponseDueAt,
       });
       // 添付ファイルを 1 件ずつ「ストレージ書き込み → メタ INSERT」の順に処理する
       for (const v of attachmentValidation.files) {

--- a/src/data/adapters/memory/tenant-repository.memory.ts
+++ b/src/data/adapters/memory/tenant-repository.memory.ts
@@ -48,6 +48,7 @@ export function makeTenantRepo(store: Store): TenantRepository {
         stripeCustomerId: null,
         stripeSubscriptionId: null,
         stripeSubscriptionStatus: null,
+        trialEndsAt: input.trialEndsAt ?? null, // §7.2 Free trial 終了日時 (任意)
         createdAt: new Date(),
       };
       // ストアの Map に登録
@@ -82,8 +83,7 @@ export function makeTenantRepo(store: Store): TenantRepository {
           data.teamsWebhookUrl !== undefined ? data.teamsWebhookUrl : t.teamsWebhookUrl,
         chatworkApiToken:
           data.chatworkApiToken !== undefined ? data.chatworkApiToken : t.chatworkApiToken,
-        chatworkRoomId:
-          data.chatworkRoomId !== undefined ? data.chatworkRoomId : t.chatworkRoomId,
+        chatworkRoomId: data.chatworkRoomId !== undefined ? data.chatworkRoomId : t.chatworkRoomId,
       };
       store.tenants.set(id, updated);
       // 防御的コピーを返す

--- a/src/data/adapters/memory/ticket-repository.memory.ts
+++ b/src/data/adapters/memory/ticket-repository.memory.ts
@@ -312,6 +312,13 @@ export function makeTicketRepo(store: Store): TicketRepository {
       });
     },
 
+    // 初回応答日時を記録する (tenantId スコープ)
+    async markFirstResponded(id, at, tenantId) {
+      const t = store.tickets.get(id);
+      if (!t || t.tenantId !== tenantId) return;
+      store.tickets.set(id, { ...t, firstRespondedAt: at, updatedAt: new Date() });
+    },
+
     // 品質メトリクスを算出して返す (tenantId スコープ。since 指定時はその日時以降作成分のみ)
     async qualityMetrics({ tenantId, since }) {
       // テナントスコープ + since 条件でチケットを絞り込む

--- a/src/data/adapters/memory/ticket-repository.memory.ts
+++ b/src/data/adapters/memory/ticket-repository.memory.ts
@@ -316,6 +316,9 @@ export function makeTicketRepo(store: Store): TicketRepository {
     async markFirstResponded(id, at, tenantId) {
       const t = store.tickets.get(id);
       if (!t || t.tenantId !== tenantId) return;
+      // 既に初回応答済みなら上書きしない (Prisma アダプタの where firstRespondedAt: null と
+      // 同じ規約に揃える。呼び出し側のスナップショット判定が古くても、ここで最終防衛する)
+      if (t.firstRespondedAt) return;
       store.tickets.set(id, { ...t, firstRespondedAt: at, updatedAt: new Date() });
     },
 

--- a/src/data/adapters/prisma/tenant-repository.prisma.ts
+++ b/src/data/adapters/prisma/tenant-repository.prisma.ts
@@ -31,6 +31,7 @@ function toTenant(row: TenantRow): Tenant {
     stripeCustomerId: row.stripeCustomerId, // Stripe Customer ID (null なら未登録)
     stripeSubscriptionId: row.stripeSubscriptionId, // Stripe Subscription ID (null なら未契約)
     stripeSubscriptionStatus: row.stripeSubscriptionStatus, // Stripe の subscription.status
+    trialEndsAt: row.trialEndsAt, // §7.2 Free trial 終了日時 (対象外/終了済みなら null)
     createdAt: row.createdAt,
   };
 }
@@ -66,6 +67,7 @@ export function makeTenantRepo(db: PrismaLike): TenantRepository {
           industry: input.industry ?? null, // 業種テンプレ識別子 (任意)
           mode: input.mode ?? 'lite', // 動作モード (既定 lite)
           inboundToken: input.inboundToken ?? null, // メール取り込みアドレスのローカルパート (任意)
+          trialEndsAt: input.trialEndsAt ?? null, // §7.2 Free trial 終了日時 (任意)
         },
       });
       // 作成行をドメイン型に変換して返す

--- a/src/data/adapters/prisma/ticket-repository.prisma.ts
+++ b/src/data/adapters/prisma/ticket-repository.prisma.ts
@@ -263,7 +263,14 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
 
     // 初回応答日時を記録する (tenantId スコープ)
     async markFirstResponded(id, at, tenantId) {
-      await db.ticket.updateMany({ where: { id, tenantId }, data: { firstRespondedAt: at } });
+      // where に firstRespondedAt: null も含めることで、既に初回応答済みの行には書き込まない
+      // ようにする (呼び出し側の !ticket.firstRespondedAt 判定はトランザクション開始前に取得した
+      // スナップショットに基づくため、ほぼ同時に届いた 2 件目以降のコメントが最初の応答時刻を
+      // 後から上書きしてしまう競合を防ぐ。2 件目以降は対象行が 0 件になり安全な no-op になる)
+      await db.ticket.updateMany({
+        where: { id, tenantId, firstRespondedAt: null },
+        data: { firstRespondedAt: at },
+      });
     },
 
     // 品質メトリクスを算出して返す (issue-backlog #25)

--- a/src/data/adapters/prisma/ticket-repository.prisma.ts
+++ b/src/data/adapters/prisma/ticket-repository.prisma.ts
@@ -261,6 +261,11 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
       });
     },
 
+    // 初回応答日時を記録する (tenantId スコープ)
+    async markFirstResponded(id, at, tenantId) {
+      await db.ticket.updateMany({ where: { id, tenantId }, data: { firstRespondedAt: at } });
+    },
+
     // 品質メトリクスを算出して返す (issue-backlog #25)
     // 平均初回応答時間・平均解決時間・再オープン率を 3 本の SQL で並列取得する。
     // Prisma ORM では日時間隔の AVG を直接計算できないため $queryRaw で PostgreSQL の

--- a/src/data/ports/tenant-repository.ts
+++ b/src/data/ports/tenant-repository.ts
@@ -16,6 +16,7 @@ export interface TenantRepository {
     industry?: string | null;
     mode?: TenantMode;
     inboundToken?: string | null;
+    trialEndsAt?: Date | null; // §7.2 Free trial の終了日時 (未指定なら null = トライアル無し)
   }): Promise<Tenant>;
   // テナントの動作モード (lite | pro) を更新し、更新後の Tenant を返す
   // id はセッション由来の tenantId のみを渡す契約 (リクエスト入力から注入しないこと = クロステナント防止)

--- a/src/data/ports/ticket-repository.ts
+++ b/src/data/ports/ticket-repository.ts
@@ -167,4 +167,7 @@ export interface TicketRepository {
   updateAssignee(id: string, assigneeId: string | null, tenantId: string): Promise<void>;
   // エスカレーション状態にする (tenantId スコープ)
   markEscalated(id: string, args: MarkEscalatedInput, tenantId: string): Promise<void>;
+  // 初回応答日時を記録する (tenantId スコープ)。呼び出し側が「まだ未応答」を確認してから
+  // 呼ぶ前提 (2 回目以降の呼び出しで上書きしないための判定は呼び出し側の責務)
+  markFirstResponded(id: string, at: Date, tenantId: string): Promise<void>;
 }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -67,6 +67,9 @@ export interface Tenant {
   stripeCustomerId: string | null; // Stripe Customer ID (cu_xxx)
   stripeSubscriptionId: string | null; // Stripe Subscription ID (sub_xxx)
   stripeSubscriptionStatus: string | null; // Stripe の subscription.status 文字列
+  // §7.2「30日間の Free trial (Standard 相当)」。トライアル終了日時 (対象外/終了済みなら null)。
+  // resolveEffectivePlan() がこの期限内だけ Standard 相当としてゲート判定する
+  trialEndsAt: Date | null;
   createdAt: Date; // 作成日時
 }
 

--- a/src/features/settings/actions/create-tenant.ts
+++ b/src/features/settings/actions/create-tenant.ts
@@ -32,6 +32,8 @@ import { generateInboundToken } from '@/lib/inbound-email';
 import { findIndustryTemplate } from '@/lib/industry-templates';
 // 優先度から解決期限を計算する SLA ヘルパー (サンプルチケットの期限算出に使う)
 import { calculateResolutionDueAt } from '@/lib/sla';
+// §7.2 Free trial の期間 (30 日) をミリ秒で表す定数
+import { FREE_TRIAL_DURATION_MS } from '@/lib/plan-guard';
 // 新規起票時の初期ステータスを mode から決める共通ルール (サンプルチケットと揃える)
 import { initialStatusForMode } from '@/domain/ticket-status';
 
@@ -93,11 +95,15 @@ export async function createTenant(formData: FormData): Promise<CreateTenantResu
 
     // 新しいテナント (組織) を作成する。mode 未指定で SMB 既定の lite になる。
     // メール取り込み (Phase 2) の専用転送アドレス用トークンを払い出して紐付ける
-    // (作成時に発行しておくことで、運用者は最初から取り込みアドレスを案内できる)
+    // (作成時に発行しておくことで、運用者は最初から取り込みアドレスを案内できる)。
+    // §7.2「30日間の Free trial (Standard 相当)」: 作成時刻から 30 日後を trialEndsAt に設定する。
+    // これにより §7.1「30分で運用開始」オンボーディングのメール取り込み体験 (Standard 以上限定)
+    // を、課金前の新規テナントでもすぐに試せるようにする
     const tenant = await tx.tenants.create({
       name: tenantName,
       industry: industry ?? null,
       inboundToken: generateInboundToken(),
+      trialEndsAt: new Date(Date.now() + FREE_TRIAL_DURATION_MS),
     });
     // パスワードを bcrypt でハッシュ化する (cost 12)
     const passwordHash = await hash(adminPassword, 12);

--- a/src/features/settings/actions/create-tenant.ts
+++ b/src/features/settings/actions/create-tenant.ts
@@ -30,8 +30,8 @@ import { createTenantSchema } from '@/lib/validations/invite';
 import { generateInboundToken } from '@/lib/inbound-email';
 // 業種テンプレートの検索関数 (Phase 3 業種テンプレ自動投入)
 import { findIndustryTemplate } from '@/lib/industry-templates';
-// 優先度から解決期限を計算する SLA ヘルパー (サンプルチケットの期限算出に使う)
-import { calculateResolutionDueAt } from '@/lib/sla';
+// 優先度から解決期限・初回応答期限を計算する SLA ヘルパー (サンプルチケットの期限算出に使う)
+import { calculateFirstResponseDueAt, calculateResolutionDueAt } from '@/lib/sla';
 // §7.2 Free trial の期間 (30 日) をミリ秒で表す定数
 import { FREE_TRIAL_DURATION_MS } from '@/lib/plan-guard';
 // 新規起票時の初期ステータスを mode から決める共通ルール (サンプルチケットと揃える)
@@ -168,8 +168,10 @@ export async function createTenant(formData: FormData): Promise<CreateTenantResu
     // 起票者には初代管理者 (adminUser) を設定する。
     // サンプルチケットは Lite モードの既定動作に合わせて初期化する (Pro でも同じ)。
     const initialStatus = initialStatusForMode(tenant.mode);
-    // サンプルチケットの解決期限は優先度 Medium ベースで自動計算する (now は上で取得済みのものを再利用)
+    // サンプルチケットの解決期限・初回応答期限は優先度 Medium ベースで自動計算する
+    // (now は上で取得済みのものを再利用)
     const resolutionDueAt = calculateResolutionDueAt('Medium', now);
+    const firstResponseDueAt = calculateFirstResponseDueAt('Medium', now);
     // サンプルチケットを 1 件ずつ直列で作成する (トランザクション内の複数クエリは直列が安全)
     for (const sample of SAMPLE_TICKETS) {
       await tx.tickets.create({
@@ -181,6 +183,7 @@ export async function createTenant(formData: FormData): Promise<CreateTenantResu
         tenantId: tenant.id, // 所属テナント
         status: initialStatus, // Lite は 'Open'、Pro は DB 既定 'New'
         resolutionDueAt, // 自動計算した解決期限
+        firstResponseDueAt, // 自動計算した初回応答期限
       });
     }
 

--- a/src/features/settings/components/BillingSection.tsx
+++ b/src/features/settings/components/BillingSection.tsx
@@ -65,8 +65,12 @@ const PLAN_INFO: Record<SubscriptionPlan, { label: string; price: string; featur
 
 // 受け取る props
 interface Props {
-  // 現在のサブスクリプションプラン
+  // 現在のサブスクリプションプラン (契約プランそのもの。プラン名・機能一覧の表示に使う)
   currentPlan: SubscriptionPlan;
+  // §7.2 Free trial 昇格後の実効プラン (トライアル対象外/終了済みなら currentPlan と同じ値)。
+  // スタッフ人数が「実際に今適用されている上限」を超えているかの判定はこちらを使う
+  // (トライアル中は Free の 3 名ではなく Standard の 10 名が適用されるため)
+  effectivePlan: SubscriptionPlan;
   // Stripe Subscription の status 文字列 (null なら未登録)
   stripeStatus: string | null;
   // Stripe Customer ID の有無 (ポータルリンクを表示するかの判断に使う)
@@ -81,6 +85,7 @@ interface Props {
 // サブスクリプション管理セクション (プラン表示 + アップグレード/管理ボタン)
 export function BillingSection({
   currentPlan,
+  effectivePlan,
   stripeStatus,
   hasStripeCustomer,
   currentUserCount,
@@ -125,15 +130,20 @@ export function BillingSection({
     });
   }
 
-  // 現在のプラン情報を取り出す
+  // 現在のプラン情報を取り出す (プラン名・機能一覧は契約プランそのものを表示する。
+  // トライアルで一時的に使える機能は上のトライアル案内バナーで別途伝える)
   const info = PLAN_INFO[currentPlan];
-  // 現在のスタッフ人数が現在プランの上限を「超えている」か (Stripe ポータルでの解約・
+  // 現在のスタッフ人数が「実際に今適用されている上限」を超えているか (Stripe ポータルでの解約・
   // ダウングレード後も既存メンバーは自動では削除されないため、ここで検知して警告する)。
+  // §7.2 Free trial 中は Standard 相当のシート数が適用される (checkSeatAvailability も
+  // resolveEffectivePlan 経由で同じ判定をしている) ため、必ず effectivePlan の上限で判定する。
+  // currentPlan (契約プランの Free) で判定すると、トライアル中で実際は上限内なのに
+  // 誤って「超えています」と表示してしまう。
   // isUserLimitReached (>= 判定) は「招待をこれ以上発行できるか」の判定用であり、
   // ちょうど上限と同数 (例: Free で 3/3 名) は正常な「満枠」状態であって「超過」ではない。
   // そのまま使うと満枠なだけの通常テナントにも「超えています」という誤った警告が
   // 常時表示されてしまうため、ここでは厳密な超過 (>) のみを判定する
-  const isOverUserLimit = currentUserCount > USER_LIMIT[currentPlan];
+  const isOverUserLimit = currentUserCount > USER_LIMIT[effectivePlan];
 
   return (
     <div className="space-y-4">
@@ -164,8 +174,8 @@ export function BillingSection({
           role="alert"
           className="rounded-lg bg-amber-50 px-3 py-2.5 text-sm text-amber-800 ring-1 ring-amber-200"
         >
-          現在のスタッフ人数 ({currentUserCount} 名) が {info.label} プランの上限 (
-          {USER_LIMIT[currentPlan]} 名) を超えています。既存メンバーはそのまま
+          現在のスタッフ人数 ({currentUserCount} 名) が {PLAN_INFO[effectivePlan].label}{' '}
+          プランの上限 ({USER_LIMIT[effectivePlan]} 名) を超えています。既存メンバーはそのまま
           利用できますが、新規メンバーの招待はできません。プランをアップグレードするか、
           メンバーを整理してください。
         </p>

--- a/src/features/settings/components/BillingSection.tsx
+++ b/src/features/settings/components/BillingSection.tsx
@@ -15,10 +15,7 @@ import type { SubscriptionPlan } from '@/domain/types';
 import { USER_LIMIT, getMonthlyTicketLimit } from '@/lib/plan-guard';
 
 // 各プランの表示設定 (名称・月額・特徴)
-const PLAN_INFO: Record<
-  SubscriptionPlan,
-  { label: string; price: string; features: string[] }
-> = {
+const PLAN_INFO: Record<SubscriptionPlan, { label: string; price: string; features: string[] }> = {
   // 無料プラン: 最小構成でお試し
   free: {
     label: 'Free',
@@ -76,6 +73,9 @@ interface Props {
   hasStripeCustomer: boolean;
   // 現在のスタッフ人数 (agent/admin のみ)。Stripe ダウングレード後の上限超過検知に使う
   currentUserCount: number;
+  // §7.2 Free trial の残り日数 (トライアル対象外/終了済みなら null)。
+  // Date は RSC 境界を跨ぐ受け渡しを避けるため、サーバー側で日数に変換済みの値を受け取る
+  trialDaysRemaining: number | null;
 }
 
 // サブスクリプション管理セクション (プラン表示 + アップグレード/管理ボタン)
@@ -84,6 +84,7 @@ export function BillingSection({
   stripeStatus,
   hasStripeCustomer,
   currentUserCount,
+  trialDaysRemaining,
 }: Props) {
   // ボタン操作中のエラーメッセージ
   const [error, setError] = useState<string | null>(null);
@@ -138,8 +139,20 @@ export function BillingSection({
     <div className="space-y-4">
       {/* エラーメッセージ */}
       {error && (
-        <p role="alert" className="rounded-lg bg-rose-50 px-3 py-2.5 text-sm text-rose-700 ring-1 ring-rose-200">
+        <p
+          role="alert"
+          className="rounded-lg bg-rose-50 px-3 py-2.5 text-sm text-rose-700 ring-1 ring-rose-200"
+        >
           {error}
+        </p>
+      )}
+
+      {/* §7.2 Free trial 中の案内: Standard 相当の機能 (メール取り込み等) が利用可能なことと
+          残り日数を伝える (trialDaysRemaining は対象外/終了済みなら null で非表示) */}
+      {trialDaysRemaining !== null && (
+        <p className="rounded-lg bg-teal-50 px-3 py-2.5 text-sm text-teal-800 ring-1 ring-teal-200">
+          トライアル期間中です（残り {trialDaysRemaining} 日）。Standard
+          相当の機能（メール取り込み等）を無料でお試しいただけます。
         </p>
       )}
 
@@ -151,8 +164,8 @@ export function BillingSection({
           role="alert"
           className="rounded-lg bg-amber-50 px-3 py-2.5 text-sm text-amber-800 ring-1 ring-amber-200"
         >
-          現在のスタッフ人数 ({currentUserCount} 名) が {info.label}{' '}
-          プランの上限 ({USER_LIMIT[currentPlan]} 名) を超えています。既存メンバーはそのまま
+          現在のスタッフ人数 ({currentUserCount} 名) が {info.label} プランの上限 (
+          {USER_LIMIT[currentPlan]} 名) を超えています。既存メンバーはそのまま
           利用できますが、新規メンバーの招待はできません。プランをアップグレードするか、
           メンバーを整理してください。
         </p>
@@ -163,7 +176,9 @@ export function BillingSection({
         {/* プラン名と月額 */}
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-teal-600">現在のプラン</p>
+            <p className="text-xs font-semibold tracking-wide text-teal-600 uppercase">
+              現在のプラン
+            </p>
             <p className="mt-0.5 text-lg font-bold text-slate-900">{info.label}</p>
           </div>
           <p className="text-sm font-semibold text-slate-700">{info.price}</p>
@@ -173,7 +188,9 @@ export function BillingSection({
           {info.features.map((f) => (
             <li key={f} className="flex items-center gap-1.5 text-sm text-slate-600">
               {/* チェックアイコン */}
-              <span className="text-teal-500" aria-hidden="true">✓</span>
+              <span className="text-teal-500" aria-hidden="true">
+                ✓
+              </span>
               {f}
             </li>
           ))}

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -27,6 +27,8 @@ import { broadcastUnreadCountToMany } from '@/features/notifications/notify';
 import { getMonthlyTicketQuota } from '@/lib/tenant-plan';
 // Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (Web フォーム・メール・LINE 取り込みと共有)
 import { notifyOutboundBestEffort } from '@/lib/outbound-notify';
+// 優先度から初回応答期限を計算する SLA ヘルパー (Web フォーム・メール・LINE 取り込みと共有)
+import { calculateFirstResponseDueAt } from '@/lib/sla';
 
 // 1 インポートあたりの最大行数 (これを超えたらエラー)
 const MAX_ROWS = 200;
@@ -202,6 +204,8 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
 
   // テナントの動作モードを取得する (初期ステータスを Lite/Pro で切り替えるために必要)
   const mode = await getCurrentTenantMode(tenantId);
+  // 取り込み時刻 (初回応答期限の計算基準。行ごとに新規生成せず統一する)
+  const now = new Date();
 
   // Lite: 'Open'(未対応)、Pro: undefined → DB 既定値 'New'(新規) を使う。
   // メール取り込み・LINE 取り込みと同じ initialStatusForMode を呼ぶことで、
@@ -362,6 +366,9 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
         tenantId, // テナントスコープを必ず付与する (クロステナント防止)
         status: initialStatus, // Lite: Open / Pro: New
         resolutionDueAt, // 期限日 (未指定なら null)
+        // 初回応答期限: CSV に対応列が無いため、常に優先度ベースで自動算出する
+        // (Web フォーム・メール・LINE 取り込みと同じ SLA ヘルパーを使う)
+        firstResponseDueAt: calculateFirstResponseDueAt(priority, now),
         locationId, // 拠点 ID (「拠点」列があれば名前解決済み、無ければ null)
       });
       // 成功カウンタをインクリメント

--- a/src/lib/plan-guard.ts
+++ b/src/lib/plan-guard.ts
@@ -39,6 +39,37 @@ export const ATTACHMENT_TOTAL_SIZE_LIMIT_BYTES: Record<SubscriptionPlan, number>
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
+// トライアル (§7.2「30日間の Free trial (Standard 相当)」)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// トライアル中に昇格させる先のプラン (Standard 相当)
+const TRIAL_EFFECTIVE_PLAN: SubscriptionPlan = 'standard';
+
+// トライアル期間 (30 日、ミリ秒)。テナント作成時に trialEndsAt = 作成時刻 + この値で設定する
+export const FREE_TRIAL_DURATION_MS = 30 * 24 * 60 * 60 * 1000;
+
+// テナントの実際の課金プラン (subscriptionPlan) とトライアル終了日時から、
+// 各種プランゲート判定に使う「実効プラン」を解決する純粋関数。
+// Free プランでトライアル期間中 (trialEndsAt が未来) なら Standard 相当として扱い、
+// それ以外 (トライアル対象外・終了済み・Standard 以上に課金済み) はそのまま返す。
+// Stripe で正式に課金プランへ上がった場合は subscriptionPlan 自体が更新されるため、
+// この関数の判定を経由しても実際のプランがそのまま尊重される (トライアルで上書きされない)。
+// SSO (Enterprise 限定) や LINE 連携 (Pro 以上限定) など Standard より上位のゲートは、
+// トライアルでは昇格しない (「Standard 相当」の範囲を超えるプラン限定機能は対象外)。
+export function resolveEffectivePlan(
+  subscriptionPlan: SubscriptionPlan,
+  trialEndsAt: Date | null,
+  now: Date = new Date(),
+): SubscriptionPlan {
+  // Free 以外は課金済み (またはそれ以上) なのでトライアル判定は不要
+  if (subscriptionPlan !== 'free') return subscriptionPlan;
+  // トライアル未設定、または既に終了していれば無印の Free のまま
+  if (trialEndsAt === null || trialEndsAt.getTime() <= now.getTime()) return subscriptionPlan;
+  // トライアル期間中: Standard 相当に昇格させる
+  return TRIAL_EFFECTIVE_PLAN;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // プラン機能可用性フラグ
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/src/lib/sla.ts
+++ b/src/lib/sla.ts
@@ -24,6 +24,26 @@ export function calculateResolutionDueAt(priority: Priority, from: Date): Date {
   return new Date(from.getTime() + hours * 60 * 60 * 1000);
 }
 
+/**
+ * Hours allowed for the first response, by priority. Same placeholder-policy
+ * caveat as SLA_RESOLUTION_HOURS_BY_PRIORITY (shorter than the resolution
+ * window since a first response is a much lighter action than resolving).
+ */
+// 優先度ごとの「初回応答までに許される時間 (時間単位)」
+export const FIRST_RESPONSE_HOURS_BY_PRIORITY: Record<Priority, number> = {
+  High: 4, // 優先度高: 4 時間
+  Medium: 8, // 優先度中: 8 時間 (営業時間内)
+  Low: 24, // 優先度低: 24 時間 (1 日)
+};
+
+// 起票時刻 from から優先度に応じた初回応答期限を計算して返す関数
+export function calculateFirstResponseDueAt(priority: Priority, from: Date): Date {
+  // 表から対応する時間数を取得
+  const hours = FIRST_RESPONSE_HOURS_BY_PRIORITY[priority];
+  // from の時刻 (ミリ秒) に hours 時間分のミリ秒を加えた新しい Date を返す
+  return new Date(from.getTime() + hours * 60 * 60 * 1000);
+}
+
 // 期限日時と解決日時から現在の SLA 状態を判定する関数
 export function getSlaState(resolutionDueAt: Date | null, resolvedAt: Date | null): SlaState {
   // 期限が未設定なら 'none' (対象外)

--- a/src/lib/sla.ts
+++ b/src/lib/sla.ts
@@ -44,8 +44,21 @@ export function calculateFirstResponseDueAt(priority: Priority, from: Date): Dat
   return new Date(from.getTime() + hours * 60 * 60 * 1000);
 }
 
-// 期限日時と解決日時から現在の SLA 状態を判定する関数
-export function getSlaState(resolutionDueAt: Date | null, resolvedAt: Date | null): SlaState {
+// 「警告 (期限間近)」とみなす残り時間のデフォルト閾値 (24 時間)。
+// 解決期限 (24〜168 時間の窓) 向けに調整された値。初回応答期限は窓が 4〜24 時間と
+// 短いため、この既定値をそのまま使うと起票直後から常に warning になってしまう
+// (回帰防止: getSlaState の呼び出し側は窓の長さに応じた閾値を明示的に渡すこと)
+const DEFAULT_WARNING_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+// 期限日時と解決日時から現在の SLA 状態を判定する関数。
+// warningThresholdMs: 「期限間近」とみなす残り時間 (ミリ秒)。省略時は解決期限向けの
+// 24 時間。初回応答期限のように窓自体が短い SLA では、呼び出し側が窓の長さに応じた
+// 値 (例: 窓の 25%) を渡すことで、起票直後からずっと warning になる誤表示を防ぐ
+export function getSlaState(
+  resolutionDueAt: Date | null,
+  resolvedAt: Date | null,
+  warningThresholdMs: number = DEFAULT_WARNING_THRESHOLD_MS,
+): SlaState {
   // 期限が未設定なら 'none' (対象外)
   if (!resolutionDueAt) return 'none';
   // 既に解決済みなら 'ok' (問題なく終わった扱い)
@@ -58,8 +71,8 @@ export function getSlaState(resolutionDueAt: Date | null, resolvedAt: Date | nul
 
   // 残り時間がマイナスなら超過
   if (msLeft < 0) return 'overdue';
-  // 残り 24 時間未満なら警告 (within 24 h)
-  if (msLeft < 24 * 60 * 60 * 1000) return 'warning';
+  // 残りが閾値未満なら警告
+  if (msLeft < warningThresholdMs) return 'warning';
   // それ以外は余裕あり
   return 'ok';
 }

--- a/src/lib/tenant-plan.ts
+++ b/src/lib/tenant-plan.ts
@@ -20,19 +20,25 @@ import {
   getMonthlyTicketLimit,
   getUserLimit,
   isUserLimitReached,
+  resolveEffectivePlan,
 } from '@/lib/plan-guard';
 // JST (日本時間) 基準の月初を計算する共通ヘルパー (endOfDayJST と同じファイルに集約)
 import { startOfMonthJST } from '@/lib/format-date';
 // バイト数を GB 表示に丸めるヘルパー (添付上限エラーメッセージ用)
 import { formatBytesAsGb } from '@/domain/attachment';
 
-// 指定テナントの現在の課金プランを返す。テナントが見つからない場合は 'free' として扱う
+// 指定テナントの現在の実効プランを返す。テナントが見つからない場合は 'free' として扱う
 // (fail-closed: 存在しない/取得できないテナントに Pro/Enterprise 限定機能を渡さない)。
+// §7.2 Free trial 中 (subscriptionPlan=free かつ trialEndsAt が未来) は Standard 相当に
+// 昇格させる (resolveEffectivePlan)。この関数を経由する呼び出し側は全てトライアルの
+// 恩恵を自動的に受ける
 export async function resolveTenantPlan(tenantId: string): Promise<SubscriptionPlan> {
   // テナントをリポジトリ経由で取得する
   const tenant = await repos.tenants.findById(tenantId);
   // 見つからなければ 'free' にフォールバックする
-  return tenant?.subscriptionPlan ?? 'free';
+  if (!tenant) return 'free';
+  // トライアル中なら Standard 相当に昇格させた実効プランを返す
+  return resolveEffectivePlan(tenant.subscriptionPlan, tenant.trialEndsAt);
 }
 
 // 月間チケット起票数の残枠を表す (Web フォーム・CSV インポート・メール/LINE 取り込みが共有する)
@@ -103,10 +109,12 @@ export async function checkSeatAvailability(
   if (!tenant) return { available: true, limit: -1 };
   // このテナントの現在のスタッフ (agent + admin) 数を数える
   const currentUserCount = await repos.users.countByTenant(tenantId);
+  // §7.2 Free trial 中なら Standard 相当のシート数を適用する
+  const effectivePlan = resolveEffectivePlan(tenant.subscriptionPlan, tenant.trialEndsAt);
   // 上限判定結果とプランの上限値を返す
   return {
-    available: !isUserLimitReached(tenant.subscriptionPlan, currentUserCount),
-    limit: getUserLimit(tenant.subscriptionPlan),
+    available: !isUserLimitReached(effectivePlan, currentUserCount),
+    limit: getUserLimit(effectivePlan),
   };
 }
 

--- a/src/lib/tenant-plan.ts
+++ b/src/lib/tenant-plan.ts
@@ -27,18 +27,37 @@ import { startOfMonthJST } from '@/lib/format-date';
 // バイト数を GB 表示に丸めるヘルパー (添付上限エラーメッセージ用)
 import { formatBytesAsGb } from '@/domain/attachment';
 
-// 指定テナントの現在の実効プランを返す。テナントが見つからない場合は 'free' として扱う
+// 契約プラン (rawPlan) と実効プラン (effectivePlan、トライアル昇格後) の両方を表す。
+// ほとんどのプランゲートは昇格後の実効プランを使うべきだが、添付累計サイズ上限
+// (ATTACHMENT_TOTAL_SIZE_LIMIT_BYTES) だけは Free=無制限 / Standard=1GB と、上位プランほど
+// 上限が緩くなるとは限らない唯一のテーブルのため、トライアル中に rawPlan='free' を
+// effectivePlan='standard' へ昇格させると逆に上限が厳しくなってしまう。
+// そのため添付上限を扱う getAttachmentQuota/checkAttachmentQuota は rawPlan を使う
+export interface TenantPlanResolution {
+  rawPlan: SubscriptionPlan; // テナントの契約プランそのもの (トライアル未適用)
+  effectivePlan: SubscriptionPlan; // トライアル昇格を適用した実効プラン
+}
+
+// 指定テナントの契約プランと実効プランを 1 回のテナント取得で両方解決する。
+// テナントが見つからない場合は両方とも 'free' として扱う
 // (fail-closed: 存在しない/取得できないテナントに Pro/Enterprise 限定機能を渡さない)。
-// §7.2 Free trial 中 (subscriptionPlan=free かつ trialEndsAt が未来) は Standard 相当に
-// 昇格させる (resolveEffectivePlan)。この関数を経由する呼び出し側は全てトライアルの
-// 恩恵を自動的に受ける
-export async function resolveTenantPlan(tenantId: string): Promise<SubscriptionPlan> {
+export async function resolveTenantPlanDetail(tenantId: string): Promise<TenantPlanResolution> {
   // テナントをリポジトリ経由で取得する
   const tenant = await repos.tenants.findById(tenantId);
   // 見つからなければ 'free' にフォールバックする
-  if (!tenant) return 'free';
-  // トライアル中なら Standard 相当に昇格させた実効プランを返す
-  return resolveEffectivePlan(tenant.subscriptionPlan, tenant.trialEndsAt);
+  if (!tenant) return { rawPlan: 'free', effectivePlan: 'free' };
+  // 契約プランそのままの値と、トライアル中なら Standard 相当に昇格させた実効プランを返す
+  return {
+    rawPlan: tenant.subscriptionPlan,
+    effectivePlan: resolveEffectivePlan(tenant.subscriptionPlan, tenant.trialEndsAt),
+  };
+}
+
+// 指定テナントの現在の実効プランを返す。§7.2 Free trial 中 (subscriptionPlan=free かつ
+// trialEndsAt が未来) は Standard 相当に昇格させる。この関数を経由する呼び出し側は全て
+// トライアルの恩恵を自動的に受ける (添付累計サイズ上限を除く。上の解説を参照)
+export async function resolveTenantPlan(tenantId: string): Promise<SubscriptionPlan> {
+  return (await resolveTenantPlanDetail(tenantId)).effectivePlan;
 }
 
 // 月間チケット起票数の残枠を表す (Web フォーム・CSV インポート・メール/LINE 取り込みが共有する)
@@ -130,6 +149,9 @@ export interface AttachmentQuota {
 // POST /api/tickets (チケット作成時添付) と POST /api/tickets/[id]/comments (コメント添付) の
 // 両方が同じ判定を使うための共通ヘルパー (§6.1 料金プラン Standard「添付1GB」)。
 // plan を既に把握している呼び出し側は渡せる (二重の tenant 取得を避ける)。
+// 渡す plan は必ず rawPlan (契約プランそのまま) を使うこと。Free trial 中の
+// effectivePlan (Standard 相当への昇格後) を渡すと、Free=無制限 → Standard=1GB へ
+// 上限が厳しくなる逆転が起きてしまう (TenantPlanResolution のコメント参照)。
 //
 // getMonthlyTicketQuota と同じく best-effort な上限であり、DB レベルの原子性は持たない
 // (check-then-act。同時並行アップロードでは合計が上限をわずかに超えうる)。
@@ -137,8 +159,9 @@ export async function getAttachmentQuota(
   tenantId: string,
   plan?: SubscriptionPlan,
 ): Promise<AttachmentQuota> {
-  // プラン未指定なら解決する
-  const resolvedPlan = plan ?? (await resolveTenantPlan(tenantId));
+  // プラン未指定なら rawPlan (トライアル未適用の契約プラン) を解決する。
+  // resolveTenantPlan (トライアル昇格あり) を使うと上の理由で上限が逆転するため使わない
+  const resolvedPlan = plan ?? (await resolveTenantPlanDetail(tenantId)).rawPlan;
   // このプランの添付累計サイズ上限を取得する (-1 = 無制限)
   const limitBytes = getAttachmentSizeLimit(resolvedPlan);
   // 無制限プランは DB 集計を行わず即座に返す (不要なクエリを避ける)

--- a/tests/data/cross-tenant-create.test.ts
+++ b/tests/data/cross-tenant-create.test.ts
@@ -24,7 +24,23 @@ async function seed() {
   const now = new Date();
   // テナント A・B を投入 (Lite モード)
   for (const t of [TENANT_A, TENANT_B]) {
-    store.tenants.set(t, { id: t, name: t, mode: 'lite', industry: null, inboundToken: null, slackWebhookUrl: null, subscriptionPlan: 'free' as const, stripeCustomerId: null, stripeSubscriptionId: null, stripeSubscriptionStatus: null, teamsWebhookUrl: null, chatworkApiToken: null, chatworkRoomId: null, createdAt: now });
+    store.tenants.set(t, {
+      id: t,
+      name: t,
+      mode: 'lite',
+      industry: null,
+      inboundToken: null,
+      slackWebhookUrl: null,
+      subscriptionPlan: 'free' as const,
+      stripeCustomerId: null,
+      stripeSubscriptionId: null,
+      stripeSubscriptionStatus: null,
+      trialEndsAt: null,
+      teamsWebhookUrl: null,
+      chatworkApiToken: null,
+      chatworkRoomId: null,
+      createdAt: now,
+    });
   }
   // テナント A のユーザーを 1 人投入する
   store.users.set(USER_A, {

--- a/tests/data/invitation-repository.contract.test.ts
+++ b/tests/data/invitation-repository.contract.test.ts
@@ -29,7 +29,23 @@ function makeMemoryContext(): InvitationContractContext {
     ];
     // 各テナントを store に直接書き込む (mode は lite で十分)
     for (const [id, name] of tenantDefs) {
-      store.tenants.set(id, { id, name, mode: 'lite', industry: null, inboundToken: null, slackWebhookUrl: null, subscriptionPlan: 'free' as const, stripeCustomerId: null, stripeSubscriptionId: null, stripeSubscriptionStatus: null, teamsWebhookUrl: null, chatworkApiToken: null, chatworkRoomId: null, createdAt: now });
+      store.tenants.set(id, {
+        id,
+        name,
+        mode: 'lite',
+        industry: null,
+        inboundToken: null,
+        slackWebhookUrl: null,
+        subscriptionPlan: 'free' as const,
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        stripeSubscriptionStatus: null,
+        trialEndsAt: null,
+        teamsWebhookUrl: null,
+        chatworkApiToken: null,
+        chatworkRoomId: null,
+        createdAt: now,
+      });
     }
     // テスト本体が使うテナント ID を返す
     return { tenantA: TENANT_A, tenantB: TENANT_B };

--- a/tests/data/notification-repository.contract.test.ts
+++ b/tests/data/notification-repository.contract.test.ts
@@ -35,7 +35,15 @@ function makeMemoryContext(): NotificationContractContext {
         mode: 'lite',
         industry: null,
         inboundToken: null, // メール取り込み未発行 (テスト用フィクスチャ)
-      slackWebhookUrl: null, subscriptionPlan: 'free' as const, stripeCustomerId: null, stripeSubscriptionId: null, stripeSubscriptionStatus: null, teamsWebhookUrl: null, chatworkApiToken: null, chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
+        slackWebhookUrl: null,
+        subscriptionPlan: 'free' as const,
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        stripeSubscriptionStatus: null,
+        trialEndsAt: null,
+        teamsWebhookUrl: null,
+        chatworkApiToken: null,
+        chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
         createdAt: now,
       });
     }

--- a/tests/data/tenant-repository.memory.test.ts
+++ b/tests/data/tenant-repository.memory.test.ts
@@ -28,7 +28,15 @@ function seed() {
       mode: 'lite',
       industry: null,
       inboundToken: null,
-      slackWebhookUrl: null, subscriptionPlan: 'free' as const, stripeCustomerId: null, stripeSubscriptionId: null, stripeSubscriptionStatus: null, teamsWebhookUrl: null, chatworkApiToken: null, chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
+      slackWebhookUrl: null,
+      subscriptionPlan: 'free' as const,
+      stripeCustomerId: null,
+      stripeSubscriptionId: null,
+      stripeSubscriptionStatus: null,
+      trialEndsAt: null,
+      teamsWebhookUrl: null,
+      chatworkApiToken: null,
+      chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
       createdAt: now,
     });
   }
@@ -95,7 +103,15 @@ describe('TenantRepository.findByInboundToken (memory)', () => {
       mode: 'lite',
       industry: null,
       inboundToken: 'token-a',
-      slackWebhookUrl: null, subscriptionPlan: 'free' as const, stripeCustomerId: null, stripeSubscriptionId: null, stripeSubscriptionStatus: null, teamsWebhookUrl: null, chatworkApiToken: null, chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
+      slackWebhookUrl: null,
+      subscriptionPlan: 'free' as const,
+      stripeCustomerId: null,
+      stripeSubscriptionId: null,
+      stripeSubscriptionStatus: null,
+      trialEndsAt: null,
+      teamsWebhookUrl: null,
+      chatworkApiToken: null,
+      chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
       createdAt: now,
     });
     store.tenants.set(TENANT_B, {
@@ -104,7 +120,15 @@ describe('TenantRepository.findByInboundToken (memory)', () => {
       mode: 'lite',
       industry: null,
       inboundToken: null,
-      slackWebhookUrl: null, subscriptionPlan: 'free' as const, stripeCustomerId: null, stripeSubscriptionId: null, stripeSubscriptionStatus: null, teamsWebhookUrl: null, chatworkApiToken: null, chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
+      slackWebhookUrl: null,
+      subscriptionPlan: 'free' as const,
+      stripeCustomerId: null,
+      stripeSubscriptionId: null,
+      stripeSubscriptionStatus: null,
+      trialEndsAt: null,
+      teamsWebhookUrl: null,
+      chatworkApiToken: null,
+      chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
       createdAt: now,
     });
   });

--- a/tests/data/ticket-repository.contract.test.ts
+++ b/tests/data/ticket-repository.contract.test.ts
@@ -27,7 +27,15 @@ function makeMemoryContext(): ContractContext {
       mode: 'lite',
       industry: null,
       inboundToken: null, // メール取り込み未発行 (テスト用フィクスチャ)
-      slackWebhookUrl: null, subscriptionPlan: 'free' as const, stripeCustomerId: null, stripeSubscriptionId: null, stripeSubscriptionStatus: null, teamsWebhookUrl: null, chatworkApiToken: null, chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
+      slackWebhookUrl: null,
+      subscriptionPlan: 'free' as const,
+      stripeCustomerId: null,
+      stripeSubscriptionId: null,
+      stripeSubscriptionStatus: null,
+      trialEndsAt: null,
+      teamsWebhookUrl: null,
+      chatworkApiToken: null,
+      chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
       createdAt: now,
     });
     // 投入するユーザーのテーブル (id, role, name)
@@ -75,7 +83,15 @@ function makeMemoryContext(): ContractContext {
       mode: 'lite',
       industry: null,
       inboundToken: null, // メール取り込み未発行 (テスト用フィクスチャ)
-      slackWebhookUrl: null, subscriptionPlan: 'free' as const, stripeCustomerId: null, stripeSubscriptionId: null, stripeSubscriptionStatus: null, teamsWebhookUrl: null, chatworkApiToken: null, chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
+      slackWebhookUrl: null,
+      subscriptionPlan: 'free' as const,
+      stripeCustomerId: null,
+      stripeSubscriptionId: null,
+      stripeSubscriptionStatus: null,
+      trialEndsAt: null,
+      teamsWebhookUrl: null,
+      chatworkApiToken: null,
+      chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
       createdAt: now,
     });
     // テナント B 専属の依頼者ユーザーを 1 名作る

--- a/tests/data/ticket-repository.contract.ts
+++ b/tests/data/ticket-repository.contract.ts
@@ -497,6 +497,35 @@ export function runTicketRepositoryContract(
       expect(fresh?.firstRespondedAt?.getTime()).toBe(respondedAt.getTime());
     });
 
+    // 回帰防止: markFirstResponded は既に初回応答済みの行を上書きしないこと (TOCTOU 対策)。
+    // POST /api/tickets/[id]/comments はトランザクション開始前に取得したチケットの
+    // firstRespondedAt スナップショットで「まだ未応答か」を判定するため、ほぼ同時に届いた
+    // 2 件目以降のコメントが古いスナップショットのまま markFirstResponded を呼んでしまいうる。
+    // その場合でも「最初の」応答時刻が後勝ちで上書きされてはならない
+    it('markFirstResponded does not overwrite an already-recorded response time', async () => {
+      const { requester, categoryId } = await ctx.seedBasicFixture();
+      const ticket = await ctx.repos.tickets.create({
+        title: '初回応答済み',
+        body: 'b',
+        priority: 'Medium',
+        creatorId: requester.id,
+        categoryId,
+        tenantId: TENANT_ID,
+      });
+
+      // 1 件目の応答 (これが「最初の応答」として記録されるべき)
+      const firstAt = new Date();
+      await ctx.repos.tickets.markFirstResponded(ticket.id, firstAt, TENANT_ID);
+
+      // 2 件目の応答 (古いスナップショット判定に基づく呼び出しを模した、後から来た呼び出し)
+      const secondAt = new Date(firstAt.getTime() + 60_000);
+      await ctx.repos.tickets.markFirstResponded(ticket.id, secondAt, TENANT_ID);
+
+      // firstRespondedAt は 1 件目の時刻のまま (2 件目で上書きされない)
+      const fresh = await ctx.repos.tickets.findById(ticket.id, TENANT_ID);
+      expect(fresh?.firstRespondedAt?.getTime()).toBe(firstAt.getTime());
+    });
+
     // dashboardStats が他テナントのチケットを集計に含めないこと
     it('dashboardStats scopes aggregates to the given tenant', async () => {
       const { requester: rA, categoryId: catA } = await ctx.seedBasicFixture();

--- a/tests/data/ticket-repository.contract.ts
+++ b/tests/data/ticket-repository.contract.ts
@@ -466,6 +466,7 @@ export function runTicketRepositoryContract(
         { reason: 'cross-tenant attempt', at: new Date() },
         tenantB,
       );
+      await ctx.repos.tickets.markFirstResponded(ticketA.id, new Date(), tenantB);
 
       // A 側の状態は一切変わっていないこと (status=New, priority=Low, assignee=null)
       const fresh = await ctx.repos.tickets.findById(ticketA.id, TENANT_ID);
@@ -473,6 +474,27 @@ export function runTicketRepositoryContract(
       expect(fresh?.priority).toBe('Low');
       expect(fresh?.assigneeId).toBeNull();
       expect(fresh?.escalatedAt).toBeNull();
+      expect(fresh?.firstRespondedAt).toBeNull();
+    });
+
+    // markFirstResponded が同テナントの行には正しく反映されること
+    it('markFirstResponded records the timestamp for a same-tenant ticket', async () => {
+      const { requester, categoryId } = await ctx.seedBasicFixture();
+      const ticket = await ctx.repos.tickets.create({
+        title: '初回応答未対応',
+        body: 'b',
+        priority: 'Medium',
+        creatorId: requester.id,
+        categoryId,
+        tenantId: TENANT_ID,
+      });
+      expect(ticket.firstRespondedAt).toBeNull();
+
+      const respondedAt = new Date();
+      await ctx.repos.tickets.markFirstResponded(ticket.id, respondedAt, TENANT_ID);
+
+      const fresh = await ctx.repos.tickets.findById(ticket.id, TENANT_ID);
+      expect(fresh?.firstRespondedAt?.getTime()).toBe(respondedAt.getTime());
     });
 
     // dashboardStats が他テナントのチケットを集計に含めないこと

--- a/tests/features/accept-invitation.test.ts
+++ b/tests/features/accept-invitation.test.ts
@@ -56,6 +56,7 @@ beforeEach(() => {
       stripeCustomerId: null,
       stripeSubscriptionId: null,
       stripeSubscriptionStatus: null,
+      trialEndsAt: null,
       teamsWebhookUrl: null,
       chatworkApiToken: null,
       chatworkRoomId: null,

--- a/tests/features/assignee-outbound-notify.test.ts
+++ b/tests/features/assignee-outbound-notify.test.ts
@@ -90,6 +90,7 @@ async function seed(slackWebhookUrl: string | null): Promise<{ ticketId: string 
     stripeCustomerId: null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
+    trialEndsAt: null,
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null,

--- a/tests/features/attachments/create-ticket-with-files.test.ts
+++ b/tests/features/attachments/create-ticket-with-files.test.ts
@@ -268,4 +268,19 @@ describe('POST /api/tickets (multipart with attachments)', () => {
     expect(store.tickets.size).toBe(0);
     expect(storage.entries.size).toBe(0);
   });
+
+  // 回帰防止: firstResponseDueAt が配線されておらず常に null のまま起票される不備があった
+  // (品質メトリクス「平均初回応答時間」が常に集計対象 0 件になっていた)
+  it('sets firstResponseDueAt on ticket creation', async () => {
+    const { POST } = await import('@/app/api/tickets/route');
+    const req = buildMultipartRequest({ title: 't', body: 'b', priority: 'High' }, [
+      makeFile('a.jpg', 'image/jpeg', 'jpeg-a'),
+    ]);
+
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+    const ticket = await res.json();
+    // 優先度 High は 4 時間後 (FIRST_RESPONSE_HOURS_BY_PRIORITY.High)
+    expect(ticket.firstResponseDueAt).not.toBeNull();
+  });
 });

--- a/tests/features/attachments/create-ticket-with-files.test.ts
+++ b/tests/features/attachments/create-ticket-with-files.test.ts
@@ -62,6 +62,7 @@ async function seed() {
     stripeCustomerId: null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
+    trialEndsAt: null,
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)

--- a/tests/features/attachments/create-ticket-with-files.test.ts
+++ b/tests/features/attachments/create-ticket-with-files.test.ts
@@ -270,6 +270,41 @@ describe('POST /api/tickets (multipart with attachments)', () => {
     expect(storage.entries.size).toBe(0);
   });
 
+  // 回帰防止: §7.2 Free trial 中のテナントは Free の添付上限 (無制限) がそのまま適用され、
+  // Standard の 1GB 上限に「昇格」して逆に厳しくならないこと (トライアルは恩恵のみを与えるべきで、
+  // Standard 相当への実効プラン昇格が添付上限だけ逆転する回帰を防ぐ)
+  it('does not apply the Standard attachment cap to a Free-trial tenant', async () => {
+    const tenant = store.tenants.get(TENANT)!;
+    // Free プランのまま、トライアル期間中 (30日後まで有効) に設定する
+    store.tenants.set(TENANT, {
+      ...tenant,
+      subscriptionPlan: 'free' as const,
+      trialEndsAt: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000),
+    });
+    // Standard の 1GB 上限ギリギリまで既に積み上げておく (Free の無制限のままなら拒否されない)
+    const ONE_GB = 1024 * 1024 * 1024;
+    await repos.attachments.create({
+      ticketId: 'other-ticket',
+      commentId: null,
+      uploaderId: REQUESTER,
+      tenantId: TENANT,
+      mimeType: 'image/jpeg',
+      size: ONE_GB - 100,
+      originalName: 'existing.jpg',
+      storageKey: `${TENANT}/other-ticket/existing.jpg`,
+      storage: 'local',
+    });
+
+    const { POST } = await import('@/app/api/tickets/route');
+    const req = buildMultipartRequest({ title: 't', body: 'b', priority: 'Medium' }, [
+      makeFile('big.jpg', 'image/jpeg', 'x'.repeat(200)),
+    ]);
+
+    const res = await POST(req);
+    // Free の無制限上限が適用されるため 201 (Standard の 1GB 上限に昇格して拒否されない)
+    expect(res.status).toBe(201);
+  });
+
   // 回帰防止: firstResponseDueAt が配線されておらず常に null のまま起票される不備があった
   // (品質メトリクス「平均初回応答時間」が常に集計対象 0 件になっていた)
   it('sets firstResponseDueAt on ticket creation', async () => {

--- a/tests/features/attachments/post-comment-route.test.ts
+++ b/tests/features/attachments/post-comment-route.test.ts
@@ -313,6 +313,48 @@ describe('POST /api/tickets/[id]/comments', () => {
   });
 
   // ─────────────────────────────────────────────
+  // SLA: 初回応答日時 (firstRespondedAt) の記録 (回帰防止: 以前は書き込み経路が存在せず、
+  // 品質メトリクス「平均初回応答時間」が常に集計対象 0 件になっていた)
+  // ─────────────────────────────────────────────
+
+  // エージェントの最初のコメントで firstRespondedAt が記録される
+  it('records firstRespondedAt on the agent first comment', async () => {
+    const { ticketId } = await seed();
+    mockSession = buildSession(AGENT, 'agent', TENANT);
+    const { POST } = await import('@/app/api/tickets/[id]/comments/route');
+    const res = await POST(buildRequest('対応します', []), makeParams(ticketId));
+    expect(res.status).toBe(201);
+    const ticket = await repos.tickets.findById(ticketId, TENANT);
+    expect(ticket?.firstRespondedAt).not.toBeNull();
+  });
+
+  // 依頼者自身のコメントは「応答」とみなさず firstRespondedAt を記録しない
+  it('does not record firstRespondedAt for a requester comment', async () => {
+    const { ticketId } = await seed();
+    mockSession = buildSession(REQUESTER, 'requester', TENANT);
+    const { POST } = await import('@/app/api/tickets/[id]/comments/route');
+    const res = await POST(buildRequest('追加の情報です', []), makeParams(ticketId));
+    expect(res.status).toBe(201);
+    const ticket = await repos.tickets.findById(ticketId, TENANT);
+    expect(ticket?.firstRespondedAt).toBeNull();
+  });
+
+  // 2 回目以降のエージェントコメントでは firstRespondedAt を上書きしない
+  it('does not overwrite firstRespondedAt on a second agent comment', async () => {
+    const { ticketId } = await seed();
+    mockSession = buildSession(AGENT, 'agent', TENANT);
+    const { POST } = await import('@/app/api/tickets/[id]/comments/route');
+    await POST(buildRequest('1 回目の返信', []), makeParams(ticketId));
+    const firstTicket = await repos.tickets.findById(ticketId, TENANT);
+    const firstRespondedAt = firstTicket?.firstRespondedAt ?? null;
+    expect(firstRespondedAt).not.toBeNull();
+
+    await POST(buildRequest('2 回目の返信', []), makeParams(ticketId));
+    const secondTicket = await repos.tickets.findById(ticketId, TENANT);
+    expect(secondTicket?.firstRespondedAt?.getTime()).toBe(firstRespondedAt?.getTime());
+  });
+
+  // ─────────────────────────────────────────────
   // 通知ルート (誰に通知が飛ぶか) の仕様
   // 旧 addComment Server Action のテストから移植 (PR レビュー指摘 #4 への対応)
   // ─────────────────────────────────────────────

--- a/tests/features/attachments/post-comment-route.test.ts
+++ b/tests/features/attachments/post-comment-route.test.ts
@@ -97,6 +97,7 @@ async function seed() {
       stripeCustomerId: null,
       stripeSubscriptionId: null,
       stripeSubscriptionStatus: null,
+      trialEndsAt: null,
       teamsWebhookUrl: null,
       chatworkApiToken: null,
       chatworkRoomId: null,

--- a/tests/features/attachments/serve-attachment.test.ts
+++ b/tests/features/attachments/serve-attachment.test.ts
@@ -56,7 +56,23 @@ async function seed() {
   const now = new Date();
   // テナント A・B を投入
   for (const t of [TENANT_A, TENANT_B]) {
-    store.tenants.set(t, { id: t, name: t, mode: 'lite', industry: null, inboundToken: null, slackWebhookUrl: null, subscriptionPlan: 'free' as const, stripeCustomerId: null, stripeSubscriptionId: null, stripeSubscriptionStatus: null, teamsWebhookUrl: null, chatworkApiToken: null, chatworkRoomId: null, createdAt: now });
+    store.tenants.set(t, {
+      id: t,
+      name: t,
+      mode: 'lite',
+      industry: null,
+      inboundToken: null,
+      slackWebhookUrl: null,
+      subscriptionPlan: 'free' as const,
+      stripeCustomerId: null,
+      stripeSubscriptionId: null,
+      stripeSubscriptionStatus: null,
+      trialEndsAt: null,
+      teamsWebhookUrl: null,
+      chatworkApiToken: null,
+      chatworkRoomId: null,
+      createdAt: now,
+    });
   }
   // ユーザーを投入する
   const users: Array<[string, 'requester' | 'agent', string]> = [
@@ -205,7 +221,7 @@ describe('GET /api/attachments/[id]', () => {
   });
 
   // 同テナント別ユーザー (requester) → 404 (チケット閲覧権限なし)
-  it('returns 404 when a requester tries to view another user\'s ticket attachment', async () => {
+  it("returns 404 when a requester tries to view another user's ticket attachment", async () => {
     const { attA } = await seed();
     // 同テナント内の別 requester (REQ_A2) が REQ_A のチケットの添付を要求
     mockSession = buildSession(REQ_A2, 'requester', TENANT_A);

--- a/tests/features/create-tenant.test.ts
+++ b/tests/features/create-tenant.test.ts
@@ -161,6 +161,26 @@ describe('createTenant', () => {
     );
   });
 
+  // 回帰防止: サンプルチケットに firstResponseDueAt (初回応答期限) が配線されておらず
+  // 常に null のまま投入される不備があった (品質メトリクス「平均初回応答時間」の集計対象から
+  // サンプルチケットが漏れてしまう)
+  it('サンプルチケットに firstResponseDueAt が設定される', async () => {
+    const createTenant = await loadAction();
+    const result = await createTenant(
+      makeForm({
+        tenantName: '新組織',
+        industry: '',
+        adminName: '管理 太郎',
+        adminEmail: 'sample-admin@example.com',
+        adminPassword: 'password123',
+      }),
+    );
+    // サンプルチケットは全て firstResponseDueAt が設定されている (null のまま放置されない)
+    const sampleTickets = [...store.tickets.values()].filter((t) => t.tenantId === result.tenantId);
+    expect(sampleTickets.length).toBeGreaterThan(0);
+    expect(sampleTickets.every((t) => t.firstResponseDueAt !== null)).toBe(true);
+  });
+
   // admin 以外は拒否されること (RBAC)
   it('admin 以外は拒否される', async () => {
     // 権限を agent に下げる

--- a/tests/features/create-tenant.test.ts
+++ b/tests/features/create-tenant.test.ts
@@ -68,6 +68,7 @@ beforeEach(() => {
     stripeCustomerId: null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
+    trialEndsAt: null,
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
@@ -102,6 +103,29 @@ describe('createTenant', () => {
     const admin = [...store.users.values()].find((u) => u.email === 'newadmin@example.com');
     expect(admin?.role).toBe('admin');
     expect(admin?.tenantId).toBe(result.tenantId);
+  });
+
+  // 回帰防止: §7.2「30日間の Free trial (Standard 相当)」。新規テナントには
+  // 作成時刻からおよそ 30 日後の trialEndsAt が設定されること
+  it('trialEndsAt が作成時刻からおよそ30日後に設定される', async () => {
+    const createTenant = await loadAction();
+    const before = Date.now();
+    const result = await createTenant(
+      makeForm({
+        tenantName: '新組織',
+        industry: '',
+        adminName: '管理 太郎',
+        adminEmail: 'trial-admin@example.com',
+        adminPassword: 'password123',
+      }),
+    );
+    const tenant = store.tenants.get(result.tenantId);
+    expect(tenant?.trialEndsAt).not.toBeNull();
+    const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+    const diff = tenant!.trialEndsAt!.getTime() - before;
+    // 実行時間の揺れを許容しつつ、およそ 30 日後であることを確認する (前後 5 秒の許容誤差)
+    expect(diff).toBeGreaterThan(THIRTY_DAYS_MS - 5000);
+    expect(diff).toBeLessThan(THIRTY_DAYS_MS + 5000);
   });
 
   // 業種テンプレートの「よくある質問」が公開済み FAQ として初期投入されること (Phase 3)

--- a/tests/features/create-ticket-outbound-notify.test.ts
+++ b/tests/features/create-ticket-outbound-notify.test.ts
@@ -70,6 +70,7 @@ async function seedTenant(slackWebhookUrl: string | null) {
     stripeCustomerId: null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
+    trialEndsAt: null,
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null,

--- a/tests/features/delete-line-config.test.ts
+++ b/tests/features/delete-line-config.test.ts
@@ -51,6 +51,7 @@ function seedTenant(plan: SubscriptionPlan) {
     stripeCustomerId: null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
+    trialEndsAt: null,
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null,

--- a/tests/features/delete-sso-config.test.ts
+++ b/tests/features/delete-sso-config.test.ts
@@ -50,6 +50,7 @@ function seedTenant(plan: SubscriptionPlan) {
     stripeCustomerId: null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
+    trialEndsAt: null,
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null,

--- a/tests/features/escalate-ticket-outbound-notify.test.ts
+++ b/tests/features/escalate-ticket-outbound-notify.test.ts
@@ -90,6 +90,7 @@ async function seed(slackWebhookUrl: string | null): Promise<{ ticketId: string 
     stripeCustomerId: null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
+    trialEndsAt: null,
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null,

--- a/tests/features/import-tickets.test.ts
+++ b/tests/features/import-tickets.test.ts
@@ -217,6 +217,18 @@ describe('importTickets', () => {
       expect(ticket?.resolutionDueAt).not.toBeNull(); // 期限日が保存されていることを確認する
     });
 
+    // 回帰防止: firstResponseDueAt が配線されておらず常に null のまま起票される不備があった。
+    // CSV には対応列が無いため、期限日 (resolutionDueAt) の指定有無に関わらず優先度ベースで
+    // 常に自動算出されることを確認する
+    it('firstResponseDueAt が優先度ベースで自動算出される', async () => {
+      const importTickets = await loadAction(); // Action を動的ロードする
+      const csv = `件名\nテスト件名`; // 期限日列を持たない最小 CSV
+      const result = await importTickets(csv);
+      expect(result.imported).toBe(1);
+      const ticket = [...store.tickets.values()][0];
+      expect(ticket?.firstResponseDueAt).not.toBeNull();
+    });
+
     // CSV インジェクション（=数式で始まる件名）はインポート時に加工しない。
     // 対策はエクスポート時 (AuditExportButton.tsx の escapeCSVCell) で行う設計方針のため、
     // DB には生の値が保存される (インポート時に ' を付加すると DB が汚染されるため)。

--- a/tests/features/import-tickets.test.ts
+++ b/tests/features/import-tickets.test.ts
@@ -82,6 +82,7 @@ function seed() {
     stripeCustomerId: null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
+    trialEndsAt: null,
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null,

--- a/tests/features/inbound-email-route.test.ts
+++ b/tests/features/inbound-email-route.test.ts
@@ -102,6 +102,7 @@ function seed() {
     stripeCustomerId: null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
+    trialEndsAt: null,
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
@@ -219,6 +220,36 @@ describe('POST /api/inbound/email', () => {
     expect(store.tickets.size).toBe(0);
   });
 
+  // 回帰防止: §7.2「30日間の Free trial (Standard 相当)」中は、Free プランのままでも
+  // メール取り込みが解禁される (オンボーディングのメール転送体験を課金前でも試せるようにする)
+  it('トライアル期間中の Free プランは起票できる (トライアル昇格)', async () => {
+    const tenant = store.tenants.get(TENANT)!;
+    // Free プラン + 未来の trialEndsAt (トライアル中) に書き換える
+    store.tenants.set(TENANT, {
+      ...tenant,
+      subscriptionPlan: 'free' as const,
+      trialEndsAt: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000),
+    });
+    const { POST } = await import('@/app/api/inbound/email/route');
+    const res = await POST(makeRequest(VALID_EMAIL));
+    expect(res.status).toBe(201);
+    expect(store.tickets.size).toBe(1);
+  });
+
+  // トライアル終了済みなら通常どおり Free プランとして隔離される
+  it('トライアル終了済みの Free プランは隔離される', async () => {
+    const tenant = store.tenants.get(TENANT)!;
+    store.tenants.set(TENANT, {
+      ...tenant,
+      subscriptionPlan: 'free' as const,
+      trialEndsAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    });
+    const { POST } = await import('@/app/api/inbound/email/route');
+    const res = await POST(makeRequest(VALID_EMAIL));
+    expect(res.status).toBe(202);
+    expect(store.tickets.size).toBe(0);
+  });
+
   // テナント外 (未知) の送信者は隔離 = 202 で起票しない
   it('未知の送信者は隔離して 202 を返す', async () => {
     const { POST } = await import('@/app/api/inbound/email/route');
@@ -242,6 +273,7 @@ describe('POST /api/inbound/email', () => {
       stripeCustomerId: null,
       stripeSubscriptionId: null,
       stripeSubscriptionStatus: null,
+      trialEndsAt: null,
       teamsWebhookUrl: null,
       chatworkApiToken: null,
       chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)

--- a/tests/features/inbound-email-route.test.ts
+++ b/tests/features/inbound-email-route.test.ts
@@ -173,6 +173,8 @@ describe('POST /api/inbound/email', () => {
     expect(ticket?.title).toBe('プリンターが動きません');
     expect(ticket?.creatorId).toBe(MEMBER_ID);
     expect(ticket?.tenantId).toBe(TENANT);
+    // 回帰防止: firstResponseDueAt が配線されておらず常に null のまま起票される不備があった
+    expect(ticket?.firstResponseDueAt).not.toBeNull();
   });
 
   // シークレット未設定 (env なし) なら fail-closed で 500

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -207,6 +207,8 @@ describe('POST /api/inbound/line', () => {
     const ticket = Array.from(store.tickets.values())[0];
     // 未連携なので起票者はプロキシ担当者
     expect(ticket.creatorId).toBe(AGENT_ID);
+    // 回帰防止: firstResponseDueAt が配線されておらず常に null のまま起票される不備があった
+    expect(ticket.firstResponseDueAt).not.toBeNull();
   });
 
   // 連携済みユーザーのメッセージは本人を起票者にする (自己解決 UI 開通)

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -81,6 +81,7 @@ function seed() {
     stripeCustomerId: null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
+    trialEndsAt: null,
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null,

--- a/tests/features/link-line-account.test.ts
+++ b/tests/features/link-line-account.test.ts
@@ -52,6 +52,7 @@ function seed(plan: SubscriptionPlan) {
     stripeCustomerId: null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
+    trialEndsAt: null,
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null,
@@ -80,9 +81,8 @@ describe('generateLineLinkCode_action', () => {
   // LINE 連携は Pro / Enterprise プランのみ (§6.1 料金プラン)。Free では拒否される
   it('Free プランでは拒否される', async () => {
     seed('free');
-    const { generateLineLinkCode_action } = await import(
-      '@/features/settings/actions/link-line-account'
-    );
+    const { generateLineLinkCode_action } =
+      await import('@/features/settings/actions/link-line-account');
     await expect(generateLineLinkCode_action()).rejects.toThrow(
       'LINE 連携は Pro / Enterprise プランでご利用いただけます。',
     );
@@ -93,9 +93,8 @@ describe('generateLineLinkCode_action', () => {
   // Standard プランでも拒否される (Standard は Lite フル + メール取り込みまで)
   it('Standard プランでは拒否される', async () => {
     seed('standard');
-    const { generateLineLinkCode_action } = await import(
-      '@/features/settings/actions/link-line-account'
-    );
+    const { generateLineLinkCode_action } =
+      await import('@/features/settings/actions/link-line-account');
     await expect(generateLineLinkCode_action()).rejects.toThrow(
       'LINE 連携は Pro / Enterprise プランでご利用いただけます。',
     );
@@ -104,9 +103,8 @@ describe('generateLineLinkCode_action', () => {
   // Pro プランならコードが発行される
   it('Pro プランでは発行に成功する', async () => {
     seed('pro');
-    const { generateLineLinkCode_action } = await import(
-      '@/features/settings/actions/link-line-account'
-    );
+    const { generateLineLinkCode_action } =
+      await import('@/features/settings/actions/link-line-account');
     const result = await generateLineLinkCode_action();
     // 生コードが返される
     expect(result.code.length).toBeGreaterThan(0);
@@ -117,9 +115,8 @@ describe('generateLineLinkCode_action', () => {
   // Enterprise プランでも発行に成功する
   it('Enterprise プランでは発行に成功する', async () => {
     seed('enterprise');
-    const { generateLineLinkCode_action } = await import(
-      '@/features/settings/actions/link-line-account'
-    );
+    const { generateLineLinkCode_action } =
+      await import('@/features/settings/actions/link-line-account');
     const result = await generateLineLinkCode_action();
     expect(result.code.length).toBeGreaterThan(0);
   });

--- a/tests/features/request-magic-link.test.ts
+++ b/tests/features/request-magic-link.test.ts
@@ -24,7 +24,12 @@ vi.mock('@/data', () => ({
 
 // EmailSender ファクトリを差し替え。send は既定で sentMessages に記録するだけだが、
 // テストから throw に差し替えたいケースのために stub にしておく
-let sendImpl: (message: { to: string; subject: string; html: string; text: string }) => Promise<void> = async (message) => {
+let sendImpl: (message: {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+}) => Promise<void> = async (message) => {
   sentMessages.push(message);
 };
 // ファクトリ自体が throw する設定エラーをシミュレートできるよう、フラグ経由で挙動を切替
@@ -66,7 +71,15 @@ beforeEach(() => {
     mode: 'lite',
     industry: null,
     inboundToken: null, // メール取り込み未発行 (テスト用フィクスチャ)
-      slackWebhookUrl: null, subscriptionPlan: 'free' as const, stripeCustomerId: null, stripeSubscriptionId: null, stripeSubscriptionStatus: null, teamsWebhookUrl: null, chatworkApiToken: null, chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
+    slackWebhookUrl: null,
+    subscriptionPlan: 'free' as const,
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+    stripeSubscriptionStatus: null,
+    trialEndsAt: null,
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
     createdAt: new Date(),
   });
 });
@@ -153,9 +166,7 @@ describe('requestMagicLink', () => {
   // 不正なメール形式は例外で弾かれること
   it('メール形式が不正なら例外を投げる', async () => {
     const requestMagicLink = await loadAction();
-    await expect(requestMagicLink({ email: 'not-an-email' })).rejects.toThrow(
-      /メールアドレス/,
-    );
+    await expect(requestMagicLink({ email: 'not-an-email' })).rejects.toThrow(/メールアドレス/);
   });
 
   // 本番で NEXTAUTH_URL が未設定なら、リンクが壊れるのを防ぐため起動時エラーにする
@@ -164,9 +175,7 @@ describe('requestMagicLink', () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('NEXTAUTH_URL', '');
     const requestMagicLink = await loadAction();
-    await expect(requestMagicLink({ email: 'agent1@example.com' })).rejects.toThrow(
-      /NEXTAUTH_URL/,
-    );
+    await expect(requestMagicLink({ email: 'agent1@example.com' })).rejects.toThrow(/NEXTAUTH_URL/);
   });
 
   // 空白だけの NEXTAUTH_URL は未指定と同じく扱う (production ならエラー)
@@ -174,9 +183,7 @@ describe('requestMagicLink', () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('NEXTAUTH_URL', '   ');
     const requestMagicLink = await loadAction();
-    await expect(requestMagicLink({ email: 'agent1@example.com' })).rejects.toThrow(
-      /NEXTAUTH_URL/,
-    );
+    await expect(requestMagicLink({ email: 'agent1@example.com' })).rejects.toThrow(/NEXTAUTH_URL/);
   });
 
   // NEXTAUTH_URL が壊れた形式 (scheme なし / 不正な URL) なら明示エラー
@@ -189,9 +196,7 @@ describe('requestMagicLink', () => {
     vi.stubEnv('NODE_ENV', 'test');
     vi.stubEnv('NEXTAUTH_URL', badUrl);
     const requestMagicLink = await loadAction();
-    await expect(requestMagicLink({ email: 'agent1@example.com' })).rejects.toThrow(
-      /NEXTAUTH_URL/,
-    );
+    await expect(requestMagicLink({ email: 'agent1@example.com' })).rejects.toThrow(/NEXTAUTH_URL/);
   });
 
   // 設定不備 (EMAIL_DRIVER 不正など) は列挙対策のマスクを越えて呼び出し側まで伝わる。
@@ -213,9 +218,7 @@ describe('requestMagicLink', () => {
       throw new Error('production では EMAIL_DRIVER=smtp の明示設定が必要です');
     };
     const requestMagicLink = await loadAction();
-    await expect(requestMagicLink({ email: 'a@example.com' })).rejects.toThrow(
-      /EMAIL_DRIVER/,
-    );
+    await expect(requestMagicLink({ email: 'a@example.com' })).rejects.toThrow(/EMAIL_DRIVER/);
     // 設定エラーは未登録メールでも同様に表面化する (列挙耐性が壊れないこと)
     await expect(requestMagicLink({ email: 'unknown@example.com' })).rejects.toThrow(
       /EMAIL_DRIVER/,

--- a/tests/features/stripe-webhook-route.test.ts
+++ b/tests/features/stripe-webhook-route.test.ts
@@ -59,6 +59,7 @@ function seedTenant(mode: 'lite' | 'pro', plan: 'free' | 'standard' | 'pro' | 'e
     stripeCustomerId: 'cus_1',
     stripeSubscriptionId: 'sub_1',
     stripeSubscriptionStatus: 'active',
+    trialEndsAt: null,
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null,

--- a/tests/features/update-line-config.test.ts
+++ b/tests/features/update-line-config.test.ts
@@ -65,6 +65,7 @@ function seedTenant(plan: SubscriptionPlan) {
     stripeCustomerId: null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
+    trialEndsAt: null,
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null,

--- a/tests/features/update-tenant-mode.test.ts
+++ b/tests/features/update-tenant-mode.test.ts
@@ -58,6 +58,7 @@ function seedTenant(plan: SubscriptionPlan) {
     stripeCustomerId: null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
+    trialEndsAt: null,
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null,

--- a/tests/features/update-ticket.test.ts
+++ b/tests/features/update-ticket.test.ts
@@ -76,6 +76,7 @@ async function seed() {
     stripeCustomerId: null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
+    trialEndsAt: null,
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)
@@ -533,6 +534,7 @@ describe('updateTicketAssignee (provider-agnostic)', () => {
       stripeCustomerId: null,
       stripeSubscriptionId: null,
       stripeSubscriptionStatus: null,
+      trialEndsAt: null,
       teamsWebhookUrl: null,
       chatworkApiToken: null,
       chatworkRoomId: null, // Slack 通知未設定 (テスト用フィクスチャ)

--- a/tests/plan-guard.test.ts
+++ b/tests/plan-guard.test.ts
@@ -6,6 +6,7 @@ import {
   USER_LIMIT,
   MONTHLY_TICKET_LIMIT,
   ATTACHMENT_TOTAL_SIZE_LIMIT_BYTES,
+  FREE_TRIAL_DURATION_MS,
   isEmailInboundAllowed,
   isAuditLogAllowed,
   isLineIntegrationAllowed,
@@ -15,6 +16,7 @@ import {
   getUserLimit,
   getMonthlyTicketLimit,
   getAttachmentSizeLimit,
+  resolveEffectivePlan,
 } from '../src/lib/plan-guard';
 // プラン型 (網羅性の担保に使う)
 import type { SubscriptionPlan } from '../src/domain/types';
@@ -124,5 +126,46 @@ describe('plan-guard: 上限到達判定と表示ヘルパー', () => {
     expect(getMonthlyTicketLimit('enterprise')).toBe(-1); // 無制限は -1
     expect(getAttachmentSizeLimit('standard')).toBe(1024 * 1024 * 1024); // 有限はそのまま
     expect(getAttachmentSizeLimit('free')).toBe(-1); // 無制限は -1
+  });
+});
+
+// §7.2「30日間の Free trial (Standard 相当)」の実効プラン解決ロジック
+describe('plan-guard: resolveEffectivePlan (Free trial)', () => {
+  // 基準時刻を固定する (時差ぶれを避ける)
+  const now = new Date('2026-04-17T00:00:00Z');
+  const future = new Date(now.getTime() + 10 * 24 * 60 * 60 * 1000); // 10 日後 (トライアル中)
+  const past = new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000); // 1 日前 (トライアル終了済み)
+
+  // 30 日 = FREE_TRIAL_DURATION_MS であることを固定する (create-tenant.ts が使う定数)
+  it('FREE_TRIAL_DURATION_MS は 30 日 (ミリ秒)', () => {
+    expect(FREE_TRIAL_DURATION_MS).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  // Free プランでトライアル期間中なら Standard に昇格する
+  it('Free プランでトライアル期間中は Standard に昇格する', () => {
+    expect(resolveEffectivePlan('free', future, now)).toBe('standard');
+  });
+
+  // トライアル終了済みなら free のまま
+  it('トライアルが終了済みなら free のまま', () => {
+    expect(resolveEffectivePlan('free', past, now)).toBe('free');
+  });
+
+  // trialEndsAt が未設定 (null) なら free のまま
+  it('trialEndsAt が null なら free のまま', () => {
+    expect(resolveEffectivePlan('free', null, now)).toBe('free');
+  });
+
+  // Free 以外のプランはトライアル判定の対象外 (課金済みプランをそのまま返す)。
+  // trialEndsAt が (Stripe 解約後の名残り等で) 未来の値のまま残っていても昇格しない
+  it('Free 以外のプランはそのまま返す (トライアル判定の対象外)', () => {
+    expect(resolveEffectivePlan('standard', future, now)).toBe('standard');
+    expect(resolveEffectivePlan('pro', future, now)).toBe('pro');
+    expect(resolveEffectivePlan('enterprise', future, now)).toBe('enterprise');
+  });
+
+  // 境界値: trialEndsAt がちょうど now と同時刻なら「終了済み」扱い (未来でなければ昇格しない)
+  it('trialEndsAt が now と同時刻なら終了済み扱い', () => {
+    expect(resolveEffectivePlan('free', now, now)).toBe('free');
   });
 });

--- a/tests/sla.test.ts
+++ b/tests/sla.test.ts
@@ -107,4 +107,29 @@ describe('getSlaState', () => {
   it('returns "ok" when deadline is more than 24 hours away and not resolved', () => {
     expect(getSlaState(future, null)).toBe('ok');
   });
+
+  // 回帰防止: 初回応答期限のように窓が短い SLA では、既定の 24 時間閾値をそのまま
+  // 使うと起票直後から常に warning になってしまう。warningThresholdMs を明示的に
+  // 渡すことで、窓の長さに応じた適切な閾値で判定できること
+  describe('warningThresholdMs (第3引数)', () => {
+    // High 優先度の初回応答期限 (4 時間窓) を想定: 窓の 25% = 1 時間
+    const highFirstResponseThresholdMs = 1 * 60 * 60 * 1000;
+
+    // 残り 3 時間 (閾値 1 時間より外) は "ok" (既定の 24 時間閾値なら誤って warning になる)
+    it('returns "ok" when remaining time exceeds the given threshold even if within 24 hours', () => {
+      const in3Hours = new Date(now.getTime() + 3 * 60 * 60 * 1000);
+      expect(getSlaState(in3Hours, null, highFirstResponseThresholdMs)).toBe('ok');
+    });
+
+    // 残り 30 分 (閾値 1 時間未満) は "warning"
+    it('returns "warning" when remaining time is within the given threshold', () => {
+      const in30Min = new Date(now.getTime() + 30 * 60 * 1000);
+      expect(getSlaState(in30Min, null, highFirstResponseThresholdMs)).toBe('warning');
+    });
+
+    // 第3引数を省略した場合は従来どおり既定の 24 時間閾値が使われる (後方互換)
+    it('defaults to the 24-hour threshold when warningThresholdMs is omitted', () => {
+      expect(getSlaState(soon, null)).toBe('warning');
+    });
+  });
 });

--- a/tests/sla.test.ts
+++ b/tests/sla.test.ts
@@ -1,9 +1,11 @@
 // Vitest のテスト DSL
 import { describe, expect, it } from 'vitest';
-// SLA 計算/状態判定/優先度ごとの解決時間テーブル
+// SLA 計算/状態判定/優先度ごとの解決時間・初回応答時間テーブル
 import {
+  calculateFirstResponseDueAt,
   calculateResolutionDueAt,
   getSlaState,
+  FIRST_RESPONSE_HOURS_BY_PRIORITY,
   SLA_RESOLUTION_HOURS_BY_PRIORITY,
 } from '../src/lib/sla';
 
@@ -35,6 +37,38 @@ describe('calculateResolutionDueAt', () => {
     expect(SLA_RESOLUTION_HOURS_BY_PRIORITY.High).toBe(24);
     expect(SLA_RESOLUTION_HOURS_BY_PRIORITY.Medium).toBe(72);
     expect(SLA_RESOLUTION_HOURS_BY_PRIORITY.Low).toBe(168);
+  });
+});
+
+// 初回応答期限算出関数のテスト (回帰防止: firstResponseDueAt が常に null のまま
+// 起票される不備が過去にあったため、計算関数自体の正しさを固定する)
+describe('calculateFirstResponseDueAt', () => {
+  // 起点時刻 (固定して時差ぶれを避ける)
+  const base = new Date('2026-04-17T00:00:00Z');
+
+  // High は 4 時間後を返す
+  it('adds 4 hours for High priority', () => {
+    const due = calculateFirstResponseDueAt('High', base);
+    expect(due.getTime() - base.getTime()).toBe(4 * 60 * 60 * 1000);
+  });
+
+  // Medium は 8 時間後を返す
+  it('adds 8 hours for Medium priority', () => {
+    const due = calculateFirstResponseDueAt('Medium', base);
+    expect(due.getTime() - base.getTime()).toBe(8 * 60 * 60 * 1000);
+  });
+
+  // Low は 24 時間後を返す
+  it('adds 24 hours for Low priority', () => {
+    const due = calculateFirstResponseDueAt('Low', base);
+    expect(due.getTime() - base.getTime()).toBe(24 * 60 * 60 * 1000);
+  });
+
+  // 公開テーブルの値が期待通りに揃っていること
+  it('exposes the hours table for each priority', () => {
+    expect(FIRST_RESPONSE_HOURS_BY_PRIORITY.High).toBe(4);
+    expect(FIRST_RESPONSE_HOURS_BY_PRIORITY.Medium).toBe(8);
+    expect(FIRST_RESPONSE_HOURS_BY_PRIORITY.Low).toBe(24);
   });
 });
 


### PR DESCRIPTION
## Summary

`docs/smb-dx-pivot-plan.md` のギャップ監査 (5巡目) で見つかった未実装項目のうち、検証可能で確度の高い上位2件を実装。

1. **fix(tickets): 初回応答期限(firstResponseDueAt)が常にnullのまま起票される不備を修正**
   - `docs/smb-dx-pivot-plan.md` §2 ギャップ分析表「SLA: 初回応答期限・解決期限を別管理...(Pro モードで詳細SLA解禁)」。
   - Port/Adapter/ドメイン型のすべての層に `firstResponseDueAt` が配線済みだったにもかかわらず、Web フォーム・CSV インポート・メール取り込み・LINE 取り込みのいずれの起票経路もこの値を渡しておらず常に null 確定だった。
   - `firstRespondedAt` (実際の初回応答日時) を書き込む経路もどこにも存在せず、ダッシュボードの品質メトリクス「平均初回応答時間」が常に集計対象 0 件になっていた。
   - `src/lib/sla.ts` に `calculateFirstResponseDueAt` / `FIRST_RESPONSE_HOURS_BY_PRIORITY` を追加し、4 つの起票経路すべてで優先度ベースに自動算出して渡すようにした。
   - `TicketRepository` port に `markFirstResponded` を追加 (両アダプタ実装)。`POST /api/tickets/[id]/comments` で、エージェントの最初のコメント時に 1 度だけ記録するようにした。
   - チケット詳細ページに Pro モード限定で「初回応答期限」バッジを追加 (Lite は計画書方針どおり「期限日」1 項目に統合したまま維持)。

2. **feat(billing): 30日間のFree trial(Standard相当)を実装**
   - `docs/smb-dx-pivot-plan.md` §7.2「30日間の Free trial（Standard 相当）」が未実装で、新規テナントが Free プランのまま作成されていた。§7.1「30分で運用開始」オンボーディングの目玉体験 (メール転送を試す) は Standard 以上限定のため、課金前の新規テナントでは体験自体を試せないという実害があった。
   - `Tenant.trialEndsAt` (nullable) を追加。テナント作成時に作成時刻+30日を設定する。
   - `plan-guard.ts` に `resolveEffectivePlan(subscriptionPlan, trialEndsAt, now)` を追加 (Free かつトライアル期間中なら Standard 相当に昇格させる純粋関数)。SSO/LINE 連携など Standard を超える機能はトライアルで昇格しない。
   - `resolveTenantPlan` / `checkSeatAvailability` をこの関数経由にし、メール取り込み Webhook のプランゲート・月間上限チェックも実効プランを使うよう修正した。
   - 設定画面の課金セクションにトライアル残り日数のバナーを追加。

3件目・5件目の発見 (監査ログの対象範囲拡大、公開セルフサインアップの要否) は影響が大きくスコープ判断が必要なため、本バッチでは見送り、次回以降にユーザー確認の上で着手する。

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (576 passed)
- [x] `npm run build`
- [x] `npm run db:generate` (Tenant.trialEndsAt 追加を反映)
- [ ] CI (lint / typecheck / unit / Prisma契約テスト / Playwright E2E) がグリーンであることを確認

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015a7mk7TDJdiL6MsDifaoYF


---
_Generated by [Claude Code](https://claude.ai/code/session_015a7mk7TDJdiL6MsDifaoYF)_