### PR TITLE
test: MagicLinkRepository契約テスト + /settings・拠点管理のE2Eテスト追加

### DIFF
--- a/e2e/location-management.spec.ts
+++ b/e2e/location-management.spec.ts
@@ -1,7 +1,9 @@
 // Playwright のテスト DSL と Page 型 (ページ操作の API)
 import { test, expect, Page } from '@playwright/test';
-// E2E 後始末で作成したテナントを消すため Prisma Client を使う
-import { PrismaClient } from '../src/generated/prisma';
+// E2E 用に DB へ直接 fixture を投入するため Prisma Client を使う (multitenant.spec.ts と同じ方針)
+import { PrismaClient, Role } from '../src/generated/prisma';
+// ログイン可能なテストユーザーを作るためパスワードをハッシュ化する
+import { hash } from 'bcryptjs';
 
 // 監査で発見したギャップ: 拠点管理 (Phase 4 多拠点 §5.2) は Server Action レベルの
 // テスト (tests/features/{create,update,delete}-location.test.ts) はあるが、実際に
@@ -9,112 +11,145 @@ import { PrismaClient } from '../src/generated/prisma';
 // 選択できる → /settings で削除するとピルが消える」という DB を跨ぐ一連の流れを
 // 検証する E2E テストが無かった。
 //
-// 拠点フィルタピルは Pro モードの従来ダッシュボードにしか出ない (Lite モードは
-// 2 タイルの簡易版に置換される) が、既定 seed テナントは mode: 'lite' で他の多数の
-// spec (lite-mode.spec.ts 等) がこの共有テナントの Lite 挙動に依存しているため、
-// 共有テナントのモードをここで 'pro' に切り替えると並列実行中の他 spec を壊す。
-// そのため tenant-create.spec.ts と同じパターンで、このテスト専用の新規テナント +
-// 管理者を作成し、そのテナントだけを Pro モードに切り替えて安全に検証する。
+// /code-review ultra 指摘対応: 当初は /settings/tenants/new の組織作成 UI +
+// 動作モード切替 UI を経由して Pro モードのテナントを用意していたが、拠点管理という
+// 本題と無関係な 2 つの UI フロー (どちらも他 spec / 単体テストで既にカバー済み) に
+// 依存する分だけテストが壊れやすく低速だった。multitenant.spec.ts の
+// seedTenantBFixture と同じ「UI を介さず fixture を直接 DB へ投入する」パターンに
+// 揃え、最初から Pro モード + Pro プランのテナントを用意することで、この spec の
+// 責務を拠点管理の検証だけに絞る。
 
-const ADMIN_EMAIL = 'admin@example.com';
-const NEW_ADMIN_EMAIL = `e2e-location-admin-${Date.now()}@example.com`;
-const NEW_TENANT_NAME = `E2E拠点テスト組織-${Date.now()}`;
+// このテスト専用の固定 ID 群 (Date.now() 由来の値と違い、CI のリトライで衝突しない。
+// upsert で冪等に投入するため何度実行しても同じ行を再利用できる)
+const TENANT_ID = 'e2e-location-tenant';
+const ADMIN_EMAIL = 'e2e-location-admin@example.com';
+const ADMIN_ID = 'e2e-location-admin';
 const LOCATION_NAME = 'E2Eテスト拠点';
+// 削除対象ではない「無関係な別拠点」の固定 ID。これが無いと拠点が 1 件しか存在しない状態で
+// 削除するため、「対象 1 件だけを削除する」ことと「テナントの全拠点を削除する」ことが
+// 区別できないテストになってしまう (/code-review ultra 指摘対応)。この拠点は削除操作の
+// 対象にせず、削除後も残っていることを確認する対照群として使う
+// 名前は正規表現の特殊文字 (括弧等) を含まないようにする (new RegExp() でそのまま使うため)
+const OTHER_LOCATION_ID = 'e2e-location-other';
+const OTHER_LOCATION_NAME = 'E2Eテスト別拠点維持用';
 
-// DB 直接操作用 Prisma Client (後始末専用)
+// DB 直接投入用 Prisma Client
 const prisma = new PrismaClient();
 
 // 共通ログイン手順 (他の e2e spec と同じパターン)
 async function login(page: Page, email: string) {
+  // ログインページへ遷移する
   await page.goto('/login');
+  // メールアドレスを入力する
   await page.getByLabel(/メールアドレス|Email/i).fill(email);
+  // 共通パスワードを入力する
   await page.getByLabel(/パスワード|Password/i).fill('password123');
+  // ログインボタンを押下する
   await page.getByRole('button', { name: /ログイン/i }).click();
+  // ロールに応じたリダイレクト先まで待機する
   await page.waitForURL(/\/dashboard|\/tickets/);
 }
 
