### PR TITLE
fix(security): SSOレート制限 + UserRepository/監査ログのテスト追加

### DIFF
--- a/e2e/audit.spec.ts
+++ b/e2e/audit.spec.ts
@@ -1,0 +1,67 @@
+// Playwright のテスト DSL と Page 型 (ページ操作の API)
+import { test, expect, Page } from '@playwright/test';
+
+// 監査で発見したギャップ: /audit ページ (Phase 4 Enterprise「監査ログ」§6.1) は
+// TicketHistory + SettingsAuditLog のマージ・admin 限定 RBAC・Pro/Enterprise プランゲート・
+// CSV エクスポートという複数の非自明な挙動を持つが、E2E テストが一切無かった。
+// 管理者専用 (isAgent ではなく role === 'admin' を直接比較する意図的な設計)・
+// プランゲート・DB 由来の一覧表示は Vitest ユニットテストの対象外 (CLAUDE.md §11) のため
+// E2E で検証する。
+
+// 共通ログイン手順 (各テストの前処理で再利用。他の e2e spec と同じパターン)
+async function login(page: Page, email: string) {
+  await page.goto('/login');
+  await page.getByLabel(/メールアドレス|Email/i).fill(email);
+  await page.getByLabel(/パスワード|Password/i).fill('password123');
+  await page.getByRole('button', { name: /ログイン/i }).click();
+  await page.waitForURL(/\/dashboard|\/tickets/);
+}
+
+test.describe('/audit 監査ログページ', () => {
+  // 管理者 (admin@example.com, シードでは pro プラン) は一覧を閲覧できる
+  test('管理者は監査ログ一覧とCSVエクスポートボタンを閲覧できる', async ({ page }) => {
+    await login(page, 'admin@example.com');
+    await page.goto('/audit');
+
+    // ページタイトルが表示される
+    await expect(page.getByRole('heading', { name: '監査ログ' })).toBeVisible();
+
+    // シード済みの TicketHistory (seed-t-02/03/05/09) がテーブルに表示される
+    // (少なくとも 1 行以上、列見出しの「担当者」を含むテーブルが存在すること)
+    await expect(page.getByRole('table', { name: '変更履歴の一覧' })).toBeVisible();
+    const rows = page.locator('table tbody tr');
+    await expect(rows.first()).toBeVisible();
+
+    // CSV エクスポートボタンが有効な状態で表示される (ログが 0 件でないため)。
+    // ボタンの aria-label がアクセシブルネームになる (可視テキストより優先される) ため
+    // aria-label の文言で照合する
+    const exportButton = page.getByRole('button', { name: /監査ログを CSV 形式でダウンロードする/ });
+    await expect(exportButton).toBeVisible();
+    await expect(exportButton).toBeEnabled();
+  });
+
+  // 依頼者 (requester) は管理者専用メッセージのみ表示され、テーブルは見えない
+  test('依頼者は監査ログを閲覧できず管理者専用メッセージが表示される', async ({ page }) => {
+    await login(page, 'requester1@example.com');
+    await page.goto('/audit');
+
+    await expect(page.getByText('この画面は管理者のみ利用できます。')).toBeVisible();
+    await expect(page.getByRole('table', { name: '変更履歴の一覧' })).toHaveCount(0);
+  });
+
+  // エージェント (agent) も admin 専用であり、isAgent(role) ではなく role==='admin' の
+  // 直接比較を採用している設計 (CLAUDE.md 記載の意図的な admin 限定パターン) を検証する
+  test('エージェントも管理者専用メッセージが表示され閲覧できない', async ({ page }) => {
+    await login(page, 'agent1@example.com');
+    await page.goto('/audit');
+
+    await expect(page.getByText('この画面は管理者のみ利用できます。')).toBeVisible();
+    await expect(page.getByRole('table', { name: '変更履歴の一覧' })).toHaveCount(0);
+  });
+
+  // middleware は /audit を認証必須ページとして扱う (未認証は /login へリダイレクト)
+  test('未認証で /audit にアクセスするとログインページへリダイレクトされる', async ({ page }) => {
+    await page.goto('/audit');
+    await page.waitForURL(/\/login/);
+  });
+});

--- a/src/app/api/auth/sso/[tenantId]/acs/route.ts
+++ b/src/app/api/auth/sso/[tenantId]/acs/route.ts
@@ -31,21 +31,16 @@ import { generateMagicLinkToken, hashMagicLinkToken } from '@/lib/magic-link';
 import { escapeHtml } from '@/lib/html-escape';
 // Route Handler 向け共通レート制限ラッパー (inbound-email/inbound-line と共有)
 import { checkRouteRateLimit } from '@/lib/route-rate-limit';
+// SSO エンドポイント群 (acs/login/metadata) が共有するレート制限の定数とメッセージ
+// (/code-review ultra 指摘対応: 3 ファイルへの同一定数の複製を集約)
+import {
+  SSO_UNAUTHENTICATED_RATE_LIMIT,
+  SSO_TENANT_RATE_LIMIT,
+  SSO_RATE_LIMIT_MESSAGE,
+} from '@/lib/sso-rate-limit';
 
 // SSO ハンドオフトークンの有効期限 (2 分)。ACS → コールバックの即時引き渡し専用なので短くする
 const SSO_HANDOFF_TTL_MS = 2 * 60 * 1000;
-
-// 監査で発見したギャップ: 他の未認証受信エンドポイント (inbound-line/inbound-email) は
-// いずれもレート制限を持つが、この ACS エンドポイントには無かった。ACS は未認証で到達でき、
-// XML パース + 署名検証という CPU コストの高い処理をリクエストごとに行うため、他の受信系と
-// 同じ二段構えの制限を適用する:
-//  - URL の tenantId は署名検証前の値で攻撃者が自由に変更できるため、これ単体をキーにすると
-//    値を変えるだけで無制限に回避・バケット増殖されてしまう (inbound-line の destination と同じ問題)。
-//    そのためテナント解決 (DB 参照) より前に固定キーで「未認証リクエスト全体」の上限を設ける。
-const SSO_ACS_UNAUTHENTICATED_RATE_LIMIT = { limit: 60, windowMs: 60_000 } as const;
-//  - テナントが実在し SSO が有効だと確認できた後は、tenantId (DB 由来で信頼できる値) を
-//    キーにしたテナント単位の制限も適用する (1 テナントからの異常な連打を抑える)。
-const SSO_ACS_TENANT_RATE_LIMIT = { limit: 20, windowMs: 60_000 } as const;
 
 // 動的セグメント (tenantId) の型
 type Params = { params: Promise<{ tenantId: string }> };
