### PR TITLE
メール転送先表示・Freeプランのロゴ表示・インボイス対応を実装

### DIFF
--- a/e2e/tenant-create.spec.ts
+++ b/e2e/tenant-create.spec.ts
@@ -75,6 +75,22 @@ test.describe('テナント作成フロー', () => {
     await newPage.goto('/tickets');
     await expect(newPage.getByText('VPN に接続できない')).toHaveCount(0);
 
+    // 回帰防止 (監査で発見): 新規テナントは §7.2 Free trial 中 (Standard 相当) のため、
+    // メール取り込みセクションが設定画面に表示されること (トライアル中はメール取り込みが
+    // 解禁される)。また Free trial 中は「ロゴ表示」バッジも非表示になること (§6.1)
+    await newPage.goto('/settings');
+    await expect(newPage.getByRole('heading', { name: 'メール取り込み' })).toBeVisible();
+    await expect(newPage.getByText('Powered by HelpDesk Hub')).toHaveCount(0);
+
+    // トライアルが終了した (= 契約プランどおり Free) 状態を模し、設定画面を再読み込みすると
+    // 「ロゴ表示」バッジが表示されること (§6.1 料金プラン「Free: ロゴ表示」)
+    await prisma.tenant.updateMany({
+      where: { name: NEW_TENANT_NAME },
+      data: { trialEndsAt: null },
+    });
+    await newPage.goto('/settings');
+    await expect(newPage.getByText('Powered by HelpDesk Hub')).toBeVisible();
+
     // 後始末
     await newContext.close();
   });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,19 @@ import nextCoreWebVitals from 'eslint-config-next/core-web-vitals';
 // Next.js + TypeScript 用の ESLint ルール集
 import nextTypescript from 'eslint-config-next/typescript';
 