-// テスト後に作成したテナントを掃除する (tenant-create.spec.ts と同じ後始末パターン)
+// このテスト専用の Pro モード + Pro プランのテナントと管理者を直接 DB へ投入する。
+// Pro モードへの昇格には Pro/Enterprise プランが必須 (isProModeAllowed) なため、
+// Stripe 決済を経由しないテスト専用の近道として最初から subscriptionPlan: 'pro' で作る
+// (tenant-create.spec.ts が trialEndsAt を直接更新するのと同種の、テストのみで許される shortcut)
+async function seedLocationTenantFixture(): Promise<void> {
+  // 共通パスワードのハッシュを 1 回だけ計算する
+  const passwordHash = await hash('password123', 12);
+  // テナントを冪等に作成/更新する (既に存在すれば mode/plan だけ揃え直す)
+  await prisma.tenant.upsert({
+    where: { id: TENANT_ID },
+    update: { mode: 'pro', subscriptionPlan: 'pro' },
+    create: { id: TENANT_ID, name: 'E2E拠点テスト組織', mode: 'pro', subscriptionPlan: 'pro' },
+  });
+  // 管理者ユーザーを冪等に作成/更新する
+  await prisma.user.upsert({
+    where: { email: ADMIN_EMAIL },
+    update: { passwordHash, role: Role.admin, tenantId: TENANT_ID },
+    create: {
+      id: ADMIN_ID,
+      email: ADMIN_EMAIL,
+      name: 'E2E拠点テスト管理者',
+      passwordHash,
+      role: Role.admin,
+      tenantId: TENANT_ID,
+    },
+  });
+  // 削除対象にしない対照群の拠点を冪等に投入する (ID 指定の削除が対象拠点だけに
+  // 効いていることを検証するため、テスト全体を通して常に存在させておく)
+  await prisma.location.upsert({
+    where: { id: OTHER_LOCATION_ID },
+    update: { name: OTHER_LOCATION_NAME, tenantId: TENANT_ID },
+    create: { id: OTHER_LOCATION_ID, name: OTHER_LOCATION_NAME, tenantId: TENANT_ID },
+  });
+}
+
+// テスト後の後始末: テナント/管理者自体は multitenant.spec.ts の fixture と同じく
+// 永続 fixture として残し削除しない (次回実行時に upsert で再利用するため)。
+// 拠点だけは Location.name に一意制約が無く重複作成され得るため、万一テストが
+// 拠点削除の前に失敗しても次回実行に影響しないよう明示的に掃除しておく
 test.afterAll(async () => {
-  await prisma.tenant.deleteMany({ where: { name: NEW_TENANT_NAME } });
-  await prisma.user.deleteMany({ where: { email: NEW_ADMIN_EMAIL } });
+  // このテナント内の同名拠点を掃除する (通常はテスト本体の削除操作で既に消えている)
+  await prisma.location.deleteMany({ where: { tenantId: TENANT_ID, name: LOCATION_NAME } });
+  // Prisma 接続を閉じる
   await prisma.$disconnect();
 });
 
 test.describe('拠点管理 (作成 → ダッシュボードのフィルタピル → 削除)', () => {
   test('管理者が拠点を作成するとダッシュボードのフィルタピルに現れ、削除すると消える', async ({
     page,
-    browser,
   }) => {
-    // このテスト専用の新規テナント + 初代管理者を作成する (共有テナントを汚染しない)
+    // このテスト専用の Pro モードテナント + 管理者を用意する
+    await seedLocationTenantFixture();
+    // 管理者としてログインする
     await login(page, ADMIN_EMAIL);
-    await page.goto('/settings/tenants/new');
-    await page.getByLabel('組織名').fill(NEW_TENANT_NAME);
-    await page.getByLabel(/業種/).selectOption({ label: '製造業' });
-    await page.getByLabel('お名前').fill('E2E拠点テスト管理者');
-    await page.getByLabel('メールアドレス').fill(NEW_ADMIN_EMAIL);
-    await page.getByLabel(/パスワード/).fill('password123');
-    await page.getByRole('button', { name: '組織を作成する' }).click();
-    await expect(page.getByRole('status')).toContainText('組織を作成しました');
 
-    // 新規テナントは既定で Free プラン (トライアル中は実効 Standard 相当) のため、
-    // Pro モードへの切替が「Pro/Enterprise プランでご利用いただけます」という警告で
-    // ブロックされる。Stripe 決済を経由せず直接 DB でプランを pro に引き上げる
-    // (tenant-create.spec.ts が trialEndsAt を直接更新するのと同じ後始末専用 Prisma 操作)
-    await prisma.tenant.updateMany({
-      where: { name: NEW_TENANT_NAME },
-      data: { subscriptionPlan: 'pro' },
-    });
-
-    // 新管理者で別コンテキストからログインする (このテナント専用の操作はこちらで行う)
-    const context = await browser.newContext();
-    const newPage = await context.newPage();
-    await login(newPage, NEW_ADMIN_EMAIL);
-
-    // 新規テナントは既定で Lite モードのため、拠点フィルタピルが出る Pro モードへ切り替える
-    // (この新規テナントは他 spec と共有されないため、モード変更しても他テストに影響しない)
-    await newPage.goto('/settings');
-    // 「保存する」ボタンは他フォーム (通知チャネル設定等) にも存在するため、動作モードの
-    // フォームに絞り込んでから操作する
-    const modeForm = newPage.locator('form', { has: newPage.getByText('動作モードを選択') });
-    await modeForm.getByRole('radio', { name: /詳細モード/ }).click();
-    await modeForm.getByRole('button', { name: '保存する' }).click();
-    await expect(newPage.getByText('モードを保存しました。')).toBeVisible();
-
+    // 設定画面へ移動する
+    await page.goto('/settings');
     // 拠点追加フォームを開く
-    await newPage.reload();
-    await newPage.getByRole('button', { name: '＋ 拠点を追加' }).click();
-    await newPage.getByLabel('拠点名').fill(LOCATION_NAME);
-    await newPage.getByRole('button', { name: '追加する' }).click();
-
+    await page.getByRole('button', { name: '＋ 拠点を追加' }).click();
+    // 拠点名を入力する
+    await page.getByLabel('拠点名').fill(LOCATION_NAME);
+    // 追加ボタンを押下する
+    await page.getByRole('button', { name: '追加する' }).click();
     // 作成成功後は window.location.reload() で再読み込みされるため、一覧に反映されるまで待つ
-    await expect(newPage.getByText(LOCATION_NAME)).toBeVisible();
+    await expect(page.getByText(LOCATION_NAME)).toBeVisible();
 
-    // ダッシュボードへ移動し、拠点フィルタピルとして表示されることを確認する
-    await newPage.goto('/dashboard');
-    const pill = newPage.getByRole('link', { name: new RegExp(LOCATION_NAME) });
+    // ダッシュボードへ移動する
+    await page.goto('/dashboard');
+    // 拠点フィルタピルとして表示されることを確認する
+    const pill = page.getByRole('link', { name: new RegExp(LOCATION_NAME) });
     await expect(pill).toBeVisible();
 
-    // ピルをクリックすると選択状態になり、URL に locationId が反映される
+    // ピルをクリックする
     await pill.click();
-    await expect(newPage).toHaveURL(/locationId=/);
-    await expect(newPage.getByRole('link', { name: new RegExp(LOCATION_NAME) })).toHaveAttribute(
+    // URL に locationId が反映されることを確認する
+    await expect(page).toHaveURL(/locationId=/);
+    // 選択状態が aria-current="true" で伝わることを確認する (色だけに依存しない a11y)
+    await expect(page.getByRole('link', { name: new RegExp(LOCATION_NAME) })).toHaveAttribute(
       'aria-current',
       'true',
     );
 
-    // /settings に戻って削除する (削除は window.confirm を伴うため自動承諾する)
-    await newPage.goto('/settings');
-    newPage.once('dialog', (dialog) => dialog.accept());
-    const locationItem = newPage.getByText(LOCATION_NAME).locator('..').locator('..');
+    // 設定画面に戻る
+    await page.goto('/settings');
+    // 削除は window.confirm を伴うため自動承諾するハンドラを仕込む
+    page.once('dialog', (dialog) => dialog.accept());
+    // 拠点名を含む <li> 要素 (リストの内部マークアップ変更に強い、セマンティックな絞り込み)
+    const locationItem = page.getByRole('listitem').filter({ hasText: LOCATION_NAME });
+    // 削除ボタンを押下する
     await locationItem.getByRole('button', { name: '削除' }).click();
-
-    // 一覧から消えることを確認する
-    await expect(newPage.getByText(LOCATION_NAME)).toHaveCount(0);
+    // 削除対象の拠点だけが一覧から消えることを確認する
+    await expect(page.getByText(LOCATION_NAME)).toHaveCount(0);
+    // 対照群の別拠点は削除操作の対象にしていないため一覧に残り続けることを確認する
+    // (id スコープの削除が正しく効いていて、テナントの全拠点を消していないことの検証)
+    await expect(page.getByText(OTHER_LOCATION_NAME)).toBeVisible();
 
     // ダッシュボードのフィルタピルからも消えることを確認する
-    await newPage.goto('/dashboard');
-    await expect(newPage.getByRole('link', { name: new RegExp(LOCATION_NAME) })).toHaveCount(0);
-
-    await context.close();
+    await page.goto('/dashboard');
+    await expect(page.getByRole('link', { name: new RegExp(LOCATION_NAME) })).toHaveCount(0);
+    // 対照群の別拠点のピルは引き続き表示されることを確認する
+    await expect(page.getByRole('link', { name: new RegExp(OTHER_LOCATION_NAME) })).toBeVisible();
   });
 });

--- a/e2e/location-management.spec.ts
+++ b/e2e/location-management.spec.ts
@@ -1,0 +1,120 @@
+// Playwright のテスト DSL と Page 型 (ページ操作の API)
+import { test, expect, Page } from '@playwright/test';
+// E2E 後始末で作成したテナントを消すため Prisma Client を使う
+import { PrismaClient } from '../src/generated/prisma';
+
+// 監査で発見したギャップ: 拠点管理 (Phase 4 多拠点 §5.2) は Server Action レベルの
+// テスト (tests/features/{create,update,delete}-location.test.ts) はあるが、実際に
+// ブラウザ経由で「/settings で拠点を作成 → ダッシュボードの拠点フィルタピルに現れる →
+// 選択できる → /settings で削除するとピルが消える」という DB を跨ぐ一連の流れを
+// 検証する E2E テストが無かった。
+//
+// 拠点フィルタピルは Pro モードの従来ダッシュボードにしか出ない (Lite モードは
+// 2 タイルの簡易版に置換される) が、既定 seed テナントは mode: 'lite' で他の多数の
+// spec (lite-mode.spec.ts 等) がこの共有テナントの Lite 挙動に依存しているため、
+// 共有テナントのモードをここで 'pro' に切り替えると並列実行中の他 spec を壊す。
+// そのため tenant-create.spec.ts と同じパターンで、このテスト専用の新規テナント +
+// 管理者を作成し、そのテナントだけを Pro モードに切り替えて安全に検証する。
+
+const ADMIN_EMAIL = 'admin@example.com';
+const NEW_ADMIN_EMAIL = `e2e-location-admin-${Date.now()}@example.com`;
+const NEW_TENANT_NAME = `E2E拠点テスト組織-${Date.now()}`;
+const LOCATION_NAME = 'E2Eテスト拠点';
+
+// DB 直接操作用 Prisma Client (後始末専用)
+const prisma = new PrismaClient();
+
+// 共通ログイン手順 (他の e2e spec と同じパターン)
+async function login(page: Page, email: string) {
+  await page.goto('/login');
+  await page.getByLabel(/メールアドレス|Email/i).fill(email);
+  await page.getByLabel(/パスワード|Password/i).fill('password123');
+  await page.getByRole('button', { name: /ログイン/i }).click();
+  await page.waitForURL(/\/dashboard|\/tickets/);
+}
+
+// テスト後に作成したテナントを掃除する (tenant-create.spec.ts と同じ後始末パターン)
+test.afterAll(async () => {
+  await prisma.tenant.deleteMany({ where: { name: NEW_TENANT_NAME } });
+  await prisma.user.deleteMany({ where: { email: NEW_ADMIN_EMAIL } });
+  await prisma.$disconnect();
+});
+
+test.describe('拠点管理 (作成 → ダッシュボードのフィルタピル → 削除)', () => {
+  test('管理者が拠点を作成するとダッシュボードのフィルタピルに現れ、削除すると消える', async ({
+    page,
+    browser,
+  }) => {
+    // このテスト専用の新規テナント + 初代管理者を作成する (共有テナントを汚染しない)
+    await login(page, ADMIN_EMAIL);
+    await page.goto('/settings/tenants/new');
+    await page.getByLabel('組織名').fill(NEW_TENANT_NAME);
+    await page.getByLabel(/業種/).selectOption({ label: '製造業' });
+    await page.getByLabel('お名前').fill('E2E拠点テスト管理者');
+    await page.getByLabel('メールアドレス').fill(NEW_ADMIN_EMAIL);
+    await page.getByLabel(/パスワード/).fill('password123');
+    await page.getByRole('button', { name: '組織を作成する' }).click();
+    await expect(page.getByRole('status')).toContainText('組織を作成しました');
+
+    // 新規テナントは既定で Free プラン (トライアル中は実効 Standard 相当) のため、
+    // Pro モードへの切替が「Pro/Enterprise プランでご利用いただけます」という警告で
+    // ブロックされる。Stripe 決済を経由せず直接 DB でプランを pro に引き上げる
+    // (tenant-create.spec.ts が trialEndsAt を直接更新するのと同じ後始末専用 Prisma 操作)
+    await prisma.tenant.updateMany({
+      where: { name: NEW_TENANT_NAME },
+      data: { subscriptionPlan: 'pro' },
+    });
+
+    // 新管理者で別コンテキストからログインする (このテナント専用の操作はこちらで行う)
+    const context = await browser.newContext();
+    const newPage = await context.newPage();
+    await login(newPage, NEW_ADMIN_EMAIL);
+
+    // 新規テナントは既定で Lite モードのため、拠点フィルタピルが出る Pro モードへ切り替える
+    // (この新規テナントは他 spec と共有されないため、モード変更しても他テストに影響しない)
+    await newPage.goto('/settings');
+    // 「保存する」ボタンは他フォーム (通知チャネル設定等) にも存在するため、動作モードの
+    // フォームに絞り込んでから操作する
+    const modeForm = newPage.locator('form', { has: newPage.getByText('動作モードを選択') });
+    await modeForm.getByRole('radio', { name: /詳細モード/ }).click();
+    await modeForm.getByRole('button', { name: '保存する' }).click();
+    await expect(newPage.getByText('モードを保存しました。')).toBeVisible();
+
+    // 拠点追加フォームを開く
+    await newPage.reload();
+    await newPage.getByRole('button', { name: '＋ 拠点を追加' }).click();
+    await newPage.getByLabel('拠点名').fill(LOCATION_NAME);
+    await newPage.getByRole('button', { name: '追加する' }).click();
+
+    // 作成成功後は window.location.reload() で再読み込みされるため、一覧に反映されるまで待つ
+    await expect(newPage.getByText(LOCATION_NAME)).toBeVisible();
+
+    // ダッシュボードへ移動し、拠点フィルタピルとして表示されることを確認する
+    await newPage.goto('/dashboard');
+    const pill = newPage.getByRole('link', { name: new RegExp(LOCATION_NAME) });
+    await expect(pill).toBeVisible();
+
+    // ピルをクリックすると選択状態になり、URL に locationId が反映される
+    await pill.click();
+    await expect(newPage).toHaveURL(/locationId=/);
+    await expect(newPage.getByRole('link', { name: new RegExp(LOCATION_NAME) })).toHaveAttribute(
+      'aria-current',
+      'true',
+    );
+
+    // /settings に戻って削除する (削除は window.confirm を伴うため自動承諾する)
+    await newPage.goto('/settings');
+    newPage.once('dialog', (dialog) => dialog.accept());
+    const locationItem = newPage.getByText(LOCATION_NAME).locator('..').locator('..');
+    await locationItem.getByRole('button', { name: '削除' }).click();
+
+    // 一覧から消えることを確認する
+    await expect(newPage.getByText(LOCATION_NAME)).toHaveCount(0);
+
+    // ダッシュボードのフィルタピルからも消えることを確認する
+    await newPage.goto('/dashboard');
+    await expect(newPage.getByRole('link', { name: new RegExp(LOCATION_NAME) })).toHaveCount(0);
+
+    await context.close();
+  });
+});

--- a/e2e/location-management.spec.ts
+++ b/e2e/location-management.spec.ts
@@ -83,12 +83,24 @@ async function seedLocationTenantFixture(): Promise<void> {
     update: { name: OTHER_LOCATION_NAME, tenantId: TENANT_ID },
     create: { id: OTHER_LOCATION_ID, name: OTHER_LOCATION_NAME, tenantId: TENANT_ID },
   });
