### PR TITLE
test(data): 拠点リポジトリの契約テスト追加 + fix(auth): SSO ACSにレート制限追加

### DIFF
--- a/src/app/api/auth/sso/[tenantId]/acs/route.ts
+++ b/src/app/api/auth/sso/[tenantId]/acs/route.ts
@@ -29,9 +29,40 @@ import { createSamlInstance, validateSamlResponse } from '@/lib/saml';
 import { generateMagicLinkToken, hashMagicLinkToken } from '@/lib/magic-link';
 // HTML 属性への安全な埋め込み用エスケープ (確認ページのトークン埋め込みに使う)
 import { escapeHtml } from '@/lib/html-escape';
+// 連打防止のための共通レート制限ヘルパー
+import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
 
 // SSO ハンドオフトークンの有効期限 (2 分)。ACS → コールバックの即時引き渡し専用なので短くする
 const SSO_HANDOFF_TTL_MS = 2 * 60 * 1000;
+
+// 監査で発見したギャップ: 他の未認証受信エンドポイント (inbound-line/inbound-email) は
+// いずれもレート制限を持つが、この ACS エンドポイントには無かった。ACS は未認証で到達でき、
+// XML パース + 署名検証という CPU コストの高い処理をリクエストごとに行うため、他の受信系と
+// 同じ二段構えの制限を適用する:
+//  - URL の tenantId は署名検証前の値で攻撃者が自由に変更できるため、これ単体をキーにすると
+//    値を変えるだけで無制限に回避・バケット増殖されてしまう (inbound-line の destination と同じ問題)。
+//    そのためテナント解決 (DB 参照) より前に固定キーで「未認証リクエスト全体」の上限を設ける。
+const SSO_ACS_UNAUTHENTICATED_RATE_LIMIT = { limit: 60, windowMs: 60_000 } as const;
+//  - テナントが実在し SSO が有効だと確認できた後は、tenantId (DB 由来で信頼できる値) を
+//    キーにしたテナント単位の制限も適用する (1 テナントからの異常な連打を抑える)。
+const SSO_ACS_TENANT_RATE_LIMIT = { limit: 20, windowMs: 60_000 } as const;
+
+// レート制限を適用し、超過していれば 429 レスポンスを返す共通ヘルパー。
+// 超過なしなら null を返し、呼び出し側はそのまま処理を続行する (inbound-line/route.ts と同じ方針)。
+function checkRateLimit(key: string, options: { limit: number; windowMs: number }) {
+  try {
+    enforceRateLimit(key, options);
+    return null;
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return NextResponse.json(
+        { error: 'しばらく時間をおいて再度お試しください' },
+        { status: 429, headers: { 'Retry-After': String(err.retryAfterSec) } },
+      );
+    }
+    throw err;
+  }
+}
 
 // 動的セグメント (tenantId) の型
 type Params = { params: Promise<{ tenantId: string }> };
