### PR TITLE
fix(settings,billing): メール転送先アドレスの自己発行導線とポータルテスト・コントラスト是正

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -39,9 +39,11 @@ export default async function AppLayout({ children }: { children: React.ReactNod
           <Header />
           {/* 各ページの内容 (縦スクロール可) ─ モバイルは余白を控えめにする */}
           <main className="flex-1 overflow-y-auto p-4 sm:p-6 md:p-8">{children}</main>
-          {/* §6.1 料金プラン「Free: ロゴ表示」。Free プラン (トライアル中を除く) のテナントにのみ表示する */}
+          {/* §6.1 料金プラン「Free: ロゴ表示」。Free プラン (トライアル中を除く) のテナントにのみ表示する。
+              text-slate-500 (背景 white 比でコントラスト比 約4.6:1) で WCAG AA (通常文 4.5:1) を満たす
+              (slate-400 は約2.56:1 で未達だったため修正) */}
           {plan === 'free' && (
-            <footer className="shrink-0 border-t border-slate-100 bg-white px-4 py-1.5 text-center text-xs text-slate-400">
+            <footer className="shrink-0 border-t border-slate-100 bg-white px-4 py-1.5 text-center text-xs text-slate-500">
               Powered by HelpDesk Hub
             </footer>
           )}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -21,6 +21,8 @@ import { BillingSection } from '@/features/settings/components/BillingSection';
 import { SsoConfigSection } from '@/features/settings/components/SsoConfigSection';
 // Phase 2 フォローアップ: テナント単位の LINE 連携設定セクション (Client Component)
 import { LineConfigSection } from '@/features/settings/components/LineConfigSection';
+// Phase 2 フォローアップ: メール取り込み転送先アドレスの (再)発行ボタン (Client Component)
+import { RegenerateInboundTokenButton } from '@/features/settings/components/RegenerateInboundTokenButton';
 // テナント情報取得 (slackWebhookUrl / 拠点一覧 / プラン情報の初期値を渡すため)
 import { repos } from '@/data';
 // プランゲート: Enterprise のみ SSO、Pro/Enterprise のみ LINE 連携、Standard 以上のみ
@@ -192,11 +194,15 @@ export default async function SettingsPage() {
             </p>
           </div>
           {inboundEmailAddress ? (
-            // 転送先アドレス (コピーしやすいよう等幅フォントで表示。LineConfigSection の
-            // Webhook URL 表示と同じスタイルに揃える)
-            <p className="rounded bg-slate-50 px-2 py-1 font-mono text-xs break-all text-slate-700 ring-1 ring-slate-200">
-              {inboundEmailAddress}
-            </p>
+            <>
+              {/* 転送先アドレス (コピーしやすいよう等幅フォントで表示。LineConfigSection の
+                  Webhook URL 表示と同じスタイルに揃える) */}
+              <p className="rounded bg-slate-50 px-2 py-1 font-mono text-xs break-all text-slate-700 ring-1 ring-slate-200">
+                {inboundEmailAddress}
+              </p>
+              {/* 漏洩・スパム混入時に管理者自身でアドレスを再発行できるようにする */}
+              <RegenerateInboundTokenButton hasExisting />
+            </>
           ) : inboundEmailUnavailableReason === 'domain' ? (
             // INBOUND_EMAIL_DOMAIN が未設定の環境向けの案内 (運用者向け。秘密情報は含まない)
             <p className="rounded-lg bg-amber-50 px-3 py-2.5 text-sm text-amber-800 ring-1 ring-amber-200">
@@ -204,11 +210,15 @@ export default async function SettingsPage() {
               運用者に環境変数 (INBOUND_EMAIL_DOMAIN) の設定を確認してください。
             </p>
           ) : (
-            // このテナントに inboundToken が未発行の場合の案内 (マイグレーション前から存在する
-            // テナント等、create-tenant.ts の自動発行を経ていないケース)
-            <p className="rounded-lg bg-amber-50 px-3 py-2.5 text-sm text-amber-800 ring-1 ring-amber-200">
-              このテナントには転送先アドレスが未発行です。サポートまでお問い合わせください。
-            </p>
+            <div className="space-y-2">
+              {/* このテナントに inboundToken が未発行の場合の案内 (マイグレーション前から存在する
+                  テナント等、create-tenant.ts の自動発行を経ていないケース)。管理者自身がこの場で
+                  発行できるようにし、サポート問い合わせを不要にする */}
+              <p className="rounded-lg bg-amber-50 px-3 py-2.5 text-sm text-amber-800 ring-1 ring-amber-200">
+                このテナントには転送先アドレスがまだ発行されていません。下のボタンから発行できます。
+              </p>
+              <RegenerateInboundTokenButton hasExisting={false} />
+            </div>
           )}
         </section>
       )}

--- a/src/data/adapters/memory/tenant-repository.memory.ts
+++ b/src/data/adapters/memory/tenant-repository.memory.ts
@@ -69,6 +69,18 @@ export function makeTenantRepo(store: Store): TenantRepository {
       return { ...updated };
     },
 
+    // メール取り込み用の inboundToken を (再)発行する
+    async updateInboundToken(id, token) {
+      // 対象テナントを Map から取得 (存在しなければエラー)
+      const t = store.tenants.get(id);
+      if (!t) throw new Error('テナントが見つかりません');
+      // inboundToken だけ差し替えた新しいオブジェクトを作り Map に書き戻す
+      const updated = { ...t, inboundToken: token };
+      store.tenants.set(id, updated);
+      // 防御的コピーを返す
+      return { ...updated };
+    },
+
     // Phase 4: 外部通知チャネル (Slack / Teams / Chatwork) の設定を部分更新する (null で無効化)
     async updateNotificationChannels(id, data) {
       // 対象テナントを Map から取得 (存在しなければエラー)

--- a/src/data/adapters/prisma/tenant-repository.prisma.ts
+++ b/src/data/adapters/prisma/tenant-repository.prisma.ts
@@ -82,6 +82,13 @@ export function makeTenantRepo(db: PrismaLike): TenantRepository {
       return toTenant(row);
     },
 
+    // メール取り込み用の inboundToken を (再)発行する。主キーで対象テナントを特定し列のみ更新する
+    async updateInboundToken(id, token) {
+      const row = await db.tenant.update({ where: { id }, data: { inboundToken: token } });
+      // 更新後の行をドメイン型に詰め替えて返す
+      return toTenant(row);
+    },
+
     // Phase 4: 外部通知チャネル (Slack / Teams / Chatwork) の設定を部分更新する (null で無効化)
     async updateNotificationChannels(id, data) {
       // 主キーで対象テナントを特定する。undefined のフィールドは Prisma が skip するため現状維持

--- a/src/data/ports/tenant-repository.ts
+++ b/src/data/ports/tenant-repository.ts
@@ -21,6 +21,10 @@ export interface TenantRepository {
   // テナントの動作モード (lite | pro) を更新し、更新後の Tenant を返す
   // id はセッション由来の tenantId のみを渡す契約 (リクエスト入力から注入しないこと = クロステナント防止)
   updateMode(id: string, mode: TenantMode): Promise<Tenant>;
+  // メール取り込み用の inboundToken を (再)発行する。マイグレーション前から存在し未発行のままの
+  // テナントへの初回発行、および漏洩・スパム混入時の再発行 (ローテーション) の両方に使う。
+  // id はセッション由来の tenantId のみを渡す契約 (クロステナント防止)
+  updateInboundToken(id: string, token: string): Promise<Tenant>;
   // Phase 4: 外部通知チャネル (Slack / Teams / Chatwork) の設定をまとめて更新する。
   // 渡したフィールドだけ更新し、undefined のフィールドは現状維持する (部分更新)。
   // null を渡すと該当チャネルの通知を無効化する (設定画面の「削除」操作に対応)。

--- a/src/features/settings/actions/regenerate-inbound-token.ts
+++ b/src/features/settings/actions/regenerate-inbound-token.ts
@@ -1,0 +1,43 @@
+'use server';
+
+// メール取り込み用の転送先アドレス (inboundToken) を (再)発行する Server Action。
+// 対象ケースは 2 つ:
+//  (a) 20260619000000_add_tenant_inbound_token マイグレーション以前から存在し、
+//      inboundToken が未発行 (null) のままのテナントへの初回発行。
+//  (b) 既存の転送先アドレスが漏洩・スパム混入した場合の再発行 (ローテーション)。
+// 管理者専用。docs/smb-dx-pivot-plan.md §4 Phase 2「メール取り込み」フォローアップ
+// (自己診断で見つかった「案内文言はあるが自己発行手段が無い」不整合の解消)。
+
+// ページキャッシュを無効化する Next.js の関数
+import { revalidatePath } from 'next/cache';
+// 現在のセッション (ログイン中ユーザー) を取得
+import { auth } from '@/lib/auth';
+// リポジトリ束 (repos) を取り込む (Prisma 直叩きを避ける)
+import { repos } from '@/data';
+// 連打防止のための共通レート制限ヘルパー
+import { enforceRateLimit } from '@/lib/rate-limit';
+// 管理者権限を強制する共通アサーション (組織設定系で共有)
+import { assertAdminSession } from '@/lib/role';
+// メール取り込み用トークンを生成するヘルパー (暗号学的乱数・16文字)
+import { generateInboundToken } from '@/lib/inbound-email';
+
+// メール取り込み用トークンを (再)発行するサーバーアクション。フォーム入力は使わないため
+// formData は受け取らず、管理者権限のみを確認して即座に新トークンを発行する
+export async function regenerateInboundToken(): Promise<void> {
+  // セッション取得
+  const session = await auth();
+  // 管理者権限を要求 (失敗時は日本語エラーを throw)
+  assertAdminSession(session);
+  // セッションから tenantId を取り出す (更新対象はログイン中テナントのみ = クロステナント防止)
+  const tenantId = session.user.tenantId;
+  // 発行操作の連打を抑制 (60 秒あたり 3 回まで、ユーザー単位)。
+  // 頻繁な再発行は転送先アドレスの使い回しができなくなる運用上のリスクでもあるため、
+  // 他の設定変更 (60秒10回) より厳しめの上限にする
+  enforceRateLimit(`inbound-token-regenerate:${session.user.id}`, { limit: 3, windowMs: 60_000 });
+
+  // 新しいトークンを生成してテナントに紐づける (既存トークンがあれば上書き = 旧アドレスは即座に無効化)
+  await repos.tenants.updateInboundToken(tenantId, generateInboundToken());
+
+  // 設定画面のキャッシュを無効化して新しい転送先アドレスを再描画させる
+  revalidatePath('/settings');
+}

--- a/src/features/settings/actions/regenerate-inbound-token.ts
+++ b/src/features/settings/actions/regenerate-inbound-token.ts
@@ -20,6 +20,10 @@ import { enforceRateLimit } from '@/lib/rate-limit';
 import { assertAdminSession } from '@/lib/role';
 // メール取り込み用トークンを生成するヘルパー (暗号学的乱数・16文字)
 import { generateInboundToken } from '@/lib/inbound-email';
+// テナントの実効プラン (トライアル昇格を含む) を解決する共通ヘルパー
+import { resolveTenantPlan } from '@/lib/tenant-plan';
+// プランゲート: メール取り込みは Standard 以上のみ利用可能 (§6.1 料金プラン)
+import { isEmailInboundAllowed } from '@/lib/plan-guard';
 
 // メール取り込み用トークンを (再)発行するサーバーアクション。フォーム入力は使わないため
 // formData は受け取らず、管理者権限のみを確認して即座に新トークンを発行する
@@ -30,13 +34,36 @@ export async function regenerateInboundToken(): Promise<void> {
   assertAdminSession(session);
   // セッションから tenantId を取り出す (更新対象はログイン中テナントのみ = クロステナント防止)
   const tenantId = session.user.tenantId;
-  // 発行操作の連打を抑制 (60 秒あたり 3 回まで、ユーザー単位)。
-  // 頻繁な再発行は転送先アドレスの使い回しができなくなる運用上のリスクでもあるため、
-  // 他の設定変更 (60秒10回) より厳しめの上限にする
-  enforceRateLimit(`inbound-token-regenerate:${session.user.id}`, { limit: 3, windowMs: 60_000 });
 
-  // 新しいトークンを生成してテナントに紐づける (既存トークンがあれば上書き = 旧アドレスは即座に無効化)
-  await repos.tenants.updateInboundToken(tenantId, generateInboundToken());
+  // プランゲート: 設定画面はメール取り込み許可プランのときだけボタンを描画するが、
+  // UI 非表示に頼らずサーバー側でも強制する (update-tenant-mode.ts の Pro ゲートと同じ方針)。
+  // 未許可プランのテナントにトークンだけが発行される (Webhook 側で結局隔離される) 状態を防ぐ
+  const plan = await resolveTenantPlan(tenantId);
+  if (!isEmailInboundAllowed(plan)) {
+    throw new Error('メール取り込みは Standard 以上のプランでご利用いただけます。');
+  }
+
+  // 発行操作の連打を抑制 (60 秒あたり 3 回まで、テナント単位)。
+  // 頻繁な再発行は転送先アドレスの使い回しができなくなる運用上のリスクであり、これは
+  // テナント全体で共有される 1 つのアドレスに対する制約なので、実行した管理者個人ではなく
+  // テナント単位でキーを切る (同一テナントの複数管理者が個別の枠を持ってしまうと
+  // 合計の再発行回数が管理者数倍になり、制限の意図を損なうため)
+  enforceRateLimit(`inbound-token-regenerate:${tenantId}`, { limit: 3, windowMs: 60_000 });
+
+  try {
+    // 新しいトークンを生成してテナントに紐づける (既存トークンがあれば上書き = 旧アドレスは即座に無効化)
+    await repos.tenants.updateInboundToken(tenantId, generateInboundToken());
+  } catch (err) {
+    // inboundToken は @unique 列のため、極めて低確率だが生成したトークンが既存の値と
+    // 衝突した場合は一意制約違反になる (create-location.ts / update-line-config.ts と同じ
+    // 検出パターン)。内部詳細 (Prisma のエラー文言) はクライアントに漏らさない (§9)
+    const message = err instanceof Error ? err.message : '';
+    console.error('[regenerate-inbound-token] トークン発行に失敗しました:', err);
+    if (message.includes('Unique constraint') || message.includes('P2002')) {
+      throw new Error('発行に失敗しました。もう一度お試しください。');
+    }
+    throw new Error('転送先アドレスの発行に失敗しました。しばらく後にもう一度お試しください。');
+  }
 
   // 設定画面のキャッシュを無効化して新しい転送先アドレスを再描画させる
   revalidatePath('/settings');

--- a/src/features/settings/components/RegenerateInboundTokenButton.tsx
+++ b/src/features/settings/components/RegenerateInboundTokenButton.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+// メール取り込み用の転送先アドレス (inboundToken) を (再)発行するボタン。
+// 未発行テナントの初回発行と、既存アドレス漏洩時の再発行 (ローテーション) を兼ねる。
+// docs/smb-dx-pivot-plan.md §4 Phase 2「メール取り込み」フォローアップ。
+
+// 送信中フラグ管理・非ブロッキング実行のためのフック
+import { useState, useTransition } from 'react';
+// 画面再描画 (revalidate 後の最新値反映) のためのルーター
+import { useRouter } from 'next/navigation';
+// トークン (再)発行のサーバーアクション
+import { regenerateInboundToken } from '@/features/settings/actions/regenerate-inbound-token';
+
+// 受け取る props (既存アドレスの有無で確認文言・ボタン文言を出し分ける)
+interface Props {
+  hasExisting: boolean; // true なら「再発行 (既存アドレス失効)」、false なら「新規発行」
+}
+
+// メール取り込み用転送先アドレスの (再)発行ボタン本体
+export function RegenerateInboundTokenButton({ hasExisting }: Props) {
+  // 送信中フラグ + トランジション (二重送信防止・ボタン無効化に使う)
+  const [isPending, startTransition] = useTransition();
+  // 再描画用ルーター (成功後に最新の転送先アドレスを反映する)
+  const router = useRouter();
+  // エラーメッセージ (サーバーアクションが throw した日本語メッセージを表示)
+  const [error, setError] = useState<string | null>(null);
+
+  // ボタン押下ハンドラ
+  function handleClick() {
+    // 既存アドレスがある場合のみ「失効する」旨の確認を挟む (誤操作防止)。
+    // 未発行テナントには何も失効しないため確認は不要
+    if (
+      hasExisting &&
+      !window.confirm(
+        '転送先アドレスを再発行しますか？ 現在のアドレスは直ちに無効になり、そこへの転送は届かなくなります。',
+      )
+    ) {
+      return;
+    }
+    // 直近のエラーをリセット
+    setError(null);
+    // トランジション内でサーバーアクションを実行
+    startTransition(async () => {
+      try {
+        // トークンを (再)発行する (失敗時は throw されるので catch で拾う)
+        await regenerateInboundToken();
+        // 発行結果 (新しい転送先アドレス) を反映するため再描画する
+        router.refresh();
+      } catch (err) {
+        // サーバーアクションの日本語エラーメッセージを表示
+        setError(err instanceof Error ? err.message : '発行に失敗しました');
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-2">
+      {/* エラーメッセージ (色だけでなくテキストでも状態を伝える) */}
+      {error && (
+        <p className="text-sm text-rose-700" role="alert">
+          {error}
+        </p>
+      )}
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={isPending}
+        className="rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isPending ? '発行中…' : hasExisting ? 'アドレスを再発行する' : '転送先アドレスを発行する'}
+      </button>
+    </div>
+  );
+}

--- a/tests/data/tenant-repository.memory.test.ts
+++ b/tests/data/tenant-repository.memory.test.ts
@@ -154,6 +154,50 @@ describe('TenantRepository.findByInboundToken (memory)', () => {
   });
 });
 
+// メール取り込み用トークンの (再)発行 updateInboundToken の単体テスト。
+// 未発行テナントへの初回発行、既存トークンからの再発行 (ローテーション)、
+// テナント分離、存在しない ID の fail-closed を確認する。
+describe('TenantRepository.updateInboundToken (memory)', () => {
+  // 各テストの前にメモリ context を作り直してテナント A・B を投入する
+  beforeEach(() => {
+    const ctx = createMemoryContext();
+    store = ctx.store;
+    repos = ctx.repos;
+    seed();
+  });
+
+  // 未発行 (null) のテナントに新しいトークンを発行できる
+  it('未発行テナントにトークンを発行できる', async () => {
+    const updated = await repos.tenants.updateInboundToken(TENANT_A, 'newtoken123');
+    expect(updated.inboundToken).toBe('newtoken123');
+    // 再取得しても永続化されている
+    const reloaded = await repos.tenants.findById(TENANT_A);
+    expect(reloaded?.inboundToken).toBe('newtoken123');
+  });
+
+  // 既存トークンを新しい値へ差し替えられる (漏洩時のローテーション用途)
+  it('既存トークンを新しい値に再発行できる', async () => {
+    await repos.tenants.updateInboundToken(TENANT_A, 'oldtoken111');
+    const updated = await repos.tenants.updateInboundToken(TENANT_A, 'newtoken222');
+    expect(updated.inboundToken).toBe('newtoken222');
+    // 旧トークンではもうテナントを特定できない
+    const byOldToken = await repos.tenants.findByInboundToken('oldtoken111');
+    expect(byOldToken).toBeNull();
+  });
+
+  // 分離: あるテナントの再発行が他テナントに波及しない
+  it('他テナントの inboundToken には影響しない', async () => {
+    await repos.tenants.updateInboundToken(TENANT_A, 'tokenfora001');
+    const tenantB = await repos.tenants.findById(TENANT_B);
+    expect(tenantB?.inboundToken).toBeNull();
+  });
+
+  // 異常系: 存在しないテナント ID はエラーになる (fail-closed)
+  it('存在しないテナント ID はエラーになる', async () => {
+    await expect(repos.tenants.updateInboundToken('no-such-tenant', 'x')).rejects.toThrow();
+  });
+});
+
 // Phase 4: 外部通知チャネル設定の部分更新 updateNotificationChannels の単体テスト。
 // 渡したフィールドだけ更新し、undefined のフィールドは現状維持することを確認する
 // (port の「部分更新 / undefined = skip」契約を memory アダプタで担保する)。

--- a/tests/features/create-portal-session.test.ts
+++ b/tests/features/create-portal-session.test.ts
@@ -1,0 +1,164 @@
+// createPortalSession (Phase 4 課金: Stripe Customer Portal セッション作成) のテスト。
+// Stripe SDK は @/lib/stripe をモックして回避し、権限ゲート・Customer ID 未登録時の
+// エラー分岐・正常系の URL 返却を検証する (実際の Stripe API は呼ばない)。
+//
+// 回帰防止: 兄弟アクション createCheckoutSession には専用テストがある一方、
+// createPortalSession にはテストが無く、role ゲートや「未登録テナント」分岐が
+// 無検証のまま変更されうる状態だったため追加する。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// メモリ実装の context (store/repos)
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// リポジトリ束の型
+import type { Repos } from '@/data/ports/unit-of-work';
+// 権限型 (テストごとにロールを切り替える)
+import type { Role } from '@/domain/types';
+
+const TENANT_ID = 'default-tenant';
+const USER_ID = 'u-admin-1';
+
+// 各テストで差し替える可変な依存
+let store: Store;
+let repos: Repos;
+// テストごとに切り替えるセッションのロール
+let sessionRole: Role = 'admin';
+// テストごとに切り替えるセッションの tenantId (未ログイン相当のテストで null にする)
+let sessionTenantId: string | null = TENANT_ID;
+
+// @/data を差し替え (getter で beforeEach の上書きを反映)
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+}));
+
+// セッションはロール・tenantId を可変にしたモックに置換
+vi.mock('@/lib/auth', () => ({
+  auth: async () => ({
+    user: { id: USER_ID, role: sessionRole, tenantId: sessionTenantId, email: 'admin@example.com' },
+  }),
+}));
+
+// Stripe SDK 呼び出しをモックする。billingPortal.sessions.create に渡された引数を記録し、
+// stripeApiState.shouldThrow を true にすると Stripe API 障害を模擬できるようにする
+const { capturedCreateArgs, stripeApiState } = vi.hoisted(() => ({
+  capturedCreateArgs: { current: null as Record<string, unknown> | null },
+  stripeApiState: { shouldThrow: false },
+}));
+vi.mock('@/lib/stripe', () => ({
+  getStripeClient: () => ({
+    billingPortal: {
+      sessions: {
+        create: async (args: Record<string, unknown>) => {
+          // Stripe API 障害を模擬するテスト用フラグ (内部詳細を返さないことを検証するため)
+          if (stripeApiState.shouldThrow) {
+            throw new Error('Stripe API がダウンしています (内部詳細)');
+          }
+          // 渡されたパラメータを記録する
+          capturedCreateArgs.current = args;
+          // Stripe Customer Portal の戻り値を模したダミー URL を返す
+          return { url: 'https://billing.stripe.com/test-portal-session' };
+        },
+      },
+    },
+  }),
+}));
+
+// 動的 import: 上のモック設定が反映された後で対象を読み込む
+async function loadAction() {
+  const mod = await import('@/features/settings/actions/create-portal-session');
+  return mod.createPortalSession;
+}
+
+// テナントを指定の stripeCustomerId でシードする
+function seedTenant(stripeCustomerId: string | null) {
+  store.tenants.set(TENANT_ID, {
+    id: TENANT_ID,
+    name: 'デフォルト組織',
+    mode: 'lite',
+    industry: null,
+    inboundToken: null,
+    slackWebhookUrl: null,
+    subscriptionPlan: stripeCustomerId ? 'standard' : 'free',
+    stripeCustomerId,
+    stripeSubscriptionId: stripeCustomerId ? 'sub_test123' : null,
+    stripeSubscriptionStatus: stripeCustomerId ? 'active' : null,
+    trialEndsAt: null,
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null,
+    createdAt: new Date(),
+  });
+}
+
+// テストごとにクリーンな状態にする
+beforeEach(() => {
+  const ctx = createMemoryContext();
+  store = ctx.store;
+  repos = ctx.repos;
+  capturedCreateArgs.current = null;
+  stripeApiState.shouldThrow = false;
+  sessionRole = 'admin';
+  sessionTenantId = TENANT_ID;
+});
+
+describe('createPortalSession', () => {
+  // 正常系: Stripe Customer ID を持つテナントならポータル URL を返す
+  it('stripeCustomerId を Customer Portal に渡し URL を返す', async () => {
+    seedTenant('cus_test123');
+    const createPortalSession = await loadAction();
+    const result = await createPortalSession();
+
+    expect(result.url).toBe('https://billing.stripe.com/test-portal-session');
+    expect(result.error).toBeUndefined();
+    // テナントの Stripe Customer ID がそのまま渡っていること
+    expect(capturedCreateArgs.current?.customer).toBe('cus_test123');
+  });
+
+  // 異常系: stripeCustomerId が無い (有料プラン未登録) テナントはポータルを開けない
+  it('stripeCustomerId が無い場合はエラーを返す', async () => {
+    seedTenant(null);
+    const createPortalSession = await loadAction();
+    const result = await createPortalSession();
+
+    expect(result.url).toBeUndefined();
+    expect(result.error).toBe('課金情報が見つかりません。まず有料プランにご登録ください。');
+  });
+
+  // 権限ゲート: admin 以外 (agent) は拒否される (課金操作は管理者専用 §9)
+  it('agent ロールは拒否される', async () => {
+    seedTenant('cus_test123');
+    sessionRole = 'agent';
+    const createPortalSession = await loadAction();
+    const result = await createPortalSession();
+
+    expect(result.url).toBeUndefined();
+    expect(result.error).toBe('この操作は管理者のみ実行できます');
+  });
+
+  // 権限ゲート: 未ログイン (tenantId 不在) は拒否される
+  it('tenantId が無いセッションは拒否される', async () => {
+    seedTenant('cus_test123');
+    sessionTenantId = null;
+    const createPortalSession = await loadAction();
+    const result = await createPortalSession();
+
+    expect(result.url).toBeUndefined();
+    expect(result.error).toBe('認証が必要です');
+  });
+
+  // 異常系: Stripe API がエラーを返した場合は内部詳細を返さず汎用メッセージにする (§9)
+  it('Stripe API エラー時は汎用メッセージを返す', async () => {
+    seedTenant('cus_test123');
+    // このテストだけ Stripe API 障害を模擬する
+    stripeApiState.shouldThrow = true;
+    const createPortalSession = await loadAction();
+    const result = await createPortalSession();
+
+    expect(result.url).toBeUndefined();
+    // 内部詳細 (Stripe のエラーメッセージ) を含まない汎用メッセージであること
+    expect(result.error).toBe(
+      'Stripe ポータルの作成に失敗しました。しばらく後にもう一度お試しください。',
+    );
+  });
+});

--- a/tests/features/regenerate-inbound-token.test.ts
+++ b/tests/features/regenerate-inbound-token.test.ts
@@ -1,0 +1,116 @@
+// regenerateInboundToken (Server Action) のテスト。
+// 未発行テナントへの初回発行、既存テナントでの再発行 (ローテーション)、
+// 管理者以外の拒否、レート制限をメモリアダプタで検証する。
+
+// Vitest の DSL とモック機能
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// メモリ実装の context (store/repos)
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// リポジトリ束の型
+import type { Repos } from '@/data/ports/unit-of-work';
+// レート制限の履歴をテスト間でクリアする内部用関数
+import { __resetRateLimits } from '@/lib/rate-limit';
+// 権限型
+import type { Role } from '@/domain/types';
+
+const TENANT_ID = 'tenant-1';
+const USER_ID = 'u-1';
+
+// 各テストで差し替える可変な依存 (Action import 前に値を入れる)
+let store: Store;
+let repos: Repos;
+// テストごとに切り替えるセッションのロール
+let sessionRole: Role = 'admin';
+
+// @/data を差し替え (getter で beforeEach の上書きを反映)
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+}));
+
+// 認証はロールを可変にしたモックに置換 (テストごとに sessionRole を切り替える)
+vi.mock('@/lib/auth', () => ({
+  auth: async () => ({
+    user: { id: USER_ID, role: sessionRole, tenantId: TENANT_ID },
+  }),
+}));
+
+// next/cache の副作用 (revalidatePath) はテストでは不要
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// 指定の inboundToken でテナントをシードする
+function seedTenant(inboundToken: string | null) {
+  store.tenants.set(TENANT_ID, {
+    id: TENANT_ID,
+    name: 'テスト組織',
+    mode: 'lite',
+    industry: null,
+    inboundToken,
+    slackWebhookUrl: null,
+    subscriptionPlan: 'free',
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+    stripeSubscriptionStatus: null,
+    trialEndsAt: null,
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null,
+    createdAt: new Date(),
+  });
+}
+
+describe('regenerateInboundToken', () => {
+  beforeEach(() => {
+    const ctx = createMemoryContext();
+    store = ctx.store;
+    repos = ctx.repos;
+    sessionRole = 'admin';
+    __resetRateLimits();
+  });
+
+  // 未発行 (null) のテナントに新しいトークンを発行できる
+  it('未発行テナントに新しいトークンを発行できる', async () => {
+    seedTenant(null);
+    const { regenerateInboundToken } =
+      await import('@/features/settings/actions/regenerate-inbound-token');
+    await regenerateInboundToken();
+    const updated = store.tenants.get(TENANT_ID);
+    expect(updated?.inboundToken).toEqual(expect.any(String));
+    expect(updated?.inboundToken).not.toBeNull();
+  });
+
+  // 既存トークンを新しい値に差し替えられる (漏洩時のローテーション用途)
+  it('既存トークンを新しい値に再発行する', async () => {
+    seedTenant('old-token-value');
+    const { regenerateInboundToken } =
+      await import('@/features/settings/actions/regenerate-inbound-token');
+    await regenerateInboundToken();
+    const updated = store.tenants.get(TENANT_ID);
+    expect(updated?.inboundToken).not.toBe('old-token-value');
+  });
+
+  // admin 以外 (agent) は拒否される (組織設定は管理者専用 §9)
+  it('agent ロールは拒否される', async () => {
+    seedTenant(null);
+    sessionRole = 'agent';
+    const { regenerateInboundToken } =
+      await import('@/features/settings/actions/regenerate-inbound-token');
+    await expect(regenerateInboundToken()).rejects.toThrow('この操作は管理者のみ実行できます');
+    // トークンは発行されないまま
+    expect(store.tenants.get(TENANT_ID)?.inboundToken).toBeNull();
+  });
+
+  // レート制限: 短時間に連打すると拒否される (60 秒あたり 3 回まで)
+  it('60秒あたり3回を超える連打は拒否される', async () => {
+    seedTenant(null);
+    const { regenerateInboundToken } =
+      await import('@/features/settings/actions/regenerate-inbound-token');
+    await regenerateInboundToken();
+    await regenerateInboundToken();
+    await regenerateInboundToken();
+    await expect(regenerateInboundToken()).rejects.toThrow();
+  });
+});

--- a/tests/features/regenerate-inbound-token.test.ts
+++ b/tests/features/regenerate-inbound-token.test.ts
@@ -14,13 +14,15 @@ import { __resetRateLimits } from '@/lib/rate-limit';
 import type { Role } from '@/domain/types';
 
 const TENANT_ID = 'tenant-1';
-const USER_ID = 'u-1';
+const DEFAULT_USER_ID = 'u-1';
 
 // 各テストで差し替える可変な依存 (Action import 前に値を入れる)
 let store: Store;
 let repos: Repos;
 // テストごとに切り替えるセッションのロール
 let sessionRole: Role = 'admin';
+// テストごとに切り替えるセッションのユーザー ID (同一テナント内の別管理者を模す)
+let sessionUserId: string = DEFAULT_USER_ID;
 
 // @/data を差し替え (getter で beforeEach の上書きを反映)
 vi.mock('@/data', () => ({
@@ -29,10 +31,10 @@ vi.mock('@/data', () => ({
   },
 }));
 
-// 認証はロールを可変にしたモックに置換 (テストごとに sessionRole を切り替える)
+// 認証はロール・ユーザー ID を可変にしたモックに置換 (テストごとに切り替える)
 vi.mock('@/lib/auth', () => ({
   auth: async () => ({
-    user: { id: USER_ID, role: sessionRole, tenantId: TENANT_ID },
+    user: { id: sessionUserId, role: sessionRole, tenantId: TENANT_ID },
   }),
 }));
 
@@ -41,8 +43,12 @@ vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
 }));
 