+  // /code-review ultra 指摘対応: LOCATION_NAME はテスト本体が UI 経由で作成するため
+  // upsert では冪等化できず、かつ Location は (tenantId, name) に一意制約を持つ。
+  // Playwright はCI で retries:2 のため、前回試行がピルクリック等で失敗し削除まで
+  // 到達しなかった場合、この行が残ったまま次の試行が始まる。すると次の試行の
+  // 「追加する」クリックは一意制約違反でエラーになるが、設定ページの初期一覧には
+  // 前回試行の残骸が既に表示されているため、作成成功を検証しているはずの
+  // `expect(page.getByText(LOCATION_NAME)).toBeVisible()` が「作成が実際には失敗した」
+  // ことを見逃したまま素通りしてしまう。各試行の開始時に必ず削除しておくことで、
+  // このテストが常に「今回の試行で本当に作成できたか」を検証するようにする。
+  await prisma.location.deleteMany({ where: { tenantId: TENANT_ID, name: LOCATION_NAME } });
 }
 
 // テスト後の後始末: テナント/管理者自体は multitenant.spec.ts の fixture と同じく
 // 永続 fixture として残し削除しない (次回実行時に upsert で再利用するため)。
-// 拠点だけは Location.name に一意制約が無く重複作成され得るため、万一テストが
-// 拠点削除の前に失敗しても次回実行に影響しないよう明示的に掃除しておく
+// Location は (tenantId, name) に一意制約があるため、万一テストが拠点削除の前に
+// 失敗した場合に残骸が残っていると次回実行の作成が一意制約違反で失敗しうる。
+// (次回実行の冒頭でも seedLocationTenantFixture 側で同様に掃除しているため、これは
+// 二重の安全網。テスト内で作成した拠点をテスト終了後にも確実に片付ける)
 test.afterAll(async () => {
   // このテナント内の同名拠点を掃除する (通常はテスト本体の削除操作で既に消えている)
   await prisma.location.deleteMany({ where: { tenantId: TENANT_ID, name: LOCATION_NAME } });

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,0 +1,61 @@
+// Playwright のテスト DSL と Page 型 (ページ操作の API)
+import { test, expect, Page } from '@playwright/test';
+
+// 監査で発見したギャップ: /settings (テナント全体の設定ハブ。動作モード切替・メンバー招待・
+// 外部通知連携・拠点管理・課金・SSO・LINE連携などを束ねる管理者専用ページ) は
+// invite.spec.ts / tenant-create.spec.ts から admin として間接的に訪問されているだけで、
+// /audit ページと同様の admin 限定 RBAC 境界そのものを検証する E2E テストが無かった。
+// admin 以外を弾く判定はページ側で isAgent(role) ではなく role === 'admin' を直接比較する
+// (§9: UI 非表示だけに頼らずサーバー側で強制する) 設計であることを確認する。
+
+// 共通ログイン手順 (他の e2e spec と同じパターン)
+async function login(page: Page, email: string) {
+  await page.goto('/login');
+  await page.getByLabel(/メールアドレス|Email/i).fill(email);
+  await page.getByLabel(/パスワード|Password/i).fill('password123');
+  await page.getByRole('button', { name: /ログイン/i }).click();
+  await page.waitForURL(/\/dashboard|\/tickets/);
+}
+
+test.describe('/settings 設定ページ', () => {
+  // 管理者 (admin@example.com) は設定ハブの主要セクションを閲覧できる
+  test('管理者は設定ページの主要セクションを閲覧できる', async ({ page }) => {
+    await login(page, 'admin@example.com');
+    await page.goto('/settings');
+
+    await expect(page.getByRole('heading', { name: '設定', exact: true })).toBeVisible();
+    // 動作モード (Lite/Pro 切替) セクション
+    await expect(page.getByRole('heading', { name: '動作モード' })).toBeVisible();
+    // メンバー招待セクション
+    await expect(page.getByRole('heading', { name: 'メンバーを招待' })).toBeVisible();
+    // 拠点・店舗管理セクション (Phase 4 多拠点)
+    await expect(page.getByRole('heading', { name: '拠点・店舗管理' })).toBeVisible();
+  });
+
+  // 依頼者 (requester) は管理者専用メッセージのみ表示され、設定セクションは見えない
+  test('依頼者は設定ページを閲覧できず管理者専用メッセージが表示される', async ({ page }) => {
+    await login(page, 'requester1@example.com');
+    await page.goto('/settings');
+
+    await expect(page.getByText('この画面は管理者のみ利用できます。')).toBeVisible();
+    await expect(page.getByRole('heading', { name: '動作モード' })).toHaveCount(0);
+  });
+
+  // エージェント (agent) も admin 専用であり、isAgent(role) ではなく role==='admin' の
+  // 直接比較を採用している設計を検証する
+  test('エージェントも管理者専用メッセージが表示され閲覧できない', async ({ page }) => {
+    await login(page, 'agent1@example.com');
+    await page.goto('/settings');
+
+    await expect(page.getByText('この画面は管理者のみ利用できます。')).toBeVisible();
+    await expect(page.getByRole('heading', { name: '動作モード' })).toHaveCount(0);
+  });
+
+  // middleware は /settings を認証必須ページとして扱う (未認証は /login へリダイレクト)
+  test('未認証で /settings にアクセスするとログインページへリダイレクトされる', async ({
+    page,
+  }) => {
+    await page.goto('/settings');
+    await page.waitForURL(/\/login/);
+  });
+});

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -10,19 +10,27 @@ import { test, expect, Page } from '@playwright/test';
 
 // 共通ログイン手順 (他の e2e spec と同じパターン)
 async function login(page: Page, email: string) {
+  // ログインページへ遷移する
   await page.goto('/login');
+  // メールアドレスを入力する
   await page.getByLabel(/メールアドレス|Email/i).fill(email);
+  // 共通パスワードを入力する
   await page.getByLabel(/パスワード|Password/i).fill('password123');
+  // ログインボタンを押下する
   await page.getByRole('button', { name: /ログイン/i }).click();
+  // ロールに応じたリダイレクト先まで待機する
   await page.waitForURL(/\/dashboard|\/tickets/);
 }
 
 test.describe('/settings 設定ページ', () => {
   // 管理者 (admin@example.com) は設定ハブの主要セクションを閲覧できる
   test('管理者は設定ページの主要セクションを閲覧できる', async ({ page }) => {
+    // 管理者としてログインする
     await login(page, 'admin@example.com');
+    // 設定画面へ移動する
     await page.goto('/settings');
 
+    // ページタイトルが表示される
     await expect(page.getByRole('heading', { name: '設定', exact: true })).toBeVisible();
     // 動作モード (Lite/Pro 切替) セクション
     await expect(page.getByRole('heading', { name: '動作モード' })).toBeVisible();
@@ -34,20 +42,28 @@ test.describe('/settings 設定ページ', () => {
 
   // 依頼者 (requester) は管理者専用メッセージのみ表示され、設定セクションは見えない
   test('依頼者は設定ページを閲覧できず管理者専用メッセージが表示される', async ({ page }) => {
+    // 依頼者としてログインする
     await login(page, 'requester1@example.com');
+    // 設定画面へ移動する
     await page.goto('/settings');
 
+    // 管理者専用メッセージが表示される
     await expect(page.getByText('この画面は管理者のみ利用できます。')).toBeVisible();
+    // 設定セクションは表示されない
     await expect(page.getByRole('heading', { name: '動作モード' })).toHaveCount(0);
   });
 
   // エージェント (agent) も admin 専用であり、isAgent(role) ではなく role==='admin' の
   // 直接比較を採用している設計を検証する
   test('エージェントも管理者専用メッセージが表示され閲覧できない', async ({ page }) => {
+    // エージェントとしてログインする
     await login(page, 'agent1@example.com');
+    // 設定画面へ移動する
     await page.goto('/settings');
 
+    // 管理者専用メッセージが表示される
     await expect(page.getByText('この画面は管理者のみ利用できます。')).toBeVisible();
+    // 設定セクションは表示されない
     await expect(page.getByRole('heading', { name: '動作モード' })).toHaveCount(0);
   });
 
@@ -55,7 +71,9 @@ test.describe('/settings 設定ページ', () => {
   test('未認証で /settings にアクセスするとログインページへリダイレクトされる', async ({
     page,
   }) => {
+    // 未認証のまま設定画面へアクセスする
     await page.goto('/settings');
+    // ログインページへリダイレクトされるまで待機する
     await page.waitForURL(/\/login/);
   });
 });

--- a/tests/data/magic-link-repository.contract.prisma.test.ts
+++ b/tests/data/magic-link-repository.contract.prisma.test.ts
@@ -1,0 +1,180 @@
+// マジックリンクトークンリポジトリ (Prisma アダプタ) の契約テスト。
+// 監査で発見したギャップ: MagicLinkRepository はメモリアダプタのテスト
+// (magic-link-repository.memory.test.ts) しか無く、認証に直結する
+// consumeValidToken (パスワードレスログインの単回使用保証) が本番 Prisma アダプタで
+// 実際に機能するかは未検証だった。特に consumeValidToken は「未消費 かつ 失効前」の
+// 行だけを原子的に更新する単一 UPDATE (updateMany) に依存しており、この単回使用の
+// 保証が PostgreSQL の行ロックの上で実際に成立するかは実 DB でしか検証できない
+// (メモリアダプタの Promise.all はシングルスレッド JS の擬似並行に過ぎない)。
+//
+// MagicLinkToken は tenantId を持たない (メール宛の一時トークンでテナント非依存) ため、
+// 他の契約テストと異なり Tenant/User のシードは不要。
+//
+// この DB 依存テストは RUN_PRISMA_CONTRACT=1 のときだけ走り、beforeEach で全テーブルを
+// TRUNCATE するため **開発 DB を指さない** こと (CLAUDE.md §テスト)。
+
+import { describe, beforeAll, afterAll, beforeEach, expect, it } from 'vitest';
+import { PrismaClient } from '@/generated/prisma';
+import { buildPrismaRepos } from '@/data/adapters/prisma';
+
+// 「経過時間」を表現するための定数 (テスト内で読みやすくするため)
+const ONE_MINUTE = 60 * 1000;
+
+const SHOULD_RUN = process.env.RUN_PRISMA_CONTRACT === '1';
+
+describe.runIf(SHOULD_RUN)('MagicLinkRepository (prisma adapter)', () => {
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    prisma = new PrismaClient();
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  // 各テスト前に関連テーブルを空にする (MagicLinkToken は tenantId 非依存なので単独で足りる)
+  beforeEach(async () => {
+    await prisma.$executeRawUnsafe('TRUNCATE TABLE "MagicLinkToken" RESTART IDENTITY CASCADE');
+  });
+
+  // create + findByTokenHash: 発行したトークンを未消費のまま取得できる
+  it('createで発行したトークンは未消費 (consumedAt=null) でfindByTokenHashから取得できる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const expiresAt = new Date(Date.now() + 15 * ONE_MINUTE);
+    const created = await repos.magicLinks.create({
+      email: 'user@example.com',
+      tokenHash: 'hash-1',
+      expiresAt,
+      requestedIp: '203.0.113.42',
+    });
+    expect(created.consumedAt).toBeNull();
+    expect(created.requestedIp).toBe('203.0.113.42');
+
+    const found = await repos.magicLinks.findByTokenHash('hash-1');
+    expect(found?.id).toBe(created.id);
+  });
+
+  // consumeValidToken: 未消費 + 失効前なら消費に成功し、2回目は null になる (単回使用)
+  it('consumeValidTokenは未消費+失効前なら1度だけ成功する', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await repos.magicLinks.create({
+      email: 'b@example.com',
+      tokenHash: 'h-once',
+      expiresAt: new Date(Date.now() + ONE_MINUTE),
+    });
+    const now = new Date();
+    const first = await repos.magicLinks.consumeValidToken({ tokenHash: 'h-once', now });
+    expect(first?.email).toBe('b@example.com');
+    expect(first?.consumedAt).toBeInstanceOf(Date);
+
+    // 2回目は既に消費済みなので null
+    const second = await repos.magicLinks.consumeValidToken({ tokenHash: 'h-once', now });
+    expect(second).toBeNull();
+  });
+
+  // consumeValidToken: 失効済みのトークンは消費できず、消費印も立たない
+  it('consumeValidTokenは失効済みならnullを返し消費印も立てない', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await repos.magicLinks.create({
+      email: 'c@example.com',
+      tokenHash: 'h-expired',
+      expiresAt: new Date(Date.now() - ONE_MINUTE), // 既に失効
+    });
+    const result = await repos.magicLinks.consumeValidToken({
+      tokenHash: 'h-expired',
+      now: new Date(),
+    });
+    expect(result).toBeNull();
+    // 消費印が立っていないこと (findByTokenHash で直接確認)
+    const row = await repos.magicLinks.findByTokenHash('h-expired');
+    expect(row?.consumedAt).toBeNull();
+  });
+
+  // consumeValidToken: 同時 2 リクエストでも実 DB の行ロックにより成功は 1 件のみ
+  // (updateMany による単一 UPDATE 文の原子性を PostgreSQL に対して検証する最重要ケース)
+  it('consumeValidTokenは同時2リクエストでも実DBの行ロックにより成功が1件のみになる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await repos.magicLinks.create({
+      email: 'd@example.com',
+      tokenHash: 'h-race',
+      expiresAt: new Date(Date.now() + ONE_MINUTE),
+    });
+    const now = new Date();
+    // Promise.all で 2 件の消費要求を同時に DB へ送る (真の並行リクエスト)
+    const [a, b] = await Promise.all([
+      repos.magicLinks.consumeValidToken({ tokenHash: 'h-race', now }),
+      repos.magicLinks.consumeValidToken({ tokenHash: 'h-race', now }),
+    ]);
+    const successes = [a, b].filter((r) => r !== null);
+    const failures = [a, b].filter((r) => r === null);
+    expect(successes).toHaveLength(1);
+    expect(failures).toHaveLength(1);
+  });
+
+  // deleteById: 指定IDを物理削除する (rollback用)。存在しないIDでも例外を投げない
+  it('deleteByIdは指定IDを削除し存在しないIDでも例外を投げない', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const created = await repos.magicLinks.create({
+      email: 'e@example.com',
+      tokenHash: 'h-delete',
+      expiresAt: new Date(Date.now() + ONE_MINUTE),
+    });
+    await repos.magicLinks.deleteById(created.id);
+    expect(await repos.magicLinks.findByTokenHash('h-delete')).toBeNull();
+    // 存在しない ID でも例外を投げない (P2025 を避けて deleteMany を使う設計の確認)
+    await expect(repos.magicLinks.deleteById('no-such-id')).resolves.not.toThrow();
+  });
+
+  // deleteExpired: 期限切れのみ削除され、有効分は残る
+  it('deleteExpiredは失効済みのみ削除する', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const now = new Date();
+    await repos.magicLinks.create({
+      email: 'f1@example.com',
+      tokenHash: 'expired-1',
+      expiresAt: new Date(now.getTime() - 5 * ONE_MINUTE),
+    });
+    await repos.magicLinks.create({
+      email: 'f2@example.com',
+      tokenHash: 'valid',
+      expiresAt: new Date(now.getTime() + 10 * ONE_MINUTE),
+    });
+    const removed = await repos.magicLinks.deleteExpired(now);
+    expect(removed).toBe(1);
+    expect(await repos.magicLinks.findByTokenHash('valid')).not.toBeNull();
+    expect(await repos.magicLinks.findByTokenHash('expired-1')).toBeNull();
+  });
+
+  // countRecentByEmail: 指定メール + since 以降の件数を正しく返す (発行レート制限用)
+  it('countRecentByEmailは同一メール宛のsince以降の件数を返す', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const now = new Date();
+    const old = await repos.magicLinks.create({
+      email: 'rate@example.com',
+      tokenHash: 'old',
+      expiresAt: new Date(now.getTime() + ONE_MINUTE),
+    });
+    // createdAt は @default(now()) のため、20分前相当に見せるよう生SQLで更新する
+    await prisma.magicLinkToken.update({
+      where: { id: old.id },
+      data: { createdAt: new Date(now.getTime() - 20 * ONE_MINUTE) },
+    });
+    await repos.magicLinks.create({
+      email: 'rate@example.com',
+      tokenHash: 'new-1',
+      expiresAt: new Date(now.getTime() + ONE_MINUTE),
+    });
+    await repos.magicLinks.create({
+      email: 'other@example.com',
+      tokenHash: 'unrelated',
+      expiresAt: new Date(now.getTime() + ONE_MINUTE),
+    });
+
+    const since = new Date(now.getTime() - 15 * ONE_MINUTE);
+    // rate@example.com 宛の過去15分以内は new-1 の1件のみ (old は範囲外)
+    expect(await repos.magicLinks.countRecentByEmail('rate@example.com', since)).toBe(1);
+    expect(await repos.magicLinks.countRecentByEmail('other@example.com', since)).toBe(1);
+  });
+});

