### PR TITLE
feat(settings): 外部通知チャネルの送信失敗可視化 + a11yフィックス + Prisma契約テスト追加

### DIFF
--- a/prisma/migrations/20260709030000_add_tenant_outbound_channel_health/migration.sql
+++ b/prisma/migrations/20260709030000_add_tenant_outbound_channel_health/migration.sql
@@ -1,0 +1,9 @@
+-- 監査で発見したギャップ: 外部通知チャネル (Slack/Teams/Chatwork) の送信失敗はサーバーログにしか
+-- 残らず、管理者が Webhook URL の失効・トークン失効に気づく手段が無かった。
+-- チャネルごとに直近の失敗日時・メッセージだけを追加する (履歴は持たない。成功したら null に戻す)。
+ALTER TABLE "Tenant" ADD COLUMN "slackLastFailureAt" TIMESTAMP(3);
+ALTER TABLE "Tenant" ADD COLUMN "slackLastFailureMessage" TEXT;
+ALTER TABLE "Tenant" ADD COLUMN "teamsLastFailureAt" TIMESTAMP(3);
+ALTER TABLE "Tenant" ADD COLUMN "teamsLastFailureMessage" TEXT;
+ALTER TABLE "Tenant" ADD COLUMN "chatworkLastFailureAt" TIMESTAMP(3);
+ALTER TABLE "Tenant" ADD COLUMN "chatworkLastFailureMessage" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -131,6 +131,17 @@ model Tenant {
   chatworkApiToken String? // Chatwork API トークン (null=通知無効)
   chatworkRoomId   String? // 投稿先の Chatwork ルーム ID (数字文字列。null=通知無効)
 
+  // 監査で発見したギャップ: 外部通知チャネルの送信失敗はこれまでサーバーログにしか残らず、
+  // 管理者は Webhook URL の失効・トークン失効に気づく手段が無かった (docs/smb-dx-pivot-plan.md
+  // §4 Phase 4)。チャネルごとに直近の失敗日時・メッセージだけを保持し (履歴は持たない)、
+  // 次の送信が成功したら null に戻す (settings 画面での「⚠️ 最終送信失敗」表示に使う)。
+  slackLastFailureAt         DateTime? // Slack 直近送信失敗日時 (成功後は null に戻る)
+  slackLastFailureMessage    String? // Slack 直近送信失敗の概要メッセージ
+  teamsLastFailureAt         DateTime? // Teams 直近送信失敗日時 (成功後は null に戻る)
+  teamsLastFailureMessage    String? // Teams 直近送信失敗の概要メッセージ
+  chatworkLastFailureAt      DateTime? // Chatwork 直近送信失敗日時 (成功後は null に戻る)
+  chatworkLastFailureMessage String? // Chatwork 直近送信失敗の概要メッセージ
+
   // Phase 4 課金: Stripe Billing 連携フィールド。
   // Stripe ダッシュボードと連携して Free/Standard/Pro のサブスクを管理する。
   // subscriptionPlan は課金状態に応じて Stripe Webhook 受信時に自動更新される。

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -172,28 +172,33 @@ export default async function DashboardPage({ searchParams }: Props) {
           <span className="text-xs font-semibold tracking-wider text-slate-500 uppercase">
             拠点で絞り込み
           </span>
-          {/* 「すべての拠点」ピル (未選択状態) */}
+          {/* 「すべての拠点」ピル (未選択状態)。選択状態は色だけでなく aria-current と
+              チェックマークでも伝える (§7 a11y「色だけに意味を持たせない」) */}
           <Link
             href="/dashboard"
+            aria-current={selectedLocationId === undefined ? 'true' : undefined}
             className={`rounded-full px-3 py-1 text-xs font-medium transition ${
               selectedLocationId === undefined
                 ? 'bg-teal-700 text-white'
                 : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50'
             }`}
           >
+            {selectedLocationId === undefined && <span aria-hidden="true">✓ </span>}
             すべての拠点
           </Link>
-          {/* 拠点ごとのピル */}
+          {/* 拠点ごとのピル (同様に aria-current + チェックマークで選択状態を明示) */}
           {locations.map((location) => (
             <Link
               key={location.id}
               href={`/dashboard?locationId=${location.id}`}
+              aria-current={selectedLocationId === location.id ? 'true' : undefined}
               className={`rounded-full px-3 py-1 text-xs font-medium transition ${
                 selectedLocationId === location.id
                   ? 'bg-teal-700 text-white'
                   : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50'
               }`}
             >
+              {selectedLocationId === location.id && <span aria-hidden="true">✓ </span>}
               {location.name}
             </Link>
           ))}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -241,19 +241,21 @@ export default async function SettingsPage() {
           teamsWebhookUrl={tenant?.teamsWebhookUrl ?? null}
           chatworkApiToken={tenant?.chatworkApiToken ?? null}
           chatworkRoomId={tenant?.chatworkRoomId ?? null}
-          // 監査で発見したギャップ対応: 直近送信失敗があるチャネルだけ警告バッジを表示する
+          // 監査で発見したギャップ対応: 直近送信失敗があるチャネルだけ警告バッジを表示する。
+          // 空文字列 (falsy だが記録は存在する) を見落とさないよう `!= null` で判定する
+          // (`&&` の truthy チェックだと message が空文字列のとき記録があるのにバッジが消える)
           slackFailure={
-            tenant?.slackLastFailureAt && tenant.slackLastFailureMessage
+            tenant?.slackLastFailureAt != null && tenant.slackLastFailureMessage != null
               ? { at: tenant.slackLastFailureAt, message: tenant.slackLastFailureMessage }
               : null
           }
           teamsFailure={
-            tenant?.teamsLastFailureAt && tenant.teamsLastFailureMessage
+            tenant?.teamsLastFailureAt != null && tenant.teamsLastFailureMessage != null
               ? { at: tenant.teamsLastFailureAt, message: tenant.teamsLastFailureMessage }
               : null
           }
           chatworkFailure={
-            tenant?.chatworkLastFailureAt && tenant.chatworkLastFailureMessage
+            tenant?.chatworkLastFailureAt != null && tenant.chatworkLastFailureMessage != null
               ? { at: tenant.chatworkLastFailureAt, message: tenant.chatworkLastFailureMessage }
               : null
           }

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -241,6 +241,22 @@ export default async function SettingsPage() {
           teamsWebhookUrl={tenant?.teamsWebhookUrl ?? null}
           chatworkApiToken={tenant?.chatworkApiToken ?? null}
           chatworkRoomId={tenant?.chatworkRoomId ?? null}
+          // 監査で発見したギャップ対応: 直近送信失敗があるチャネルだけ警告バッジを表示する
+          slackFailure={
+            tenant?.slackLastFailureAt && tenant.slackLastFailureMessage
+              ? { at: tenant.slackLastFailureAt, message: tenant.slackLastFailureMessage }
+              : null
+          }
+          teamsFailure={
+            tenant?.teamsLastFailureAt && tenant.teamsLastFailureMessage
+              ? { at: tenant.teamsLastFailureAt, message: tenant.teamsLastFailureMessage }
+              : null
+          }
+          chatworkFailure={
+            tenant?.chatworkLastFailureAt && tenant.chatworkLastFailureMessage
+              ? { at: tenant.chatworkLastFailureAt, message: tenant.chatworkLastFailureMessage }
+              : null
+          }
         />
       </section>
 

--- a/src/data/adapters/memory/tenant-repository.memory.ts
+++ b/src/data/adapters/memory/tenant-repository.memory.ts
@@ -168,17 +168,22 @@ export function makeTenantRepo(store: Store): TenantRepository {
       // 失敗時は日時とメッセージを、成功 (クリア) 時は両方 null にする
       const at = failure ? failure.at : null;
       const message = failure ? failure.message : null;
+      // 更新後のテナント (チャネルに応じて書き換えるフィールドが変わる)
       let updated: Tenant;
+      // チャネルキーで分岐する (3 種類のみなので switch で列挙する)
       switch (channel) {
         case 'slack':
+          // Slack 用の 2 フィールドだけを差し替えた新しいオブジェクトを作る
           updated = { ...t, slackLastFailureAt: at, slackLastFailureMessage: message };
-          break;
+          break; // 他のケースに落ちないよう抜ける
         case 'teams':
+          // Teams 用の 2 フィールドだけを差し替えた新しいオブジェクトを作る
           updated = { ...t, teamsLastFailureAt: at, teamsLastFailureMessage: message };
-          break;
+          break; // 他のケースに落ちないよう抜ける
         case 'chatwork':
+          // Chatwork 用の 2 フィールドだけを差し替えた新しいオブジェクトを作る
           updated = { ...t, chatworkLastFailureAt: at, chatworkLastFailureMessage: message };
-          break;
+          break; // 他のケースに落ちないよう抜ける
       }
       store.tenants.set(id, updated);
       // 防御的コピーを返す

--- a/src/data/adapters/memory/tenant-repository.memory.ts
+++ b/src/data/adapters/memory/tenant-repository.memory.ts
@@ -159,5 +159,30 @@ export function makeTenantRepo(store: Store): TenantRepository {
       // 防御的コピーを返す
       return { ...updated };
     },
+
+    // Phase 4: 外部通知チャネル 1 件の送信結果を記録する (失敗時は日時+メッセージ、成功時は null でクリア)
+    async recordOutboundChannelResult(id, channel, failure) {
+      // 対象テナントを Map から取得 (存在しなければエラー)
+      const t = store.tenants.get(id);
+      if (!t) throw new Error('テナントが見つかりません');
+      // 失敗時は日時とメッセージを、成功 (クリア) 時は両方 null にする
+      const at = failure ? failure.at : null;
+      const message = failure ? failure.message : null;
+      let updated: Tenant;
+      switch (channel) {
+        case 'slack':
+          updated = { ...t, slackLastFailureAt: at, slackLastFailureMessage: message };
+          break;
+        case 'teams':
+          updated = { ...t, teamsLastFailureAt: at, teamsLastFailureMessage: message };
+          break;
+        case 'chatwork':
+          updated = { ...t, chatworkLastFailureAt: at, chatworkLastFailureMessage: message };
+          break;
+      }
+      store.tenants.set(id, updated);
+      // 防御的コピーを返す
+      return { ...updated };
+    },
   };
 }

--- a/src/data/adapters/prisma/tenant-repository.prisma.ts
+++ b/src/data/adapters/prisma/tenant-repository.prisma.ts
@@ -33,6 +33,13 @@ function toTenant(row: TenantRow): Tenant {
     stripeSubscriptionStatus: row.stripeSubscriptionStatus, // Stripe の subscription.status
     trialEndsAt: row.trialEndsAt, // §7.2 Free trial 終了日時 (対象外/終了済みなら null)
     trialReminderLastSentDaysBefore: row.trialReminderLastSentDaysBefore, // §7.2.1 冪等化フラグ
+    // 外部通知チャネルの直近送信失敗 (チャネルごとに 1 件のみ。成功後は null)
+    slackLastFailureAt: row.slackLastFailureAt,
+    slackLastFailureMessage: row.slackLastFailureMessage,
+    teamsLastFailureAt: row.teamsLastFailureAt,
+    teamsLastFailureMessage: row.teamsLastFailureMessage,
+    chatworkLastFailureAt: row.chatworkLastFailureAt,
+    chatworkLastFailureMessage: row.chatworkLastFailureMessage,
     createdAt: row.createdAt,
   };
 }
@@ -143,6 +150,29 @@ export function makeTenantRepo(db: PrismaLike): TenantRepository {
         where: { id },
         data: { trialReminderLastSentDaysBefore: daysBefore },
       });
+      // 更新後の行をドメイン型に詰め替えて返す
+      return toTenant(row);
+    },
+
+    // Phase 4: 外部通知チャネル 1 件の送信結果を記録する (失敗時は日時+メッセージ、成功時は null でクリア)。
+    // チャネルごとにカラムが分かれているため switch で明示的に振り分ける (動的キーで any を使わない)
+    async recordOutboundChannelResult(id, channel, failure) {
+      // 失敗時は日時とメッセージを、成功 (クリア) 時は両方 null を書き込む
+      const at = failure ? failure.at : null;
+      const message = failure ? failure.message : null;
+      let data: Prisma.TenantUpdateInput;
+      switch (channel) {
+        case 'slack':
+          data = { slackLastFailureAt: at, slackLastFailureMessage: message };
+          break;
+        case 'teams':
+          data = { teamsLastFailureAt: at, teamsLastFailureMessage: message };
+          break;
+        case 'chatwork':
+          data = { chatworkLastFailureAt: at, chatworkLastFailureMessage: message };
+          break;
+      }
+      const row = await db.tenant.update({ where: { id }, data });
       // 更新後の行をドメイン型に詰め替えて返す
       return toTenant(row);
     },