@@ -67,13 +62,15 @@ export async function POST(req: Request, { params }: Params) {
   // 変え続けることでのレート制限回避・DB 負荷増大を防ぐ。詳細は定数の定義コメント参照)
   const unauthLimitResponse = checkRouteRateLimit(
     'sso-acs:unauthenticated',
-    SSO_ACS_UNAUTHENTICATED_RATE_LIMIT,
-    'しばらく時間をおいて再度お試しください',
+    SSO_UNAUTHENTICATED_RATE_LIMIT,
+    SSO_RATE_LIMIT_MESSAGE,
   );
+  // 制限超過なら 429 をそのまま返す (超過なしなら null が返り後続処理を続ける)
   if (unauthLimitResponse) return unauthLimitResponse;
 
   // SSO が利用可能か検証する (不可ならログイン画面へ)
   const ctx = await loadEnabledSsoContext(tenantId);
+  // 無効な SSO 設定・テナント不在ならエラーリダイレクトで打ち切る
   if (!ctx.ok) return errorRedirect('sso-unavailable');
 
   // テナントが実在し SSO が有効だと確認できたので、ここからは信頼できる tenantId を
@@ -81,9 +78,10 @@ export async function POST(req: Request, { params }: Params) {
   // CPU コストが高いため、その前に弾く)
   const tenantLimitResponse = checkRouteRateLimit(
     `sso-acs:${tenantId}`,
-    SSO_ACS_TENANT_RATE_LIMIT,
-    'しばらく時間をおいて再度お試しください',
+    SSO_TENANT_RATE_LIMIT,
+    SSO_RATE_LIMIT_MESSAGE,
   );
+  // テナント単位の制限超過なら 429 をそのまま返す
   if (tenantLimitResponse) return tenantLimitResponse;
 
   // POST ボディ (application/x-www-form-urlencoded) から SAMLResponse を取り出す

--- a/src/app/api/auth/sso/[tenantId]/login/route.ts
+++ b/src/app/api/auth/sso/[tenantId]/login/route.ts
@@ -18,6 +18,20 @@ import { loadEnabledSsoContext } from '@/lib/sso-context';
 import { createSamlInstance, getSsoLoginUrl } from '@/lib/saml';
 // 信頼できるアプリケーションベース URL の解決 (NEXTAUTH_URL 優先・req.url の Host ヘッダに依存しない)
 import { resolveAppBaseUrl } from '@/lib/app-url';
+// Route Handler 向け共通レート制限ラッパー (acs/route.ts と共有)
+import { checkRouteRateLimit } from '@/lib/route-rate-limit';
+
+// 監査で発見したギャップ: 同じ SSO エンドポイント群のうち acs/route.ts だけがレート制限済みで、
+// この /login エンドポイントには無かった。未認証で到達でき、有効な SSO であれば
+// AuthnRequest 生成 (createSamlInstance + getSsoLoginUrl) という相応のコストがかかる処理を
+// 都度行うため、acs/route.ts と同じ二段構えの制限を適用する。
+//  - URL の tenantId は DB 検証前の値で攻撃者が自由に変更できるため、これ単体をキーにすると
+//    値を変えるだけで無制限に回避できてしまう (acs/route.ts と同じ理由)。テナント解決
+//    (loadEnabledSsoContext の DB 参照) より前に固定キーで全体の上限を設ける。
+const SSO_LOGIN_UNAUTHENTICATED_RATE_LIMIT = { limit: 60, windowMs: 60_000 } as const;
+//  - テナントが実在し SSO が有効だと確認できた後は、tenantId (DB 由来で信頼できる値) を
+//    キーにしたテナント単位の制限も、コストの高い AuthnRequest 生成の前に適用する。
+const SSO_LOGIN_TENANT_RATE_LIMIT = { limit: 20, windowMs: 60_000 } as const;
 
 // 動的セグメント (tenantId) の型 (Next.js 15 では params は Promise)
 type Params = { params: Promise<{ tenantId: string }> };
@@ -33,9 +47,27 @@ export async function GET(_req: Request, { params }: Params) {
   const errorRedirect = () =>
     NextResponse.redirect(new URL('/login?error=sso-unavailable', baseUrl), 303);
 
+  // 固定キーの全体レート制限を適用する (テナント解決より前に置き、URL の tenantId を
+  // 変え続けることでのレート制限回避・DB 負荷増大を防ぐ)
+  const unauthLimitResponse = checkRouteRateLimit(
+    'sso-login:unauthenticated',
+    SSO_LOGIN_UNAUTHENTICATED_RATE_LIMIT,
+    'しばらく時間をおいて再度お試しください',
+  );
+  if (unauthLimitResponse) return unauthLimitResponse;
+
   // SSO が利用可能か検証する (不可ならログイン画面へ)
   const ctx = await loadEnabledSsoContext(tenantId);
   if (!ctx.ok) return errorRedirect();
+
+  // テナントが実在し SSO が有効だと確認できたので、信頼できる tenantId をキーにした
+  // テナント単位のレート制限を、この後の AuthnRequest 生成の前に適用する
+  const tenantLimitResponse = checkRouteRateLimit(
+    `sso-login:${tenantId}`,
+    SSO_LOGIN_TENANT_RATE_LIMIT,
+    'しばらく時間をおいて再度お試しください',
+  );
+  if (tenantLimitResponse) return tenantLimitResponse;
 
   try {
     // テナントの SSO 設定から SAML SP インスタンスを構築する

--- a/src/app/api/auth/sso/[tenantId]/login/route.ts
+++ b/src/app/api/auth/sso/[tenantId]/login/route.ts
@@ -20,18 +20,18 @@ import { createSamlInstance, getSsoLoginUrl } from '@/lib/saml';
 import { resolveAppBaseUrl } from '@/lib/app-url';
 // Route Handler 向け共通レート制限ラッパー (acs/route.ts と共有)
 import { checkRouteRateLimit } from '@/lib/route-rate-limit';
+// SSO エンドポイント群 (acs/login/metadata) が共有するレート制限の定数とメッセージ
+import {
+  SSO_UNAUTHENTICATED_RATE_LIMIT,
+  SSO_TENANT_RATE_LIMIT,
+  SSO_RATE_LIMIT_MESSAGE,
+} from '@/lib/sso-rate-limit';
 
 // 監査で発見したギャップ: 同じ SSO エンドポイント群のうち acs/route.ts だけがレート制限済みで、
 // この /login エンドポイントには無かった。未認証で到達でき、有効な SSO であれば
 // AuthnRequest 生成 (createSamlInstance + getSsoLoginUrl) という相応のコストがかかる処理を
-// 都度行うため、acs/route.ts と同じ二段構えの制限を適用する。
-//  - URL の tenantId は DB 検証前の値で攻撃者が自由に変更できるため、これ単体をキーにすると
-//    値を変えるだけで無制限に回避できてしまう (acs/route.ts と同じ理由)。テナント解決
-//    (loadEnabledSsoContext の DB 参照) より前に固定キーで全体の上限を設ける。
-const SSO_LOGIN_UNAUTHENTICATED_RATE_LIMIT = { limit: 60, windowMs: 60_000 } as const;
-//  - テナントが実在し SSO が有効だと確認できた後は、tenantId (DB 由来で信頼できる値) を
-//    キーにしたテナント単位の制限も、コストの高い AuthnRequest 生成の前に適用する。
-const SSO_LOGIN_TENANT_RATE_LIMIT = { limit: 20, windowMs: 60_000 } as const;
+// 都度行うため、acs/route.ts と同じ二段構えの制限を適用する (制限値・理由は
+// src/lib/sso-rate-limit.ts のコメント参照)。
 
 // 動的セグメント (tenantId) の型 (Next.js 15 では params は Promise)
 type Params = { params: Promise<{ tenantId: string }> };
@@ -51,22 +51,25 @@ export async function GET(_req: Request, { params }: Params) {
   // 変え続けることでのレート制限回避・DB 負荷増大を防ぐ)
   const unauthLimitResponse = checkRouteRateLimit(
     'sso-login:unauthenticated',
-    SSO_LOGIN_UNAUTHENTICATED_RATE_LIMIT,
-    'しばらく時間をおいて再度お試しください',
+    SSO_UNAUTHENTICATED_RATE_LIMIT,
+    SSO_RATE_LIMIT_MESSAGE,
   );
+  // 制限超過なら 429 をそのまま返す (超過なしなら null が返り後続処理を続ける)
   if (unauthLimitResponse) return unauthLimitResponse;
 
   // SSO が利用可能か検証する (不可ならログイン画面へ)
   const ctx = await loadEnabledSsoContext(tenantId);
+  // 無効な SSO 設定・テナント不在ならエラーリダイレクトで打ち切る
   if (!ctx.ok) return errorRedirect();
 
   // テナントが実在し SSO が有効だと確認できたので、信頼できる tenantId をキーにした
   // テナント単位のレート制限を、この後の AuthnRequest 生成の前に適用する
   const tenantLimitResponse = checkRouteRateLimit(
     `sso-login:${tenantId}`,
-    SSO_LOGIN_TENANT_RATE_LIMIT,
-    'しばらく時間をおいて再度お試しください',
+    SSO_TENANT_RATE_LIMIT,
+    SSO_RATE_LIMIT_MESSAGE,
   );
+  // テナント単位の制限超過なら 429 をそのまま返す
   if (tenantLimitResponse) return tenantLimitResponse;
 
   try {

--- a/src/app/api/auth/sso/[tenantId]/metadata/route.ts
+++ b/src/app/api/auth/sso/[tenantId]/metadata/route.ts
@@ -19,13 +19,21 @@ import { resolveAppBaseUrl } from '@/lib/app-url';
 import { buildSpMetadataXml } from '@/lib/saml';
 // Route Handler 向け共通レート制限ラッパー (login/acs の各 route.ts と共有)
 import { checkRouteRateLimit } from '@/lib/route-rate-limit';
+// SSO エンドポイント群 (acs/login/metadata) が共有するレート制限の定数とメッセージ
+import {
+  SSO_UNAUTHENTICATED_RATE_LIMIT,
+  SSO_TENANT_RATE_LIMIT,
+  SSO_RATE_LIMIT_MESSAGE,
+} from '@/lib/sso-rate-limit';
 
 // 監査で発見したギャップ: 同じ SSO エンドポイント群のうち login/acs はレート制限済みで、
 // このエンドポイントには無かった。未認証で到達でき、リクエストごとに DB 参照
-// (tenants.findById) が発生するため、URL の tenantId を変え続けて連打されると DB 負荷に
-// つながる。tenantId は DB 検証前の値で攻撃者が自由に変更できるため、login/acs と同じ
-// 理由で固定キーの全体制限にする (テナント単位のキーだけでは変更するだけで回避できる)。
-const SSO_METADATA_RATE_LIMIT = { limit: 60, windowMs: 60_000 } as const;
+// (tenants.findById) が発生するため、login/acs と同じ二段構えの制限を適用する
+// (制限値・理由は src/lib/sso-rate-limit.ts のコメント参照)。
+// /code-review ultra 指摘対応: 当初はテナント単位の第二段を省略していたが、それでは
+// 有効な 1 テナントだけで固定キーの共有予算 (60秒60回) を独占でき、login/acs が持つ
+// 「1 テナントからの連打を抑える」という保護がこのエンドポイントだけ欠けてしまうため、
+// login/acs と同じ二段構えに揃えた。
 
 // 動的セグメント (tenantId) の型
 type Params = { params: Promise<{ tenantId: string }> };
@@ -34,12 +42,13 @@ type Params = { params: Promise<{ tenantId: string }> };
 export async function GET(_req: Request, { params }: Params) {
   // 固定キーの全体レート制限を適用する (DB 参照より前に置き、URL の tenantId を
   // 変え続けることでのレート制限回避・DB 負荷増大を防ぐ)
-  const limitResponse = checkRouteRateLimit(
+  const unauthLimitResponse = checkRouteRateLimit(
     'sso-metadata:unauthenticated',
-    SSO_METADATA_RATE_LIMIT,
-    'しばらく時間をおいて再度お試しください',
+    SSO_UNAUTHENTICATED_RATE_LIMIT,
+    SSO_RATE_LIMIT_MESSAGE,
   );
-  if (limitResponse) return limitResponse;
+  // 制限超過なら 429 をそのまま返す (超過なしなら null が返り後続処理を続ける)
+  if (unauthLimitResponse) return unauthLimitResponse;
 
   // URL の tenantId を取り出す
   const { tenantId } = await params;
@@ -49,6 +58,18 @@ export async function GET(_req: Request, { params }: Params) {
   if (!tenant || !isSsoAllowed(tenant.subscriptionPlan)) {
     return new NextResponse('SSO はこのテナントでは利用できません。', { status: 404 });
   }
+
+  // テナントが実在し SSO (Enterprise プラン) が有効だと確認できたので、信頼できる
+  // tenantId をキーにしたテナント単位のレート制限も適用する (1 テナントが固定キーの
+  // 共有予算を独占してしまうのを防ぐ)
+  const tenantLimitResponse = checkRouteRateLimit(
+    `sso-metadata:${tenantId}`,
+    SSO_TENANT_RATE_LIMIT,
+    SSO_RATE_LIMIT_MESSAGE,
+  );
+  // テナント単位の制限超過なら 429 をそのまま返す
+  if (tenantLimitResponse) return tenantLimitResponse;
+
   // SP メタデータ XML を組み立てる (秘密情報を含まない SP の URL のみ)
   const xml = buildSpMetadataXml(resolveAppBaseUrl(), tenantId);
   // XML として返す

--- a/src/app/api/auth/sso/[tenantId]/metadata/route.ts
+++ b/src/app/api/auth/sso/[tenantId]/metadata/route.ts
@@ -17,12 +17,30 @@ import { isSsoAllowed } from '@/lib/plan-guard';
 import { resolveAppBaseUrl } from '@/lib/app-url';
 // SP メタデータ XML 生成 (純粋関数)
 import { buildSpMetadataXml } from '@/lib/saml';
+// Route Handler 向け共通レート制限ラッパー (login/acs の各 route.ts と共有)
+import { checkRouteRateLimit } from '@/lib/route-rate-limit';
+
+// 監査で発見したギャップ: 同じ SSO エンドポイント群のうち login/acs はレート制限済みで、
+// このエンドポイントには無かった。未認証で到達でき、リクエストごとに DB 参照
+// (tenants.findById) が発生するため、URL の tenantId を変え続けて連打されると DB 負荷に
+// つながる。tenantId は DB 検証前の値で攻撃者が自由に変更できるため、login/acs と同じ
+// 理由で固定キーの全体制限にする (テナント単位のキーだけでは変更するだけで回避できる)。
+const SSO_METADATA_RATE_LIMIT = { limit: 60, windowMs: 60_000 } as const;
 
 // 動的セグメント (tenantId) の型
 type Params = { params: Promise<{ tenantId: string }> };
 
 // GET ハンドラ: SP メタデータ XML を返す
 export async function GET(_req: Request, { params }: Params) {
+  // 固定キーの全体レート制限を適用する (DB 参照より前に置き、URL の tenantId を
+  // 変え続けることでのレート制限回避・DB 負荷増大を防ぐ)
+  const limitResponse = checkRouteRateLimit(
+    'sso-metadata:unauthenticated',
+    SSO_METADATA_RATE_LIMIT,
+    'しばらく時間をおいて再度お試しください',
+  );
+  if (limitResponse) return limitResponse;
+
   // URL の tenantId を取り出す
   const { tenantId } = await params;
   // テナントを取得する

--- a/src/lib/sso-rate-limit.ts
+++ b/src/lib/sso-rate-limit.ts
@@ -1,0 +1,19 @@
+// SSO (SAML) エンドポイント群 (acs/login/metadata) が共有するレート制限の定数。
+// /code-review ultra 指摘対応: 「固定キーの全体制限 (60秒60回) → tenantId 確定後の
+// テナント単位制限 (60秒20回)」という同一の制限値・エラーメッセージが acs/route.ts・
+// login/route.ts・metadata/route.ts の 3 箇所に複製されていたため (CLAUDE.md §6
+// 「2〜3 箇所目で共通化する」を超過)、ここに集約する。
+//
+// tenantId は DB 検証前 (URL セグメント) の値で攻撃者が自由に変更できるため、これ単体を
+// キーにすると値を変えるだけで無制限に回避されてしまう。そのためテナント解決 (DB 参照) より
+// 前に固定キーで全体の上限を設け、テナントの実在・SSO 有効性を確認できた後にさらに
+// tenantId (DB 由来で信頼できる値) をキーにしたテナント単位の制限を重ねる二段構えにする。
+
+// 固定キーの全体レート制限 (テナント解決前に適用)
+export const SSO_UNAUTHENTICATED_RATE_LIMIT = { limit: 60, windowMs: 60_000 } as const;
+
+// テナント単位のレート制限 (テナントの実在・SSO 有効性を確認できた後に適用)
+export const SSO_TENANT_RATE_LIMIT = { limit: 20, windowMs: 60_000 } as const;
+
+// レート制限超過時にクライアントへ返す共通の日本語メッセージ
+export const SSO_RATE_LIMIT_MESSAGE = 'しばらく時間をおいて再度お試しください';

--- a/tests/data/user-fixtures.ts
+++ b/tests/data/user-fixtures.ts
@@ -1,0 +1,26 @@
+// UserRepository のメモリアダプタ単体テストで共有するフィクスチャヘルパー。
+// /code-review ultra 指摘対応: 同一の putUser() 実装が user-line-link.memory.test.ts と
+// user-repository.memory.test.ts に複製されていたため (CLAUDE.md §6)、ここに集約する。
+
+import type { Store } from '@/data/adapters/memory';
+
+// テスト用メンバーを 1 人ストアに置く小ヘルパー
+export function putUser(
+  store: Store, // 書き込み先のメモリストア
+  id: string, // ユーザー ID
+  tenantId: string, // 所属テナント ID
+  extra: Record<string, unknown> = {}, // 上書きしたいフィールド (role/email/lineUserId 等)
+): void {
+  const now = new Date();
+  store.users.set(id, {
+    id,
+    email: `${id}@example.com`,
+    name: id,
+    passwordHash: 'x',
+    role: 'requester',
+    tenantId,
+    createdAt: now,
+    updatedAt: now,
+    ...extra,
+  });
+}

--- a/tests/data/user-line-link.memory.test.ts
+++ b/tests/data/user-line-link.memory.test.ts
@@ -6,28 +6,13 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { createMemoryContext, type Store } from '@/data/adapters/memory';
 import type { Repos } from '@/data/ports/unit-of-work';
 import { hashLineLinkCode, normalizeLineLinkCode } from '@/lib/line-link';
+import { putUser } from './user-fixtures';
 
 const TENANT = 'default-tenant';
 const OTHER_TENANT = 'other-tenant';
 
 let store: Store;
 let repos: Repos;
-
-// テスト用メンバーを 1 人ストアに置く小ヘルパー
-function putUser(id: string, tenantId: string, extra: Record<string, unknown> = {}) {
-  const now = new Date();
-  store.users.set(id, {
-    id,
-    email: `${id}@example.com`,
-    name: id,
-    passwordHash: 'x',
-    role: 'requester',
-    tenantId,
-    createdAt: now,
-    updatedAt: now,
-    ...extra,
-  });
-}
 
 // 生コードを正規化してハッシュ化する (発行側と同じ手順)
 async function codeHashOf(rawCode: string): Promise<string> {
@@ -43,7 +28,7 @@ describe('UserRepository LINE 紐付け (memory)', () => {
 
   // findByLineUserId: 紐付け済みメンバーを返し、別テナントには漏れない
   it('findByLineUserId はテナントスコープで引く', async () => {
-    putUser('u1', TENANT, { lineUserId: 'Uline1' });
+    putUser(store, 'u1', TENANT, { lineUserId: 'Uline1' });
     // 同 tenant では引ける
     expect((await repos.users.findByLineUserId(TENANT, 'Uline1'))?.id).toBe('u1');
     // 別 tenant からは見えない (クロステナント漏洩防止)
@@ -54,7 +39,7 @@ describe('UserRepository LINE 紐付け (memory)', () => {
 
   // setLineLinkCode → linkLineUserByCode で連携が成立し、コードは消費される
   it('発行コードで連携が成立し、コードが消費される', async () => {
-    putUser('u1', TENANT);
+    putUser(store, 'u1', TENANT);
     const expiresAt = new Date(Date.now() + 10 * 60 * 1000);
     const hash = await codeHashOf('AB7K-9QF2');
     await repos.users.setLineLinkCode('u1', TENANT, { codeHash: hash, expiresAt });
@@ -82,7 +67,7 @@ describe('UserRepository LINE 紐付け (memory)', () => {
 
   // 失効済みコードは invalid
   it('失効したコードは invalid を返す', async () => {
-    putUser('u1', TENANT);
+    putUser(store, 'u1', TENANT);
     const hash = await codeHashOf('AB7K-9QF2');
     // 既に失効している有効期限を設定する
     await repos.users.setLineLinkCode('u1', TENANT, {
@@ -100,7 +85,7 @@ describe('UserRepository LINE 紐付け (memory)', () => {
 
   // 別テナントのコードは取り込み先テナントでは消費できない (クロステナント防止)
   it('別テナントのコードは消費できない', async () => {
-    putUser('uOther', OTHER_TENANT);
+    putUser(store, 'uOther', OTHER_TENANT);
     const hash = await codeHashOf('AB7K-9QF2');
     await repos.users.setLineLinkCode('uOther', OTHER_TENANT, {
       codeHash: hash,
@@ -118,8 +103,8 @@ describe('UserRepository LINE 紐付け (memory)', () => {
 
   // その LINE ユーザー ID が別メンバーに連携済みなら conflict
   it('LINE ユーザー ID が別メンバーに連携済みなら conflict', async () => {
-    putUser('u1', TENANT, { lineUserId: 'Uline1' }); // 既に Uline1 を持つ
-    putUser('u2', TENANT); // u2 が同じ Uline1 を取りにくる
+    putUser(store, 'u1', TENANT, { lineUserId: 'Uline1' }); // 既に Uline1 を持つ
+    putUser(store, 'u2', TENANT); // u2 が同じ Uline1 を取りにくる
     const hash = await codeHashOf('ZZ11-2233');
     await repos.users.setLineLinkCode('u2', TENANT, {
       codeHash: hash,
@@ -138,7 +123,7 @@ describe('UserRepository LINE 紐付け (memory)', () => {
 
   // unlinkLineUser は lineUserId と発行中コードをまとめてクリアする
   it('unlinkLineUser で連携を解除する', async () => {
-    putUser('u1', TENANT, {
+    putUser(store, 'u1', TENANT, {
       lineUserId: 'Uline1',
       lineLinkCodeHash: 'h',
       lineLinkCodeExpiresAt: new Date(),

--- a/tests/data/user-repository.memory.test.ts
+++ b/tests/data/user-repository.memory.test.ts
@@ -1,0 +1,154 @@
+// UserRepository (メモリアダプタ) の単体テスト。
+// 監査で発見したギャップ: LINE 紐付け系の 4 メソッドは user-line-link.memory.test.ts で
+// カバー済みだったが、findById/findByEmail/create (メール一意制約)・listAgents*/
+// findSummariesByIds/listAgentEmails/listAdminEmails/countByTenant はテストが無かった。
+// 特に countByTenant (Phase 4 課金のシート上限判定に使う) と listAdminEmails
+// (trial-reminder の通知先取得に使う) はテナント分離を誤ると課金・通知の不具合に直結するため
+// 重点的に検証する。
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+import type { Repos } from '@/data/ports/unit-of-work';
+
+const TENANT = 'default-tenant';
+const OTHER_TENANT = 'other-tenant';
+
+let store: Store;
+let repos: Repos;
+
+// テスト用メンバーを 1 人ストアに置く小ヘルパー (user-line-link.memory.test.ts と同型)
+function putUser(id: string, tenantId: string, extra: Record<string, unknown> = {}) {
+  const now = new Date();
+  store.users.set(id, {
+    id,
+    email: `${id}@example.com`,
+    name: id,
+    passwordHash: 'x',
+    role: 'requester',
+    tenantId,
+    createdAt: now,
+    updatedAt: now,
+    ...extra,
+  });
+}
+
+describe('UserRepository (memory)', () => {
+  beforeEach(() => {
+    const ctx = createMemoryContext();
+    store = ctx.store;
+    repos = ctx.repos;
+  });
+
+  // findById: 存在するユーザーを返し、破壊防止のため複製を返す (tenantId スコープなし)
+  it('findByIdはIDで1件取得し、複製を返す (直接変更してもストアに影響しない)', async () => {
+    putUser('u1', TENANT);
+    const found = await repos.users.findById('u1');
+    expect(found?.id).toBe('u1');
+    // 返り値を書き換えてもストア本体には影響しないこと (防御的コピーの確認)
+    if (found) found.name = '書き換え後';
+    expect(store.users.get('u1')?.name).toBe('u1');
+    // 存在しない ID は null
+    expect(await repos.users.findById('no-such-user')).toBeNull();
+  });
+
+  // findByEmail: テナント横断で検索できる (ログインフロー用)
+  it('findByEmailはテナントを横断してメールで検索する', async () => {
+    putUser('u1', TENANT, { email: 'agent@example.com' });
+    putUser('u2', OTHER_TENANT, { email: 'other@example.com' });
+    // 別テナントのユーザーでもメール一致で見つかる (ログイン時点ではテナント未確定のため)
+    expect((await repos.users.findByEmail('other@example.com'))?.id).toBe('u2');
+    expect(await repos.users.findByEmail('nobody@example.com')).toBeNull();
+  });
+
+  // create: 新規ユーザーを作成できる
+  it('createは新規ユーザーを作成しIDを採番する', async () => {
+    const user = await repos.users.create({
+      email: 'new@example.com',
+      name: '新規太郎',
+      passwordHash: 'hashed',
+      role: 'requester',
+      tenantId: TENANT,
+    });
+    expect(user.id).toBeTruthy();
+    expect(user.email).toBe('new@example.com');
+    expect(store.users.get(user.id)?.tenantId).toBe(TENANT);
+  });
+
+  // create: メール一意制約 (@unique) をテナント横断で強制する
+  it('createは既存メールと重複するとテナントを問わず例外を投げる', async () => {
+    putUser('u1', TENANT, { email: 'dup@example.com' });
+    await expect(
+      repos.users.create({
+        email: 'dup@example.com',
+        name: '別テナントの人',
+        passwordHash: 'x',
+        role: 'requester',
+        tenantId: OTHER_TENANT,
+      }),
+    ).rejects.toThrow();
+  });
+
+  // listAgents: agent/admin のみを名前順で返し、requester と他テナントは除外する
+  it('listAgentsはagent/adminのみを名前順で返す', async () => {
+    putUser('u-req', TENANT, { role: 'requester', name: 'requester太郎' });
+    putUser('u-agent-b', TENANT, { role: 'agent', name: 'ぶらぼー' });
+    putUser('u-agent-a', TENANT, { role: 'admin', name: 'あいうえお' });
+    putUser('u-other-tenant-agent', OTHER_TENANT, { role: 'agent', name: 'あ他テナント' });
+
+    const agents = await repos.users.listAgents(TENANT);
+    expect(agents.map((a) => a.id)).toEqual(['u-agent-a', 'u-agent-b']);
+  });
+
+  // listAgentIds: ID のみを返す (テナント分離込み)
+  it('listAgentIdsはagent/adminのIDのみを返す', async () => {
+    putUser('u-req', TENANT, { role: 'requester' });
+    putUser('u-agent', TENANT, { role: 'agent' });
+    putUser('u-other-tenant', OTHER_TENANT, { role: 'admin' });
+
+    const ids = await repos.users.listAgentIds(TENANT);
+    expect(ids).toEqual(['u-agent']);
+  });
+
+  // findSummariesByIds: 指定 ID かつ同テナントのユーザーのみ抽出する
+  it('findSummariesByIdsは指定IDかつ同テナントのユーザーのみ返す', async () => {
+    putUser('u1', TENANT, { name: 'ユーザー1' });
+    putUser('u2', TENANT, { name: 'ユーザー2' });
+    putUser('u3', OTHER_TENANT, { name: '別テナントのユーザー' });
+
+    const summaries = await repos.users.findSummariesByIds(['u1', 'u3', 'no-such-id'], TENANT);
+    // u3 は別テナントなので除外され、no-such-id は存在しないので除外される
+    expect(summaries).toEqual([{ id: 'u1', name: 'ユーザー1' }]);
+  });
+
+  // listAgentEmails: agent/admin の id + email をテナントスコープで返す (一斉メール送信用)
+  it('listAgentEmailsはagent/adminのid+emailを返す', async () => {
+    putUser('u-req', TENANT, { role: 'requester', email: 'req@example.com' });
+    putUser('u-agent', TENANT, { role: 'agent', email: 'agent@example.com' });
+    putUser('u-other-tenant', OTHER_TENANT, { role: 'admin', email: 'other@example.com' });
+
+    const emails = await repos.users.listAgentEmails(TENANT);
+    expect(emails).toEqual([{ id: 'u-agent', email: 'agent@example.com' }]);
+  });
+
+  // listAdminEmails: admin のみ (agent は含まない) — trial-reminder 等の通知先取得に使う
+  it('listAdminEmailsはadminのみを返しagentは含まない', async () => {
+    putUser('u-agent', TENANT, { role: 'agent', email: 'agent@example.com' });
+    putUser('u-admin', TENANT, { role: 'admin', email: 'admin@example.com' });
+    putUser('u-other-tenant-admin', OTHER_TENANT, { role: 'admin', email: 'other@example.com' });
+
+    const admins = await repos.users.listAdminEmails(TENANT);
+    expect(admins).toEqual([{ id: 'u-admin', email: 'admin@example.com' }]);
+  });
+
+  // countByTenant: agent/admin のみをシート数としてカウントし、requester は含まない
+  it('countByTenantはagent/adminのみを数えrequesterは含まない (シート上限判定用)', async () => {
+    putUser('u-req-1', TENANT, { role: 'requester' });
+    putUser('u-req-2', TENANT, { role: 'requester' });
+    putUser('u-agent', TENANT, { role: 'agent' });
+    putUser('u-admin', TENANT, { role: 'admin' });
+    putUser('u-other-tenant-agent', OTHER_TENANT, { role: 'agent' });
+
+    expect(await repos.users.countByTenant(TENANT)).toBe(2);
+    expect(await repos.users.countByTenant(OTHER_TENANT)).toBe(1);
+  });
+});

--- a/tests/data/user-repository.memory.test.ts
+++ b/tests/data/user-repository.memory.test.ts
@@ -9,28 +9,13 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createMemoryContext, type Store } from '@/data/adapters/memory';
 import type { Repos } from '@/data/ports/unit-of-work';
+import { putUser } from './user-fixtures';
 
 const TENANT = 'default-tenant';
 const OTHER_TENANT = 'other-tenant';
 
 let store: Store;
 let repos: Repos;
-
-// テスト用メンバーを 1 人ストアに置く小ヘルパー (user-line-link.memory.test.ts と同型)
-function putUser(id: string, tenantId: string, extra: Record<string, unknown> = {}) {
-  const now = new Date();
-  store.users.set(id, {
-    id,
-    email: `${id}@example.com`,
-    name: id,
-    passwordHash: 'x',
-    role: 'requester',
-    tenantId,
-    createdAt: now,
-    updatedAt: now,
-    ...extra,
-  });
-}
 
 describe('UserRepository (memory)', () => {
   beforeEach(() => {
@@ -41,7 +26,7 @@ describe('UserRepository (memory)', () => {
 
   // findById: 存在するユーザーを返し、破壊防止のため複製を返す (tenantId スコープなし)
   it('findByIdはIDで1件取得し、複製を返す (直接変更してもストアに影響しない)', async () => {
-    putUser('u1', TENANT);
+    putUser(store, 'u1', TENANT);
     const found = await repos.users.findById('u1');
     expect(found?.id).toBe('u1');
     // 返り値を書き換えてもストア本体には影響しないこと (防御的コピーの確認)
@@ -53,8 +38,8 @@ describe('UserRepository (memory)', () => {
 
   // findByEmail: テナント横断で検索できる (ログインフロー用)
   it('findByEmailはテナントを横断してメールで検索する', async () => {
-    putUser('u1', TENANT, { email: 'agent@example.com' });
-    putUser('u2', OTHER_TENANT, { email: 'other@example.com' });
+    putUser(store, 'u1', TENANT, { email: 'agent@example.com' });
+    putUser(store, 'u2', OTHER_TENANT, { email: 'other@example.com' });
     // 別テナントのユーザーでもメール一致で見つかる (ログイン時点ではテナント未確定のため)
     expect((await repos.users.findByEmail('other@example.com'))?.id).toBe('u2');
     expect(await repos.users.findByEmail('nobody@example.com')).toBeNull();
@@ -76,7 +61,7 @@ describe('UserRepository (memory)', () => {
 
   // create: メール一意制約 (@unique) をテナント横断で強制する
   it('createは既存メールと重複するとテナントを問わず例外を投げる', async () => {
-    putUser('u1', TENANT, { email: 'dup@example.com' });
+    putUser(store, 'u1', TENANT, { email: 'dup@example.com' });
     await expect(
       repos.users.create({
         email: 'dup@example.com',
@@ -90,10 +75,10 @@ describe('UserRepository (memory)', () => {
 
   // listAgents: agent/admin のみを名前順で返し、requester と他テナントは除外する
   it('listAgentsはagent/adminのみを名前順で返す', async () => {
-    putUser('u-req', TENANT, { role: 'requester', name: 'requester太郎' });
-    putUser('u-agent-b', TENANT, { role: 'agent', name: 'ぶらぼー' });
-    putUser('u-agent-a', TENANT, { role: 'admin', name: 'あいうえお' });
-    putUser('u-other-tenant-agent', OTHER_TENANT, { role: 'agent', name: 'あ他テナント' });
+    putUser(store, 'u-req', TENANT, { role: 'requester', name: 'requester太郎' });
+    putUser(store, 'u-agent-b', TENANT, { role: 'agent', name: 'ぶらぼー' });
+    putUser(store, 'u-agent-a', TENANT, { role: 'admin', name: 'あいうえお' });
+    putUser(store, 'u-other-tenant-agent', OTHER_TENANT, { role: 'agent', name: 'あ他テナント' });
 
     const agents = await repos.users.listAgents(TENANT);
     expect(agents.map((a) => a.id)).toEqual(['u-agent-a', 'u-agent-b']);
@@ -101,9 +86,9 @@ describe('UserRepository (memory)', () => {
 
   // listAgentIds: ID のみを返す (テナント分離込み)
   it('listAgentIdsはagent/adminのIDのみを返す', async () => {
-    putUser('u-req', TENANT, { role: 'requester' });
-    putUser('u-agent', TENANT, { role: 'agent' });
-    putUser('u-other-tenant', OTHER_TENANT, { role: 'admin' });
+    putUser(store, 'u-req', TENANT, { role: 'requester' });
+    putUser(store, 'u-agent', TENANT, { role: 'agent' });
+    putUser(store, 'u-other-tenant', OTHER_TENANT, { role: 'admin' });
 
     const ids = await repos.users.listAgentIds(TENANT);
     expect(ids).toEqual(['u-agent']);
@@ -111,9 +96,9 @@ describe('UserRepository (memory)', () => {
 
   // findSummariesByIds: 指定 ID かつ同テナントのユーザーのみ抽出する
   it('findSummariesByIdsは指定IDかつ同テナントのユーザーのみ返す', async () => {
-    putUser('u1', TENANT, { name: 'ユーザー1' });
-    putUser('u2', TENANT, { name: 'ユーザー2' });
-    putUser('u3', OTHER_TENANT, { name: '別テナントのユーザー' });
+    putUser(store, 'u1', TENANT, { name: 'ユーザー1' });
+    putUser(store, 'u2', TENANT, { name: 'ユーザー2' });
+    putUser(store, 'u3', OTHER_TENANT, { name: '別テナントのユーザー' });
 
     const summaries = await repos.users.findSummariesByIds(['u1', 'u3', 'no-such-id'], TENANT);
     // u3 は別テナントなので除外され、no-such-id は存在しないので除外される
@@ -122,9 +107,9 @@ describe('UserRepository (memory)', () => {
 
   // listAgentEmails: agent/admin の id + email をテナントスコープで返す (一斉メール送信用)
   it('listAgentEmailsはagent/adminのid+emailを返す', async () => {
-    putUser('u-req', TENANT, { role: 'requester', email: 'req@example.com' });
-    putUser('u-agent', TENANT, { role: 'agent', email: 'agent@example.com' });
-    putUser('u-other-tenant', OTHER_TENANT, { role: 'admin', email: 'other@example.com' });
+    putUser(store, 'u-req', TENANT, { role: 'requester', email: 'req@example.com' });
+    putUser(store, 'u-agent', TENANT, { role: 'agent', email: 'agent@example.com' });
+    putUser(store, 'u-other-tenant', OTHER_TENANT, { role: 'admin', email: 'other@example.com' });
 
     const emails = await repos.users.listAgentEmails(TENANT);
     expect(emails).toEqual([{ id: 'u-agent', email: 'agent@example.com' }]);
@@ -132,9 +117,9 @@ describe('UserRepository (memory)', () => {
 
   // listAdminEmails: admin のみ (agent は含まない) — trial-reminder 等の通知先取得に使う
   it('listAdminEmailsはadminのみを返しagentは含まない', async () => {
-    putUser('u-agent', TENANT, { role: 'agent', email: 'agent@example.com' });
-    putUser('u-admin', TENANT, { role: 'admin', email: 'admin@example.com' });
-    putUser('u-other-tenant-admin', OTHER_TENANT, { role: 'admin', email: 'other@example.com' });
+    putUser(store, 'u-agent', TENANT, { role: 'agent', email: 'agent@example.com' });
+    putUser(store, 'u-admin', TENANT, { role: 'admin', email: 'admin@example.com' });
+    putUser(store, 'u-other-tenant-admin', OTHER_TENANT, { role: 'admin', email: 'other@example.com' });
 
     const admins = await repos.users.listAdminEmails(TENANT);
     expect(admins).toEqual([{ id: 'u-admin', email: 'admin@example.com' }]);
@@ -142,11 +127,11 @@ describe('UserRepository (memory)', () => {
 
   // countByTenant: agent/admin のみをシート数としてカウントし、requester は含まない
   it('countByTenantはagent/adminのみを数えrequesterは含まない (シート上限判定用)', async () => {
-    putUser('u-req-1', TENANT, { role: 'requester' });
-    putUser('u-req-2', TENANT, { role: 'requester' });
-    putUser('u-agent', TENANT, { role: 'agent' });
-    putUser('u-admin', TENANT, { role: 'admin' });
-    putUser('u-other-tenant-agent', OTHER_TENANT, { role: 'agent' });
+    putUser(store, 'u-req-1', TENANT, { role: 'requester' });
+    putUser(store, 'u-req-2', TENANT, { role: 'requester' });
+    putUser(store, 'u-agent', TENANT, { role: 'agent' });
+    putUser(store, 'u-admin', TENANT, { role: 'admin' });
+    putUser(store, 'u-other-tenant-agent', OTHER_TENANT, { role: 'agent' });
 
     expect(await repos.users.countByTenant(TENANT)).toBe(2);
     expect(await repos.users.countByTenant(OTHER_TENANT)).toBe(1);

--- a/tests/features/sso-acs-route.test.ts
+++ b/tests/features/sso-acs-route.test.ts
@@ -7,6 +7,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { __resetRateLimits } from '@/lib/rate-limit';
+import { expectRateLimitTripsAfter } from './sso-rate-limit-assertions';
 
 const TENANT_ID = 'tenant-1';
 
@@ -37,22 +38,12 @@ describe('POST /api/auth/sso/[tenantId]/acs のレート制限', () => {
 
   // 固定キーの全体レート制限 (60秒60回) を超えると 429 を返す
   it('未認証全体のレート制限を超えると429を返す', async () => {
-    for (let i = 0; i < 60; i++) {
-      const res = await postAcs(`tenant-${i}`);
-      expect(res.status).not.toBe(429);
-    }
-    const res = await postAcs('tenant-over-limit');
-    expect(res.status).toBe(429);
+    await expectRateLimitTripsAfter((i) => postAcs(`tenant-${i}`), 60);
   });
 
   // テナント単位のレート制限 (60秒20回) を超えると429を返す (同一テナントへの連打)
   it('同一テナントへの連打はテナント単位のレート制限で429を返す', async () => {
-    for (let i = 0; i < 20; i++) {
-      const res = await postAcs(TENANT_ID);
-      expect(res.status).not.toBe(429);
-    }
-    const res = await postAcs(TENANT_ID);
-    expect(res.status).toBe(429);
+    await expectRateLimitTripsAfter(() => postAcs(TENANT_ID), 20);
   });
 
   // レート制限内であれば SAMLResponse 欠落により sso-invalid へリダイレクトされる

--- a/tests/features/sso-login-route.test.ts
+++ b/tests/features/sso-login-route.test.ts
@@ -1,0 +1,66 @@
+// GET /api/auth/sso/[tenantId]/login のレート制限テスト。
+// 監査で発見したギャップ: 同じ SSO エンドポイント群のうち acs/route.ts (sso-acs-route.test.ts)
+// だけがレート制限済みで、この /login エンドポイントには無かった。未認証で到達でき、
+// AuthnRequest 生成という相応のコストがかかる処理を都度行うため、acs と同じ二段構えの
+// レート制限を追加した。このテストはレート制限が正しく効くことに焦点を当てる。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetRateLimits } from '@/lib/rate-limit';
+
+const TENANT_ID = 'tenant-1';
+
+// loadEnabledSsoContext を「常に SSO 利用可能」に固定する (テナント単位レート制限の検証に必要)
+vi.mock('@/lib/sso-context', () => ({
+  loadEnabledSsoContext: vi.fn(async () => ({
+    ok: true,
+    tenant: { id: TENANT_ID, name: 'テスト組織' },
+    config: { idpEntityId: 'https://idp.example.com/entity' },
+    baseUrl: 'http://localhost:3000',
+  })),
+}));
+
+// createSamlInstance / getSsoLoginUrl をモックし、実際の SAML 処理を経由せず IdP URL を返す
+vi.mock('@/lib/saml', () => ({
+  createSamlInstance: vi.fn(() => ({})),
+  getSsoLoginUrl: vi.fn(async () => 'https://idp.example.com/sso/login?SAMLRequest=xxx'),
+}));
+
+// リクエストを 1 件送るヘルパー
+async function getLogin(tenantId: string): Promise<Response> {
+  const { GET } = await import('@/app/api/auth/sso/[tenantId]/login/route');
+  const req = new Request(`http://localhost:3000/api/auth/sso/${tenantId}/login`);
+  return GET(req, { params: Promise.resolve({ tenantId }) });
+}
+
+describe('GET /api/auth/sso/[tenantId]/login のレート制限', () => {
+  beforeEach(() => {
+    __resetRateLimits();
+  });
+
+  // 固定キーの全体レート制限 (60秒60回) を超えると 429 を返す
+  it('未認証全体のレート制限を超えると429を返す', async () => {
+    for (let i = 0; i < 60; i++) {
+      const res = await getLogin(`tenant-${i}`);
+      expect(res.status).not.toBe(429);
+    }
+    const res = await getLogin('tenant-over-limit');
+    expect(res.status).toBe(429);
+  });
+
+  // テナント単位のレート制限 (60秒20回) を超えると429を返す (同一テナントへの連打)
+  it('同一テナントへの連打はテナント単位のレート制限で429を返す', async () => {
+    for (let i = 0; i < 20; i++) {
+      const res = await getLogin(TENANT_ID);
+      expect(res.status).not.toBe(429);
+    }
+    const res = await getLogin(TENANT_ID);
+    expect(res.status).toBe(429);
+  });
+
+  // レート制限内であれば通常どおり IdP のログイン URL へ 303 リダイレクトされる
+  it('レート制限内なら通常どおりIdPのログインURLへリダイレクトする', async () => {
+    const res = await getLogin(TENANT_ID);
+    expect(res.status).toBe(303);
+    expect(res.headers.get('location')).toBe('https://idp.example.com/sso/login?SAMLRequest=xxx');
+  });
+});

--- a/tests/features/sso-login-route.test.ts
+++ b/tests/features/sso-login-route.test.ts
@@ -6,6 +6,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { __resetRateLimits } from '@/lib/rate-limit';
+import { expectRateLimitTripsAfter } from './sso-rate-limit-assertions';
 
 const TENANT_ID = 'tenant-1';
 
@@ -39,22 +40,12 @@ describe('GET /api/auth/sso/[tenantId]/login のレート制限', () => {
 
   // 固定キーの全体レート制限 (60秒60回) を超えると 429 を返す
   it('未認証全体のレート制限を超えると429を返す', async () => {
-    for (let i = 0; i < 60; i++) {
-      const res = await getLogin(`tenant-${i}`);
-      expect(res.status).not.toBe(429);
-    }
-    const res = await getLogin('tenant-over-limit');
-    expect(res.status).toBe(429);
+    await expectRateLimitTripsAfter((i) => getLogin(`tenant-${i}`), 60);
   });
 
   // テナント単位のレート制限 (60秒20回) を超えると429を返す (同一テナントへの連打)
   it('同一テナントへの連打はテナント単位のレート制限で429を返す', async () => {
-    for (let i = 0; i < 20; i++) {
-      const res = await getLogin(TENANT_ID);
-      expect(res.status).not.toBe(429);
-    }
-    const res = await getLogin(TENANT_ID);
-    expect(res.status).toBe(429);
+    await expectRateLimitTripsAfter(() => getLogin(TENANT_ID), 20);
   });
 
   // レート制限内であれば通常どおり IdP のログイン URL へ 303 リダイレクトされる

--- a/tests/features/sso-metadata-route.test.ts
+++ b/tests/features/sso-metadata-route.test.ts
@@ -1,0 +1,52 @@
+// GET /api/auth/sso/[tenantId]/metadata のレート制限テスト。
+// 監査で発見したギャップ: 同じ SSO エンドポイント群のうち login/acs はレート制限済みで、
+// このエンドポイントには無かった。未認証で到達でき、リクエストごとに DB 参照
+// (tenants.findById) が発生するため、固定キーの全体レート制限を追加した。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetRateLimits } from '@/lib/rate-limit';
+
+const TENANT_ID = 'tenant-1';
+
+// repos.tenants.findById を Enterprise プランのテナントに固定する
+vi.mock('@/data', () => ({
+  repos: {
+    tenants: {
+      findById: vi.fn(async (id: string) => ({
+        id,
+        name: 'テスト組織',
+        subscriptionPlan: 'enterprise',
+      })),
+    },
+  },
+}));
+
+// リクエストを 1 件送るヘルパー
+async function getMetadata(tenantId: string): Promise<Response> {
+  const { GET } = await import('@/app/api/auth/sso/[tenantId]/metadata/route');
+  const req = new Request(`http://localhost:3000/api/auth/sso/${tenantId}/metadata`);
+  return GET(req, { params: Promise.resolve({ tenantId }) });
+}
+
+describe('GET /api/auth/sso/[tenantId]/metadata のレート制限', () => {
+  beforeEach(() => {
+    __resetRateLimits();
+  });
+
+  // 固定キーの全体レート制限 (60秒60回) を超えると 429 を返す
+  it('未認証全体のレート制限を超えると429を返す', async () => {
+    for (let i = 0; i < 60; i++) {
+      const res = await getMetadata(`tenant-${i}`);
+      expect(res.status).not.toBe(429);
+    }
+    const res = await getMetadata('tenant-over-limit');
+    expect(res.status).toBe(429);
+  });
+
+  // レート制限内であれば通常どおり SP メタデータ XML (200) を返す
+  it('レート制限内なら通常どおりメタデータXMLを返す', async () => {
+    const res = await getMetadata(TENANT_ID);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('application/xml');
+  });
+});

--- a/tests/features/sso-metadata-route.test.ts
+++ b/tests/features/sso-metadata-route.test.ts
@@ -1,10 +1,11 @@
 // GET /api/auth/sso/[tenantId]/metadata のレート制限テスト。
 // 監査で発見したギャップ: 同じ SSO エンドポイント群のうち login/acs はレート制限済みで、
 // このエンドポイントには無かった。未認証で到達でき、リクエストごとに DB 参照
-// (tenants.findById) が発生するため、固定キーの全体レート制限を追加した。
+// (tenants.findById) が発生するため、login/acs と同じ二段構えのレート制限を追加した。
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { __resetRateLimits } from '@/lib/rate-limit';
+import { expectRateLimitTripsAfter } from './sso-rate-limit-assertions';
 
 const TENANT_ID = 'tenant-1';
 
@@ -35,12 +36,14 @@ describe('GET /api/auth/sso/[tenantId]/metadata のレート制限', () => {
 
   // 固定キーの全体レート制限 (60秒60回) を超えると 429 を返す
   it('未認証全体のレート制限を超えると429を返す', async () => {
-    for (let i = 0; i < 60; i++) {
-      const res = await getMetadata(`tenant-${i}`);
-      expect(res.status).not.toBe(429);
-    }
-    const res = await getMetadata('tenant-over-limit');
-    expect(res.status).toBe(429);
+    await expectRateLimitTripsAfter((i) => getMetadata(`tenant-${i}`), 60);
+  });
+
+  // テナント単位のレート制限 (60秒20回) を超えると429を返す (同一テナントへの連打)。
+  // /code-review ultra 指摘対応: login/acs と同じ「1テナントが固定キーの共有予算を
+  // 独占できてしまう」保護を metadata にも揃えたことの検証
+  it('同一テナントへの連打はテナント単位のレート制限で429を返す', async () => {
+    await expectRateLimitTripsAfter(() => getMetadata(TENANT_ID), 20);
   });
 
   // レート制限内であれば通常どおり SP メタデータ XML (200) を返す

--- a/tests/features/sso-rate-limit-assertions.ts
+++ b/tests/features/sso-rate-limit-assertions.ts
@@ -1,0 +1,22 @@
+// SSO エンドポイント群 (acs/login/metadata) のレート制限テストで共有するアサーションヘルパー。
+// /code-review ultra 指摘対応: 「上限回数までは 429 にならず、上限+1回目で 429 になる」という
+// 同一の検証ループが 3 つのテストファイルに複製されていたため (CLAUDE.md §6
+// 「2〜3 箇所目で共通化する」を超過)、ここに集約する。
+
+import { expect } from 'vitest';
+
+// makeRequest(i) を limit 回呼び出し、いずれも 429 でないことを確認したのち、
+// もう 1 回呼び出して 429 になることを確認する
+export async function expectRateLimitTripsAfter(
+  makeRequest: (i: number) => Promise<Response>, // i 回目のリクエストを送る関数 (呼び出し元が引数の使い道を決める)
+  limit: number, // この回数までは通っていいレート制限の上限
+): Promise<void> {
+  // 上限までは通常どおり (429 ではない) レスポンスが返るはず
+  for (let i = 0; i < limit; i++) {
+    const res = await makeRequest(i);
+    expect(res.status).not.toBe(429);
+  }
+  // 上限+1回目は 429 になるはず
+  const res = await makeRequest(limit);
+  expect(res.status).toBe(429);
+}


### PR DESCRIPTION
## 概要

`docs/smb-dx-pivot-plan.md` の未実装/ギャップ監査で見つかった項目のうち 3 件を実装。

### 1. SSOログイン/メタデータエンドポイントにレート制限を追加
`docs/smb-dx-pivot-plan.md` §6.1 Enterprise「SSO(SAML)」の同じエンドポイント群のうち `acs/route.ts` だけがレート制限済み(PR #186)で、`login/route.ts`・`metadata/route.ts` には無かった。両方とも未認証で到達でき、`/login` は AuthnRequest 生成という相応のコストがかかる処理を、`/metadata` はリクエストごとの DB 参照(`tenants.findById`)を、それぞれ都度行う。`acs/route.ts` と同じ設計(tenantId は DB 検証前の値で攻撃者が自由に変更できるため、固定キーの全体制限 + テナント単位制限の二段構え)を適用した。

### 2. UserRepositoryのメモリアダプタ単体テストを追加
LINE連携系の4メソッドのみテスト済みで、`findById`・`findByEmail`・`create`(メール一意制約)・`listAgents`系・`listAdminEmails`・`countByTenant` にはテストが無かった。特に `countByTenant`(Phase 4課金のシート上限判定)と `listAdminEmails`(trial-reminderの通知先取得)を重点的に検証。

### 3. /audit 監査ログページのE2Eテストを追加
Phase 4 Enterprise「監査ログ」機能に対応する `/audit` ページ(TicketHistory + SettingsAuditLogのマージ表示・admin限定RBAC・Pro/Enterpriseプランゲート・CSVエクスポート)にE2Eテストが一切無かった。管理者/依頼者/エージェント/未認証の4パターンを検証。

## 検証

- `npm run typecheck` / `npm run lint` / `npx vitest run`(766 passed / 108 skipped)— いずれも成功
- ローカル PostgreSQL 16 + dev サーバーに対して `npx playwright test`(31件、新規4件含む)を実行し全件成功を確認済み(既存の1件のflaky失敗は単体再実行で再現せず、並列実行時のDB競合による既知の事象と確認)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xr355dSJHNHurUjVPUEUyx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr355dSJHNHurUjVPUEUyx)_