--- a/tests/data/magic-link-repository.contract.prisma.test.ts
+++ b/tests/data/magic-link-repository.contract.prisma.test.ts
@@ -26,11 +26,14 @@ describe.runIf(SHOULD_RUN)('MagicLinkRepository (prisma adapter)', () => {
   let prisma: PrismaClient;
 
   beforeAll(async () => {
+    // Prisma クライアントを生成する
     prisma = new PrismaClient();
+    // DB へ接続する
     await prisma.$connect();
   });
 
   afterAll(async () => {
+    // DB 接続を閉じる
     await prisma.$disconnect();
   });
 
@@ -41,30 +44,40 @@ describe.runIf(SHOULD_RUN)('MagicLinkRepository (prisma adapter)', () => {
 
   // create + findByTokenHash: 発行したトークンを未消費のまま取得できる
   it('createで発行したトークンは未消費 (consumedAt=null) でfindByTokenHashから取得できる', async () => {
+    // 本番 Prisma アダプタの repos を組み立てる
     const repos = buildPrismaRepos(prisma);
+    // 15 分後を失効時刻とする
     const expiresAt = new Date(Date.now() + 15 * ONE_MINUTE);
+    // トークンを 1 件発行する
     const created = await repos.magicLinks.create({
       email: 'user@example.com',
       tokenHash: 'hash-1',
       expiresAt,
       requestedIp: '203.0.113.42',
     });
+    // 作成直後は未消費 (consumedAt が null) であること
     expect(created.consumedAt).toBeNull();
+    // 発行元 IP が保存されていること
     expect(created.requestedIp).toBe('203.0.113.42');
 
+    // tokenHash で同じ行を引けること
     const found = await repos.magicLinks.findByTokenHash('hash-1');
     expect(found?.id).toBe(created.id);
   });
 
   // consumeValidToken: 未消費 + 失効前なら消費に成功し、2回目は null になる (単回使用)
   it('consumeValidTokenは未消費+失効前なら1度だけ成功する', async () => {
+    // 本番 Prisma アダプタの repos を組み立てる
     const repos = buildPrismaRepos(prisma);
+    // 消費対象のトークンを 1 件発行する
     await repos.magicLinks.create({
       email: 'b@example.com',
       tokenHash: 'h-once',
       expiresAt: new Date(Date.now() + ONE_MINUTE),
     });
+    // 消費時刻として使う現在時刻
     const now = new Date();
+    // 1 回目の消費: 成功して行が返るはず
     const first = await repos.magicLinks.consumeValidToken({ tokenHash: 'h-once', now });
     expect(first?.email).toBe('b@example.com');
     expect(first?.consumedAt).toBeInstanceOf(Date);
@@ -76,16 +89,20 @@ describe.runIf(SHOULD_RUN)('MagicLinkRepository (prisma adapter)', () => {
 
   // consumeValidToken: 失効済みのトークンは消費できず、消費印も立たない
   it('consumeValidTokenは失効済みならnullを返し消費印も立てない', async () => {
+    // 本番 Prisma アダプタの repos を組み立てる
     const repos = buildPrismaRepos(prisma);
+    // 既に失効済みのトークンを発行する
     await repos.magicLinks.create({
       email: 'c@example.com',
       tokenHash: 'h-expired',
       expiresAt: new Date(Date.now() - ONE_MINUTE), // 既に失効
     });
+    // 失効済みトークンの消費を試みる
     const result = await repos.magicLinks.consumeValidToken({
       tokenHash: 'h-expired',
       now: new Date(),
     });
+    // 消費に失敗して null が返ること
     expect(result).toBeNull();
     // 消費印が立っていないこと (findByTokenHash で直接確認)
     const row = await repos.magicLinks.findByTokenHash('h-expired');
@@ -95,33 +112,44 @@ describe.runIf(SHOULD_RUN)('MagicLinkRepository (prisma adapter)', () => {
   // consumeValidToken: 同時 2 リクエストでも実 DB の行ロックにより成功は 1 件のみ
   // (updateMany による単一 UPDATE 文の原子性を PostgreSQL に対して検証する最重要ケース)
   it('consumeValidTokenは同時2リクエストでも実DBの行ロックにより成功が1件のみになる', async () => {
+    // 本番 Prisma アダプタの repos を組み立てる
     const repos = buildPrismaRepos(prisma);
+    // 競合させるトークンを 1 件発行する
     await repos.magicLinks.create({
       email: 'd@example.com',
       tokenHash: 'h-race',
       expiresAt: new Date(Date.now() + ONE_MINUTE),
     });
+    // 両リクエストで共有する消費時刻
     const now = new Date();
     // Promise.all で 2 件の消費要求を同時に DB へ送る (真の並行リクエスト)
     const [a, b] = await Promise.all([
       repos.magicLinks.consumeValidToken({ tokenHash: 'h-race', now }),
       repos.magicLinks.consumeValidToken({ tokenHash: 'h-race', now }),
     ]);
+    // 成功 (null でない) 側を抽出する
     const successes = [a, b].filter((r) => r !== null);
+    // 失敗 (null) 側を抽出する
     const failures = [a, b].filter((r) => r === null);
+    // 成功はちょうど 1 件だけであること
     expect(successes).toHaveLength(1);
+    // 失敗もちょうど 1 件だけであること
     expect(failures).toHaveLength(1);
   });
 
   // deleteById: 指定IDを物理削除する (rollback用)。存在しないIDでも例外を投げない
   it('deleteByIdは指定IDを削除し存在しないIDでも例外を投げない', async () => {
+    // 本番 Prisma アダプタの repos を組み立てる
     const repos = buildPrismaRepos(prisma);
+    // 削除対象のトークンを 1 件発行する
     const created = await repos.magicLinks.create({
       email: 'e@example.com',
       tokenHash: 'h-delete',
       expiresAt: new Date(Date.now() + ONE_MINUTE),
     });
+    // 発行したトークンを削除する
     await repos.magicLinks.deleteById(created.id);
+    // 削除後は findByTokenHash で見つからないこと
     expect(await repos.magicLinks.findByTokenHash('h-delete')).toBeNull();
     // 存在しない ID でも例外を投げない (P2025 を避けて deleteMany を使う設計の確認)
     await expect(repos.magicLinks.deleteById('no-such-id')).resolves.not.toThrow();
@@ -129,28 +157,39 @@ describe.runIf(SHOULD_RUN)('MagicLinkRepository (prisma adapter)', () => {
 
   // deleteExpired: 期限切れのみ削除され、有効分は残る
   it('deleteExpiredは失効済みのみ削除する', async () => {
+    // 本番 Prisma アダプタの repos を組み立てる
     const repos = buildPrismaRepos(prisma);
+    // 基準となる現在時刻
     const now = new Date();
+    // 既に失効済みのトークンを発行する
     await repos.magicLinks.create({
       email: 'f1@example.com',
       tokenHash: 'expired-1',
       expiresAt: new Date(now.getTime() - 5 * ONE_MINUTE),
     });
+    // まだ有効なトークンを発行する
     await repos.magicLinks.create({
       email: 'f2@example.com',
       tokenHash: 'valid',
       expiresAt: new Date(now.getTime() + 10 * ONE_MINUTE),
     });
+    // 期限切れ一括削除を実行する
     const removed = await repos.magicLinks.deleteExpired(now);
+    // 削除件数は 1 件のはず (失効済みの 1 件のみ)
     expect(removed).toBe(1);
+    // 有効なトークンは残っていること
     expect(await repos.magicLinks.findByTokenHash('valid')).not.toBeNull();
+    // 失効済みトークンは削除されていること
     expect(await repos.magicLinks.findByTokenHash('expired-1')).toBeNull();
   });
 
   // countRecentByEmail: 指定メール + since 以降の件数を正しく返す (発行レート制限用)
   it('countRecentByEmailは同一メール宛のsince以降の件数を返す', async () => {
+    // 本番 Prisma アダプタの repos を組み立てる
     const repos = buildPrismaRepos(prisma);
+    // 基準となる現在時刻
     const now = new Date();
+    // 古いトークンを 1 件発行する (後で createdAt を過去にずらす)
     const old = await repos.magicLinks.create({
       email: 'rate@example.com',
       tokenHash: 'old',
@@ -161,20 +200,24 @@ describe.runIf(SHOULD_RUN)('MagicLinkRepository (prisma adapter)', () => {
       where: { id: old.id },
       data: { createdAt: new Date(now.getTime() - 20 * ONE_MINUTE) },
     });
+    // 同じメール宛に新しいトークンを 1 件発行する
     await repos.magicLinks.create({
       email: 'rate@example.com',
       tokenHash: 'new-1',
       expiresAt: new Date(now.getTime() + ONE_MINUTE),
     });
+    // 別メール宛のトークンも 1 件発行する (対象外であることの確認用)
     await repos.magicLinks.create({
       email: 'other@example.com',
       tokenHash: 'unrelated',
       expiresAt: new Date(now.getTime() + ONE_MINUTE),
     });
 
+    // 過去 15 分以内を対象とする基準時刻
     const since = new Date(now.getTime() - 15 * ONE_MINUTE);
     // rate@example.com 宛の過去15分以内は new-1 の1件のみ (old は範囲外)
     expect(await repos.magicLinks.countRecentByEmail('rate@example.com', since)).toBe(1);
+    // other@example.com 宛は 1 件
     expect(await repos.magicLinks.countRecentByEmail('other@example.com', since)).toBe(1);
   });
 });


### PR DESCRIPTION
## 概要

`docs/smb-dx-pivot-plan.md` の未実装/ギャップ監査で見つかった項目のうち 3 件を実装(いずれもテスト追加)。

### 1. MagicLinkRepositoryのPrisma契約テストを追加
認証に直結する `consumeValidToken`(パスワードレスログインの単回使用保証)が、メモリアダプタのテストしか無く本番Prismaアダプタで実際に機能するか未検証だった。「未消費 かつ 失効前」の行だけを原子的に更新する単一UPDATE (`updateMany`) の単回使用保証を、実DBに対する同時2リクエストで検証するテストを含め7件追加。

### 2. /settings 設定ページのE2Eテストを追加
テナント設定ハブ(動作モード・招待・通知連携・拠点・課金・SSO・LINE連携)の admin 限定 RBAC 境界を検証するE2Eテストが無かった。`/audit` と同じパターンで管理者/依頼者/エージェント/未認証の4パターンを検証。

### 3. 拠点管理のE2Eテストを追加(作成→ダッシュボードのフィルタピル→削除)
拠点管理(Phase 4 多拠点)はServer Actionレベルのテストはあるが、ブラウザ経由で「作成→ダッシュボードのフィルタピルに現れる→選択→削除するとピルが消える」というDBを跨ぐ流れの検証が無かった。拠点フィルタピルはProモード限定のため、共有seedテナント(Liteモード)を汚染しないよう専用の新規テナントを作成して検証する設計にした。

## 検証

- `npm run typecheck` / `npm run lint` / `npx vitest run`(767 passed / 115 skipped)— いずれも成功
- ローカル PostgreSQL 16 に対して `RUN_PRISMA_CONTRACT=1 npx vitest run --no-file-parallelism`(契約テスト計115件)— 成功
- ローカル dev サーバー + 同DBに対して `npx playwright test`(36件、新規5件含む)を実行し全件成功を確認済み(既存の1件のflaky失敗は単体再実行で再現せず、並列実行時のリソース競合による既知の事象と確認)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xr355dSJHNHurUjVPUEUyx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr355dSJHNHurUjVPUEUyx)_