### PR TITLE
fix(tickets): チケット詳細ページに tenantId ガードを追加しクロステナント漏洩を防ぐ

### DIFF
--- a/src/app/(app)/tickets/[id]/page.tsx
+++ b/src/app/(app)/tickets/[id]/page.tsx
@@ -54,8 +54,12 @@ export default async function TicketDetailPage({ params }: Props) {
   const { id } = await params;
   // セッション取得
   const session = await auth();
-  // 未ログインなら描画しない
-  if (!session?.user?.id) return null;
+  // 未ログイン or tenantId 不在なら描画しない。tenantId が undefined のまま下の
+  // findByIdWithDetail に渡すと、Prisma が where から tenantId 条件を脱落させ
+  // (undefined 条件を無視する仕様)、全テナントのチケットに一致してしまう。
+  // 他の認証済みページ (tickets/page.tsx, notifications/page.tsx 等) と同じく
+  // ここでも tenantId を明示チェックしてクロステナント漏洩を多層防御で防ぐ (CLAUDE.md §3/§9)。
+  if (!session?.user?.id || !session.user.tenantId) return null;
 
   // ロール判定
   const isAgent = checkIsAgent(session.user.role);


### PR DESCRIPTION
## 概要 / 対応 Phase

Phase 0（マルチテナント基盤）の不変条件「全 Query で `where.tenantId` を強制する」の**多層防御の穴**を塞ぐ。`docs/smb-dx-pivot-plan.md` §5.1。

## 不具合の内容

`src/app/(app)/tickets/[id]/page.tsx` の認証ガードは `if (!session?.user?.id) return null;` で、**`tenantId` を検証していない**。この 1 ページだけが例外で、他の全認証済みページ（`tickets/page.tsx:69`, `dashboard/page.tsx`, `notifications/page.tsx:17`, `settings/*`, `faq/page.tsx`, `audit/page.tsx` 等）は `if (!session?.user?.id || !session.user.tenantId) return null;` を持つ。

アダプタは `where: { id, tenantId }` でクエリを組むが（`ticket-repository.prisma.ts`）、**Prisma は `undefined` の条件を where から脱落させる**。もし `tenantId` が `undefined` になると `findFirst({ where: { id } })` に退化し、**任意テナントのチケット**（本文・コメント・履歴・添付メタデータ）に一致し得る。エージェントは RBAC（79 行）を通過するため、エージェント面の露出になる。

**現状の悪用可能性（正直な評価）**: `Session['user'].tenantId` は非 optional `string` 型で、JWT callback が補完し、DB 列も `NOT NULL` のため、現行不変条件下では `undefined` にならず**今すぐ悪用できるわけではない**。しかしチーム全体がこのガードを他の全ページで必須としており、ここだけ欠けているのは意図的なトレードオフではなく**潜在バグ**。将来の auth callback 改修・テスト用モックセッション・`id` は載るが `tenantId` を載せない SSO/OAuth 経路のいずれかでガードが崩れた瞬間に実クロステナント漏洩になる。

## 修正

他ページと同じく `tenantId` を明示チェックする 1 行の多層防御（＋理由コメント）。これにより以降の `const tenantId = session.user.tenantId;` が `string` に絞り込まれる。

```ts
if (!session?.user?.id || !session.user.tenantId) return null;
```

## テスト / 検証

- `npm run typecheck` / `npm run lint` / `npm run format --check`（対象ファイル）いずれもクリーン。
- `npm run test` 全 767 件パス（108 skip）。
- ページ層の tenant ガードは本リポジトリのどのページも単体テスト対象外（DB/クロステナント挙動はアダプタ契約テスト `*.contract.prisma.test.ts` とマルチテナント E2E がカバー）。§11 に従い、既存パターンに揃える本 1 行変更に単体テストは追加しない。

## 検証コマンド

```
npm run db:generate && npm run typecheck && npm run lint && npm run test
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01DKvNnpbad1PyjKWQXzF7M6)_