--- a/src/data/adapters/prisma/tenant-repository.prisma.ts
+++ b/src/data/adapters/prisma/tenant-repository.prisma.ts
@@ -160,17 +160,22 @@ export function makeTenantRepo(db: PrismaLike): TenantRepository {
       // 失敗時は日時とメッセージを、成功 (クリア) 時は両方 null を書き込む
       const at = failure ? failure.at : null;
       const message = failure ? failure.message : null;
+      // Prisma の更新データ (チャネルに応じて書き込むカラムが変わる)
       let data: Prisma.TenantUpdateInput;
+      // チャネルキーで分岐する (3 種類のみなので switch で列挙する)
       switch (channel) {
         case 'slack':
+          // Slack 用の 2 カラムだけを更新対象にする
           data = { slackLastFailureAt: at, slackLastFailureMessage: message };
-          break;
+          break; // 他のケースに落ちないよう抜ける
         case 'teams':
+          // Teams 用の 2 カラムだけを更新対象にする
           data = { teamsLastFailureAt: at, teamsLastFailureMessage: message };
-          break;
+          break; // 他のケースに落ちないよう抜ける
         case 'chatwork':
+          // Chatwork 用の 2 カラムだけを更新対象にする
           data = { chatworkLastFailureAt: at, chatworkLastFailureMessage: message };
-          break;
+          break; // 他のケースに落ちないよう抜ける
       }
       const row = await db.tenant.update({ where: { id }, data });
       // 更新後の行をドメイン型に詰め替えて返す

--- a/src/data/ports/tenant-repository.ts
+++ b/src/data/ports/tenant-repository.ts
@@ -1,5 +1,5 @@
-// ドメイン層の Tenant 型とテナントモード・課金プラン型を参照
-import type { SubscriptionPlan, Tenant, TenantMode } from '@/domain/types';
+// ドメイン層の Tenant 型とテナントモード・課金プラン型・外部通知チャネルキー型を参照
+import type { OutboundChannelKey, SubscriptionPlan, Tenant, TenantMode } from '@/domain/types';
 
 // Tenant 操作の契約 (port)。取得系に加え、Lite/Pro モード切替の更新系を提供する
 export interface TenantRepository {
@@ -65,7 +65,7 @@ export interface TenantRepository {
   // id はセッション/内部呼び出し由来の tenantId のみを渡すこと (クロステナント更新防止)
   recordOutboundChannelResult(
     id: string,
-    channel: 'slack' | 'teams' | 'chatwork',
+    channel: OutboundChannelKey,
     failure: { message: string; at: Date } | null,
   ): Promise<Tenant>;
 }

--- a/src/data/ports/tenant-repository.ts
+++ b/src/data/ports/tenant-repository.ts
@@ -59,4 +59,13 @@ export interface TenantRepository {
   // 遅延・欠落があっても同じマイルストーン (5 | 1) を二重送信しないよう、送信成功後に呼ぶ。
   // id はセッション/cron由来のテナント ID のみを渡すこと (クロステナント更新防止)
   updateTrialReminderLastSent(id: string, daysBefore: number): Promise<Tenant>;
+  // Phase 4: 外部通知チャネル (Slack/Teams/Chatwork) 1 件の送信結果を記録する。
+  // failure に { message, at } を渡すと直近の失敗として記録し、null を渡すと直近の失敗記録を
+  // クリアする (次の送信が成功したとき呼ぶ)。履歴は持たず直近 1 件のみを保持する設計 (§6 一元管理)。
+  // id はセッション/内部呼び出し由来の tenantId のみを渡すこと (クロステナント更新防止)
+  recordOutboundChannelResult(
+    id: string,
+    channel: 'slack' | 'teams' | 'chatwork',
+    failure: { message: string; at: Date } | null,
+  ): Promise<Tenant>;
 }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -35,6 +35,13 @@ export type SettingsAuditAction =
   | 'line_config_delete' // LINE 連携設定の削除
   | 'notification_channels_update'; // 通知チャネル設定の更新
 
+// Phase 4 外部通知チャネルの識別キー (Tenant.<channel>WebhookUrl 等・
+// <channel>LastFailureAt/Message 列に対応)。src/data/ports/tenant-repository.ts
+// (recordOutboundChannelResult) と src/lib/outbound-notify.ts の唯一の参照元。
+// 値を追加したら両アダプタの switch (tenant-repository.{prisma,memory}.ts) と
+// outbound-notify.ts の channelHasRecordedFailure・settings 画面も更新すること
+export type OutboundChannelKey = 'slack' | 'teams' | 'chatwork';
+
 // FAQ 候補の公開状態 (候補/公開中/却下)
 export type FaqStatus = 'Candidate' | 'Published' | 'Rejected';
 

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -72,6 +72,15 @@ export interface Tenant {
   chatworkApiToken: string | null;
   // Phase 4: 外部通知チャネル。投稿先の Chatwork ルーム ID (数字文字列。null なら通知無効)
   chatworkRoomId: string | null;
+  // 外部通知チャネルの直近送信失敗 (履歴は持たず直近 1 件のみ。成功したら null に戻る)。
+  // 既存フィクスチャ・呼び出しを壊さないよう任意 (optional) とし、アダプタは常に null か値で埋める
+  // (trialReminderLastSentDaysBefore と同じパターン)
+  slackLastFailureAt?: Date | null;
+  slackLastFailureMessage?: string | null;
+  teamsLastFailureAt?: Date | null;
+  teamsLastFailureMessage?: string | null;
+  chatworkLastFailureAt?: Date | null;
+  chatworkLastFailureMessage?: string | null;
   // Phase 4 課金: Stripe Billing 連携フィールド
   subscriptionPlan: SubscriptionPlan; // 現在の課金プラン (既定: free)
   stripeCustomerId: string | null; // Stripe Customer ID (cu_xxx)

--- a/src/features/settings/actions/update-notification-channels.ts
+++ b/src/features/settings/actions/update-notification-channels.ts
@@ -63,6 +63,10 @@ export async function updateNotificationChannels(
   // 検証済みの tenantId (セッション由来)
   const tenantId = session.user.tenantId;
 
+  // 監査で発見したギャップ対応: 更新前の設定値を取得しておく。どのチャネルが実際に
+  // 変更されたか (=管理者が修正を試みたか) を後で判定するために使う
+  const beforeTenant = await repos.tenants.findById(tenantId);
+
   // 通知チャネル設定変更の連打を抑制 (60 秒あたり 10 回まで、テナント単位。
   // create/update/delete-location.ts と同じ上限・キー粒度の方針)
   const rateLimitError = checkRateLimit(`notification-channels-mutate:${tenantId}`, {
@@ -112,6 +116,31 @@ export async function updateNotificationChannels(
 
   // 設定ページを再レンダリングして最新値を反映する (監査ログの成否に関わらず必ず実行する)
   revalidatePath('/settings');
+
+  // 監査で発見したギャップ対応: 設定値が実際に変わったチャネルだけ、直近の送信失敗記録を
+  // クリアする (管理者が Webhook URL/トークンを直したのに「⚠️ 最終送信失敗」バッジが
+  // 次の送信成功まで残り続けるのを防ぐ)。触っていないチャネルは本当に直したわけではないため
+  // 失敗記録を残したままにする。記録クリア自体の失敗は保存結果に影響させない (ログのみ)
+  try {
+    if (beforeTenant && slackResult.value !== beforeTenant.slackWebhookUrl) {
+      // Slack の Webhook URL が変わったのでクリアする
+      await repos.tenants.recordOutboundChannelResult(tenantId, 'slack', null);
+    }
+    if (beforeTenant && teamsResult.value !== beforeTenant.teamsWebhookUrl) {
+      // Teams の Webhook URL が変わったのでクリアする
+      await repos.tenants.recordOutboundChannelResult(tenantId, 'teams', null);
+    }
+    if (
+      beforeTenant &&
+      (chatworkApiToken !== beforeTenant.chatworkApiToken ||
+        chatworkRoomId !== beforeTenant.chatworkRoomId)
+    ) {
+      // Chatwork のトークン/ルーム ID のどちらかが変わったのでクリアする
+      await repos.tenants.recordOutboundChannelResult(tenantId, 'chatwork', null);
+    }
+  } catch (err) {
+    console.error('[update-notification-channels] 失敗記録のクリアに失敗しました:', err);
+  }
 
   // §4.2 フォローアップ: 監査ログに「誰が通知チャネル設定を更新したか」を記録する
   // (chatworkApiToken 等の秘匿情報は記録しない。アクション名のみ)。

--- a/src/features/settings/components/NotificationChannelsForm.tsx
+++ b/src/features/settings/components/NotificationChannelsForm.tsx
@@ -4,6 +4,8 @@
 import { useActionState, useTransition } from 'react';
 // 外部通知チャネル設定を更新するサーバーアクション
 import { updateNotificationChannels } from '@/features/settings/actions/update-notification-channels';
+// 日本時間 (Asia/Tokyo) を明示してフォーマットする共通関数 (ブラウザのタイムゾーンに依存させない §6 一元管理)
+import { formatDateTimeJP } from '@/lib/format-date';
 
 // 1 チャネル分の直近送信失敗情報 (未発生なら null)
 interface ChannelFailure {
@@ -24,13 +26,17 @@ interface Props {
   chatworkFailure: ChannelFailure | null;
 }
 
-// 直近送信失敗の警告バッジ。色だけでなく「⚠️」と文言でも状態を伝える (§7 a11y)
+// 直近送信失敗の警告バッジ。色だけでなく「⚠️」と文言でも状態を伝える (§7 a11y)。
+// role="alert" は付けない: これは初回表示 (SSR) から存在する静的な状態表示であり、
+// フォーム送信後に動的に現れる state.error/state.success (下記) とは異なり
+// 「即時に読み上げてほしい変化」ではないため (CLAUDE.md §7 aria-live の使いどころ)
 function ChannelFailureBadge({ failure }: { failure: ChannelFailure | null }) {
   // 失敗記録が無ければ何も表示しない (正常系)
   if (!failure) return null;
   return (
-    <p role="alert" className="mt-1 text-xs text-rose-700">
-      ⚠️ 最終送信失敗: {failure.at.toLocaleString('ja-JP')}（{failure.message}）
+    <p className="mt-1 text-xs text-rose-700">
+      {/* JST を明示するフォーマッタで統一する (ブラウザのタイムゾーンに依存させない) */}
+      ⚠️ 最終送信失敗: {formatDateTimeJP(failure.at)}（{failure.message}）
     </p>
   );
 }

--- a/src/features/settings/components/NotificationChannelsForm.tsx
+++ b/src/features/settings/components/NotificationChannelsForm.tsx
@@ -5,12 +5,34 @@ import { useActionState, useTransition } from 'react';
 // 外部通知チャネル設定を更新するサーバーアクション
 import { updateNotificationChannels } from '@/features/settings/actions/update-notification-channels';
 
+// 1 チャネル分の直近送信失敗情報 (未発生なら null)
+interface ChannelFailure {
+  at: Date; // 直近の失敗日時
+  message: string; // 失敗の概要メッセージ (Webhook/API のエラー応答由来)
+}
+
 // フォームが受け取る props (現在設定済みの各チャネル値)
 interface Props {
   slackWebhookUrl: string | null; // 現在の Slack Incoming Webhook URL (未設定なら null)
   teamsWebhookUrl: string | null; // 現在の Teams Incoming Webhook URL (未設定なら null)
   chatworkApiToken: string | null; // 現在の Chatwork API トークン (未設定なら null)
   chatworkRoomId: string | null; // 現在の Chatwork ルーム ID (未設定なら null)
+  // 監査で発見したギャップ対応: 各チャネルの直近送信失敗 (Tenant.*LastFailureAt/Message から)。
+  // 未発生・既にクリア済みなら null
+  slackFailure: ChannelFailure | null;
+  teamsFailure: ChannelFailure | null;
+  chatworkFailure: ChannelFailure | null;
+}
+
+// 直近送信失敗の警告バッジ。色だけでなく「⚠️」と文言でも状態を伝える (§7 a11y)
+function ChannelFailureBadge({ failure }: { failure: ChannelFailure | null }) {
+  // 失敗記録が無ければ何も表示しない (正常系)
+  if (!failure) return null;
+  return (
+    <p role="alert" className="mt-1 text-xs text-rose-700">
+      ⚠️ 最終送信失敗: {failure.at.toLocaleString('ja-JP')}（{failure.message}）
+    </p>
+  );
 }
 
 // 入力フィールド共通の Tailwind クラス (見た目を一元管理する)
@@ -28,6 +50,9 @@ export function NotificationChannelsForm({
   teamsWebhookUrl,
   chatworkApiToken,
   chatworkRoomId,
+  slackFailure,
+  teamsFailure,
+  chatworkFailure,
 }: Props) {
   // Server Action のレスポンス状態 (error / success) を管理する
   const [state, formAction] = useActionState(updateNotificationChannels, {});
@@ -63,6 +88,7 @@ export function NotificationChannelsForm({
           autoComplete="off"
           className={fieldClass}
         />
+        <ChannelFailureBadge failure={slackFailure} />
       </div>
 
       {/* ── Microsoft Teams ─────────────────────────────────── */}
@@ -82,6 +108,7 @@ export function NotificationChannelsForm({
           autoComplete="off"
           className={fieldClass}
         />
+        <ChannelFailureBadge failure={teamsFailure} />
       </div>
 
       {/* ── Chatwork ────────────────────────────────────────── */}
@@ -122,6 +149,7 @@ export function NotificationChannelsForm({
             />
           </div>
         </div>
+        <ChannelFailureBadge failure={chatworkFailure} />
       </div>
 
       {/* エラーメッセージ (入力エラーまたは送信失敗) */}

--- a/src/lib/outbound-notify.ts
+++ b/src/lib/outbound-notify.ts
@@ -20,20 +20,19 @@ import { isUnsafeUrl } from '@/lib/ssrf-guard';
 import { resolveAppBaseUrl } from '@/lib/app-url';
 // 優先度の日本語ラベル (外部通知本文に使う)
 import { PRIORITY_LABELS } from '@/lib/constants';
-// 新規作成されたチケットの型 (通知本文の組み立てに使う最小限のフィールドのみ参照)
-import type { Ticket } from '@/domain/types';
+// 新規作成されたチケットの型 (通知本文の組み立てに使う最小限のフィールドのみ参照)、
+// 外部通知チャネルの識別キー型 (唯一の参照元。ここでは再宣言しない §6 一元管理)、
+// および失敗記録の有無判定に使う Tenant 型
+import type { OutboundChannelKey, Tenant, Ticket } from '@/domain/types';
 
 // notifyNewTicketOutbound が参照する最小限のチケット情報。
 // メール/LINE 取り込みは冪等化ヘルパーが { id, alreadyExisted } しか返さず、通知のためだけに
 // フル Ticket を再取得するのは無駄なため、呼び出し元が持つ最小限のフィールドだけ要求する。
 export type NewTicketNotifyInput = Pick<Ticket, 'id' | 'title' | 'priority'>;
 
-// テナントの通知チャネル健全性を記録する際のキー (Tenant の slack/teams/chatwork*LastFailure* 列に対応)
-type ChannelKey = 'slack' | 'teams' | 'chatwork';
-
 // 設定済みチャネルを表す内部型 (ログ・健全性記録用のキー/チャネル名と送信実体をペアで持つ)
 interface ResolvedChannel {
-  key: ChannelKey; // 健全性記録用のキー (repos.tenants.recordOutboundChannelResult に渡す)
+  key: OutboundChannelKey; // 健全性記録用のキー (repos.tenants.recordOutboundChannelResult に渡す)
   name: string; // ログ表示用のチャネル名 (Slack / Teams / Chatwork)
   notifier: OutboundNotifier; // 実際の送信を行う Adapter
 }
@@ -42,13 +41,21 @@ interface ResolvedChannel {
 // DB 肥大化・画面崩れを防ぐ上限を設ける。§8 パフォーマンス)
 const FAILURE_MESSAGE_MAX_LENGTH = 300;
 
+// チャネルごとの直近失敗記録の有無を読む Tenant フィールド名。channelHasRecordedFailure が参照する
+// (OutboundChannelKey → Tenant.<channel>LastFailureAt のフィールド名の対応表。§6 一元管理)
+const CHANNEL_FAILURE_AT_FIELD = {
+  slack: 'slackLastFailureAt', // Slack の直近失敗日時フィールド名
+  teams: 'teamsLastFailureAt', // Teams の直近失敗日時フィールド名
+  chatwork: 'chatworkLastFailureAt', // Chatwork の直近失敗日時フィールド名
+} as const satisfies Record<OutboundChannelKey, string>;
+
 // Webhook URL を SSRF チェックして安全なら channels リストへ追加する共通ヘルパー。
 // Slack / Teams のように「ユーザーが入力した URL を保存して後で叩く」チャネルに共通して使う。
 // Chatwork のような固定ホスト宛チャネルには不要なため呼ばない。
 // 将来チャネルを追加するときも、このヘルパーを呼べば SSRF 二重防御を取り込める。
 function addWebhookChannel(
   channels: ResolvedChannel[], // 追加先のチャネル一覧 (破壊的に追加する)
-  key: ChannelKey, // 健全性記録用のキー
+  key: OutboundChannelKey, // 健全性記録用のキー
   name: string, // ログ表示用のチャネル名
   url: string, // ユーザーが設定した Webhook URL
   factory: (url: string) => OutboundNotifier, // URL を受け取って Adapter を生成するファクトリ
@@ -131,7 +138,7 @@ export async function sendOutboundNotification(
           );
           // 管理画面向けに直近の失敗日時・概要メッセージを記録する (履歴ではなく最新 1 件のみ)
           await repos.tenants.recordOutboundChannelResult(tenantId, channel.key, {
-            message: String(result.reason).slice(0, FAILURE_MESSAGE_MAX_LENGTH),
+            message: formatFailureMessage(result.reason),
             at: new Date(),
           });
         } else if (hadPriorFailure) {
@@ -148,17 +155,24 @@ export async function sendOutboundNotification(
 
 // 指定チャネルの直近失敗が記録済みかどうかを判定する (成功時の不要な DB 書き込みを避けるための判定専用)
 function channelHasRecordedFailure(
-  tenant: { slackLastFailureAt?: Date | null; teamsLastFailureAt?: Date | null; chatworkLastFailureAt?: Date | null },
-  channel: ChannelKey,
+  tenant: Pick<Tenant, 'slackLastFailureAt' | 'teamsLastFailureAt' | 'chatworkLastFailureAt'>,
+  channel: OutboundChannelKey,
 ): boolean {
-  switch (channel) {
-    case 'slack':
-      return tenant.slackLastFailureAt != null;
-    case 'teams':
-      return tenant.teamsLastFailureAt != null;
-    case 'chatwork':
-      return tenant.chatworkLastFailureAt != null;
-  }
+  // CHANNEL_FAILURE_AT_FIELD でチャネルキーを対応する Tenant のフィールド名に変換する
+  const fieldName = CHANNEL_FAILURE_AT_FIELD[channel];
+  // そのフィールドが null/undefined でなければ「失敗記録あり」と判定する
+  return tenant[fieldName] != null;
+}
+
+// Promise.allSettled の reason (拒否理由) を、管理画面に表示できる安全な文字列に変換する。
+// - Error インスタンスなら message だけを使う (スタックトレース等の内部詳細は含めない)
+// - Error 以外 (将来 Notifier 実装が非 Error を reject した場合の保険) は String() にフォールバックする
+// - サロゲートペア (絵文字等) の途中で文字列を切らないよう、コードポイント単位で切り詰める
+function formatFailureMessage(reason: unknown): string {
+  // Error インスタンスなら message を、そうでなければ文字列化した値を使う
+  const raw = reason instanceof Error ? reason.message : String(reason);
+  // Array.from はコードポイント単位で分割するため、.slice() と違いサロゲートペアを壊さない
+  return Array.from(raw).slice(0, FAILURE_MESSAGE_MAX_LENGTH).join('');
 }
 
 // tenantId + 呼び出し元コンテキストを受け取り、ベース URL 解決 + 送信 + ベストエフォート

--- a/src/lib/outbound-notify.ts
+++ b/src/lib/outbound-notify.ts
@@ -28,11 +28,19 @@ import type { Ticket } from '@/domain/types';
 // フル Ticket を再取得するのは無駄なため、呼び出し元が持つ最小限のフィールドだけ要求する。
 export type NewTicketNotifyInput = Pick<Ticket, 'id' | 'title' | 'priority'>;
 
-// 設定済みチャネルを表す内部型 (ログ用のチャネル名と送信実体をペアで持つ)
+// テナントの通知チャネル健全性を記録する際のキー (Tenant の slack/teams/chatwork*LastFailure* 列に対応)
+type ChannelKey = 'slack' | 'teams' | 'chatwork';
+
+// 設定済みチャネルを表す内部型 (ログ・健全性記録用のキー/チャネル名と送信実体をペアで持つ)
 interface ResolvedChannel {
+  key: ChannelKey; // 健全性記録用のキー (repos.tenants.recordOutboundChannelResult に渡す)
   name: string; // ログ表示用のチャネル名 (Slack / Teams / Chatwork)
   notifier: OutboundNotifier; // 実際の送信を行う Adapter
 }
+
+// 管理画面に表示する失敗メッセージの最大文字数 (Webhook/API のエラーレスポンスは長大な場合があるため
+// DB 肥大化・画面崩れを防ぐ上限を設ける。§8 パフォーマンス)
+const FAILURE_MESSAGE_MAX_LENGTH = 300;
 
 // Webhook URL を SSRF チェックして安全なら channels リストへ追加する共通ヘルパー。
 // Slack / Teams のように「ユーザーが入力した URL を保存して後で叩く」チャネルに共通して使う。
@@ -40,6 +48,7 @@ interface ResolvedChannel {
 // 将来チャネルを追加するときも、このヘルパーを呼べば SSRF 二重防御を取り込める。
 function addWebhookChannel(
   channels: ResolvedChannel[], // 追加先のチャネル一覧 (破壊的に追加する)
+  key: ChannelKey, // 健全性記録用のキー
   name: string, // ログ表示用のチャネル名
   url: string, // ユーザーが設定した Webhook URL
   factory: (url: string) => OutboundNotifier, // URL を受け取って Adapter を生成するファクトリ
@@ -55,7 +64,7 @@ function addWebhookChannel(
     return;
   }
   // URL が安全であればチャネル一覧へ追加する
-  channels.push({ name, notifier: factory(url) });
+  channels.push({ key, name, notifier: factory(url) });
 }
 
 // 指定テナントの設定済み外部通知チャネルにメッセージを送信する。
@@ -77,13 +86,13 @@ export async function sendOutboundNotification(
   // ── Slack ───────────────────────────────────────────────────────────────────
   // slackWebhookUrl が設定済みであれば SSRF 検証のうえチャネルへ追加する
   if (tenant.slackWebhookUrl) {
-    addWebhookChannel(channels, 'Slack', tenant.slackWebhookUrl, createSlackNotifier);
+    addWebhookChannel(channels, 'slack', 'Slack', tenant.slackWebhookUrl, createSlackNotifier);
   }
 
   // ── Teams ───────────────────────────────────────────────────────────────────
   // teamsWebhookUrl が設定済みであれば SSRF 検証のうえチャネルへ追加する
   if (tenant.teamsWebhookUrl) {
-    addWebhookChannel(channels, 'Teams', tenant.teamsWebhookUrl, createTeamsNotifier);
+    addWebhookChannel(channels, 'teams', 'Teams', tenant.teamsWebhookUrl, createTeamsNotifier);
   }
 
   // ── Chatwork ──────────────────────────────────────────────────────────────────
@@ -91,6 +100,7 @@ export async function sendOutboundNotification(
   // 送信先ホストは api.chatwork.com 固定 (ユーザー入力ではない) のため SSRF 検証は不要。
   if (tenant.chatworkApiToken && tenant.chatworkRoomId) {
     channels.push({
+      key: 'chatwork',
       name: 'Chatwork',
       notifier: createChatworkNotifier(tenant.chatworkApiToken, tenant.chatworkRoomId),
     });
@@ -102,17 +112,53 @@ export async function sendOutboundNotification(
   // 全チャネルへ並行送信する。1 つが失敗しても他チャネルの送信は止めない (allSettled)
   const results = await Promise.allSettled(channels.map((c) => c.notifier.send(message)));
 
-  // 失敗したチャネルだけをログに残す (チケット操作の成否には影響させない)
-  results.forEach((result, index) => {
-    if (result.status === 'rejected') {
-      // どのチャネルで失敗したかを明示してログに残す。
-      // セキュリティ: reason の詳細はサーバーログのみに残し、レスポンスには含めない
-      console.error(
-        `[outbound-notify] ${channels[index].name} 通知の送信に失敗しました:`,
-        result.reason,
-      );
-    }
-  });
+  // 監査で発見したギャップ対応: 失敗はログに残すだけでなく、管理画面で気づけるよう
+  // Tenant の直近失敗記録にも書き込む。成功時は「前回失敗が記録されているときだけ」クリアし、
+  // 毎回 DB を書きに行かないようにする (§8 パフォーマンス)。この記録処理自体の失敗は
+  // ログに残すのみに留め、本来の送信結果判定には影響させない (非クリティカルな副作用)。
+  await Promise.all(
+    results.map(async (result, index) => {
+      const channel = channels[index];
+      // このチャネルの直近失敗記録が既にあるかどうか (成功時の不要な書き込みを避けるため)
+      const hadPriorFailure = channelHasRecordedFailure(tenant, channel.key);
+      try {
+        if (result.status === 'rejected') {
+          // どのチャネルで失敗したかを明示してログに残す。
+          // セキュリティ: reason の詳細はサーバーログのみに残し、レスポンスには含めない
+          console.error(
+            `[outbound-notify] ${channel.name} 通知の送信に失敗しました:`,
+            result.reason,
+          );
+          // 管理画面向けに直近の失敗日時・概要メッセージを記録する (履歴ではなく最新 1 件のみ)
+          await repos.tenants.recordOutboundChannelResult(tenantId, channel.key, {
+            message: String(result.reason).slice(0, FAILURE_MESSAGE_MAX_LENGTH),
+            at: new Date(),
+          });
+        } else if (hadPriorFailure) {
+          // 前回失敗が記録されている状態から今回は成功したので、警告表示をクリアする
+          await repos.tenants.recordOutboundChannelResult(tenantId, channel.key, null);
+        }
+      } catch (err) {
+        // 記録自体の失敗はログに残すだけで、通知送信自体の成否判定には影響させない
+        console.error(`[outbound-notify] ${channel.name} の送信結果記録に失敗しました:`, err);
+      }
+    }),
+  );
+}
+
+// 指定チャネルの直近失敗が記録済みかどうかを判定する (成功時の不要な DB 書き込みを避けるための判定専用)
+function channelHasRecordedFailure(
+  tenant: { slackLastFailureAt?: Date | null; teamsLastFailureAt?: Date | null; chatworkLastFailureAt?: Date | null },
+  channel: ChannelKey,
+): boolean {
+  switch (channel) {
+    case 'slack':
+      return tenant.slackLastFailureAt != null;
+    case 'teams':
+      return tenant.teamsLastFailureAt != null;
+    case 'chatwork':
+      return tenant.chatworkLastFailureAt != null;
+  }
 }
 
 // tenantId + 呼び出し元コンテキストを受け取り、ベース URL 解決 + 送信 + ベストエフォート

--- a/tests/data/attachment-repository.contract.prisma.test.ts
+++ b/tests/data/attachment-repository.contract.prisma.test.ts
@@ -1,0 +1,226 @@
+// 添付メタデータ用リポジトリ (Prisma アダプタ) の契約テスト。
+// 監査で発見したギャップ: tests/data/attachment-repository.memory.test.ts (メモリアダプタ) しか
+// テストが無く、Phase 1 の「スマホ写真添付」機能のテナント境界 (findById/delete の
+// tenantId 不一致時の null/no-op) や、Ticket 削除時の ON DELETE CASCADE が実 DB で
+// 正しく動くかは未検証だった (CLAUDE.md §11「メモリのみのテストは実装の誤った自信を生む」)。
+// クロステナントのファイル漏洩・孤児レコード化を回帰として防ぐことが目的。
+//
+// この DB 依存テストは RUN_PRISMA_CONTRACT=1 のときだけ走り、beforeEach で全テーブルを
+// TRUNCATE するため **開発 DB を指さない** こと。
+
+import { describe, beforeAll, afterAll, beforeEach, expect, it } from 'vitest';
+import { PrismaClient } from '@/generated/prisma';
+import { buildPrismaRepos } from '@/data/adapters/prisma';
+
+const TENANT_A = 'tenant-a';
+const TENANT_B = 'tenant-b';
+const USER_A = 'user-a';
+const USER_B = 'user-b';
+
+const SHOULD_RUN = process.env.RUN_PRISMA_CONTRACT === '1';
+
+describe.runIf(SHOULD_RUN)('AttachmentRepository (prisma adapter)', () => {
+  let prisma: PrismaClient;
+  // 各テストで使うチケット ID (テナント A・B にそれぞれ 1 件ずつ作成する)
+  let ticketA: string;
+  let ticketB: string;
+
+  beforeAll(async () => {
+    prisma = new PrismaClient();
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  // 各テスト前に全テーブルを空にし、テナント A/B・ユーザー・チケットを 1 件ずつ用意する
+  // (Attachment は ticketId/uploaderId/tenantId の 3 つの FK を必須にするため)
+  beforeEach(async () => {
+    await prisma.$executeRawUnsafe(
+      'TRUNCATE TABLE "Location","Attachment","TicketHistory","TicketComment","Notification","FaqCandidate","Ticket","Category","MagicLinkToken","User","Tenant" RESTART IDENTITY CASCADE',
+    );
+    await prisma.tenant.create({ data: { id: TENANT_A, name: 'テナントA', mode: 'lite' } });
+    await prisma.tenant.create({ data: { id: TENANT_B, name: 'テナントB', mode: 'lite' } });
+    await prisma.user.create({
+      data: {
+        id: USER_A,
+        email: 'a@example.com',
+        name: 'ユーザーA',
+        passwordHash: 'x',
+        role: 'agent',
+        tenantId: TENANT_A,
+      },
+    });
+    await prisma.user.create({
+      data: {
+        id: USER_B,
+        email: 'b@example.com',
+        name: 'ユーザーB',
+        passwordHash: 'x',
+        role: 'agent',
+        tenantId: TENANT_B,
+      },
+    });
+    const repos = buildPrismaRepos(prisma);
+    const ta = await repos.tickets.create({
+      title: 'テナントAのチケット',
+      body: '本文',
+      priority: 'Medium',
+      creatorId: USER_A,
+      categoryId: null,
+      locationId: null,
+      tenantId: TENANT_A,
+    });
+    ticketA = ta.id;
+    const tb = await repos.tickets.create({
+      title: 'テナントBのチケット',
+      body: '本文',
+      priority: 'Medium',
+      creatorId: USER_B,
+      categoryId: null,
+      locationId: null,
+      tenantId: TENANT_B,
+    });
+    ticketB = tb.id;
+  });
+
+  // 添付を 1 件作成でき、同一テナントで findById できる
+  it('createしたものと同一テナントでfindByIdできる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const created = await repos.attachments.create({
+      ticketId: ticketA,
+      commentId: null,
+      uploaderId: USER_A,
+      tenantId: TENANT_A,
+      mimeType: 'image/jpeg',
+      size: 1024,
+      originalName: 'photo.jpg',
+      storageKey: `${TENANT_A}/${ticketA}/aaaa.jpg`,
+      storage: 'local',
+    });
+    const found = await repos.attachments.findById(created.id, TENANT_A);
+    expect(found?.originalName).toBe('photo.jpg');
+  });
+
+  // 他テナントの ID で findById すると null (クロステナント漏洩防止の要)
+  it('他テナントIDでfindByIdするとnullになる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const created = await repos.attachments.create({
+      ticketId: ticketA,
+      commentId: null,
+      uploaderId: USER_A,
+      tenantId: TENANT_A,
+      mimeType: 'image/jpeg',
+      size: 1024,
+      originalName: 'photo.jpg',
+      storageKey: `${TENANT_A}/${ticketA}/aaaa.jpg`,
+      storage: 'local',
+    });
+    const found = await repos.attachments.findById(created.id, TENANT_B);
+    expect(found).toBeNull();
+  });
+
+  // listByTicket は同一テナントの行のみを古い順に返す
+  it('listByTicketは同一テナントの行のみ古い順に返す', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const a1 = await repos.attachments.create({
+      ticketId: ticketA,
+      commentId: null,
+      uploaderId: USER_A,
+      tenantId: TENANT_A,
+      mimeType: 'image/jpeg',
+      size: 100,
+      originalName: 'a1.jpg',
+      storageKey: `${TENANT_A}/${ticketA}/a1.jpg`,
+      storage: 'local',
+    });
+    const a2 = await repos.attachments.create({
+      ticketId: ticketA,
+      commentId: null,
+      uploaderId: USER_A,
+      tenantId: TENANT_A,
+      mimeType: 'image/jpeg',
+      size: 100,
+      originalName: 'a2.jpg',
+      storageKey: `${TENANT_A}/${ticketA}/a2.jpg`,
+      storage: 'local',
+    });
+    const list = await repos.attachments.listByTicket(ticketA, TENANT_A);
+    expect(list.map((x) => x.id)).toEqual([a1.id, a2.id]);
+  });
+
+  // sumSizeByTenant は同一テナントの添付サイズのみを DB 側で集計する (aggregate SUM)
+  it('sumSizeByTenantは同一テナントの合計バイト数を返す', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await repos.attachments.create({
+      ticketId: ticketA,
+      commentId: null,
+      uploaderId: USER_A,
+      tenantId: TENANT_A,
+      mimeType: 'image/jpeg',
+      size: 1000,
+      originalName: 'a1.jpg',
+      storageKey: `${TENANT_A}/${ticketA}/a1.jpg`,
+      storage: 'local',
+    });
+    await repos.attachments.create({
+      ticketId: ticketB,
+      commentId: null,
+      uploaderId: USER_B,
+      tenantId: TENANT_B,
+      mimeType: 'image/jpeg',
+      size: 500,
+      originalName: 'b1.jpg',
+      storageKey: `${TENANT_B}/${ticketB}/b1.jpg`,
+      storage: 'local',
+    });
+    expect(await repos.attachments.sumSizeByTenant(TENANT_A)).toBe(1000);
+    expect(await repos.attachments.sumSizeByTenant(TENANT_B)).toBe(500);
+  });
+
+  // 添付が無いテナントは 0 を返す (aggregate の _sum が null になるケースの防御)
+  it('添付が無いテナントのsumSizeByTenantは0になる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    expect(await repos.attachments.sumSizeByTenant(TENANT_A)).toBe(0);
+  });
+
+  // 他テナントの ID を渡した削除は no-op (元行が残る)
+  it('他テナントIDでのdeleteはno-opになる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const created = await repos.attachments.create({
+      ticketId: ticketA,
+      commentId: null,
+      uploaderId: USER_A,
+      tenantId: TENANT_A,
+      mimeType: 'image/jpeg',
+      size: 100,
+      originalName: 'a1.jpg',
+      storageKey: `${TENANT_A}/${ticketA}/a1.jpg`,
+      storage: 'local',
+    });
+    await repos.attachments.delete(created.id, TENANT_B);
+    expect(await repos.attachments.findById(created.id, TENANT_A)).not.toBeNull();
+    await repos.attachments.delete(created.id, TENANT_A);
+    expect(await repos.attachments.findById(created.id, TENANT_A)).toBeNull();
+  });
+
+  // 親チケットを削除すると添付メタデータも連鎖削除される (ON DELETE CASCADE の実 DB 検証)
+  it('親チケット削除で添付メタデータも連鎖削除される', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const created = await repos.attachments.create({
+      ticketId: ticketA,
+      commentId: null,
+      uploaderId: USER_A,
+      tenantId: TENANT_A,
+      mimeType: 'image/jpeg',
+      size: 100,
+      originalName: 'a1.jpg',
+      storageKey: `${TENANT_A}/${ticketA}/a1.jpg`,
+      storage: 'local',
+    });
+    // チケットを直接 Prisma で削除する (Ticket の ON DELETE CASCADE を検証したいので repos 経由ではなく直叩き)
+    await prisma.ticket.delete({ where: { id: ticketA } });
+    expect(await repos.attachments.findById(created.id, TENANT_A)).toBeNull();
+  });
+});

--- a/tests/data/tenant-repository.contract.prisma.test.ts
+++ b/tests/data/tenant-repository.contract.prisma.test.ts
@@ -1,0 +1,154 @@
+// テナントリポジトリ (Prisma アダプタ) の契約テスト。
+// 監査で発見したギャップ: tests/data/tenant-repository.memory.test.ts (メモリアダプタ) しか
+// テストが無く、Tenant は Slack/Teams/Chatwork のシークレット・SSO/LINE 連携・Stripe 課金状態を
+// 保持する最重要テーブルにもかかわらず、本番 Prisma アダプタでの動作検証が無かった
+// (CLAUDE.md §11「メモリのみのテストは実装の誤った自信を生む」)。
+// 特に updateNotificationChannels の「undefined は skip」という部分更新契約、
+// listActiveTrials の日付比較・並び順、そして新規追加した recordOutboundChannelResult
+// (外部通知チャネルの直近送信失敗記録) が実 DB で正しく動くかを重点的に検証する。
+//
+// この DB 依存テストは RUN_PRISMA_CONTRACT=1 のときだけ走り、beforeEach で全テーブルを
+// TRUNCATE するため **開発 DB を指さない** こと。
+
+import { describe, beforeAll, afterAll, beforeEach, expect, it } from 'vitest';
+import { PrismaClient } from '@/generated/prisma';
+import { buildPrismaRepos } from '@/data/adapters/prisma';
+
+const SHOULD_RUN = process.env.RUN_PRISMA_CONTRACT === '1';
+
+describe.runIf(SHOULD_RUN)('TenantRepository (prisma adapter)', () => {
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    prisma = new PrismaClient();
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  // 各テスト前に全テーブルを空にする (Tenant 自体が対象なので他テーブルは巻き添えで空にするだけ)
+  beforeEach(async () => {
+    await prisma.$executeRawUnsafe(
+      'TRUNCATE TABLE "Location","Attachment","TicketHistory","TicketComment","Notification","FaqCandidate","Ticket","Category","MagicLinkToken","User","Tenant" RESTART IDENTITY CASCADE',
+    );
+  });
+
+  // 新規テナントを作成できる (mode 省略時は既定の lite)
+  it('新規テナントを作成できる (mode省略時はlite)', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const tenant = await repos.tenants.create({ name: 'テスト組織' });
+    expect(tenant.mode).toBe('lite');
+    expect(tenant.subscriptionPlan).toBe('free');
+    expect(tenant.inboundToken).toBeNull();
+  });
+
+  // inboundToken は @unique 制約でテナント間の重複を拒否する
+  it('inboundTokenの重複はエラーになる (@unique制約)', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await repos.tenants.create({ name: 'A組織', inboundToken: 'dup-token' });
+    await expect(
+      repos.tenants.create({ name: 'B組織', inboundToken: 'dup-token' }),
+    ).rejects.toThrow();
+  });
+
+  // updateMode で Lite/Pro を切り替えられ、他テナントには波及しない
+  it('updateModeは対象テナントのみを更新する', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const a = await repos.tenants.create({ name: 'A組織', mode: 'lite' });
+    const b = await repos.tenants.create({ name: 'B組織', mode: 'lite' });
+    await repos.tenants.updateMode(a.id, 'pro');
+    const reloadedA = await repos.tenants.findById(a.id);
+    const reloadedB = await repos.tenants.findById(b.id);
+    expect(reloadedA?.mode).toBe('pro');
+    expect(reloadedB?.mode).toBe('lite');
+  });
+
+  // updateNotificationChannels は渡したフィールドだけ更新し、undefined は現状維持する (部分更新契約)
+  it('updateNotificationChannelsは指定フィールドだけ更新し他は維持する', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const tenant = await repos.tenants.create({ name: 'A組織' });
+    await repos.tenants.updateNotificationChannels(tenant.id, {
+      slackWebhookUrl: 'https://hooks.slack.com/services/AAA',
+      teamsWebhookUrl: 'https://teams.example/webhook',
+    });
+    // Slack だけ無効化する (teamsWebhookUrl は undefined = 現状維持のはず)
+    const updated = await repos.tenants.updateNotificationChannels(tenant.id, {
+      slackWebhookUrl: null,
+    });
+    expect(updated.slackWebhookUrl).toBeNull();
+    expect(updated.teamsWebhookUrl).toBe('https://teams.example/webhook');
+  });
+
+  // recordOutboundChannelResult: 失敗記録は指定チャネルのカラムだけを更新する
+  it('recordOutboundChannelResultは指定チャネルのカラムだけを更新する', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const tenant = await repos.tenants.create({ name: 'A組織' });
+    const at = new Date('2026-07-09T12:00:00Z');
+    const updated = await repos.tenants.recordOutboundChannelResult(tenant.id, 'chatwork', {
+      message: 'HTTP 401',
+      at,
+    });
+    expect(updated.chatworkLastFailureAt?.toISOString()).toBe(at.toISOString());
+    expect(updated.chatworkLastFailureMessage).toBe('HTTP 401');
+    // 他チャネルのカラムは無関係のまま (null)
+    expect(updated.slackLastFailureAt ?? null).toBeNull();
+    expect(updated.teamsLastFailureAt ?? null).toBeNull();
+  });
+
+  // recordOutboundChannelResult: null を渡すと失敗記録がクリアされる (次回送信成功時を想定)
+  it('recordOutboundChannelResultにnullを渡すと失敗記録がクリアされる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const tenant = await repos.tenants.create({ name: 'A組織' });
+    await repos.tenants.recordOutboundChannelResult(tenant.id, 'slack', {
+      message: 'timeout',
+      at: new Date(),
+    });
+    const cleared = await repos.tenants.recordOutboundChannelResult(tenant.id, 'slack', null);
+    expect(cleared.slackLastFailureAt ?? null).toBeNull();
+    expect(cleared.slackLastFailureMessage ?? null).toBeNull();
+    // 再取得しても永続化されている
+    const reloaded = await repos.tenants.findById(tenant.id);
+    expect(reloaded?.slackLastFailureAt ?? null).toBeNull();
+  });
+
+  // 存在しないテナント ID への記録はエラーになる (fail-closed)
+  it('存在しないテナントIDへのrecordOutboundChannelResultはエラーになる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await expect(
+      repos.tenants.recordOutboundChannelResult('no-such-tenant', 'slack', {
+        message: 'x',
+        at: new Date(),
+      }),
+    ).rejects.toThrow();
+  });
+
+  // listActiveTrials: free プランかつ trialEndsAt > now のテナントだけを、終了が近い順・上限件数で返す
+  it('listActiveTrialsは進行中のfreeトライアルのみを終了が近い順に返す', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const now = new Date('2026-07-01T00:00:00Z');
+    await repos.tenants.create({
+      name: 'trial-far',
+      trialEndsAt: new Date('2026-07-20T00:00:00Z'),
+    });
+    await repos.tenants.create({
+      name: 'trial-near',
+      trialEndsAt: new Date('2026-07-05T00:00:00Z'),
+    });
+    await repos.tenants.create({ name: 'trial-expired', trialEndsAt: new Date('2026-06-25T00:00:00Z') });
+    await repos.tenants.create({ name: 'no-trial' }); // trialEndsAt 未指定 (null)
+
+    const result = await repos.tenants.listActiveTrials(now, 100);
+    expect(result.map((t) => t.name)).toEqual(['trial-near', 'trial-far']);
+  });
+
+  // findByInboundToken: トークン一致でテナントを特定でき、他テナントとは混線しない
+  it('findByInboundTokenはトークンが一致するテナントのみを返す', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await repos.tenants.create({ name: 'A組織', inboundToken: 'token-a' });
+    const b = await repos.tenants.create({ name: 'B組織', inboundToken: 'token-b' });
+    const found = await repos.tenants.findByInboundToken('token-b');
+    expect(found?.id).toBe(b.id);
+  });
+});

--- a/tests/data/tenant-repository.memory.test.ts
+++ b/tests/data/tenant-repository.memory.test.ts
@@ -345,3 +345,60 @@ describe('TenantRepository.updateTrialReminderLastSent (memory)', () => {
     await expect(repos.tenants.updateTrialReminderLastSent('no-such-tenant', 5)).rejects.toThrow();
   });
 });
