### PR TITLE
fix(settings): 設定系アクションのレート制限漏れとSSO証明書バグを修正

### DIFF
--- a/src/features/settings/actions/create-location.ts
+++ b/src/features/settings/actions/create-location.ts
@@ -12,7 +12,7 @@ import { revalidatePath } from 'next/cache';
 // line-config-context.ts / sso-context.ts と同じ非throw系アクションで共有する)
 import { assertTenantAdmin } from '@/lib/tenant-admin-gate';
 // 連打防止のための共通レート制限ヘルパー
-import { enforceRateLimit } from '@/lib/rate-limit';
+import { checkRateLimit } from '@/lib/rate-limit';
 
 // 作成結果の戻り値型
 export interface CreateLocationResult {
@@ -31,17 +31,17 @@ export async function createLocation(formData: FormData): Promise<CreateLocation
   // 検証済みの tenantId (セッション由来)
   const tenantId = gate.tenantId;
 
-  try {
-    // 拠点の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位で共有)。
-    // ユーザー単位ではなくテナント単位にする理由: 拠点は「テナント全体の設定」であり、
-    // 同一テナントの複数管理者が個別の枠を持つと合計の操作回数が管理者数倍になり、
-    // 制限の意図 (拠点乱造の抑止) を損なう (regenerate-inbound-token.ts と同じ方針)。
-    // create/update/delete で同じキーを共有するのも同じ理由 (アクション別に分けると
-    // 実質の上限が action 数倍になってしまう)
-    enforceRateLimit(`location-mutate:${tenantId}`, { limit: 10, windowMs: 60_000 });
-  } catch (err) {
-    return { error: err instanceof Error ? err.message : 'しばらく時間をおいて再度お試しください' };
-  }
+  // 拠点の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位で共有)。
+  // ユーザー単位ではなくテナント単位にする理由: 拠点は「テナント全体の設定」であり、
+  // 同一テナントの複数管理者が個別の枠を持つと合計の操作回数が管理者数倍になり、
+  // 制限の意図 (拠点乱造の抑止) を損なう (regenerate-inbound-token.ts と同じ方針)。
+  // create/update/delete で同じキーを共有するのも同じ理由 (アクション別に分けると
+  // 実質の上限が action 数倍になってしまう)
+  const rateLimitError = checkRateLimit(`location-mutate:${tenantId}`, {
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (rateLimitError) return { error: rateLimitError };
 
   // フォームデータから入力値を取り出す
   const name = (formData.get('name') ?? '').toString().trim();

--- a/src/features/settings/actions/delete-line-config.ts
+++ b/src/features/settings/actions/delete-line-config.ts
@@ -13,7 +13,7 @@ import { repos } from '@/data';
 // LINE 連携設定削除の共有認可ゲート (ログイン済み・admin・自テナント。プラン不問)
 import { assertLineConfigOwner } from '@/lib/line-config-context';
 // 連打防止のための共通レート制限ヘルパー
-import { enforceRateLimit } from '@/lib/rate-limit';
+import { checkRateLimit } from '@/lib/rate-limit';
 
 // 削除結果型 (useActionState 互換)
 export interface DeleteLineConfigState {
@@ -33,13 +33,13 @@ export async function deleteLineConfig(
   // 検証済みの tenantId (セッション由来)
   const tenantId = gate.tenantId;
 
-  try {
-    // LINE 連携設定の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位で
-    // update-line-config.ts と共有する)
-    enforceRateLimit(`line-config-mutate:${tenantId}`, { limit: 10, windowMs: 60_000 });
-  } catch (err) {
-    return { error: err instanceof Error ? err.message : 'しばらく時間をおいて再度お試しください' };
-  }
+  // LINE 連携設定の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位で
+  // update-line-config.ts と共有する)
+  const rateLimitError = checkRateLimit(`line-config-mutate:${tenantId}`, {
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (rateLimitError) return { error: rateLimitError };
 
   try {
     // LINE 連携設定を削除する (tenantId スコープ)

--- a/src/features/settings/actions/delete-line-config.ts
+++ b/src/features/settings/actions/delete-line-config.ts
@@ -12,6 +12,8 @@ import { revalidatePath } from 'next/cache';
 import { repos } from '@/data';
 // LINE 連携設定削除の共有認可ゲート (ログイン済み・admin・自テナント。プラン不問)
 import { assertLineConfigOwner } from '@/lib/line-config-context';
+// 連打防止のための共通レート制限ヘルパー
+import { enforceRateLimit } from '@/lib/rate-limit';
 
 // 削除結果型 (useActionState 互換)
 export interface DeleteLineConfigState {
@@ -30,6 +32,14 @@ export async function deleteLineConfig(
   if (!gate.ok) return { error: gate.error };
   // 検証済みの tenantId (セッション由来)
   const tenantId = gate.tenantId;
+
+  try {
+    // LINE 連携設定の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位で
+    // update-line-config.ts と共有する)
+    enforceRateLimit(`line-config-mutate:${tenantId}`, { limit: 10, windowMs: 60_000 });
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'しばらく時間をおいて再度お試しください' };
+  }
 
   try {
     // LINE 連携設定を削除する (tenantId スコープ)

--- a/src/features/settings/actions/delete-location.ts
+++ b/src/features/settings/actions/delete-location.ts
@@ -11,7 +11,7 @@ import { revalidatePath } from 'next/cache';
 // 「ログイン済み・admin・自テナント」を検証する共有ゲート (throw せず {ok,error} を返す契約)
 import { assertTenantAdmin } from '@/lib/tenant-admin-gate';
 // 連打防止のための共通レート制限ヘルパー
-import { enforceRateLimit } from '@/lib/rate-limit';
+import { checkRateLimit } from '@/lib/rate-limit';
 
 // 削除結果の戻り値型
 export interface DeleteLocationResult {
@@ -30,13 +30,13 @@ export async function deleteLocation(locationId: string): Promise<DeleteLocation
   // 検証済みの tenantId (セッション由来)
   const tenantId = gate.tenantId;
 
-  try {
-    // 拠点の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位・
-    // create/update/delete で共有。create-location.ts のコメント参照)
-    enforceRateLimit(`location-mutate:${tenantId}`, { limit: 10, windowMs: 60_000 });
-  } catch (err) {
-    return { error: err instanceof Error ? err.message : 'しばらく時間をおいて再度お試しください' };
-  }
+  // 拠点の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位・
+  // create/update/delete で共有。create-location.ts のコメント参照)
+  const rateLimitError = checkRateLimit(`location-mutate:${tenantId}`, {
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (rateLimitError) return { error: rateLimitError };
 
   try {
     // tenantId をスコープに含めて削除 (他テナントの拠点を削除できないよう保護)

--- a/src/features/settings/actions/delete-sso-config.ts
+++ b/src/features/settings/actions/delete-sso-config.ts
@@ -13,7 +13,7 @@ import { repos } from '@/data';
 // SSO 設定削除の共有認可ゲート (ログイン済み・admin・自テナント。プラン不問)
 import { assertSsoConfigOwner } from '@/lib/sso-context';
 // 連打防止のための共通レート制限ヘルパー
-import { enforceRateLimit } from '@/lib/rate-limit';
+import { checkRateLimit } from '@/lib/rate-limit';
 
 // 削除結果型 (useActionState 互換)
 export interface DeleteSsoConfigState {
@@ -33,13 +33,13 @@ export async function deleteSsoConfig(
   // 検証済みの tenantId (セッション由来)
   const tenantId = gate.tenantId;
 
-  try {
-    // SSO 設定の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位で
-    // update-sso-config.ts と共有する)
-    enforceRateLimit(`sso-config-mutate:${tenantId}`, { limit: 10, windowMs: 60_000 });
-  } catch (err) {
-    return { error: err instanceof Error ? err.message : 'しばらく時間をおいて再度お試しください' };
-  }
+  // SSO 設定の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位で
+  // update-sso-config.ts と共有する)
+  const rateLimitError = checkRateLimit(`sso-config-mutate:${tenantId}`, {
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (rateLimitError) return { error: rateLimitError };
 
   try {
     // SSO 設定を削除する (tenantId スコープ)

--- a/src/features/settings/actions/delete-sso-config.ts
+++ b/src/features/settings/actions/delete-sso-config.ts
@@ -12,6 +12,8 @@ import { revalidatePath } from 'next/cache';
 import { repos } from '@/data';
 // SSO 設定削除の共有認可ゲート (ログイン済み・admin・自テナント。プラン不問)
 import { assertSsoConfigOwner } from '@/lib/sso-context';
+// 連打防止のための共通レート制限ヘルパー
+import { enforceRateLimit } from '@/lib/rate-limit';
 
 // 削除結果型 (useActionState 互換)
 export interface DeleteSsoConfigState {
@@ -30,6 +32,14 @@ export async function deleteSsoConfig(
   if (!gate.ok) return { error: gate.error };
   // 検証済みの tenantId (セッション由来)
   const tenantId = gate.tenantId;
+
+  try {
+    // SSO 設定の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位で
+    // update-sso-config.ts と共有する)
+    enforceRateLimit(`sso-config-mutate:${tenantId}`, { limit: 10, windowMs: 60_000 });
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'しばらく時間をおいて再度お試しください' };
+  }
 
   try {
     // SSO 設定を削除する (tenantId スコープ)

--- a/src/features/settings/actions/update-line-config.ts
+++ b/src/features/settings/actions/update-line-config.ts
@@ -11,6 +11,8 @@ import { repos } from '@/data';
 import { assertLineConfigAdmin } from '@/lib/line-config-context';
 // LINE ユーザー ID / Bot User ID の正規形式 (Webhook 受信側と共有する単一の源)
 import { LINE_USER_ID_PATTERN } from '@/lib/line-link';
+// 連打防止のための共通レート制限ヘルパー
+import { enforceRateLimit } from '@/lib/rate-limit';
 
 // 入力長の上限 (DoS・異常入力対策)
 const CHANNEL_SECRET_MAX = 256; // チャネルシークレットの最大長
@@ -33,6 +35,15 @@ export async function updateLineConfig(
   if (!gate.ok) return { error: gate.error };
   // 検証済みの tenantId (セッション由来)
   const tenantId = gate.tenantId;
+
+  try {
+    // LINE 連携設定の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位で
+    // create/update/delete-location.ts と共有する)。update/delete で同じキーを共有する
+    // 理由も同じ (アクション別に分けると実質の上限が action 数倍になってしまう)
+    enforceRateLimit(`line-config-mutate:${tenantId}`, { limit: 10, windowMs: 60_000 });
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'しばらく時間をおいて再度お試しください' };
+  }
 
   // フォームから各値を取り出して前後空白を除去する。
   // channelSecret / channelAccessToken は書き込み専用フィールド (§9 秘密情報をフロントに

--- a/src/features/settings/actions/update-line-config.ts
+++ b/src/features/settings/actions/update-line-config.ts
@@ -12,7 +12,7 @@ import { assertLineConfigAdmin } from '@/lib/line-config-context';
 // LINE ユーザー ID / Bot User ID の正規形式 (Webhook 受信側と共有する単一の源)
 import { LINE_USER_ID_PATTERN } from '@/lib/line-link';
 // 連打防止のための共通レート制限ヘルパー
-import { enforceRateLimit } from '@/lib/rate-limit';
+import { checkRateLimit } from '@/lib/rate-limit';
 
 // 入力長の上限 (DoS・異常入力対策)
 const CHANNEL_SECRET_MAX = 256; // チャネルシークレットの最大長
@@ -36,14 +36,14 @@ export async function updateLineConfig(
   // 検証済みの tenantId (セッション由来)
   const tenantId = gate.tenantId;
 
-  try {
-    // LINE 連携設定の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位で
-    // create/update/delete-location.ts と共有する)。update/delete で同じキーを共有する
-    // 理由も同じ (アクション別に分けると実質の上限が action 数倍になってしまう)
-    enforceRateLimit(`line-config-mutate:${tenantId}`, { limit: 10, windowMs: 60_000 });
-  } catch (err) {
-    return { error: err instanceof Error ? err.message : 'しばらく時間をおいて再度お試しください' };
-  }
+  // LINE 連携設定の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位で
+  // create/update/delete-location.ts と共有する)。update/delete で同じキーを共有する
+  // 理由も同じ (アクション別に分けると実質の上限が action 数倍になってしまう)
+  const rateLimitError = checkRateLimit(`line-config-mutate:${tenantId}`, {
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (rateLimitError) return { error: rateLimitError };
 
   // フォームから各値を取り出して前後空白を除去する。
   // channelSecret / channelAccessToken は書き込み専用フィールド (§9 秘密情報をフロントに

--- a/src/features/settings/actions/update-location.ts
+++ b/src/features/settings/actions/update-location.ts
@@ -11,7 +11,7 @@ import { revalidatePath } from 'next/cache';
 // 「ログイン済み・admin・自テナント」を検証する共有ゲート (throw せず {ok,error} を返す契約)
 import { assertTenantAdmin } from '@/lib/tenant-admin-gate';
 // 連打防止のための共通レート制限ヘルパー
-import { enforceRateLimit } from '@/lib/rate-limit';
+import { checkRateLimit } from '@/lib/rate-limit';
 
 // 更新結果の戻り値型
 export interface UpdateLocationResult {
@@ -33,13 +33,13 @@ export async function updateLocation(
   // 検証済みの tenantId (セッション由来)
   const tenantId = gate.tenantId;
 
-  try {
-    // 拠点の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位・
-    // create/update/delete で共有。create-location.ts のコメント参照)
-    enforceRateLimit(`location-mutate:${tenantId}`, { limit: 10, windowMs: 60_000 });
-  } catch (err) {
-    return { error: err instanceof Error ? err.message : 'しばらく時間をおいて再度お試しください' };
-  }
+  // 拠点の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位・
+  // create/update/delete で共有。create-location.ts のコメント参照)
+  const rateLimitError = checkRateLimit(`location-mutate:${tenantId}`, {
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (rateLimitError) return { error: rateLimitError };
 
   // 更新後の名前と説明を取り出す
   const name = (formData.get('name') ?? '').toString().trim();

--- a/src/features/settings/actions/update-notification-channels.ts
+++ b/src/features/settings/actions/update-notification-channels.ts
@@ -12,6 +12,8 @@ import { auth } from '@/lib/auth';
 import { repos } from '@/data';
 // SSRF 対策ガード (プライベート IP / ループバック / IPv6-mapped などを拒否する)
 import { isUnsafeUrl } from '@/lib/ssrf-guard';
+// 連打防止のための共通レート制限ヘルパー
+import { enforceRateLimit } from '@/lib/rate-limit';
 
 // Chatwork API トークンの最大長 (常識的な上限。これを超える入力は不正として弾く)
 const CHATWORK_TOKEN_MAX_LENGTH = 200;
@@ -58,6 +60,16 @@ export async function updateNotificationChannels(
   if (session.user.role !== 'admin') {
     return { error: 'この操作は管理者のみ実行できます' };
   }
+  // 検証済みの tenantId (セッション由来)
+  const tenantId = session.user.tenantId;
+
+  try {
+    // 通知チャネル設定変更の連打を抑制 (60 秒あたり 10 回まで、テナント単位。
+    // create/update/delete-location.ts と同じ上限・キー粒度の方針)
+    enforceRateLimit(`notification-channels-mutate:${tenantId}`, { limit: 10, windowMs: 60_000 });
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'しばらく時間をおいて再度お試しください' };
+  }
 
   // ── Slack / Teams Webhook URL の検証 ────────────────────────────────────────
   // フォームから各チャネルの入力値を取り出す (未入力は空文字列)
@@ -91,7 +103,7 @@ export async function updateNotificationChannels(
   const chatworkRoomId = hasRoomId ? chatworkRoomIdRaw : null;
 
   // テナントの通知チャネル設定を一括更新する (セッション由来の tenantId のみ使用してクロステナント防止)
-  await repos.tenants.updateNotificationChannels(session.user.tenantId, {
+  await repos.tenants.updateNotificationChannels(tenantId, {
     slackWebhookUrl: slackResult.value,
     teamsWebhookUrl: teamsResult.value,
     chatworkApiToken,

--- a/src/features/settings/actions/update-notification-channels.ts
+++ b/src/features/settings/actions/update-notification-channels.ts
@@ -13,7 +13,7 @@ import { repos } from '@/data';
 // SSRF 対策ガード (プライベート IP / ループバック / IPv6-mapped などを拒否する)
 import { isUnsafeUrl } from '@/lib/ssrf-guard';
 // 連打防止のための共通レート制限ヘルパー
-import { enforceRateLimit } from '@/lib/rate-limit';
+import { checkRateLimit } from '@/lib/rate-limit';
 
 // Chatwork API トークンの最大長 (常識的な上限。これを超える入力は不正として弾く)
 const CHATWORK_TOKEN_MAX_LENGTH = 200;
@@ -63,13 +63,13 @@ export async function updateNotificationChannels(
   // 検証済みの tenantId (セッション由来)
   const tenantId = session.user.tenantId;
 
-  try {
-    // 通知チャネル設定変更の連打を抑制 (60 秒あたり 10 回まで、テナント単位。
-    // create/update/delete-location.ts と同じ上限・キー粒度の方針)
-    enforceRateLimit(`notification-channels-mutate:${tenantId}`, { limit: 10, windowMs: 60_000 });
-  } catch (err) {
-    return { error: err instanceof Error ? err.message : 'しばらく時間をおいて再度お試しください' };
-  }
+  // 通知チャネル設定変更の連打を抑制 (60 秒あたり 10 回まで、テナント単位。
+  // create/update/delete-location.ts と同じ上限・キー粒度の方針)
+  const rateLimitError = checkRateLimit(`notification-channels-mutate:${tenantId}`, {
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (rateLimitError) return { error: rateLimitError };
 
   // ── Slack / Teams Webhook URL の検証 ────────────────────────────────────────
   // フォームから各チャネルの入力値を取り出す (未入力は空文字列)

--- a/src/features/settings/actions/update-sso-config.ts
+++ b/src/features/settings/actions/update-sso-config.ts
@@ -14,7 +14,7 @@ import { assertSsoConfigAdmin } from '@/lib/sso-context';
 // 証明書の base64 正規化 (SAML SP コアと共有する純粋ヘルパー)
 import { normalizeCert } from '@/lib/saml-cert';
 // 連打防止のための共通レート制限ヘルパー
-import { enforceRateLimit } from '@/lib/rate-limit';
+import { checkRateLimit } from '@/lib/rate-limit';
 
 // 入力長の上限 (DoS・異常入力対策。EntityID/URL は十分長め、証明書は数 KB を想定)
 const ENTITY_ID_MAX = 1024; // IdP EntityID の最大長
@@ -67,15 +67,15 @@ export async function updateSsoConfig(
   // 検証済みの tenantId (セッション由来)
   const tenantId = gate.tenantId;
 
-  try {
-    // SSO 設定の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位で
-    // delete-sso-config.ts と共有する)。update/delete で同じキーを共有する理由も
-    // create/update/delete-location.ts と同じ (アクション別に分けると実質の上限が
-    // action 数倍になってしまう)
-    enforceRateLimit(`sso-config-mutate:${tenantId}`, { limit: 10, windowMs: 60_000 });
-  } catch (err) {
-    return { error: err instanceof Error ? err.message : 'しばらく時間をおいて再度お試しください' };
-  }
+  // SSO 設定の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位で
+  // delete-sso-config.ts と共有する)。update/delete で同じキーを共有する理由も
+  // create/update/delete-location.ts と同じ (アクション別に分けると実質の上限が
+  // action 数倍になってしまう)
+  const rateLimitError = checkRateLimit(`sso-config-mutate:${tenantId}`, {
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (rateLimitError) return { error: rateLimitError };
 
   // フォームから各値を取り出して前後空白を除去する
   const idpEntityId = String(formData.get('idpEntityId') ?? '').trim();

--- a/src/features/settings/actions/update-sso-config.ts
+++ b/src/features/settings/actions/update-sso-config.ts
@@ -13,6 +13,8 @@ import { repos } from '@/data';
 import { assertSsoConfigAdmin } from '@/lib/sso-context';
 // 証明書の base64 正規化 (SAML SP コアと共有する純粋ヘルパー)
 import { normalizeCert } from '@/lib/saml-cert';
+// 連打防止のための共通レート制限ヘルパー
+import { enforceRateLimit } from '@/lib/rate-limit';
 
 // 入力長の上限 (DoS・異常入力対策。EntityID/URL は十分長め、証明書は数 KB を想定)
 const ENTITY_ID_MAX = 1024; // IdP EntityID の最大長
@@ -30,8 +32,13 @@ function validateCert(rawCert: string): string | null {
   if (!/^[A-Za-z0-9+/=]+$/.test(b64)) return null;
   // PEM にラップして X509 としてパースを試みる
   try {
-    // 64 文字ごとに改行を入れて標準的な PEM を組み立てる
-    const pem = `-----BEGIN CERTIFICATE-----\n${b64.replace(/(.{64})/g, '$1\n')}\n-----END CERTIFICATE-----\n`;
+    // 64 文字ごとに改行を入れて標準的な PEM を組み立てる。
+    // b64.length が 64 の倍数のとき /(.{64})/g は最後のチャンクの後ろにも改行を挿入するため、
+    // 末尾の余分な改行を trim してから END 行を続けないと、END 行の直前に空行が入った
+    // 不正な PEM になり X509Certificate が正当な証明書でも「wrong tag」で拒否してしまう
+    // (証明書の base64 長がたまたま 64 の倍数になるだけの入力が誤って弾かれるバグだった)
+    const wrapped = b64.replace(/(.{64})/g, '$1\n').replace(/\n+$/, '');
+    const pem = `-----BEGIN CERTIFICATE-----\n${wrapped}\n-----END CERTIFICATE-----\n`;
     // パースに成功すれば妥当な証明書 (例外なら不正)
     new X509Certificate(pem);
     // 正規化済み base64 を返す
@@ -59,6 +66,16 @@ export async function updateSsoConfig(
   if (!gate.ok) return { error: gate.error };
   // 検証済みの tenantId (セッション由来)
   const tenantId = gate.tenantId;
+
+  try {
+    // SSO 設定の作成・更新・削除の連打を抑制 (60 秒あたり 10 回まで、テナント単位で
+    // delete-sso-config.ts と共有する)。update/delete で同じキーを共有する理由も
+    // create/update/delete-location.ts と同じ (アクション別に分けると実質の上限が
+    // action 数倍になってしまう)
+    enforceRateLimit(`sso-config-mutate:${tenantId}`, { limit: 10, windowMs: 60_000 });
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'しばらく時間をおいて再度お試しください' };
+  }
 
   // フォームから各値を取り出して前後空白を除去する
   const idpEntityId = String(formData.get('idpEntityId') ?? '').trim();
@@ -89,7 +106,9 @@ export async function updateSsoConfig(
   // 証明書の検証 (X509 としてパースできること)
   const cert = validateCert(idpX509CertRaw);
   if (!cert) {
-    return { error: 'IdP の X.509 証明書が正しくありません (PEM または base64 本体を貼り付けてください)' };
+    return {
+      error: 'IdP の X.509 証明書が正しくありません (PEM または base64 本体を貼り付けてください)',
+    };
   }
 
   try {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -124,6 +124,27 @@ function sweepStaleBuckets(now: number): void {
   }
 }
 
+// Server Action で使う定型ラッパー。`{error}` を返す契約のアクション (useActionState 互換や
+// create/update/delete-location.ts のような非throw系アクション) は元々 enforceRateLimit の
+// try/catch を各所で手書きしていたが、8 箇所目で完全に同一の 6 行を複製する状態になった
+// (CLAUDE.md §6 の「2〜3 箇所目で共通化する」を超過)。この関数に集約し、レート制限超過なら
+// ユーザー向けメッセージを、問題なければ null を返す (呼び出し側は `if (msg) return {error: msg}`
+// と 1 行で済ませられる)。
+export function checkRateLimit(
+  key: string, // "userId:scope" や "tenantId:scope" 形式のキー
+  options: RateLimitOptions, // 制限値
+  now?: number, // 現在時刻 (テスト時に差し替えできるよう引数化。省略時は Date.now())
+): string | null {
+  try {
+    enforceRateLimit(key, options, now);
+    // 超過していなければ null (エラー無し)
+    return null;
+  } catch (err) {
+    // RateLimitError の日本語メッセージ、それ以外は汎用メッセージにフォールバック
+    return err instanceof Error ? err.message : 'しばらく時間をおいて再度お試しください';
+  }
+}
+
 /** Testing helper: clear all buckets between test cases. */
 // テスト間で状態を初期化するためのヘルパー関数 (本番コードからは呼ばない)
 export function __resetRateLimits(): void {

--- a/tests/features/delete-line-config.test.ts
+++ b/tests/features/delete-line-config.test.ts
@@ -10,6 +10,8 @@ import { createMemoryContext, type Store } from '@/data/adapters/memory';
 import type { Repos } from '@/data/ports/unit-of-work';
 // 課金プランの型 (フィクスチャ切替に使う)
 import type { SubscriptionPlan } from '@/domain/types';
+// レート制限バケットをテスト間で初期化するヘルパー
+import { __resetRateLimits } from '@/lib/rate-limit';
 
 const TENANT_ID = 'tenant-1';
 const ADMIN_ID = 'u-admin-1';
@@ -38,6 +40,19 @@ vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
 }));
 
+// FormData を組み立てるヘルパー (updateLineConfig との共有レート制限テストで使う)
+function makeForm(input: {
+  channelSecret?: string;
+  channelAccessToken?: string;
+  botUserId?: string;
+}): FormData {
+  const fd = new FormData();
+  fd.set('channelSecret', input.channelSecret ?? '');
+  fd.set('channelAccessToken', input.channelAccessToken ?? '');
+  fd.set('botUserId', input.botUserId ?? '');
+  return fd;
+}
+
 // 指定プランのテナントをシードする
 function seedTenant(plan: SubscriptionPlan) {
   store.tenants.set(TENANT_ID, {
@@ -65,6 +80,7 @@ describe('deleteLineConfig', () => {
     store = ctx.store;
     repos = ctx.repos;
     sessionUser = { id: ADMIN_ID, role: 'admin', tenantId: TENANT_ID };
+    __resetRateLimits();
   });
 
   // 本 PR の主眼: Pro 在籍中に作った設定を Standard へ降格した後でも削除できる
@@ -114,5 +130,27 @@ describe('deleteLineConfig', () => {
     const result = await deleteLineConfig({}, new FormData());
 
     expect(result.error).toBe('認証が必要です');
+  });
+
+  // レート制限は update/delete-line-config でテナント単位に共有する (update だけで
+  // 上限を使い切っても delete が同じテナントでは拒否されることを確認する)
+  it('updateとレート制限を共有する', async () => {
+    seedTenant('pro');
+    const { updateLineConfig } = await import('@/features/settings/actions/update-line-config');
+    const { deleteLineConfig } = await import('@/features/settings/actions/delete-line-config');
+
+    // update だけで上限 (10回) を使い切る
+    for (let i = 0; i < 10; i++) {
+      const result = await updateLineConfig(
+        {},
+        makeForm({ channelSecret: 's1', channelAccessToken: 't1', botUserId: BOT_USER_ID }),
+      );
+      expect(result.error).toBeUndefined();
+    }
+
+    // 同じテナントの delete も共有の上限に達しているため拒否される
+    const deleteResult = await deleteLineConfig({}, new FormData());
+    expect(deleteResult.error).toEqual(expect.any(String));
+    expect(deleteResult.success).toBeUndefined();
   });
 });

--- a/tests/features/delete-sso-config.test.ts
+++ b/tests/features/delete-sso-config.test.ts
@@ -10,9 +10,22 @@ import { createMemoryContext, type Store } from '@/data/adapters/memory';
 import type { Repos } from '@/data/ports/unit-of-work';
 // 課金プランの型 (フィクスチャ切替に使う)
 import type { SubscriptionPlan } from '@/domain/types';
+// レート制限バケットをテスト間で初期化するヘルパー
+import { __resetRateLimits } from '@/lib/rate-limit';
 
 const TENANT_ID = 'tenant-1';
 const ADMIN_ID = 'u-admin-1';
+// 妥当な自己署名証明書 (update-sso-config.test.ts と同じ使い捨てテスト証明書)
+const VALID_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIBejCCASGgAwIBAgIUTU0oqjbacH2Bdi53MhfEyhAUx94wCgYIKoZIzj0EAwIw
+EzERMA8GA1UEAwwIVGVzdCBJZFAwHhcNMjYwNzA5MDk1MzQyWhcNMzYwNzA2MDk1
+MzQyWjATMREwDwYDVQQDDAhUZXN0IElkUDBZMBMGByqGSM49AgEGCCqGSM49AwEH
+A0IABLYCfBxmzqJwohrT33aa8LoP5ocduX1u8BxvglgdZlSifPmU115wmHH3WjpQ
+Az+Mc0D17StwBdvddsHk4cBuj82jUzBRMB0GA1UdDgQWBBTDj3SgGLTG5xUTmI5Y
+QF8cFaXunjAfBgNVHSMEGDAWgBTDj3SgGLTG5xUTmI5YQF8cFaXunjAPBgNVHRMB
+Af8EBTADAQH/MAoGCCqGSM49BAMCA0cAMEQCIGNBELNismu2/iXXJpiLbjwNfAdR
+yGVurItfB5ICiWtfAiAJB2Sy0no9JH1syJpJAR5/13FZ8wuGSgJV1GxUF4C9yQ==
+-----END CERTIFICATE-----`;
 
 // 各テストで差し替える可変な依存 (Action import 前に値を入れる)
 let store: Store;
@@ -64,6 +77,7 @@ describe('deleteSsoConfig', () => {
     store = ctx.store;
     repos = ctx.repos;
     sessionUser = { id: ADMIN_ID, role: 'admin', tenantId: TENANT_ID };
+    __resetRateLimits();
   });
 
   // 本 PR の主眼: Enterprise 在籍中に作った設定を Pro へ降格した後でも削除できる
@@ -115,5 +129,28 @@ describe('deleteSsoConfig', () => {
     const result = await deleteSsoConfig({}, new FormData());
 
     expect(result.error).toBe('認証が必要です');
+  });
+
+  // レート制限は update/delete-sso-config でテナント単位に共有する (update だけで
+  // 上限を使い切っても delete が同じテナントでは拒否されることを確認する)
+  it('updateとレート制限を共有する', async () => {
+    seedTenant('enterprise');
+    const { updateSsoConfig } = await import('@/features/settings/actions/update-sso-config');
+    const { deleteSsoConfig } = await import('@/features/settings/actions/delete-sso-config');
+
+    // update だけで上限 (10回) を使い切る
+    for (let i = 0; i < 10; i++) {
+      const fd = new FormData();
+      fd.set('idpEntityId', 'https://idp.example.com/entity');
+      fd.set('idpSsoUrl', 'https://idp.example.com/sso');
+      fd.set('idpX509Cert', VALID_CERT_PEM);
+      const result = await updateSsoConfig({}, fd);
+      expect(result.error).toBeUndefined();
+    }
+
+    // 同じテナントの delete も共有の上限に達しているため拒否される
+    const deleteResult = await deleteSsoConfig({}, new FormData());
+    expect(deleteResult.error).toEqual(expect.any(String));
+    expect(deleteResult.success).toBeUndefined();
   });
 });

--- a/tests/features/update-line-config.test.ts
+++ b/tests/features/update-line-config.test.ts
@@ -10,6 +10,8 @@ import { createMemoryContext, type Store } from '@/data/adapters/memory';
 import type { Repos } from '@/data/ports/unit-of-work';
 // 課金プランの型 (フィクスチャ切替に使う)
 import type { SubscriptionPlan } from '@/domain/types';
+// レート制限バケットをテスト間で初期化するヘルパー
+import { __resetRateLimits } from '@/lib/rate-limit';
 
 const TENANT_ID = 'tenant-1';
 const ADMIN_ID = 'u-admin-1';
@@ -78,6 +80,7 @@ describe('updateLineConfig', () => {
     const ctx = createMemoryContext();
     store = ctx.store;
     repos = ctx.repos;
+    __resetRateLimits();
   });
 
   // Standard プランでは LINE 連携自体が使えない (§6.1 料金プラン)
@@ -171,5 +174,25 @@ describe('updateLineConfig', () => {
       makeForm({ channelSecret: 's1', channelAccessToken: 't1', botUserId: BOT_USER_ID_A }),
     );
     expect(result.error).toBe('この Bot User ID は既に別のテナントで登録されています');
+  });
+
+  // レート制限: 60秒あたり10回を超える連打は拒否される (create/update/delete-location.ts と
+  // 同じ「テナント単位で共有」の方針。update-sso-config.test.ts も参照)
+  it('60秒あたり10回を超える連打は拒否される', async () => {
+    seedTenant('pro');
+    const { updateLineConfig } = await import('@/features/settings/actions/update-line-config');
+    for (let i = 0; i < 10; i++) {
+      const result = await updateLineConfig(
+        {},
+        makeForm({ channelSecret: 's1', channelAccessToken: 't1', botUserId: BOT_USER_ID_A }),
+      );
+      expect(result.error).toBeUndefined();
+    }
+    const result = await updateLineConfig(
+      {},
+      makeForm({ channelSecret: 's1', channelAccessToken: 't1', botUserId: BOT_USER_ID_A }),
+    );
+    expect(result.error).toEqual(expect.any(String));
+    expect(result.success).toBeUndefined();
   });
 });

--- a/tests/features/update-notification-channels.test.ts
+++ b/tests/features/update-notification-channels.test.ts
@@ -1,0 +1,170 @@
+// updateNotificationChannels (Server Action) のテスト。
+// 管理者ゲート・SSRF ガード・Chatwork 入力検証・レート制限をメモリアダプタで検証する。
+// これまでこのアクションにテストが存在しなかったギャップを埋める。
+
+// Vitest の DSL とモック機能
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// メモリ実装の context (store/repos)
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// リポジトリ束の型
+import type { Repos } from '@/data/ports/unit-of-work';
+// レート制限バケットをテスト間で初期化するヘルパー
+import { __resetRateLimits } from '@/lib/rate-limit';
+
+const TENANT_ID = 'tenant-1';
+const ADMIN_ID = 'u-admin-1';
+
+// 各テストで差し替える可変な依存 (Action import 前に値を入れる)
+let store: Store;
+let repos: Repos;
+// 認証モックが返すセッション (テストごとに差し替える)
+let sessionUser: { id: string; role: string; tenantId: string | null } | null;
+
+// @/data を差し替え (getter で beforeEach の上書きを反映)
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+}));
+
+// 認証はテストごとに差し替え可能なセッションを返すモックに置換
+vi.mock('@/lib/auth', () => ({
+  auth: async () => (sessionUser ? { user: sessionUser } : null),
+}));
+
+// next/cache の副作用 (revalidatePath) はテストでは不要
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// FormData を組み立てるヘルパー (未指定フィールドは空欄送信扱い)
+function makeForm(input: {
+  slackWebhookUrl?: string;
+  teamsWebhookUrl?: string;
+  chatworkApiToken?: string;
+  chatworkRoomId?: string;
+}): FormData {
+  const fd = new FormData();
+  fd.set('slackWebhookUrl', input.slackWebhookUrl ?? '');
+  fd.set('teamsWebhookUrl', input.teamsWebhookUrl ?? '');
+  fd.set('chatworkApiToken', input.chatworkApiToken ?? '');
+  fd.set('chatworkRoomId', input.chatworkRoomId ?? '');
+  return fd;
+}
+
+// テナントを最小構成でシードする
+function seedTenant() {
+  store.tenants.set(TENANT_ID, {
+    id: TENANT_ID,
+    name: 'テスト組織',
+    mode: 'lite',
+    industry: null,
+    inboundToken: null,
+    slackWebhookUrl: null,
+    subscriptionPlan: 'pro',
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+    stripeSubscriptionStatus: null,
+    trialEndsAt: null,
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null,
+    createdAt: new Date(),
+  });
+}
+
+describe('updateNotificationChannels', () => {
+  beforeEach(() => {
+    const ctx = createMemoryContext();
+    store = ctx.store;
+    repos = ctx.repos;
+    sessionUser = { id: ADMIN_ID, role: 'admin', tenantId: TENANT_ID };
+    seedTenant();
+    __resetRateLimits();
+  });
+
+  // 未ログイン (tenantId 不在) は拒否される
+  it('tenantIdが無いセッションは拒否される', async () => {
+    sessionUser = { id: ADMIN_ID, role: 'admin', tenantId: null };
+    const { updateNotificationChannels } =
+      await import('@/features/settings/actions/update-notification-channels');
+    const result = await updateNotificationChannels({}, makeForm({}));
+    expect(result.error).toBe('認証が必要です');
+  });
+
+  // admin 以外は拒否される
+  it('agent ロールは拒否される', async () => {
+    sessionUser = { id: 'u-agent-1', role: 'agent', tenantId: TENANT_ID };
+    const { updateNotificationChannels } =
+      await import('@/features/settings/actions/update-notification-channels');
+    const result = await updateNotificationChannels({}, makeForm({}));
+    expect(result.error).toBe('この操作は管理者のみ実行できます');
+  });
+
+  // 妥当な Slack Webhook URL は保存できる
+  it('妥当なSlack Webhook URLを保存できる', async () => {
+    const { updateNotificationChannels } =
+      await import('@/features/settings/actions/update-notification-channels');
+    const result = await updateNotificationChannels(
+      {},
+      makeForm({ slackWebhookUrl: 'https://hooks.slack.com/services/xxx' }),
+    );
+    expect(result.success).toBe(true);
+    const saved = await repos.tenants.findById(TENANT_ID);
+    expect(saved?.slackWebhookUrl).toBe('https://hooks.slack.com/services/xxx');
+  });
+
+  // https 以外の Webhook URL は拒否される
+  it('httpsで始まらないWebhook URLは拒否される', async () => {
+    const { updateNotificationChannels } =
+      await import('@/features/settings/actions/update-notification-channels');
+    const result = await updateNotificationChannels(
+      {},
+      makeForm({ slackWebhookUrl: 'http://hooks.slack.com/services/xxx' }),
+    );
+    expect(result.error).toBe('Slack の Webhook URL は https:// で始まる必要があります');
+  });
+
+  // SSRF 対策: プライベート IP 宛の Webhook URL は拒否される
+  it('内部ネットワーク宛のWebhook URLは拒否される', async () => {
+    const { updateNotificationChannels } =
+      await import('@/features/settings/actions/update-notification-channels');
+    const result = await updateNotificationChannels(
+      {},
+      makeForm({ teamsWebhookUrl: 'https://169.254.169.254/latest/meta-data' }),
+    );
+    expect(result.error).toBe('Teams に内部ネットワークの Webhook URL は設定できません');
+  });
+
+  // Chatwork はトークン・ルーム ID を対で入力する必要がある
+  it('Chatworkはトークンだけの入力だと拒否される', async () => {
+    const { updateNotificationChannels } =
+      await import('@/features/settings/actions/update-notification-channels');
+    const result = await updateNotificationChannels({}, makeForm({ chatworkApiToken: 'tok123' }));
+    expect(result.error).toBe('Chatwork は API トークンとルーム ID の両方を入力してください');
+  });
+
+  // Chatwork ルーム ID は数字以外を拒否する (パスインジェクション対策)
+  it('Chatworkルーム IDが数字以外だと拒否される', async () => {
+    const { updateNotificationChannels } =
+      await import('@/features/settings/actions/update-notification-channels');
+    const result = await updateNotificationChannels(
+      {},
+      makeForm({ chatworkApiToken: 'tok123', chatworkRoomId: '123/../etc' }),
+    );
+    expect(result.error).toBe('Chatwork ルーム ID は数字で入力してください');
+  });
+
+  // レート制限: 60秒あたり10回を超える連打は拒否される
+  it('60秒あたり10回を超える連打は拒否される', async () => {
+    const { updateNotificationChannels } =
+      await import('@/features/settings/actions/update-notification-channels');
+    for (let i = 0; i < 10; i++) {
+      const result = await updateNotificationChannels({}, makeForm({}));
+      expect(result.error).toBeUndefined();
+    }
+    const result = await updateNotificationChannels({}, makeForm({}));
+    expect(result.error).toEqual(expect.any(String));
+    expect(result.success).toBeUndefined();
+  });
+});

--- a/tests/features/update-sso-config.test.ts
+++ b/tests/features/update-sso-config.test.ts
@@ -1,0 +1,163 @@
+// updateSsoConfig (Server Action) のテスト。
+// プランゲート・入力検証 (URL/証明書)・レート制限をメモリアダプタで検証する。
+// これまでこのアクションにテストが存在しなかったギャップを埋める
+// (監査で発見。delete-sso-config.test.ts はテスト済みだったが update 側は未検証だった)。
+
+// Vitest の DSL とモック機能
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// メモリ実装の context (store/repos)
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// リポジトリ束の型
+import type { Repos } from '@/data/ports/unit-of-work';
+// 課金プランの型 (フィクスチャ切替に使う)
+import type { SubscriptionPlan } from '@/domain/types';
+// レート制限バケットをテスト間で初期化するヘルパー
+import { __resetRateLimits } from '@/lib/rate-limit';
+
+const TENANT_ID = 'tenant-1';
+const ADMIN_ID = 'u-admin-1';
+
+// テスト用の妥当な自己署名証明書 (X509Certificate でパース可能な実在の PEM。
+// openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 で生成した使い捨て証明書)。
+// この証明書は base64 本体の長さがちょうど 512 文字 (64 の倍数) になっており、
+// validateCert の「64 文字ごとに改行を入れる」ラップ処理が末尾に余分な空行を作ってしまう
+// バグ (本 PR で修正) の回帰テストを兼ねる。長さが 64 の倍数でない証明書だとこのバグを
+// 再現しないため、意図的にこの条件を満たす証明書を選んでいる
+const VALID_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIBejCCASGgAwIBAgIUTU0oqjbacH2Bdi53MhfEyhAUx94wCgYIKoZIzj0EAwIw
+EzERMA8GA1UEAwwIVGVzdCBJZFAwHhcNMjYwNzA5MDk1MzQyWhcNMzYwNzA2MDk1
+MzQyWjATMREwDwYDVQQDDAhUZXN0IElkUDBZMBMGByqGSM49AgEGCCqGSM49AwEH
+A0IABLYCfBxmzqJwohrT33aa8LoP5ocduX1u8BxvglgdZlSifPmU115wmHH3WjpQ
+Az+Mc0D17StwBdvddsHk4cBuj82jUzBRMB0GA1UdDgQWBBTDj3SgGLTG5xUTmI5Y
+QF8cFaXunjAfBgNVHSMEGDAWgBTDj3SgGLTG5xUTmI5YQF8cFaXunjAPBgNVHRMB
+Af8EBTADAQH/MAoGCCqGSM49BAMCA0cAMEQCIGNBELNismu2/iXXJpiLbjwNfAdR
+yGVurItfB5ICiWtfAiAJB2Sy0no9JH1syJpJAR5/13FZ8wuGSgJV1GxUF4C9yQ==
+-----END CERTIFICATE-----`;
+
+// 各テストで差し替える可変な依存 (Action import 前に値を入れる)
+let store: Store;
+let repos: Repos;
+// 認証モックが返すセッション (テストごとに差し替える)
+let sessionUser: { id: string; role: string; tenantId: string } | null;
+
+// @/data を差し替え (getter で beforeEach の上書きを反映)
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+}));
+
+// 認証はテストごとに差し替え可能なセッションを返すモックに置換
+vi.mock('@/lib/auth', () => ({
+  auth: async () => (sessionUser ? { user: sessionUser } : null),
+}));
+
+// next/cache の副作用 (revalidatePath) はテストでは不要
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// FormData を組み立てるヘルパー
+function makeForm(input: {
+  idpEntityId?: string;
+  idpSsoUrl?: string;
+  idpX509Cert?: string;
+  enabled?: boolean;
+}): FormData {
+  const fd = new FormData();
+  fd.set('idpEntityId', input.idpEntityId ?? 'https://idp.example.com/entity');
+  fd.set('idpSsoUrl', input.idpSsoUrl ?? 'https://idp.example.com/sso');
+  fd.set('idpX509Cert', input.idpX509Cert ?? VALID_CERT_PEM);
+  if (input.enabled) fd.set('enabled', 'on');
+  return fd;
+}
+
+// 指定プランのテナントをシードする
+function seedTenant(plan: SubscriptionPlan) {
+  store.tenants.set(TENANT_ID, {
+    id: TENANT_ID,
+    name: 'テスト組織',
+    mode: 'lite',
+    industry: null,
+    inboundToken: null,
+    slackWebhookUrl: null,
+    subscriptionPlan: plan,
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+    stripeSubscriptionStatus: null,
+    trialEndsAt: null,
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null,
+    createdAt: new Date(),
+  });
+}
+
+describe('updateSsoConfig', () => {
+  beforeEach(() => {
+    const ctx = createMemoryContext();
+    store = ctx.store;
+    repos = ctx.repos;
+    sessionUser = { id: ADMIN_ID, role: 'admin', tenantId: TENANT_ID };
+    __resetRateLimits();
+  });
+
+  // Pro プランでは SSO 自体が使えない (§6.1 料金プラン、Enterprise 限定)
+  it('Pro プランでは保存が拒否される', async () => {
+    seedTenant('pro');
+    const { updateSsoConfig } = await import('@/features/settings/actions/update-sso-config');
+    const result = await updateSsoConfig({}, makeForm({}));
+    expect(result.error).toEqual(expect.any(String));
+    expect(await repos.ssoConfigs.findByTenant(TENANT_ID)).toBeNull();
+  });
+
+  // admin 以外は保存できない
+  it('agent ロールは拒否される', async () => {
+    seedTenant('enterprise');
+    sessionUser = { id: 'u-agent-1', role: 'agent', tenantId: TENANT_ID };
+    const { updateSsoConfig } = await import('@/features/settings/actions/update-sso-config');
+    const result = await updateSsoConfig({}, makeForm({}));
+    expect(result.error).toBe('この操作は管理者のみ実行できます');
+  });
+
+  // 妥当な入力なら Enterprise プランで保存できる
+  it('Enterprise プランで妥当な入力なら保存できる', async () => {
+    seedTenant('enterprise');
+    const { updateSsoConfig } = await import('@/features/settings/actions/update-sso-config');
+    const result = await updateSsoConfig({}, makeForm({ enabled: true }));
+    expect(result.success).toBe(true);
+    const saved = await repos.ssoConfigs.findByTenant(TENANT_ID);
+    expect(saved?.idpEntityId).toBe('https://idp.example.com/entity');
+    expect(saved?.enabled).toBe(true);
+  });
+
+  // https 以外の SSO URL は拒否される (ブラウザのリダイレクト先になるため)
+  it('httpsで始まらないSSO URLは拒否される', async () => {
+    seedTenant('enterprise');
+    const { updateSsoConfig } = await import('@/features/settings/actions/update-sso-config');
+    const result = await updateSsoConfig({}, makeForm({ idpSsoUrl: 'http://idp.example.com/sso' }));
+    expect(result.error).toBe('IdP の SSO URL は https:// で始まる必要があります');
+  });
+
+  // パースできない証明書は拒否される
+  it('不正な証明書は拒否される', async () => {
+    seedTenant('enterprise');
+    const { updateSsoConfig } = await import('@/features/settings/actions/update-sso-config');
+    const result = await updateSsoConfig({}, makeForm({ idpX509Cert: 'not-a-certificate' }));
+    expect(result.error).toEqual(expect.any(String));
+    expect(await repos.ssoConfigs.findByTenant(TENANT_ID)).toBeNull();
+  });
+
+  // レート制限: 60秒あたり10回を超える連打は拒否される (delete-sso-config.ts と共有)
+  it('60秒あたり10回を超える連打は拒否される', async () => {
+    seedTenant('enterprise');
+    const { updateSsoConfig } = await import('@/features/settings/actions/update-sso-config');
+    for (let i = 0; i < 10; i++) {
+      const result = await updateSsoConfig({}, makeForm({}));
+      expect(result.error).toBeUndefined();
+    }
+    const result = await updateSsoConfig({}, makeForm({}));
+    expect(result.error).toEqual(expect.any(String));
+    expect(result.success).toBeUndefined();
+  });
+});

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -6,6 +6,7 @@ import {
   __resetRateLimits,
   __getRateLimitBucketCount,
   enforceRateLimit,
+  checkRateLimit,
 } from '../src/lib/rate-limit';
 
 // レート制限ヘルパーの仕様確認テスト群
@@ -85,5 +86,28 @@ describe('enforceRateLimit', () => {
     // 窓 (60 秒) の途中で他キーを呼んでも、まだ生きているキーは消えない
     enforceRateLimit('other-key', { limit: 5, windowMs: 60_000 }, t0 + 5_000);
     expect(__getRateLimitBucketCount()).toBe(2);
+  });
+});
+
+// checkRateLimit (throw せず {error} を返す契約のアクション向けラッパー) の仕様確認テスト群
+describe('checkRateLimit', () => {
+  beforeEach(() => {
+    __resetRateLimits();
+  });
+
+  // 上限以内なら null (エラー無し) を返す
+  it('returns null when within the limit', () => {
+    const now = 1_000_000;
+    expect(checkRateLimit('k', { limit: 3, windowMs: 10_000 }, now)).toBeNull();
+  });
+
+  // 上限を超えると enforceRateLimit と同じ日本語メッセージを文字列で返す (例外を投げない)
+  it('returns the Japanese message string instead of throwing once over the limit', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < 3; i += 1) {
+      expect(checkRateLimit('k', { limit: 3, windowMs: 10_000 }, now + i)).toBeNull();
+    }
+    const message = checkRateLimit('k', { limit: 3, windowMs: 10_000 }, now + 4);
+    expect(message).toEqual(expect.stringMatching(/操作の頻度/));
   });
 });


### PR DESCRIPTION
## 対応 Phase / 項目

`docs/smb-dx-pivot-plan.md` §2.1「LINE 連携のマルチテナント化」/ §6.1 Enterprise「SSO(SAML)」/ §4 Phase 4「Slack / Chatwork / Microsoft Teams 通知 Adapter」フォローアップ。

監査で発見したギャップ: PR #182 でロケーション操作 (create/update/delete-location.ts) にレート制限を統一した際と同じ観点で全設定系アクションを横断的に確認したところ、LINE 連携設定・SSO 設定・通知チャネル設定の 3 系統がいずれもレート制限を欠いていた（`enforceRateLimit` 呼び出しなし）。

## 変更内容 (3コミット、各1論理変更)

### 1. `fix(settings)`: LINE 連携設定にレート制限を追加

`update-line-config.ts` / `delete-line-config.ts` に `line-config-mutate:${tenantId}` を追加（60秒10回、update/delete で共有）。回帰テストも追加。

### 2. `fix(settings)`: SSO 設定にレート制限を追加 + 証明書 PEM ラップの不具合を修正

`update-sso-config.ts` / `delete-sso-config.ts` に `sso-config-mutate:${tenantId}` を追加。

**副次的に発見した実バグ**: `update-sso-config.ts` にテストが1件も無かったため、今回新規作成する過程で `validateCert` の潜在バグを発見した。証明書の base64 本体の長さがちょうど 64 の倍数のとき、64文字ごとに改行を挿入する正規表現が最後のチャンクの後ろにも改行を入れてしまい、END 行の直前に空行が入った不正な PEM になっていた。`X509Certificate` はこれを `wrong tag` エラーで拒否するため、内容自体は正当な証明書であっても base64 長がたまたま 64 の倍数になるだけで Enterprise 管理者が SSO 設定を保存できない不具合があった。末尾の余分な改行を trim するよう修正し、この条件を再現する実在の証明書を回帰テストのフィクスチャに採用した。

### 3. `fix(settings)`: 通知チャネル設定の更新にレート制限とテストを追加

`update-notification-channels.ts` (Slack/Teams/Chatwork Webhook 設定) にテストが1件も無かったため、`notification-channels-mutate:${tenantId}` のレート制限追加と合わせて、管理者ゲート・SSRF ガード・Chatwork 入力検証を検証するテストを新規作成した。

## 検証方法

- `npm run typecheck`: pass
- `npm run lint`: pass
- `npm run test`: 688 passed / 48 skipped（新規追加分を含む）
- 画面確認: レート制限追加は既存のフォーム送信フローに影響しない (エラーメッセージが表示されるのは連打時のみ)。SSO 証明書バグはユニットテストで再現・修正を確認済み。

## スコープ外 (次バッチで対応予定)

監査では他に 2 件のギャップを確認済みだが、本 PR のスコープ（レート制限の横展開）に収まらないため次バッチに回す:
- 監査ログ (Pro/Enterprise) が SSO/LINE 設定変更・通知チャネル変更などを記録していない
- 多拠点対応 (`locationId`) がチケット一覧の絞り込みには使われているが、ダッシュボードの集計・品質指標には反映されていない

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr355dSJHNHurUjVPUEUyx)_