-// 指定の inboundToken でテナントをシードする
-function seedTenant(inboundToken: string | null) {
+// 指定の inboundToken でテナントをシードする。プランは既定でメール取り込み許可プラン
+// (standard) にする (regenerateInboundToken 自体のプランゲートを検証するテストのみ free を渡す)
+function seedTenant(
+  inboundToken: string | null,
+  subscriptionPlan: 'free' | 'standard' = 'standard',
+) {
   store.tenants.set(TENANT_ID, {
     id: TENANT_ID,
     name: 'テスト組織',
@@ -50,7 +56,7 @@ function seedTenant(inboundToken: string | null) {
     industry: null,
     inboundToken,
     slackWebhookUrl: null,
-    subscriptionPlan: 'free',
+    subscriptionPlan,
     stripeCustomerId: null,
     stripeSubscriptionId: null,
     stripeSubscriptionStatus: null,
@@ -68,6 +74,7 @@ describe('regenerateInboundToken', () => {
     store = ctx.store;
     repos = ctx.repos;
     sessionRole = 'admin';
+    sessionUserId = DEFAULT_USER_ID;
     __resetRateLimits();
   });
 
@@ -112,5 +119,33 @@ describe('regenerateInboundToken', () => {
     await regenerateInboundToken();
     await regenerateInboundToken();
     await expect(regenerateInboundToken()).rejects.toThrow();
+  });
+
+  // レート制限はテナント単位でキーを切る (同一テナントの複数管理者が個別の枠を
+  // 持つと合計の再発行回数が管理者数倍になり、制限の意図を損なうため)
+  it('同一テナントの別ユーザーとも上限を共有する', async () => {
+    seedTenant(null);
+    const { regenerateInboundToken } =
+      await import('@/features/settings/actions/regenerate-inbound-token');
+    // ユーザー u-1 として上限まで発行する
+    await regenerateInboundToken();
+    await regenerateInboundToken();
+    await regenerateInboundToken();
+    // 同一テナントの別ユーザーに切り替えても、テナント単位の上限を共有するため拒否される
+    sessionUserId = 'u-2';
+    await expect(regenerateInboundToken()).rejects.toThrow();
+  });
+
+  // プランゲート: メール取り込み非許可プラン (Free) ではサーバー側でも拒否される
+  // (設定画面はボタン自体を出し分けるが、Server Action 側でも UI 非表示に頼らず強制する §9)
+  it('Free プランのテナントは拒否される', async () => {
+    seedTenant(null, 'free');
+    const { regenerateInboundToken } =
+      await import('@/features/settings/actions/regenerate-inbound-token');
+    await expect(regenerateInboundToken()).rejects.toThrow(
+      'メール取り込みは Standard 以上のプランでご利用いただけます。',
+    );
+    // トークンは発行されないまま
+    expect(store.tenants.get(TENANT_ID)?.inboundToken).toBeNull();
   });
 });


### PR DESCRIPTION
## 対応 Phase / 項目

`docs/smb-dx-pivot-plan.md` Phase 2「メール取り込み」フォローアップ（既存機能の未対応ギャップの解消）。ロードマップ (Phase 0〜4) 自体はすべて `[x]` 済みのため、本 PR は既存実装の監査で見つかった具体的な未対応ギャップ 3 件への対応です。

## 変更内容

1. **メール取り込み転送先アドレスの自己発行導線を追加**
   - `20260619000000_add_tenant_inbound_token` マイグレーション以前から存在し `inboundToken` が未発行のままのテナントは、これまで「サポートまでお問い合わせください」としか案内できなかった（`src/app/(app)/settings/page.tsx`）。
   - 管理者がその場でトークンを発行・再発行（漏洩/スパム混入時のローテーション用途にも対応）できる `regenerateInboundToken` Server Action と `RegenerateInboundTokenButton` を追加。
   - `TenantRepository` に `updateInboundToken` を Port/Prisma アダプタ/メモリアダプタへ追加し、既存の `updateMode` 等と同じ「セッション由来の tenantId のみを渡す」契約に揃えた。
   - レート制限（60秒3回まで）・管理者権限アサーション・監査観点のテスト（`tests/features/regenerate-inbound-token.test.ts`、`tests/data/tenant-repository.memory.test.ts`）を追加。

2. **`createPortalSession`（Stripe Customer Portal）のテスト追加**
   - 兄弟アクション `createCheckoutSession` には専用テストがある一方、`createPortalSession` は無検証のまま変更されうる状態だった。
   - `tests/features/create-portal-session.test.ts` を同パターンで追加し、admin ロールゲート・`stripeCustomerId` 未登録時のエラー分岐・Stripe API 障害時の汎用メッセージ化（内部詳細の非露出 §9）を検証。

3. **Free プランフッターのコントラスト是正**
   - `src/app/(app)/layout.tsx` の「Powered by HelpDesk Hub」表記が `text-slate-400`（白背景比 約2.56:1）で WCAG AA（通常文 4.5:1）未達だったため `text-slate-500`（約4.6:1）に修正。

## 検証方法

- `npm run typecheck`: pass
- `npm run lint`: pass
- `npm run test`: 597 passed / 45 skipped（DB 契約テストは未実行環境のため skip）
- 画面確認: 該当 UI は設定画面の管理者専用セクション（未発行/漏洩ローテーションの両分岐）とフッター表示。ロジックはテストで担保、Dev サーバーでの目視確認は未実施。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr355dSJHNHurUjVPUEUyx)_