+// Prisma の生成物 (@/generated/prisma 配下) への直接 import を禁止するパターン。
+// ESLint 9 のフラットコンフィグは、同じファイルに複数の設定ブロックがマッチしても
+// 同一ルールキー (ここでは no-restricted-imports) は後勝ち (深いマージではなく丸ごと置換) になる。
+// そのため、下の「src 全体向けブロック」とは別に「tenant-cache.ts / tenant-plan.ts 向けブロック」でも
+// 同じ no-restricted-imports を設定すると、後者がこのパターンを黙って消してしまう。
+// 定数化して両方のブロックの patterns 配列に含めることで、上書きによる規約の骨抜けを防ぐ。
+const PRISMA_GENERATED_IMPORT_PATTERN = {
+  // Prisma の生成物 (@/generated/prisma 配下) への直接 import を禁止対象にする
+  group: ['@/generated/prisma', '@/generated/prisma/*'],
+  // 違反したときに開発者へ表示するメッセージ (代わりに使うべき場所を案内)
+  message: 'Prisma 生成物の直接 import は禁止。enum/型は正準である @/domain/types を使うこと。',
+};
+
 // ESLint 9 のフラットコンフィグ (配列で複数のルール塊を結合する書き方)
 const config = [
   {
@@ -38,15 +51,8 @@ const config = [
       'no-restricted-imports': [
         'error',
         {
-          patterns: [
-            {
-              // Prisma の生成物 (@/generated/prisma 配下) への直接 import を禁止対象にする
-              group: ['@/generated/prisma', '@/generated/prisma/*'],
-              // 違反したときに開発者へ表示するメッセージ (代わりに使うべき場所を案内)
-              message:
-                'Prisma 生成物の直接 import は禁止。enum/型は正準である @/domain/types を使うこと。',
-            },
-          ],
+          // 共有定数を使う (下の tenant-cache.ts / tenant-plan.ts 向けブロックと同じ制限を維持するため)
+          patterns: [PRISMA_GENERATED_IMPORT_PATTERN],
         },
       ],
     },
@@ -62,8 +68,13 @@ const config = [
         'error',
         {
           patterns: [
+            // no-restricted-imports は同一ファイルに複数ブロックがマッチしても後勝ち (丸ごと置換) の
+            // ため、上の src 全体向けブロックの Prisma 生成物禁止をここでも明示的に含めて維持する
+            PRISMA_GENERATED_IMPORT_PATTERN,
             {
+              // このファイルは @/lib/auth (next-auth) に依存してはいけない (下記コメント参照)
               group: ['@/lib/auth'],
+              // 違反したときに開発者へ表示するメッセージ (理由を明記)
               message:
                 'このファイルは @/lib/auth (next-auth) に依存できない。importOriginal() で部分モックする既存テストが next-auth 内部依存の解決に失敗して壊れるため (src/lib/tenant-cache.ts のコメント参照)。',
             },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,11 +8,11 @@ const config = [
   {
     // Lint 対象から除外するパス (生成物・依存・成果物)
     ignores: [
-      '.next/**',              // Next.js のビルド出力
-      'node_modules/**',       // npm の依存パッケージ
-      'src/generated/**',      // Prisma の生成物
-      'playwright-report/**',  // Playwright のレポート
-      'test-results/**',       // E2E のスクリーンショット等
+      '.next/**', // Next.js のビルド出力
+      'node_modules/**', // npm の依存パッケージ
+      'src/generated/**', // Prisma の生成物
+      'playwright-report/**', // Playwright のレポート
+      'test-results/**', // E2E のスクリーンショット等
     ],
   },
   // Next 推奨ルールを展開してマージ
@@ -29,8 +29,8 @@ const config = [
       '@typescript-eslint/no-unused-vars': [
         'warn',
         {
-          argsIgnorePattern: '^_',       // 関数引数の _ プレフィックスを無視
-          varsIgnorePattern: '^_',       // 変数宣言の _ プレフィックスを無視
+          argsIgnorePattern: '^_', // 関数引数の _ プレフィックスを無視
+          varsIgnorePattern: '^_', // 変数宣言の _ プレフィックスを無視
           destructuredArrayIgnorePattern: '^_', // 分割代入の _ プレフィックスを無視
         },
       ],
@@ -43,7 +43,29 @@ const config = [
               // Prisma の生成物 (@/generated/prisma 配下) への直接 import を禁止対象にする
               group: ['@/generated/prisma', '@/generated/prisma/*'],
               // 違反したときに開発者へ表示するメッセージ (代わりに使うべき場所を案内)
-              message: 'Prisma 生成物の直接 import は禁止。enum/型は正準である @/domain/types を使うこと。',
+              message:
+                'Prisma 生成物の直接 import は禁止。enum/型は正準である @/domain/types を使うこと。',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // src/lib/tenant-cache.ts と src/lib/tenant-plan.ts は @/lib/auth (next-auth) に依存しては
+    // いけない。依存すると @/lib/tenant-plan を importOriginal() で部分モックする既存テスト
+    // (tests/features/inbound-line-route.test.ts 等) が next-auth 内部依存の解決に失敗して壊れる
+    // (回帰防止: コメントだけでなく lint でも機械的に検知できるようにする)
+    files: ['src/lib/tenant-cache.ts', 'src/lib/tenant-plan.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@/lib/auth'],
+              message:
+                'このファイルは @/lib/auth (next-auth) に依存できない。importOriginal() で部分モックする既存テストが next-auth 内部依存の解決に失敗して壊れるため (src/lib/tenant-cache.ts のコメント参照)。',
             },
           ],
         },

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -8,6 +8,9 @@ import { Sidebar } from '@/components/layout/Sidebar';
 import { MobileNavProvider } from '@/components/layout/MobileNavProvider';
 // 現在テナントの動作モード(lite | pro)を取得するヘルパー
 import { getCurrentTenantMode } from '@/lib/tenant';
+// §6.1 料金プラン「Free: ロゴ表示」の判定用。トライアル中の実効プランを返す
+// (Free trial 中は Standard 相当のためロゴを表示しない)
+import { resolveTenantPlan } from '@/lib/tenant-plan';
 
 // (app) Route Group の共通レイアウト (認証後の画面骨格)
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
@@ -18,6 +21,9 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   // テナントの動作モード (lite | pro) を取得し、メニュー出し分けに使う
   // (tenantId を渡して二重 session 読み込みを回避。未ログイン時は既定 lite)
   const mode = await getCurrentTenantMode(session?.user?.tenantId);
+  // §6.1 料金プラン表「Free: ロゴ表示」。実効プラン (トライアル昇格を含む) が free の
+  // テナントにだけ「Powered by」表記を出す (Standard 以上・トライアル中は非表示)
+  const plan = session?.user?.tenantId ? await resolveTenantPlan(session.user.tenantId) : 'free';
 
   return (
     // モバイルでのサイドバー開閉状態を Header (トグルボタン) と Sidebar (ドロワー本体) で共有する
@@ -33,6 +39,12 @@ export default async function AppLayout({ children }: { children: React.ReactNod
           <Header />
           {/* 各ページの内容 (縦スクロール可) ─ モバイルは余白を控えめにする */}
           <main className="flex-1 overflow-y-auto p-4 sm:p-6 md:p-8">{children}</main>
+          {/* §6.1 料金プラン「Free: ロゴ表示」。Free プラン (トライアル中を除く) のテナントにのみ表示する */}
+          {plan === 'free' && (
+            <footer className="shrink-0 border-t border-slate-100 bg-white px-4 py-1.5 text-center text-xs text-slate-400">
+              Powered by HelpDesk Hub
+            </footer>
+          )}
         </div>
       </div>
     </MobileNavProvider>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -22,14 +22,22 @@ import { SsoConfigSection } from '@/features/settings/components/SsoConfigSectio
 import { LineConfigSection } from '@/features/settings/components/LineConfigSection';
 // テナント情報取得 (slackWebhookUrl / 拠点一覧 / プラン情報の初期値を渡すため)
 import { repos } from '@/data';
-// プランゲート: Enterprise のみ SSO、Pro/Enterprise のみ LINE 連携を表示する。
-// resolveEffectivePlan は §7.2 Free trial 中の実効プラン (Standard 相当) を解決する
-// 唯一の判定ロジック (SSOT)。トライアル中かどうかの判定をここで再実装しない
-import { isLineIntegrationAllowed, isSsoAllowed, resolveEffectivePlan } from '@/lib/plan-guard';
+// プランゲート: Enterprise のみ SSO、Pro/Enterprise のみ LINE 連携、Standard 以上のみ
+// メール取り込みを表示する。resolveEffectivePlan は §7.2 Free trial 中の実効プラン
+// (Standard 相当) を解決する唯一の判定ロジック (SSOT)。トライアル中かどうかの判定を
+// ここで再実装しない
+import {
+  isEmailInboundAllowed,
+  isLineIntegrationAllowed,
+  isSsoAllowed,
+  resolveEffectivePlan,
+} from '@/lib/plan-guard';
 // SSO の SP エンドポイント URL を組み立てるヘルパー
 import { buildSpUrls } from '@/lib/saml';
 // アプリの公開ベース URL を解決するヘルパー (SP URL の組み立てに使う)
 import { resolveAppBaseUrl } from '@/lib/app-url';
+// メール取り込み用の転送先アドレスを組み立てるヘルパー (取り込みトークン + 配信ドメイン)
+import { buildInboundAddress } from '@/lib/inbound-email';
 
 // /settings : テナント設定ページ (現状は Lite/Pro モードの切替のみ。管理者専用)
 export default async function SettingsPage() {
@@ -97,6 +105,18 @@ export default async function SettingsPage() {
   // Webhook 受信 URL (LINE Developers コンソールに登録する値)
   const lineWebhookUrl = `${resolveAppBaseUrl()}/api/inbound/line`;
 
+  // §7.1 オンボーディング「専用のメール転送先を表示する」(Standard 以上、Free trial 中も含む)。
+  // ダッシュボードの「はじめかた」案内・新規テナントのサンプルチケット本文は、この画面に転送先が
+  // 表示されている前提の文言になっているため、ここで実際に表示する (回帰防止: 監査で発見された
+  // 「案内文言はあるのに表示箇所が存在しない」不整合)
+  const emailInboundAllowed = isEmailInboundAllowed(effectivePlan);
+  // 配信ドメイン (INBOUND_EMAIL_DOMAIN) が未設定の環境では組み立てられないため null のままにする
+  const inboundEmailDomain = process.env.INBOUND_EMAIL_DOMAIN?.trim() || null;
+  const inboundEmailAddress =
+    tenant?.inboundToken && inboundEmailDomain
+      ? buildInboundAddress(tenant.inboundToken, inboundEmailDomain)
+      : null;
+
   return (
     <div className="mx-auto max-w-2xl space-y-6">
       {/* ヘッダー: タイトル + 説明文 */}
@@ -135,6 +155,42 @@ export default async function SettingsPage() {
         {/* 招待リンク発行フォーム本体 */}
         <InviteForm />
       </section>
+
+      {/* メール取り込みカード (Standard 以上。Free trial 中も実効プランで許可される)。
+          §7.1 オンボーディング手順4「専用のメール転送先を表示する」に対応する */}
+      {emailInboundAllowed && (
+        <section className="space-y-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+          <div>
+            {/* セクション見出し */}
+            <h2 className="text-base font-semibold text-slate-900">メール取り込み</h2>
+            {/* 説明: 下記アドレスへ転送するとチケット化される旨を伝える */}
+            <p className="mt-1 text-sm text-slate-500">
+              今まで使っているメールアドレス宛の問い合わせを、下記の専用アドレスへ自動転送すると
+              自動でチケットが作成されます。Gmail・Outlook の自動転送設定の手順は
+              <Link
+                href="/help/email-integration"
+                className="text-teal-700 underline underline-offset-2 hover:text-teal-800"
+              >
+                ヘルプページ
+              </Link>
+              をご覧ください。
+            </p>
+          </div>
+          {inboundEmailAddress ? (
+            // 転送先アドレス (コピーしやすいよう等幅フォントで表示。LineConfigSection の
+            // Webhook URL 表示と同じスタイルに揃える)
+            <p className="rounded bg-slate-50 px-2 py-1 font-mono text-xs break-all text-slate-700 ring-1 ring-slate-200">
+              {inboundEmailAddress}
+            </p>
+          ) : (
+            // INBOUND_EMAIL_DOMAIN が未設定の環境向けの案内 (運用者向け。秘密情報は含まない)
+            <p className="rounded-lg bg-amber-50 px-3 py-2.5 text-sm text-amber-800 ring-1 ring-amber-200">
+              メール取り込み用のドメインが未設定のため、転送先アドレスを表示できません。
+              運用者に環境変数 (INBOUND_EMAIL_DOMAIN) の設定を確認してください。
+            </p>
+          )}
+        </section>
+      )}
 
       {/* Phase 4: Slack / Teams / Chatwork 外部通知カード */}
       <section className="space-y-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -2,6 +2,9 @@
 import { auth } from '@/lib/auth';
 // 現在ログイン中のテナントの動作モード (lite | pro) を取得するヘルパー
 import { getCurrentTenantMode } from '@/lib/tenant';
+// tenantId → Tenant のリクエストスコープ共有キャッシュ。(app)/layout.tsx 等と同じキャッシュ
+// 経由でテナント本体を取得し、同一リクエスト内での冗長な Tenant SELECT を避ける
+import { getCachedTenant } from '@/lib/tenant-cache';
 // クライアント遷移付きリンク (テナント作成画面への導線)
 import Link from 'next/link';
 // モードの日本語ラベル (現在値の表示に使う)
@@ -60,8 +63,9 @@ export default async function SettingsPage() {
   const mode = await getCurrentTenantMode(session.user.tenantId);
   // Phase 4: テナント情報・拠点一覧・現在のスタッフ人数を並列取得する
   const [tenant, locations, currentUserCount] = await Promise.all([
-    // テナント情報 (slackWebhookUrl / プラン / Stripe 情報の現在値を取得)
-    repos.tenants.findById(session.user.tenantId),
+    // テナント情報 (slackWebhookUrl / プラン / Stripe 情報の現在値を取得)。共有キャッシュ経由
+    // にすることで、同一リクエスト内の (app)/layout.tsx (mode/plan 解決) と Tenant SELECT を共有する
+    getCachedTenant(session.user.tenantId),
     // 拠点一覧 (LocationsSection の初期値として渡す)
     repos.locations.listByTenant(session.user.tenantId),
     // 現在のスタッフ人数 (agent/admin のみ)。Stripe ダウングレード後にプラン上限を
@@ -116,6 +120,14 @@ export default async function SettingsPage() {
     tenant?.inboundToken && inboundEmailDomain
       ? buildInboundAddress(tenant.inboundToken, inboundEmailDomain)
       : null;
+  // アドレスが組み立てられない場合の原因は 2 通りある (このテナント固有の inboundToken 未発行 か、
+  // 環境側の INBOUND_EMAIL_DOMAIN 未設定か) ので、案内メッセージを取り違えないよう区別する。
+  // inboundToken は新規テナント作成時 (create-tenant.ts) にのみ自動発行され、それ以前に作成された
+  // テナントには自動付与されない (20260619000000_add_tenant_inbound_token マイグレーション参照) ため
+  // 実運用でも起こりうる
+  const inboundEmailUnavailableReason = tenant?.inboundToken
+    ? 'domain' // トークンはあるがドメイン未設定
+    : 'token'; // このテナントにトークン自体が未発行
 
   return (
     <div className="mx-auto max-w-2xl space-y-6">
@@ -182,11 +194,17 @@ export default async function SettingsPage() {
             <p className="rounded bg-slate-50 px-2 py-1 font-mono text-xs break-all text-slate-700 ring-1 ring-slate-200">
               {inboundEmailAddress}
             </p>
-          ) : (
+          ) : inboundEmailUnavailableReason === 'domain' ? (
             // INBOUND_EMAIL_DOMAIN が未設定の環境向けの案内 (運用者向け。秘密情報は含まない)
             <p className="rounded-lg bg-amber-50 px-3 py-2.5 text-sm text-amber-800 ring-1 ring-amber-200">
               メール取り込み用のドメインが未設定のため、転送先アドレスを表示できません。
               運用者に環境変数 (INBOUND_EMAIL_DOMAIN) の設定を確認してください。
+            </p>
+          ) : (
+            // このテナントに inboundToken が未発行の場合の案内 (マイグレーション前から存在する
+            // テナント等、create-tenant.ts の自動発行を経ていないケース)
+            <p className="rounded-lg bg-amber-50 px-3 py-2.5 text-sm text-amber-800 ring-1 ring-amber-200">
+              このテナントには転送先アドレスが未発行です。サポートまでお問い合わせください。
             </p>
           )}
         </section>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,7 +1,5 @@
 // 現在のセッション (ログイン情報) を取得
 import { auth } from '@/lib/auth';
-// 現在ログイン中のテナントの動作モード (lite | pro) を取得するヘルパー
-import { getCurrentTenantMode } from '@/lib/tenant';
 // tenantId → Tenant のリクエストスコープ共有キャッシュ。(app)/layout.tsx 等と同じキャッシュ
 // 経由でテナント本体を取得し、同一リクエスト内での冗長な Tenant SELECT を避ける
 import { getCachedTenant } from '@/lib/tenant-cache';
@@ -59,8 +57,6 @@ export default async function SettingsPage() {
     );
   }
 
-  // 現在のテナントモード (lite | pro) を取得してフォームの初期値にする
-  const mode = await getCurrentTenantMode(session.user.tenantId);
   // Phase 4: テナント情報・拠点一覧・現在のスタッフ人数を並列取得する
   const [tenant, locations, currentUserCount] = await Promise.all([
     // テナント情報 (slackWebhookUrl / プラン / Stripe 情報の現在値を取得)。共有キャッシュ経由
@@ -72,6 +68,10 @@ export default async function SettingsPage() {
     // 超えていないかを BillingSection で警告表示するために使う
     repos.users.countByTenant(session.user.tenantId),
   ]);
+  // 現在のテナントモード (lite | pro)。上で既に取得済みの tenant から導出する
+  // (getCurrentTenantMode を別途呼ぶと同じ Tenant 行を再取得する不要な関数呼び出しになるため、
+  // このページでは他のテナント項目 (subscriptionPlan 等) と同じ ?? フォールバック方式に揃える)
+  const mode = tenant?.mode ?? 'lite';
 
   // Phase 4 Enterprise: SSO は Enterprise プランのみ、Phase 2 フォローアップ: LINE 連携は
   // Pro / Enterprise プランのみ新規設定・再設定が可能。ただし既存設定はプラン降格後も

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -116,6 +116,8 @@ export default async function SettingsPage() {
   const emailInboundAllowed = isEmailInboundAllowed(effectivePlan);
   // 配信ドメイン (INBOUND_EMAIL_DOMAIN) が未設定の環境では組み立てられないため null のままにする
   const inboundEmailDomain = process.env.INBOUND_EMAIL_DOMAIN?.trim() || null;
+  // テナント固有の inboundToken と配信ドメインが両方揃ったときだけ転送先アドレスを組み立てる
+  // (どちらか一方でも欠けていれば表示できないので null のままにする)
   const inboundEmailAddress =
     tenant?.inboundToken && inboundEmailDomain
       ? buildInboundAddress(tenant.inboundToken, inboundEmailDomain)
@@ -124,8 +126,9 @@ export default async function SettingsPage() {
   // 環境側の INBOUND_EMAIL_DOMAIN 未設定か) ので、案内メッセージを取り違えないよう区別する。
   // inboundToken は新規テナント作成時 (create-tenant.ts) にのみ自動発行され、それ以前に作成された
   // テナントには自動付与されない (20260619000000_add_tenant_inbound_token マイグレーション参照) ため
-  // 実運用でも起こりうる
-  const inboundEmailUnavailableReason = tenant?.inboundToken
+  // 実運用でも起こりうる。'domain' | 'token' の型は下の三項演算子の分岐だけで使う一時的なラベルの
+  // ため、他ファイルと共有する定数化はせずリテラル型のまま扱う (§6 の「共有すべき値」には該当しない)
+  const inboundEmailUnavailableReason: 'domain' | 'token' = tenant?.inboundToken
     ? 'domain' // トークンはあるがドメイン未設定
     : 'token'; // このテナントにトークン自体が未発行
 

--- a/src/features/settings/actions/create-checkout-session.ts
+++ b/src/features/settings/actions/create-checkout-session.ts
@@ -94,6 +94,10 @@ export async function createCheckoutSession(
           tenantId: session.user.tenantId, // Webhook でテナントを特定するためのキー
         },
       },
+      // §8 リスク対策「IT導入補助金の審査要件 (インボイス対応)」。日本の適格請求書等保存方式
+      // (インボイス制度) に対応するため、顧客の登録番号 (T+13桁) を Checkout 画面で収集できるように
+      // する。任意入力扱い (required: 'never') とし、未登録の顧客の決済を妨げない
+      tax_id_collection: { enabled: true },
     });
 
     // Stripe Checkout の支払いページ URL を返す

--- a/src/lib/tenant-cache.ts
+++ b/src/lib/tenant-cache.ts
@@ -1,0 +1,19 @@
+// tenantId → Tenant のリクエストスコープ共有キャッシュ。
+//
+// src/lib/tenant.ts (getCurrentTenantMode) と src/lib/tenant-plan.ts (resolveTenantPlanDetail)
+// の両方が「tenantId から Tenant 本体を取得する」処理を必要とするため、独立したこのファイルに
+// 切り出す。tenant.ts は auth() のフォールバック用に @/lib/auth (next-auth) を import しており、
+// tenant-plan.ts がそこから getCachedTenant を import すると next-auth 一式まで芋づる式に
+// バンドルされてしまい、@/lib/tenant-plan を importOriginal() で部分モックする既存テスト
+// (例: tests/features/inbound-line-route.test.ts) が next-auth 内部の 'next/server' 解決に
+// 失敗して壊れる。そのため next-auth 非依存のこの最小モジュールを両者の共有先にする。
+import { cache } from 'react';
+import { repos } from '@/data';
+import type { Tenant } from '@/domain/types';
+
+// cache() でラップし、同一リクエスト内で複数の呼び出し元 (layout の getCurrentTenantMode /
+// resolveTenantPlan、各ページの直接取得) が同じ tenantId を引いても Tenant への冗長な
+// SELECT を 1 回にまとめる。
+export const getCachedTenant = cache(async (tenantId: string): Promise<Tenant | null> => {
+  return repos.tenants.findById(tenantId);
+});

--- a/src/lib/tenant-cache.ts
+++ b/src/lib/tenant-cache.ts
@@ -7,13 +7,17 @@
 // バンドルされてしまい、@/lib/tenant-plan を importOriginal() で部分モックする既存テスト
 // (例: tests/features/inbound-line-route.test.ts) が next-auth 内部の 'next/server' 解決に
 // 失敗して壊れる。そのため next-auth 非依存のこの最小モジュールを両者の共有先にする。
+// React の cache() で「同一リクエスト内の同じ tenantId での呼び出し」をメモ化する
 import { cache } from 'react';
+// データ層の Composition Root (Prisma 直叩きを避ける入口)
 import { repos } from '@/data';
+// Tenant のドメイン型 (戻り値の型付けに使う)
 import type { Tenant } from '@/domain/types';
 
 // cache() でラップし、同一リクエスト内で複数の呼び出し元 (layout の getCurrentTenantMode /
 // resolveTenantPlan、各ページの直接取得) が同じ tenantId を引いても Tenant への冗長な
 // SELECT を 1 回にまとめる。
 export const getCachedTenant = cache(async (tenantId: string): Promise<Tenant | null> => {
+  // リポジトリ経由で tenantId から Tenant 本体を取得して返す
   return repos.tenants.findById(tenantId);
 });

--- a/src/lib/tenant-plan.ts
+++ b/src/lib/tenant-plan.ts
@@ -7,8 +7,20 @@
 // DB 参照を伴うこのヘルパーは別ファイルに分離する
 // (src/lib/sso-context.ts が isSsoAllowed の上にテナント参照を重ねているのと同じ考え方)。
 
+// React の cache() で「同一リクエスト内の同じ tenantId での呼び出し」をメモ化する。
+// (app)/layout.tsx が全ページ共通でこの経由のプラン解決を呼ぶため、同一リクエスト内で
+// 他の呼び出し (Server Action 等) と重複しても Tenant への冗長な SELECT を避けられる
+// (src/lib/tenant.ts の getCurrentTenantMode と同じ考え方)
+import { cache } from 'react';
 // データ層の Composition Root (Prisma 直叩きを避ける入口)
 import { repos } from '@/data';
+// tenantId → Tenant のリクエストスコープ共有キャッシュ (getCurrentTenantMode と同じ Tenant 行を
+// 取りに行くため、ここでも同じキャッシュ経由にして冗長な SELECT を避ける)。
+// @/lib/tenant ではなく @/lib/tenant-cache から直接 import する: @/lib/tenant は
+// @/lib/auth (next-auth) に依存しており、経由すると @/lib/tenant-plan を importOriginal() で
+// 部分モックする既存テスト (inbound-line-route.test.ts 等) が next-auth の内部依存解決に
+// 巻き込まれて壊れるため
+import { getCachedTenant } from '@/lib/tenant-cache';
 // リポジトリ束の型 (トランザクション内の tx / 非トランザクションの repos のどちらも受け取れるようにする)
 import type { Repos } from '@/data/ports/unit-of-work';
 // 課金プランの型
@@ -41,17 +53,19 @@ export interface TenantPlanResolution {
 // 指定テナントの契約プランと実効プランを 1 回のテナント取得で両方解決する。
 // テナントが見つからない場合は両方とも 'free' として扱う
 // (fail-closed: 存在しない/取得できないテナントに Pro/Enterprise 限定機能を渡さない)。
-export async function resolveTenantPlanDetail(tenantId: string): Promise<TenantPlanResolution> {
-  // テナントをリポジトリ経由で取得する
-  const tenant = await repos.tenants.findById(tenantId);
-  // 見つからなければ 'free' にフォールバックする
-  if (!tenant) return { rawPlan: 'free', effectivePlan: 'free' };
-  // 契約プランそのままの値と、トライアル中なら Standard 相当に昇格させた実効プランを返す
-  return {
-    rawPlan: tenant.subscriptionPlan,
-    effectivePlan: resolveEffectivePlan(tenant.subscriptionPlan, tenant.trialEndsAt),
-  };
-}
+export const resolveTenantPlanDetail = cache(
+  async (tenantId: string): Promise<TenantPlanResolution> => {
+    // Tenant を共有キャッシュ経由で取得する (getCurrentTenantMode 等と同一リクエスト内で共有)
+    const tenant = await getCachedTenant(tenantId);
+    // 見つからなければ 'free' にフォールバックする
+    if (!tenant) return { rawPlan: 'free', effectivePlan: 'free' };
+    // 契約プランそのままの値と、トライアル中なら Standard 相当に昇格させた実効プランを返す
+    return {
+      rawPlan: tenant.subscriptionPlan,
+      effectivePlan: resolveEffectivePlan(tenant.subscriptionPlan, tenant.trialEndsAt),
+    };
+  },
+);
 
 // 指定テナントの現在の実効プランを返す。§7.2 Free trial 中 (subscriptionPlan=free かつ
 // trialEndsAt が未来) は Standard 相当に昇格させる。この関数を経由する呼び出し側は全て

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -2,10 +2,12 @@
 import { cache } from 'react';
 // セッションからログインユーザーの tenantId を取得するための NextAuth 関数
 import { auth } from '@/lib/auth';
-// Composition Root からテナント取得用リポジトリ束を取り込む
-import { repos } from '@/data';
 // テナントモード型 (lite | pro) をドメイン層から取り込む
 import type { TenantMode } from '@/domain/types';
+// tenantId → Tenant のリクエストスコープ共有キャッシュ (tenant-plan.ts と共有する。
+// このファイルから re-export すると @/lib/auth への依存ごと引き込んでしまうため、
+// tenant-cache.ts を直接 import する側で使う)
+import { getCachedTenant } from '@/lib/tenant-cache';
 
 // 現在ログイン中のテナントの mode (lite | pro) を取得するヘルパー
 // - 引数 tenantId が渡されればその値で Tenant を引く (page で既に session を取っているケース向けの最適化)
@@ -25,8 +27,8 @@ export const getCurrentTenantMode = cache(async (tenantId?: string): Promise<Ten
     // セッションから取り出した tenantId を以降の処理で利用する
     resolvedTenantId = session.user.tenantId;
   }
-  // Tenant リポジトリ (port 経由) で tenantId から Tenant 本体を取得
-  const tenant = await repos.tenants.findById(resolvedTenantId);
+  // Tenant リポジトリを共有キャッシュ経由で取得する (getCachedTenant が同一リクエスト内の重複を吸収)
+  const tenant = await getCachedTenant(resolvedTenantId);
   // Tenant が見つからなければ既定 mode (lite) にフォールバック (削除/不整合への防御)
   return tenant?.mode ?? 'lite';
 });

--- a/tests/features/create-checkout-session.test.ts
+++ b/tests/features/create-checkout-session.test.ts
@@ -1,0 +1,113 @@
+// createCheckoutSession (Phase 4 課金: Stripe Checkout セッション作成) のテスト。
+// Stripe SDK は @/lib/stripe をモックして回避し、渡された作成パラメータを検証する
+// (実際の Stripe API は呼ばない)。
+//
+// 回帰防止 (§8 リスク対策「IT導入補助金の審査要件」): 日本のインボイス制度対応として
+// Stripe Checkout に tax_id_collection を有効化したが、実装時の単純な削除・タイポで
+// 意図せず消えてしまう可能性があるため、実際に渡るパラメータを固定する。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// メモリ実装の context (store/repos/uow)
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// リポジトリ束 / UnitOfWork の型
+import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
+
+// 各テスト前に書き換える依存。Action import 前に getter で参照させる
+let store: Store;
+let repos: Repos;
+let uow: UnitOfWork;
+
+// @/data を差し替え。getter で参照することで、テスト中の上書きが反映される
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+  get uow() {
+    return uow;
+  },
+}));
+
+// セッションは admin 固定 (課金操作は admin のみ許可されるため)
+vi.mock('@/lib/auth', () => ({
+  auth: async () => ({
+    user: { id: 'admin-1', role: 'admin', tenantId: 'default-tenant', email: 'admin@example.com' },
+  }),
+}));
+
+// Stripe SDK 呼び出しをモックする。checkout.sessions.create に渡された引数を
+// capturedCreateArgs に記録し、テストからパラメータの中身を検証できるようにする
+const { capturedCreateArgs } = vi.hoisted(() => ({
+  capturedCreateArgs: { current: null as Record<string, unknown> | null },
+}));
+vi.mock('@/lib/stripe', () => ({
+  getStripeClient: () => ({
+    checkout: {
+      sessions: {
+        create: async (args: Record<string, unknown>) => {
+          // 渡されたパラメータを記録する
+          capturedCreateArgs.current = args;
+          // Stripe Checkout の戻り値を模したダミー URL を返す
+          return { url: 'https://checkout.stripe.com/test-session' };
+        },
+      },
+    },
+  }),
+  STRIPE_PRICE_IDS: { standard: 'price_standard_test', pro: 'price_pro_test' },
+}));
+
+// 動的 import: 上のモック設定が反映された後で対象を読み込む
+async function loadAction() {
+  const mod = await import('@/features/settings/actions/create-checkout-session');
+  return mod.createCheckoutSession;
+}
+
+// テストごとにクリーンな状態にする
+beforeEach(() => {
+  const ctx = createMemoryContext();
+  store = ctx.store;
+  repos = ctx.repos;
+  uow = ctx.uow;
+  capturedCreateArgs.current = null;
+  // 呼び出し元テナントを 1 つ用意しておく
+  store.tenants.set('default-tenant', {
+    id: 'default-tenant',
+    name: 'デフォルト組織',
+    mode: 'lite',
+    industry: null,
+    inboundToken: null,
+    slackWebhookUrl: null,
+    subscriptionPlan: 'free',
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+    stripeSubscriptionStatus: null,
+    trialEndsAt: null,
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null,
+    createdAt: new Date(),
+  });
+});
+
+describe('createCheckoutSession', () => {
+  // 回帰防止: インボイス制度対応 (tax_id_collection) が Checkout セッション作成時に
+  // 有効化されていること
+  it('tax_id_collection を有効にして Checkout セッションを作成する', async () => {
+    const createCheckoutSession = await loadAction();
+    const result = await createCheckoutSession('standard');
+
+    // 正常にセッション URL が返る
+    expect(result.url).toBe('https://checkout.stripe.com/test-session');
+    // Stripe へ渡したパラメータに tax_id_collection.enabled が含まれる
+    expect(capturedCreateArgs.current?.tax_id_collection).toEqual({ enabled: true });
+  });
+
+  // 正常系: 選択したプランの Price ID が line_items に渡ること
+  it('選択したプランの Price ID を line_items に渡す', async () => {
+    const createCheckoutSession = await loadAction();
+    await createCheckoutSession('pro');
+
+    expect(capturedCreateArgs.current?.line_items).toEqual([
+      { price: 'price_pro_test', quantity: 1 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

`docs/smb-dx-pivot-plan.md` のギャップ監査 (6巡目) で見つかった、実装内容が明確で小規模な3件を実装。

1. **feat(settings,billing): メール転送先アドレス表示とFreeプランのロゴ表示バッジを追加**
   - §7.1 オンボーディングシナリオ手順4「専用のメール転送先を表示する」が未実装だった。ダッシュボードの「はじめかた」案内やテナント作成時のサンプルチケット本文は「設定画面に転送先アドレスが表示される」前提の文言になっているにもかかわらず、実際には `/settings` のどこにもメール転送先アドレスを表示する箇所が存在しなかった。
   - Standard 以上 (Free trial 中も実効プランで許可) のテナントに、既存の `buildInboundAddress` ヘルパーと `tenant.inboundToken` を使って転送先アドレスを表示する「メール取り込み」セクションを追加した。`INBOUND_EMAIL_DOMAIN` 環境変数が未設定の環境では、運用者向けの案内メッセージにフォールバックする。
   - §6.1 料金プラン表「Free: ロゴ表示」が未実装だった。実効プラン (Free trial 昇格を含む) が free のテナントにのみ、認証後レイアウトの下部に「Powered by HelpDesk Hub」の控えめなフッターバッジを表示するようにした。Free trial 中は他の Standard 限定機能と同様にバッジも非表示になる。

2. **feat(billing): Stripe Checkoutにインボイス制度対応(登録番号収集)を追加**
   - §8 リスク対策「IT導入補助金の審査落ち」への対応として「補助金対象要件（インボイス対応・セキュリティ自己宣言）をPhase 4で整備」と明記されていたが、日本の適格請求書等保存方式（インボイス制度）で必要となる取引先登録番号の収集が一切組み込まれていなかった。
   - Stripe Checkout セッション作成時に `tax_id_collection: { enabled: true }` を追加し、Stripe 標準機能として顧客が登録番号（T+13桁）を入力できるようにした（任意入力のため未登録の顧客の決済は妨げない）。

なお、5巡目監査で見つかっていた「監査ログの対象範囲拡大」「公開セルフサインアップ」の2件は、実装にあたって製品スコープ・セキュリティ設計上の判断が必要なため、引き続き見送り、ユーザー確認の上で次回以降に着手する。

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (584 passed)
- [x] `npm run build`
- [ ] CI (lint / typecheck / unit / Prisma契約テスト / Playwright E2E) がグリーンであることを確認

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015a7mk7TDJdiL6MsDifaoYF

---
_Generated by [Claude Code](https://claude.ai/code/session_015a7mk7TDJdiL6MsDifaoYF)_