@@ -49,9 +80,23 @@ export async function POST(req: Request, { params }: Params) {
   const errorRedirect = (code: SsoErrorCode) =>
     NextResponse.redirect(new URL(`/login?error=${code}`, baseUrl), 303);
 
+  // 固定キーの全体レート制限を適用する (テナント解決より前に置き、URL の tenantId を
+  // 変え続けることでのレート制限回避・DB 負荷増大を防ぐ。詳細は定数の定義コメント参照)
+  const unauthLimitResponse = checkRateLimit(
+    'sso-acs:unauthenticated',
+    SSO_ACS_UNAUTHENTICATED_RATE_LIMIT,
+  );
+  if (unauthLimitResponse) return unauthLimitResponse;
+
   // SSO が利用可能か検証する (不可ならログイン画面へ)
   const ctx = await loadEnabledSsoContext(tenantId);
   if (!ctx.ok) return errorRedirect('sso-unavailable');
+
+  // テナントが実在し SSO が有効だと確認できたので、ここからは信頼できる tenantId を
+  // キーにしたテナント単位のレート制限を適用する (この後の XML パース・署名検証は
+  // CPU コストが高いため、その前に弾く)
+  const tenantLimitResponse = checkRateLimit(`sso-acs:${tenantId}`, SSO_ACS_TENANT_RATE_LIMIT);
+  if (tenantLimitResponse) return tenantLimitResponse;
 
   // POST ボディ (application/x-www-form-urlencoded) から SAMLResponse を取り出す
   let samlResponse: string;

--- a/src/app/api/auth/sso/[tenantId]/acs/route.ts
+++ b/src/app/api/auth/sso/[tenantId]/acs/route.ts
@@ -29,8 +29,8 @@ import { createSamlInstance, validateSamlResponse } from '@/lib/saml';
 import { generateMagicLinkToken, hashMagicLinkToken } from '@/lib/magic-link';
 // HTML 属性への安全な埋め込み用エスケープ (確認ページのトークン埋め込みに使う)
 import { escapeHtml } from '@/lib/html-escape';
-// 連打防止のための共通レート制限ヘルパー
-import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
+// Route Handler 向け共通レート制限ラッパー (inbound-email/inbound-line と共有)
+import { checkRouteRateLimit } from '@/lib/route-rate-limit';
 
 // SSO ハンドオフトークンの有効期限 (2 分)。ACS → コールバックの即時引き渡し専用なので短くする
 const SSO_HANDOFF_TTL_MS = 2 * 60 * 1000;
@@ -46,23 +46,6 @@ const SSO_ACS_UNAUTHENTICATED_RATE_LIMIT = { limit: 60, windowMs: 60_000 } as co
 //  - テナントが実在し SSO が有効だと確認できた後は、tenantId (DB 由来で信頼できる値) を
 //    キーにしたテナント単位の制限も適用する (1 テナントからの異常な連打を抑える)。
 const SSO_ACS_TENANT_RATE_LIMIT = { limit: 20, windowMs: 60_000 } as const;
-
-// レート制限を適用し、超過していれば 429 レスポンスを返す共通ヘルパー。
-// 超過なしなら null を返し、呼び出し側はそのまま処理を続行する (inbound-line/route.ts と同じ方針)。
-function checkRateLimit(key: string, options: { limit: number; windowMs: number }) {
-  try {
-    enforceRateLimit(key, options);
-    return null;
-  } catch (err) {
-    if (err instanceof RateLimitError) {
-      return NextResponse.json(
-        { error: 'しばらく時間をおいて再度お試しください' },
-        { status: 429, headers: { 'Retry-After': String(err.retryAfterSec) } },
-      );
-    }
-    throw err;
-  }
-}
 
 // 動的セグメント (tenantId) の型
 type Params = { params: Promise<{ tenantId: string }> };
@@ -82,9 +65,10 @@ export async function POST(req: Request, { params }: Params) {
 
   // 固定キーの全体レート制限を適用する (テナント解決より前に置き、URL の tenantId を
   // 変え続けることでのレート制限回避・DB 負荷増大を防ぐ。詳細は定数の定義コメント参照)
-  const unauthLimitResponse = checkRateLimit(
+  const unauthLimitResponse = checkRouteRateLimit(
     'sso-acs:unauthenticated',
     SSO_ACS_UNAUTHENTICATED_RATE_LIMIT,
+    'しばらく時間をおいて再度お試しください',
   );
   if (unauthLimitResponse) return unauthLimitResponse;
 
@@ -95,7 +79,11 @@ export async function POST(req: Request, { params }: Params) {
   // テナントが実在し SSO が有効だと確認できたので、ここからは信頼できる tenantId を
   // キーにしたテナント単位のレート制限を適用する (この後の XML パース・署名検証は
   // CPU コストが高いため、その前に弾く)
-  const tenantLimitResponse = checkRateLimit(`sso-acs:${tenantId}`, SSO_ACS_TENANT_RATE_LIMIT);
+  const tenantLimitResponse = checkRouteRateLimit(
+    `sso-acs:${tenantId}`,
+    SSO_ACS_TENANT_RATE_LIMIT,
+    'しばらく時間をおいて再度お試しください',
+  );
   if (tenantLimitResponse) return tenantLimitResponse;
 
   // POST ボディ (application/x-www-form-urlencoded) から SAMLResponse を取り出す

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -42,8 +42,8 @@ import {
 } from '@/lib/inbound-email';
 // エージェント権限判定 (スレッド追記の RBAC に使用)
 import { isAgent } from '@/lib/role';
-// 公開エンドポイントの流量制限 (§9: DoS / リソース枯渇防止)
-import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
+// 公開エンドポイントの流量制限 (§9: DoS / リソース枯渇防止。Route Handler 向け共通ラッパー)
+import { checkRouteRateLimit } from '@/lib/route-rate-limit';
 // 優先度から解決期限を計算する SLA ヘルパー (Web フォーム起票と同じ既定値に揃える)
 import { calculateFirstResponseDueAt, calculateResolutionDueAt } from '@/lib/sla';
 // 受領自動返信 (メンバー改善 #1) のための送信基盤・本文生成・リンク組み立てヘルパー
@@ -385,18 +385,12 @@ export async function POST(req: Request) {
 
   // テナント単位で取り込み流量を制限する (シークレット漏洩時の起票スパムを抑える §9)。
   // 超過時は 429 + Retry-After で返し、プロバイダの後刻リトライに委ねる
-  try {
-    enforceRateLimit(`inbound-email:${tenant.id}`, INBOUND_RATE_LIMIT);
-  } catch (err) {
-    // 流量超過専用エラーだけを 429 にマップ。それ以外は想定外なので上位へ投げる
-    if (err instanceof RateLimitError) {
-      return NextResponse.json(
-        { error: '取り込みが混み合っています' },
-        { status: 429, headers: { 'Retry-After': String(err.retryAfterSec) } },
-      );
-    }
-    throw err;
-  }
+  const rateLimitResponse = checkRouteRateLimit(
+    `inbound-email:${tenant.id}`,
+    INBOUND_RATE_LIMIT,
+    '取り込みが混み合っています',
+  );
+  if (rateLimitResponse) return rateLimitResponse;
 
   // 送信元ドメイン認証 (SPF/DKIM/DMARC) の検証 (§8 リスク表「送信元ドメイン検証」)。
   // プロバイダが算出した結果を消費し、ポリシーが 'enforce' のとき明示 'fail' なら隔離する。

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -47,8 +47,8 @@ import {
 } from '@/lib/idempotent-ticket-creation';
 // 新規起票時の初期ステータスを mode から決める共通ルール (Web フォーム起票と単一の源を共有)
 import { initialStatusForMode } from '@/domain/ticket-status';
-// 公開エンドポイントの流量制限 (§9: DoS / リソース枯渇防止)
-import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
+// 公開エンドポイントの流量制限 (§9: DoS / リソース枯渇防止。Route Handler 向け共通ラッパー)
+import { checkRouteRateLimit } from '@/lib/route-rate-limit';
 // 優先度から解決期限を計算する SLA ヘルパー (他の取り込みチャネルと同じ既定値に揃える)
 import { calculateFirstResponseDueAt, calculateResolutionDueAt } from '@/lib/sla';
 // LINE メンバー紐付け: 受信テキストの正規化・コード形判定・ハッシュ化 (発行は Web 設定画面側)
@@ -82,26 +82,6 @@ const LINE_UNAUTHENTICATED_RATE_LIMIT = { limit: 600, windowMs: 60_000 } as cons
 // (シークレット漏洩時のスパムを抑える)。lineConfig.tenantId は DB 由来の信頼できる値
 // (botUserId の @unique 制約でテナントと 1:1) なので、これをキーにする。
 const LINE_RATE_LIMIT = { limit: 120, windowMs: 60_000 } as const;
-
-// レート制限を適用し、超過していれば 429 レスポンスを返す共通ヘルパー。
-// 超過なしなら null を返し、呼び出し側はそのまま処理を続行する。
-function checkRateLimit(key: string, options: { limit: number; windowMs: number }) {
-  try {
-    // 同期の流量制限チェック (超過時は RateLimitError を throw する)
-    enforceRateLimit(key, options);
-    // 超過なし: 呼び出し側へ処理続行を伝える
-    return null;
-  } catch (err) {
-    // 流量超過専用エラーだけを 429 にマップ。それ以外は想定外なので上位へ再 throw する
-    if (err instanceof RateLimitError) {
-      return NextResponse.json(
-        { error: '取り込みが混み合っています' },
-        { status: 429, headers: { 'Retry-After': String(err.retryAfterSec) } },
-      );
-    }
-    throw err;
-  }
-}
 
 // チケットタイトルとして使うテキストの最大文字数 (長すぎる場合は末尾を省略する)
 const MAX_TITLE_LENGTH = 100;
@@ -256,9 +236,10 @@ export async function POST(req: Request) {
 
   // 固定キーの全体レート制限を適用する (DB 参照より前に置き、destination を変え続ける
   // ことでのレート制限回避・DB 負荷増大を防ぐ。詳細は定数の定義コメント参照)
-  const unauthLimitResponse = checkRateLimit(
+  const unauthLimitResponse = checkRouteRateLimit(
     'inbound-line:unauthenticated',
     LINE_UNAUTHENTICATED_RATE_LIMIT,
+    '取り込みが混み合っています',
   );
   if (unauthLimitResponse) return unauthLimitResponse;
 
@@ -272,9 +253,10 @@ export async function POST(req: Request) {
 
   // テナントが解決できたので、ここからは信頼できる tenantId をキーにしたチャネル単位の
   // レート制限を適用する (destination のような攻撃者が操作可能な値はキーに使わない)。
-  const tenantLimitResponse = checkRateLimit(
+  const tenantLimitResponse = checkRouteRateLimit(
     `inbound-line:${lineConfig.tenantId}`,
     LINE_RATE_LIMIT,
+    '取り込みが混み合っています',
   );
   if (tenantLimitResponse) return tenantLimitResponse;
 

--- a/src/lib/route-rate-limit.ts
+++ b/src/lib/route-rate-limit.ts
@@ -1,0 +1,39 @@
+// Route Handler (Next.js API ルート) 向けのレート制限ラッパー。
+// /code-review ultra 指摘対応: 「enforceRateLimit を try/catch し、RateLimitError なら
+// 429 + Retry-After の NextResponse を返す」という同一の 10 行前後のコードが
+// inbound/email/route.ts (インライン)・inbound/line/route.ts (ローカル関数)・
+// sso/[tenantId]/acs/route.ts (ローカル関数) の 3 箇所に複製されていたため
+// (CLAUDE.md §6「2〜3 箇所目で共通化する」を超過)、ここに集約する。
+//
+// src/lib/rate-limit.ts の checkRateLimit (Server Action 向け・string | null を返す契約) とは
+// 戻り値の型が異なるため、同名衝突を避けて別名にしている (Route Handler は NextResponse を返す
+// 契約、Server Action は {error} 用のメッセージ文字列を返す契約で、用途が異なる)。
+
+// HTTP レスポンス生成
+import { NextResponse } from 'next/server';
+// レート制限の本体とオプション型・専用エラー型
+import { enforceRateLimit, RateLimitError, type RateLimitOptions } from '@/lib/rate-limit';
+
+// レート制限を適用し、超過していれば 429 + Retry-After の NextResponse を返す。
+// 超過なしなら null を返し、呼び出し側はそのまま処理を続行する。
+export function checkRouteRateLimit(
+  key: string, // レート制限のキー (呼び出し元がスコープを決める)
+  options: RateLimitOptions, // 制限値 (limit / windowMs)
+  errorMessage: string, // 超過時にクライアントへ返す日本語メッセージ (呼び出し元の文脈に合わせる)
+): NextResponse | null {
+  try {
+    // 同期の流量制限チェック (超過時は RateLimitError を throw する)
+    enforceRateLimit(key, options);
+    // 超過なし: 呼び出し側へ処理続行を伝える
+    return null;
+  } catch (err) {
+    // 流量超過専用エラーだけを 429 にマップ。それ以外は想定外なので上位へ再 throw する
+    if (err instanceof RateLimitError) {
+      return NextResponse.json(
+        { error: errorMessage },
+        { status: 429, headers: { 'Retry-After': String(err.retryAfterSec) } },
+      );
+    }
+    throw err;
+  }
+}

--- a/tests/data/location-repository.contract.prisma.test.ts
+++ b/tests/data/location-repository.contract.prisma.test.ts
@@ -1,0 +1,202 @@
+// 拠点リポジトリ (Prisma アダプタ) の契約テスト。
+// Phase 4 多拠点 (docs/smb-dx-pivot-plan.md §5.2)。テナント分離・重複名エラー・
+// 削除時のチケット locationId SetNull カスケードを実 DB に対して検証する。
+// 監査で発見したギャップ: これまで tests/data/location-repository.memory.test.ts
+// (メモリアダプタ) しかテストが無く、update() の「事前 findFirst でテナント所有を
+// 確認してから PK だけで更新する」という非自明な実装や、DB 側の @@unique([tenantId, name])
+// 制約・ON DELETE SET NULL カスケードが実際に本番 Prisma アダプタで動くかは未検証だった
+// (CLAUDE.md §11「メモリのみのテストは実装の誤った自信を生む」)。
+//
+// この DB 依存テストは RUN_PRISMA_CONTRACT=1 のときだけ走り、beforeEach で全テーブルを
+// TRUNCATE するため **開発 DB を指さない** こと。
+
+import { describe, beforeAll, afterAll, beforeEach, expect, it } from 'vitest';
+import { PrismaClient } from '@/generated/prisma';
+import { buildPrismaRepos } from '@/data/adapters/prisma';
+
+const TENANT_A = 'default-tenant';
+const TENANT_B = 'tenant-b';
+const USER_A = 'user-a';
+
+const SHOULD_RUN = process.env.RUN_PRISMA_CONTRACT === '1';
+
+describe.runIf(SHOULD_RUN)('LocationRepository (prisma adapter)', () => {
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    prisma = new PrismaClient();
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  // 各テスト前に全テーブルを空にし、テナント A / B + テナント A のユーザーを作成する
+  // (削除時のチケットカスケードテストで Ticket.creatorId の FK 先が必要)
+  beforeEach(async () => {
+    await prisma.$executeRawUnsafe(
+      'TRUNCATE TABLE "Location","Attachment","TicketHistory","TicketComment","Notification","FaqCandidate","Ticket","Category","MagicLinkToken","User","Tenant" RESTART IDENTITY CASCADE',
+    );
+    await prisma.tenant.create({ data: { id: TENANT_A, name: 'デフォルト組織', mode: 'lite' } });
+    await prisma.tenant.create({ data: { id: TENANT_B, name: '別組織', mode: 'lite' } });
+    await prisma.user.create({
+      data: {
+        id: USER_A,
+        email: 'admin@example.com',
+        name: '管理者太郎',
+        passwordHash: 'x',
+        role: 'admin',
+        tenantId: TENANT_A,
+      },
+    });
+  });
+
+  // 新規拠点を作成できる
+  it('新規拠点を作成できる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const location = await repos.locations.create({
+      tenantId: TENANT_A,
+      name: '渋谷本店',
+      description: '本社',
+    });
+    expect(location.id).toEqual(expect.any(String));
+    expect(location.name).toBe('渋谷本店');
+  });
+
+  // 同一テナント内で同名の拠点は作成できない (@@unique([tenantId, name]))
+  it('同一テナント内の重複名はエラーになる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await repos.locations.create({ tenantId: TENANT_A, name: '渋谷本店', description: null });
+    await expect(
+      repos.locations.create({ tenantId: TENANT_A, name: '渋谷本店', description: null }),
+    ).rejects.toThrow();
+  });
+
+  // 別テナントであれば同名の拠点を作成できる (一意制約がテナントスコープであること)
+  it('別テナントであれば同名でも作成できる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await repos.locations.create({ tenantId: TENANT_A, name: '渋谷本店', description: null });
+    const location = await repos.locations.create({
+      tenantId: TENANT_B,
+      name: '渋谷本店',
+      description: null,
+    });
+    expect(location.tenantId).toBe(TENANT_B);
+  });
+
+  // テナントスコープで絞り込み、他テナントの拠点は含まれない
+  it('listByTenantは自テナントの拠点のみを返す', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await repos.locations.create({ tenantId: TENANT_A, name: 'A拠点', description: null });
+    await repos.locations.create({ tenantId: TENANT_B, name: 'B拠点', description: null });
+    const result = await repos.locations.listByTenant(TENANT_A);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('A拠点');
+  });
+
+  // 他テナントの ID を渡すと null を返す (クロステナントアクセス防止)
+  it('findByIdは他テナントの拠点IDにnullを返す', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const location = await repos.locations.create({
+      tenantId: TENANT_A,
+      name: 'A拠点',
+      description: null,
+    });
+    const result = await repos.locations.findById(location.id, TENANT_B);
+    expect(result).toBeNull();
+  });
+
+  // 名前・説明を更新できる (update() の findFirst→PKのみ更新パターンの正常系)
+  it('名前と説明を更新できる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const location = await repos.locations.create({
+      tenantId: TENANT_A,
+      name: '旧名称',
+      description: '旧説明',
+    });
+    const updated = await repos.locations.update(location.id, TENANT_A, {
+      name: '新名称',
+      description: '新説明',
+    });
+    expect(updated.name).toBe('新名称');
+    expect(updated.description).toBe('新説明');
+  });
+
+  // 他テナントの拠点 ID を更新しようとするとエラーになる (fail-closed)。
+  // update() は Prisma の制約上 PK のみで解決するため、事前 findFirst によるテナント
+  // 所有確認が実際に機能しているかが本番 Prisma アダプタでの最重要な検証ポイント
+  it('他テナントの拠点IDを更新しようとするとエラーになり実際に変更されない', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const location = await repos.locations.create({
+      tenantId: TENANT_A,
+      name: 'A拠点',
+      description: null,
+    });
+    await expect(
+      repos.locations.update(location.id, TENANT_B, { name: '乗っ取り' }),
+    ).rejects.toThrow();
+    // 実際にテナント A 側の値が変更されていないことを確認する
+    const reloaded = await repos.locations.findById(location.id, TENANT_A);
+    expect(reloaded?.name).toBe('A拠点');
+  });
+
+  // 存在しない拠点 ID はエラーになる
+  it('存在しない拠点IDの更新はエラーになる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await expect(
+      repos.locations.update('no-such-location', TENANT_A, { name: 'x' }),
+    ).rejects.toThrow();
+  });
+
+  // 削除すると紐づくチケットの locationId が null になる (DB の ON DELETE SET NULL を検証)
+  it('削除すると紐づくチケットのlocationIdがnullになる (ON DELETE SET NULL)', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const location = await repos.locations.create({
+      tenantId: TENANT_A,
+      name: 'A拠点',
+      description: null,
+    });
+    const ticket = await repos.tickets.create({
+      title: 'テスト',
+      body: '本文',
+      priority: 'Medium',
+      creatorId: USER_A,
+      categoryId: null,
+      locationId: location.id,
+      tenantId: TENANT_A,
+    });
+
+    await repos.locations.delete(location.id, TENANT_A);
+
+    const reloaded = await repos.tickets.findById(ticket.id, TENANT_A);
+    expect(reloaded?.locationId).toBeNull();
+  });
+
+  // 削除された拠点自体はもう取得できない
+  it('削除後は拠点自体が取得できなくなる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const location = await repos.locations.create({
+      tenantId: TENANT_A,
+      name: 'A拠点',
+      description: null,
+    });
+    await repos.locations.delete(location.id, TENANT_A);
+    const result = await repos.locations.findById(location.id, TENANT_A);
+    expect(result).toBeNull();
+  });
+
+  // 他テナントの拠点 ID を削除しようとしても no-op (deleteMany の想定挙動)
+  it('他テナントの拠点IDを削除しようとしてもno-opになる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const location = await repos.locations.create({
+      tenantId: TENANT_A,
+      name: 'A拠点',
+      description: null,
+    });
+    await repos.locations.delete(location.id, TENANT_B);
+    // テナント A から見ればまだ存在しているはず
+    const result = await repos.locations.findById(location.id, TENANT_A);
+    expect(result).not.toBeNull();
+  });
+});

