### PR TITLE
fix(billing): createCheckoutSessionのtargetPlanに実行時バリデーションを追加

### DIFF
--- a/src/features/settings/actions/create-checkout-session.ts
+++ b/src/features/settings/actions/create-checkout-session.ts
@@ -17,6 +17,8 @@ import { resolveAppBaseUrl } from '@/lib/app-url';
 import type { SubscriptionPlan } from '@/domain/types';
 // 連打防止のための共通レート制限ヘルパー
 import { checkRateLimit } from '@/lib/rate-limit';
+// targetPlan の許可リスト検証スキーマ (standard | pro のみ)
+import { checkoutTargetPlanSchema } from '@/lib/validations/billing';
 
 // チェックアウトセッション作成の戻り値型
 interface CreateCheckoutResult {
@@ -50,6 +52,15 @@ export async function createCheckoutSession(
   // ここで弾かないと下のフォールバックで誤って Pro の Price ID が使われてしまうため明示的に拒否する。
   if (targetPlan === 'enterprise') {
     return { error: 'Enterprise プランは個別見積です。お問い合わせください。' };
+  }
+
+  // Server Action は POST エンドポイントとして直接呼び出せるため、TypeScript の引数型
+  // (SubscriptionPlan) はコンパイル時の契約に過ぎず実行時の保証にはならない。free/enterprise
+  // 以外の未知の値が来た場合に下のフォールバックで誤って Pro の Price ID が使われないよう、
+  // standard | pro の許可リストで検証する (§9 入力は信用しない)
+  const planCheck = checkoutTargetPlanSchema.safeParse(targetPlan);
+  if (!planCheck.success) {
+    return { error: planCheck.error.issues[0]?.message ?? 'プランの指定が正しくありません' };
   }
 
   // 対象プランの Stripe Price ID を取得する (ここに来る時点で standard | pro に絞られている)

--- a/src/lib/validations/billing.ts
+++ b/src/lib/validations/billing.ts
@@ -1,0 +1,12 @@
+// Zod (スキーマ検証ライブラリ) をインポート
+import { z } from 'zod';
+
+// Stripe Checkout を経由してセルフサーブでアップグレードできるプランは
+// standard / pro の 2 つのみ (free はチェックアウト不要、enterprise は個別見積のため
+// createCheckoutSession の手前で明示的に弾く)。Server Action は POST エンドポイントとして
+// 直接叩けるため、TypeScript の引数型はコンパイル時の契約に過ぎず実行時の保証にならない。
+// 不正な値(未定義の文字列等)を Pro の Price ID へ暗黙にフォールバックさせないよう、
+// ここで許可リスト検証する(§9 入力は信用しない)。
+export const checkoutTargetPlanSchema = z.enum(['standard', 'pro'], {
+  message: 'プランの指定が正しくありません',
+});

--- a/tests/features/create-checkout-session.test.ts
+++ b/tests/features/create-checkout-session.test.ts
@@ -125,4 +125,18 @@ describe('createCheckoutSession', () => {
       { price: 'price_pro_test', quantity: 1 },
     ]);
   });
+
+  // 監査で発見したギャップ対応: Server Action は POST エンドポイントとして直接呼び出せるため
+  // TypeScript の引数型は実行時の保証にならない。standard/pro/free/enterprise 以外の
+  // 未知の値を渡した場合、誤って Pro の Price ID にフォールバックせず拒否すること
+  it('standard/pro/free/enterprise以外の値はPriceIDにフォールバックせず拒否する', async () => {
+    const createCheckoutSession = await loadAction();
+    // @ts-expect-error 実行時の不正値(フォーム改ざん等)を意図的に渡すテスト
+    const result = await createCheckoutSession('xyz');
+
+    expect(result.error).toEqual(expect.any(String));
+    expect(result.url).toBeUndefined();
+    // Stripe API が一切呼ばれていないこと (Pro Price ID へのフォールバックが起きていない)
+    expect(capturedCreateArgs.current).toBeNull();
+  });
 });


### PR DESCRIPTION
## 概要

自動コードレビューで検出した、`docs/smb-dx-pivot-plan.md` §6「マネタイズ・販売戦略」の Stripe Checkout セッション作成における入力検証ギャップを修正する。

### 問題

`createCheckoutSession(targetPlan: SubscriptionPlan)` は Server Action としてクライアントから直接呼び出せるため、TypeScript の引数型はコンパイル時の契約に過ぎず実行時の保証にならない。実装は `free` と `enterprise` を明示的に拒否した後、残りの値を `targetPlan === 'standard' ? STRIPE_PRICE_IDS.standard : STRIPE_PRICE_IDS.pro` というフォールバックで解決していたため、タイポや直接 POST による未知の値(例: `"xyz"`)が来ると、拒否されずに **Pro の Price ID** で Checkout セッションが作成されてしまっていた(§9「入力は信用しない」に反する)。

### 修正内容

- `src/lib/validations/billing.ts` を新設し、既存の `tenant.ts`(`tenantModeSchema`)/`invite.ts`(`invitableRoleSchema`)と同じ `z.enum` パターンで `checkoutTargetPlanSchema`(`standard` | `pro` のみ)を定義。
- `createCheckoutSession` で `free`/`enterprise` の明示チェックの後、残りの値を `safeParse` で検証し、許可リスト外なら Stripe API を呼ばずにエラーを返す。
- 回帰防止テストを1件追加(`standard/pro/free/enterprise以外の値はPriceIDにフォールバックせず拒否する`)。

### 変更対象ファイル

- `src/lib/validations/billing.ts`(新規)
- `src/features/settings/actions/create-checkout-session.ts`
- `tests/features/create-checkout-session.test.ts`

## テスト計画

- [x] `npm run typecheck` — 成功
- [x] `npm run lint` — 成功
- [x] `npm run test` — 846件全件成功(Prisma契約テストはDocker DBが無いこの環境ではスキップ)
- [ ] `/code-review ultra`
- [ ] `/security-review ultra`


---
_Generated by [Claude Code](https://claude.ai/code/session_01NdyJr2B3BZVeyobNY4NpPW)_