+
+// 監査で発見したギャップ対応: 外部通知チャネルの直近送信結果を記録する
+// recordOutboundChannelResult の単体テスト。チャネルごとのカラム分離・テナント分離・
+// 失敗記録のクリアを確認する。
+describe('TenantRepository.recordOutboundChannelResult (memory)', () => {
+  beforeEach(() => {
+    const ctx = createMemoryContext();
+    store = ctx.store;
+    repos = ctx.repos;
+    seed();
+  });
+
+  // Slack の失敗を記録できる (Teams/Chatwork には影響しない)
+  it('指定チャネルの失敗だけを記録し他チャネルには影響しない', async () => {
+    const at = new Date('2026-07-09T12:00:00Z');
+    const updated = await repos.tenants.recordOutboundChannelResult(TENANT_A, 'slack', {
+      message: 'HTTP 404',
+      at,
+    });
+    expect(updated.slackLastFailureAt).toEqual(at);
+    expect(updated.slackLastFailureMessage).toBe('HTTP 404');
+    // Teams/Chatwork は未記録のまま
+    expect(updated.teamsLastFailureAt ?? null).toBeNull();
+    expect(updated.chatworkLastFailureAt ?? null).toBeNull();
+  });
+
+  // null を渡すと失敗記録がクリアされる (次回送信成功時の呼び出しを想定)
+  it('null を渡すと失敗記録がクリアされる', async () => {
+    await repos.tenants.recordOutboundChannelResult(TENANT_A, 'teams', {
+      message: 'timeout',
+      at: new Date(),
+    });
+    const cleared = await repos.tenants.recordOutboundChannelResult(TENANT_A, 'teams', null);
+    expect(cleared.teamsLastFailureAt ?? null).toBeNull();
+    expect(cleared.teamsLastFailureMessage ?? null).toBeNull();
+  });
+
+  // 分離: あるテナントの記録が他テナントに波及しない
+  it('他テナントの記録には影響しない', async () => {
+    await repos.tenants.recordOutboundChannelResult(TENANT_A, 'chatwork', {
+      message: 'HTTP 401',
+      at: new Date(),
+    });
+    const tenantB = await repos.tenants.findById(TENANT_B);
+    expect(tenantB?.chatworkLastFailureAt ?? null).toBeNull();
+  });
+
+  // 異常系: 存在しないテナント ID はエラーになる (fail-closed)
+  it('存在しないテナント ID はエラーになる', async () => {
+    await expect(
+      repos.tenants.recordOutboundChannelResult('no-such-tenant', 'slack', {
+        message: 'x',
+        at: new Date(),
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/features/outbound-notify-channel-health.test.ts
+++ b/tests/features/outbound-notify-channel-health.test.ts
@@ -10,9 +10,10 @@ import { createMemoryContext, type Store } from '@/data/adapters/memory';
 // 型のみ
 import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
 
-// テスト用テナント ID と Slack Webhook URL (実際には送信されない。SSRF ガードを通す公開ホスト)
+// テスト用テナント ID と Slack/Teams Webhook URL (実際には送信されない。SSRF ガードを通す公開ホスト)
 const TENANT = 'default-tenant';
 const SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/xxx';
+const TEAMS_WEBHOOK_URL = 'https://prod-00.japaneast.logic.azure.com/webhook';
 
 // 各テストで差し替える可変な依存 (動的 import 前に値を入れる)
 let store: Store;
@@ -124,6 +125,74 @@ describe('sendOutboundNotification のチャネル健全性記録', () => {
 
     // 前回失敗が無いので、成功時にわざわざ DB を書きに行かない
     expect(recordSpy).not.toHaveBeenCalled();
+  });
+
+  it('複数チャネル設定時、片方の失敗がもう片方の記録に混線しない', async () => {
+    const now = new Date();
+    // Slack と Teams の両方を設定したテナントを投入する
+    store.tenants.set(TENANT, {
+      id: TENANT,
+      name: 'デフォルト組織',
+      mode: 'lite',
+      industry: null,
+      inboundToken: null,
+      slackWebhookUrl: SLACK_WEBHOOK_URL,
+      teamsWebhookUrl: TEAMS_WEBHOOK_URL,
+      subscriptionPlan: 'free' as const,
+      stripeCustomerId: null,
+      stripeSubscriptionId: null,
+      stripeSubscriptionStatus: null,
+      trialEndsAt: null,
+      chatworkApiToken: null,
+      chatworkRoomId: null,
+      createdAt: now,
+    });
+    // URL で振り分けて Slack だけ失敗させ、Teams は成功させる
+    fetchMock.mockImplementation((url: string) => {
+      if (url === SLACK_WEBHOOK_URL) return Promise.reject(new Error('slack down'));
+      return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('ok') });
+    });
+    const { sendOutboundNotification } = await import('@/lib/outbound-notify');
+
+    await sendOutboundNotification(TENANT, { subject: '件名', body: '本文' });
+
+    const tenant = await repos.tenants.findById(TENANT);
+    // Slack は失敗記録が残る
+    expect(tenant?.slackLastFailureAt).toBeInstanceOf(Date);
+    expect(tenant?.slackLastFailureMessage).toContain('slack down');
+    // Teams は成功しているので失敗記録は無い (Slack の失敗が混線していない)
+    expect(tenant?.teamsLastFailureAt ?? null).toBeNull();
+    expect(tenant?.teamsLastFailureMessage ?? null).toBeNull();
+  });
+
+  it('失敗メッセージは300コードポイントに切り詰められ、サロゲートペアを壊さない', async () => {
+    await seedTenant();
+    // 絵文字 (サロゲートペア = UTF-16 2 単位/文字) を含む長いメッセージで失敗させる
+    const longMessage = '😀'.repeat(310);
+    fetchMock.mockRejectedValueOnce(new Error(longMessage));
+    const { sendOutboundNotification } = await import('@/lib/outbound-notify');
+
+    await sendOutboundNotification(TENANT, { subject: '件名', body: '本文' });
+
+    const tenant = await repos.tenants.findById(TENANT);
+    const message = tenant?.slackLastFailureMessage ?? '';
+    // コードポイント単位で 300 文字に切り詰められている (.slice() のような UTF-16 単位切り捨てだと
+    // サロゲートペアの片割れが残り、文字化けする)
+    expect(Array.from(message)).toHaveLength(300);
+    // 壊れたサロゲート (置換文字 U+FFFD) を含まない
+    expect(message).not.toContain('�');
+  });
+
+  it('Errorの失敗メッセージは冗長な "Error: " 接頭辞を含まない', async () => {
+    await seedTenant();
+    fetchMock.mockRejectedValueOnce(new Error('HTTP 404 - channel_not_found'));
+    const { sendOutboundNotification } = await import('@/lib/outbound-notify');
+
+    await sendOutboundNotification(TENANT, { subject: '件名', body: '本文' });
+
+    const tenant = await repos.tenants.findById(TENANT);
+    // String(error) だと "Error: HTTP 404 - ..." になってしまうため、message だけを使う
+    expect(tenant?.slackLastFailureMessage).toBe('HTTP 404 - channel_not_found');
   });
 
   it('健全性記録自体が失敗しても送信結果の処理は継続する (非クリティカルな副作用)', async () => {

--- a/tests/features/outbound-notify-channel-health.test.ts
+++ b/tests/features/outbound-notify-channel-health.test.ts
@@ -1,0 +1,147 @@
+// sendOutboundNotification (src/lib/outbound-notify.ts) のチャネル健全性記録の仕様確認テスト。
+// 監査で発見したギャップ: 外部通知チャネル (Slack/Teams/Chatwork) の送信失敗はこれまで
+// サーバーログにしか残らず、管理者は Webhook URL の失効・トークン失効に気づく手段が無かった。
+// 失敗時に Tenant.slackLastFailureAt/Message 等へ記録し、次回成功時にクリアすることを検証する。
+
+// Vitest の DSL とモック機能
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// メモリ実装の context (store/repos/uow)
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// 型のみ
+import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
+
+// テスト用テナント ID と Slack Webhook URL (実際には送信されない。SSRF ガードを通す公開ホスト)
+const TENANT = 'default-tenant';
+const SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/xxx';
+
+// 各テストで差し替える可変な依存 (動的 import 前に値を入れる)
+let store: Store;
+let repos: Repos;
+let uow: UnitOfWork;
+// fetch のモック関数 (Slack Adapter が呼ぶ)
+let fetchMock: ReturnType<typeof vi.fn>;
+
+// src/lib/webhook-fetch.ts は undici の fetch を直接 import しているため、
+// vi.stubGlobal('fetch', ...) だけでは差し替わらない (create-ticket-outbound-notify.test.ts と同じ手法)
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: ((...args: Parameters<typeof globalThis.fetch>) =>
+      globalThis.fetch(...args)) as unknown as typeof actual.fetch,
+  };
+});
+
+// @/data モジュールを差し替え (getter で参照することで beforeEach の上書きを反映)
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+  get uow() {
+    return uow;
+  },
+}));
+
+// Slack Webhook 設定済みのテナントを 1 件投入する
+async function seedTenant() {
+  const now = new Date();
+  store.tenants.set(TENANT, {
+    id: TENANT,
+    name: 'デフォルト組織',
+    mode: 'lite',
+    industry: null,
+    inboundToken: null,
+    slackWebhookUrl: SLACK_WEBHOOK_URL,
+    subscriptionPlan: 'free' as const,
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+    stripeSubscriptionStatus: null,
+    trialEndsAt: null,
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null,
+    createdAt: now,
+  });
+}
+
+beforeEach(() => {
+  // 毎回新しい context を作って独立な状態にする
+  const ctx = createMemoryContext();
+  store = ctx.store;
+  repos = ctx.repos;
+  uow = ctx.uow;
+  // 動的 import の結果をリセット (mock 設定を反映させるため)
+  vi.resetModules();
+  // fetch は既定で成功させる (各テストで必要に応じて reject させる)
+  fetchMock = vi
+    .fn()
+    .mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve('ok') });
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('sendOutboundNotification のチャネル健全性記録', () => {
+  it('送信失敗時に直近の失敗日時とメッセージを記録する', async () => {
+    await seedTenant();
+    // Slack Webhook への送信を失敗させる (ネットワークエラーを模擬)
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    const { sendOutboundNotification } = await import('@/lib/outbound-notify');
+
+    await sendOutboundNotification(TENANT, { subject: '件名', body: '本文' });
+
+    const tenant = await repos.tenants.findById(TENANT);
+    expect(tenant?.slackLastFailureAt).toBeInstanceOf(Date);
+    expect(tenant?.slackLastFailureMessage).toContain('network down');
+  });
+
+  it('失敗記録がある状態で次回送信が成功すると記録がクリアされる', async () => {
+    await seedTenant();
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    const { sendOutboundNotification } = await import('@/lib/outbound-notify');
+
+    // 1 回目: 失敗して記録される
+    await sendOutboundNotification(TENANT, { subject: '件名1', body: '本文1' });
+    const afterFailure = await repos.tenants.findById(TENANT);
+    expect(afterFailure?.slackLastFailureAt).not.toBeNull();
+
+    // 2 回目: Webhook URL を直したので成功する (fetchMock は既定で成功を返す)
+    await sendOutboundNotification(TENANT, { subject: '件名2', body: '本文2' });
+    const afterSuccess = await repos.tenants.findById(TENANT);
+    expect(afterSuccess?.slackLastFailureAt).toBeNull();
+    expect(afterSuccess?.slackLastFailureMessage).toBeNull();
+  });
+
+  it('失敗記録が無い状態で成功しても余分な書き込みをしない (§8 パフォーマンス)', async () => {
+    await seedTenant();
+    const { sendOutboundNotification } = await import('@/lib/outbound-notify');
+    // recordOutboundChannelResult の呼び出し回数を監視する
+    const recordSpy = vi.spyOn(repos.tenants, 'recordOutboundChannelResult');
+
+    await sendOutboundNotification(TENANT, { subject: '件名', body: '本文' });
+
+    // 前回失敗が無いので、成功時にわざわざ DB を書きに行かない
+    expect(recordSpy).not.toHaveBeenCalled();
+  });
+
+  it('健全性記録自体が失敗しても送信結果の処理は継続する (非クリティカルな副作用)', async () => {
+    await seedTenant();
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    const { sendOutboundNotification } = await import('@/lib/outbound-notify');
+    // 記録処理そのものを失敗させる (例: DB 接続断)
+    vi.spyOn(repos.tenants, 'recordOutboundChannelResult').mockRejectedValueOnce(
+      new Error('DB down'),
+    );
+    // 想定内のログ出力なのでコンソールを黙らせる
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // 記録処理の失敗が外へ伝播せず、呼び出し元からは正常終了に見えること
+    await expect(
+      sendOutboundNotification(TENANT, { subject: '件名', body: '本文' }),
+    ).resolves.toBeUndefined();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/tests/features/update-notification-channels.test.ts
+++ b/tests/features/update-notification-channels.test.ts
@@ -159,6 +159,51 @@ describe('updateNotificationChannels', () => {
     expect(result.error).toBe('Chatwork ルーム ID は数字で入力してください');
   });
 
+  // 監査で発見したギャップ対応: Webhook URL を修正して保存すると、その場ですぐに
+  // 直近の失敗記録 (「⚠️ 最終送信失敗」バッジ) がクリアされる (次の送信成功を待たない)
+  it('チャネルの設定値を変更すると直近の失敗記録がクリアされる', async () => {
+    // あらかじめ Slack の失敗を記録しておく (前回の Webhook URL が壊れていた想定)
+    await repos.tenants.recordOutboundChannelResult(TENANT_ID, 'slack', {
+      message: 'HTTP 404',
+      at: new Date(),
+    });
+    const { updateNotificationChannels } =
+      await import('@/features/settings/actions/update-notification-channels');
+    // 正しい URL に修正して保存する
+    const result = await updateNotificationChannels(
+      {},
+      makeForm({ slackWebhookUrl: 'https://hooks.slack.com/services/fixed' }),
+    );
+    expect(result.success).toBe(true);
+    const saved = await repos.tenants.findById(TENANT_ID);
+    // 失敗記録が消えていること (次の送信成功を待たずにバッジが消える)
+    expect(saved?.slackLastFailureAt ?? null).toBeNull();
+    expect(saved?.slackLastFailureMessage ?? null).toBeNull();
+  });
+
+  // 触っていないチャネルの失敗記録は残る (実際に直したわけではないため)
+  it('変更していないチャネルの失敗記録は保持される', async () => {
+    // Slack はあらかじめ正しい URL で設定済み・失敗記録もある状態にする
+    await repos.tenants.updateNotificationChannels(TENANT_ID, {
+      slackWebhookUrl: 'https://hooks.slack.com/services/unchanged',
+    });
+    await repos.tenants.recordOutboundChannelResult(TENANT_ID, 'slack', {
+      message: 'HTTP 500',
+      at: new Date(),
+    });
+    const { updateNotificationChannels } =
+      await import('@/features/settings/actions/update-notification-channels');
+    // Slack の値は変えずに、フォームを再送信する (実質同じ値で保存)
+    const result = await updateNotificationChannels(
+      {},
+      makeForm({ slackWebhookUrl: 'https://hooks.slack.com/services/unchanged' }),
+    );
+    expect(result.success).toBe(true);
+    const saved = await repos.tenants.findById(TENANT_ID);
+    // 値を変えていないので、失敗記録は消えずに残っている
+    expect(saved?.slackLastFailureAt).not.toBeNull();
+  });
+
   // レート制限: 60秒あたり10回を超える連打は拒否される
   it('60秒あたり10回を超える連打は拒否される', async () => {
     const { updateNotificationChannels } =


### PR DESCRIPTION
## 概要

`docs/smb-dx-pivot-plan.md` の未実装/ギャップ監査で見つかった項目のうち 3 件を実装。

### 1. 外部通知チャネルの送信失敗を管理画面に表示 (Phase 4 フォローアップ)
Slack/Teams/Chatwork への送信失敗はこれまでサーバーログにしか残らず、管理者が Webhook URL の失効・トークン失効に気づく手段が無かった。Tenant に `<channel>LastFailureAt/Message` を追加し、送信失敗時に記録・次回成功時にクリアするようにした。設定画面の通知チャネルフォームに「⚠️ 最終送信失敗」の警告バッジを追加。

- `prisma/schema.prisma` + マイグレーション追加
- `src/data/ports/tenant-repository.ts` に `recordOutboundChannelResult` を追加、Prisma/メモリ両アダプタで実装
- `src/lib/outbound-notify.ts`: 送信結果を記録 (成功時は前回失敗があるときだけ書き込み、余分な DB 書き込みを避ける)
- `src/features/settings/components/NotificationChannelsForm.tsx` + `settings/page.tsx`: 警告バッジ表示

### 2. ダッシュボードの拠点フィルタピルに非色インジケータを追加 (a11y)
PR #184 で追加した拠点フィルタピルが選択状態を色のみで表現しており、CLAUDE.md §7「色だけに意味を持たせない」に反していた。`aria-current` とチェックマークを追加。

### 3. テナント/添付リポジトリの Prisma 契約テストを追加
`TenantRepository`(シークレット・課金状態を保持する最重要テーブル) と `AttachmentRepository`(Phase 1 写真添付) がメモリアダプタのテストしか持たず、本番 Prisma アダプタでの動作が未検証だった。ローカル PostgreSQL 16 で `RUN_PRISMA_CONTRACT=1` 実行し、両ファイル計 16 テストの成功と `prisma migrate deploy` がクリーン DB に最後まで適用できることを確認済み。

## 検証

- `npm run typecheck` / `npm run lint` / `npx vitest run` (710 passed / 79 skipped) — いずれも成功
- ローカル PostgreSQL 16 に対して `RUN_PRISMA_CONTRACT=1 npx vitest run --no-file-parallelism` — 全 79 契約テスト成功 (新規 16 件含む)
- `prisma migrate deploy` をクリーン DB に対して実行し、新規マイグレーションが最後まで適用できることを確認

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xr355dSJHNHurUjVPUEUyx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr355dSJHNHurUjVPUEUyx)_