--- a/tests/features/sso-acs-route.test.ts
+++ b/tests/features/sso-acs-route.test.ts
@@ -1,0 +1,65 @@
+// POST /api/auth/sso/[tenantId]/acs のレート制限テスト。
+// 監査で発見したギャップ: 他の未認証受信エンドポイント (inbound-line/inbound-email) と異なり、
+// この ACS エンドポイントにはレート制限が無かった。ACS は未認証で到達でき、XML パース + 署名検証
+// という CPU コストの高い処理をリクエストごとに行うため、二段構えのレート制限を追加した。
+// このテストは SAML 検証そのものではなく、レート制限が正しく効くことに焦点を当てる
+// (SAMLResponse を意図的に省略し、レート制限チェックの後段で sso-invalid になることを利用する)。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetRateLimits } from '@/lib/rate-limit';
+
+const TENANT_ID = 'tenant-1';
+
+// loadEnabledSsoContext を「常に SSO 利用可能」に固定する (テナント単位レート制限の検証に必要)
+vi.mock('@/lib/sso-context', () => ({
+  loadEnabledSsoContext: vi.fn(async () => ({
+    ok: true,
+    tenant: { id: TENANT_ID, name: 'テスト組織' },
+    config: { idpEntityId: 'https://idp.example.com/entity' },
+    baseUrl: 'http://localhost:3000',
+  })),
+}));
+
+// リクエストを 1 件送るヘルパー (SAMLResponse は意図的に省略する)
+async function postAcs(tenantId: string): Promise<Response> {
+  const { POST } = await import('@/app/api/auth/sso/[tenantId]/acs/route');
+  const req = new Request(`http://localhost:3000/api/auth/sso/${tenantId}/acs`, {
+    method: 'POST',
+    body: new URLSearchParams(), // SAMLResponse フィールドなし
+  });
+  return POST(req, { params: Promise.resolve({ tenantId }) });
+}
+
+describe('POST /api/auth/sso/[tenantId]/acs のレート制限', () => {
+  beforeEach(() => {
+    __resetRateLimits();
+  });
+
+  // 固定キーの全体レート制限 (60秒60回) を超えると 429 を返す
+  it('未認証全体のレート制限を超えると429を返す', async () => {
+    for (let i = 0; i < 60; i++) {
+      const res = await postAcs(`tenant-${i}`);
+      expect(res.status).not.toBe(429);
+    }
+    const res = await postAcs('tenant-over-limit');
+    expect(res.status).toBe(429);
+  });
+
+  // テナント単位のレート制限 (60秒20回) を超えると429を返す (同一テナントへの連打)
+  it('同一テナントへの連打はテナント単位のレート制限で429を返す', async () => {
+    for (let i = 0; i < 20; i++) {
+      const res = await postAcs(TENANT_ID);
+      expect(res.status).not.toBe(429);
+    }
+    const res = await postAcs(TENANT_ID);
+    expect(res.status).toBe(429);
+  });
+
+  // レート制限内であれば SAMLResponse 欠落により sso-invalid へリダイレクトされる
+  // (429 ではなく通常のエラーハンドリングが働くことの確認)
+  it('レート制限内ならSAMLResponse欠落で通常どおりsso-invalidにリダイレクトする', async () => {
+    const res = await postAcs(TENANT_ID);
+    expect(res.status).toBe(303);
+    expect(res.headers.get('location')).toContain('error=sso-invalid');
+  });
+});

--- a/tests/route-rate-limit.test.ts
+++ b/tests/route-rate-limit.test.ts
@@ -1,0 +1,46 @@
+// checkRouteRateLimit (Route Handler 向けレート制限ラッパー) の仕様確認テスト。
+// /code-review ultra 指摘対応: inbound-email/inbound-line/sso-acs の 3 ルートに複製されていた
+// 「enforceRateLimit を try/catch し、RateLimitError なら 429 の NextResponse を返す」処理を
+// src/lib/route-rate-limit.ts に集約した。その集約先自体の単体テスト。
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { __resetRateLimits } from '@/lib/rate-limit';
+import { checkRouteRateLimit } from '@/lib/route-rate-limit';
+
+describe('checkRouteRateLimit', () => {
+  beforeEach(() => {
+    __resetRateLimits();
+  });
+
+  // 上限以内なら null を返し、呼び出し側が処理を続行できる
+  it('returns null when within the limit', () => {
+    const result = checkRouteRateLimit('k', { limit: 3, windowMs: 10_000 }, 'メッセージ');
+    expect(result).toBeNull();
+  });
+
+  // 上限を超えると 429 + Retry-After ヘッダの NextResponse を返す
+  it('returns a 429 response with the given message once over the limit', async () => {
+    for (let i = 0; i < 3; i++) {
+      expect(checkRouteRateLimit('k2', { limit: 3, windowMs: 10_000 }, 'メッセージ')).toBeNull();
+    }
+    const response = checkRouteRateLimit(
+      'k2',
+      { limit: 3, windowMs: 10_000 },
+      'カスタムメッセージ',
+    );
+    expect(response).not.toBeNull();
+    expect(response?.status).toBe(429);
+    expect(response?.headers.get('Retry-After')).toEqual(expect.any(String));
+    const body = await response?.json();
+    expect(body).toEqual({ error: 'カスタムメッセージ' });
+  });
+
+  // 異なるキーは独立してカウントされる
+  it('tracks keys independently', () => {
+    for (let i = 0; i < 3; i++) {
+      checkRouteRateLimit('k3-a', { limit: 3, windowMs: 10_000 }, 'メッセージ');
+    }
+    // 別キーはまだ上限に達していないので null
+    expect(checkRouteRateLimit('k3-b', { limit: 3, windowMs: 10_000 }, 'メッセージ')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 対応 Phase / 項目

`docs/smb-dx-pivot-plan.md` §5.2「多店舗・多拠点対応」（テスト網羅性フォローアップ）/ §6.1 Enterprise「SSO(SAML)」（セキュリティ一貫性フォローアップ）。

監査で発見した2件のギャップに対応する。

## 変更内容 (2コミット、各1論理変更)

### 1. `test(data)`: 拠点リポジトリのPrisma契約テストを追加

`tests/data/location-repository.memory.test.ts`（メモリアダプタ）しかテストが無く、`update()` の「事前 `findFirst` でテナント所有を確認してから PK だけで更新する」という非自明な実装や、DB 側の `@@unique([tenantId, name])` 制約・`ON DELETE SET NULL` カスケードが実際に本番 Prisma アダプタで動くかは未検証だった（CLAUDE.md §11「メモリのみのテストは実装の誤った自信を生む」）。他の Phase 2〜4 リポジトリ（line-config / sso-config / settings-audit-log 等）は軒並み契約テストのペアを持っており、`LocationRepository` だけこの慣習から外れていた。

`tests/data/location-repository.contract.prisma.test.ts` を新規作成し、メモリ版と同じ観点（テナント分離・重複名エラー・クロステナント更新/削除の fail-closed・削除カスケード）を実 DB に対して検証する。

### 2. `fix(auth)`: SSO ACSエンドポイントにレート制限を追加

他の未認証受信エンドポイント（inbound-line/inbound-email/webhooks/stripe 等）はいずれもレート制限を持つが、`POST /api/auth/sso/[tenantId]/acs` だけ欠けていた。ACS は未認証で到達でき、IdP からの SAMLResponse を受け取るたびに XML パース + 署名検証という CPU コストの高い処理を行うため、他の受信系と同じ不整合だった。

- URL の `tenantId` は署名検証前の値で攻撃者が自由に変更できるため、これ単体をキーにすると値を変えるだけで無制限に回避・バケット増殖されてしまう（`inbound-line` の `destination` と同じ問題）。テナント解決（DB 参照）より前に固定キーで「未認証リクエスト全体」の上限を設ける（`sso-acs:unauthenticated`, 60秒60回）。
- テナントが実在し SSO が有効だと確認できた後は、`tenantId`（DB 由来で信頼できる値）をキーにしたテナント単位の制限も追加する（`sso-acs:<tenantId>`, 60秒20回）。
- レート制限のテストを新規作成。

SP メタデータ・ログイン開始（login/metadata）の 2 エンドポイントは未認証の DB 参照のみで攻撃者由来の XML パース/署名検証を行わないため、本 PR のスコープからは除外した。

## 検証方法

- `npm run typecheck`: pass
- `npm run lint`: pass
- `npm run test`: 699 passed / 63 skipped（新規追加分を含む。Prisma 契約テストはこの環境に DB が無いため skip — CI の `prisma-contract` ジョブで実行される）

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr355dSJHNHurUjVPUEUyx)_