### PR TITLE
fix(inbound): メール取り込みの新規起票をエージェントへアプリ内通知する

### DIFF
--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -350,6 +350,26 @@ CSV エクスポート（`GET /api/tickets/export`）側のヘッダー・デー
 - CSV 上の列名「解決期限」はチケット詳細画面 (`/tickets/[id]`) の表示ラベルとしては引き続き使われて
   おり、この変更は CSV の列名のみを対象とする（画面表示の用語は変更していない）。
 
+#### 3.5 フォローアップ（2026-07-13）: メール取り込みの新規起票がエージェントへアプリ内通知されていなかった
+
+監査で発見したギャップ: 新規問い合わせの入口チャネル（§5.3 入口チャネルの Adapter 化）は Web フォーム・
+LINE・CSV インポート・メールの 4 系統あるが、「新規起票をエージェントへ即時に気づかせる」アプリ内通知
+（`Notification` テーブルへの `type: 'imported'` 書き込み ＋ SSE での未読件数即時配信）は LINE 取り込み
+（`processLineEvent`）と CSV インポート（`import-tickets.ts`）にしか実装されておらず、メール取り込み
+（`POST /api/inbound/email`）だけが欠けていた。メール起票が担当者に伝わる経路は Slack/Teams/Chatwork
+通知（`notifyNewTicketOutbound`）だけだったが、これはテナントごとに個別設定が必要な任意のオプトイン
+機能であり、未設定のテナント（§1 の「町工場の事務員」ペルソナのように最小構成で始める中小企業ほど
+起こりやすい）では、メールで届いた問い合わせに誰も気づけないまま `/tickets` を手動で開くまで放置され
+得た。
+
+- `src/app/api/inbound/email/route.ts`: 新規起票確定後（重複判定の直後、Slack 等の外部通知より前）に、
+  `repos.users.listAgents(tenant.id)` でテナント内の全エージェントを取得し、送信者自身がエージェントなら
+  本人以外へ、依頼者からの起票なら全エージェントへ `type: 'imported'` の通知を作成する。LINE 取り込みの
+  `notifyTargets` 判定・`Promise.allSettled` による部分失敗許容・`broadcastUnreadCountToMany` での SSE
+  即時配信を、そのまま同じ形で踏襲した（通知失敗はログのみでチケット起票自体は成功のまま継続する）。
+- `tests/features/inbound-email-route.test.ts`: 新規起票時にエージェント宛の `imported` 通知が作成される
+  ことを検証する回帰テストを追加した。
+
 ### Phase 4 — マネタイズと運用（継続）
 
 - [x] サブスク課金（Stripe Billing）: Free / Standard / Pro の 3 段階

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -628,6 +628,59 @@ export async function POST(req: Request) {
     return NextResponse.json({ status: 'duplicate', ticketId }, { status: 200 });
   }
 
+  // 新規起票をテナント内の全エージェントへアプリ内通知する (LINE 取り込み・CSV インポートと同じ
+  // 'imported' 種別を共有)。Slack/Teams/Chatwork 通知は任意設定のオプトイン機能のため、未設定の
+  // テナントではメール起票にエージェントが誰も気づけない非対称な穴があった (LINE/CSV は既に対応済み)。
+  // 失敗してもチケット起票自体は確定済みのため、ログのみ残して続行する (§9 fail-safe)。
+  try {
+    // テナント内のエージェント/管理者一覧を取得する (LINE 取り込みと同じヘルパー)
+    const agents = await repos.users.listAgents(tenant.id);
+    // 通知対象: 送信者自身がエージェントなら本人以外、依頼者からの起票なら全エージェントへ通知する
+    const notifyTargets = isAgent(sender.role)
+      ? agents.filter((a) => a.id !== sender.id) // エージェント自身の起票は本人以外へ通知
+      : agents; // 依頼者からの起票は全エージェントへ通知
+    if (notifyTargets.length > 0) {
+      // 各エージェントへ通知を作成する。allSettled で 1 件失敗しても他を止めない
+      const notifyResults = await Promise.allSettled(
+        notifyTargets.map((a) =>
+          repos.notifications.create({
+            userId: a.id, // 通知受信者: 各エージェント
+            type: 'imported', // メール取り込みによる新規起票通知 (inbound チャネルは 'imported' を使う)
+            message: `メールから新しい問い合わせが届きました：${email.subject}`, // 通知文言
+            ticketId, // 紐付けチケット
+            tenantId: tenant.id, // テナントスコープ
+          }),
+        ),
+      );
+      // 通知作成に成功したエージェント ID だけを SSE 配信対象にする (失敗分は DB レコードが無いためスキップ)
+      const succeededIds = notifyTargets
+        .filter((_, i) => notifyResults[i]?.status === 'fulfilled')
+        .map((a) => a.id);
+      const failedCount = notifyTargets.length - succeededIds.length;
+      if (failedCount > 0) {
+        // 失敗件数だけログに残す
+        console.warn(
+          `[POST /api/inbound/email] ${failedCount} notification(s) failed to create for new ticket`,
+          ticketId,
+        );
+      }
+      // 未読カウントを SSE で即時配信して通知ベルに反映させる (成功分のみ)
+      if (succeededIds.length > 0) {
+        await broadcastUnreadCountToMany(succeededIds, tenant.id).catch((err) => {
+          // SSE 配信失敗はバッジ更新が遅れるだけ。ログのみ残して続行する
+          console.warn('[POST /api/inbound/email] failed to broadcast unread count', err);
+        });
+      }
+    }
+  } catch (notifyErr) {
+    // 通知失敗はログのみ (チケット起票は完了しているため応答は成功扱いのまま)
+    console.warn(
+      '[POST /api/inbound/email] failed to notify agents for new ticket',
+      ticketId,
+      notifyErr,
+    );
+  }
+
   // Phase 4: 新規起票を Slack/Teams/Chatwork へ通知する (Web フォーム・LINE・CSV と同じ経路)。
   // メール取り込みは担当者が画面を開かなくても起票された事実に気づけることが重要なため、
   // 受領自動返信と同様にベストエフォートで送る (失敗してもチケット作成のレスポンスには影響しない)

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -32,7 +32,7 @@ import { initialStatusForMode } from '@/domain/ticket-status';
 // コメント通知の宛先決定 (Web フォーム経由コメントと共有するヘルパー)
 import { resolveCommentRecipients } from '@/lib/comment-recipients';
 // 未読件数を SSE で即時配信するヘルパー (コメント追記時の通知扇形)
-import { broadcastUnreadCountToMany } from '@/features/notifications/notify';
+import { broadcastUnreadCountToMany, notifyAgentsOfNewTicket } from '@/features/notifications/notify';
 // 受信メールの正規化ヘルパー (純粋関数) と生ヘッダ読み取り、送信元認証 (SPF/DKIM/DMARC) の判定
 import {
   parseInboundEmail,
@@ -628,9 +628,9 @@ export async function POST(req: Request) {
     return NextResponse.json({ status: 'duplicate', ticketId }, { status: 200 });
   }
 
-  // 新規起票をテナント内の全エージェントへアプリ内通知する (LINE 取り込み・CSV インポートと同じ
-  // 'imported' 種別を共有)。Slack/Teams/Chatwork 通知は任意設定のオプトイン機能のため、未設定の
-  // テナントではメール起票にエージェントが誰も気づけない非対称な穴があった (LINE/CSV は既に対応済み)。
+  // 新規起票をテナント内の全エージェントへアプリ内通知する (LINE 取り込みと共有ヘルパーを使う)。
+  // Slack/Teams/Chatwork 通知は任意設定のオプトイン機能のため、未設定のテナントではメール起票に
+  // エージェントが誰も気づけない非対称な穴があった (LINE/CSV は既に対応済み)。
   // 失敗してもチケット起票自体は確定済みのため、ログのみ残して続行する (§9 fail-safe)。
   try {
     // テナント内のエージェント/管理者一覧を取得する (LINE 取り込みと同じヘルパー)
@@ -639,39 +639,14 @@ export async function POST(req: Request) {
     const notifyTargets = isAgent(sender.role)
       ? agents.filter((a) => a.id !== sender.id) // エージェント自身の起票は本人以外へ通知
       : agents; // 依頼者からの起票は全エージェントへ通知
-    if (notifyTargets.length > 0) {
-      // 各エージェントへ通知を作成する。allSettled で 1 件失敗しても他を止めない
-      const notifyResults = await Promise.allSettled(
-        notifyTargets.map((a) =>
-          repos.notifications.create({
-            userId: a.id, // 通知受信者: 各エージェント
-            type: 'imported', // メール取り込みによる新規起票通知 (inbound チャネルは 'imported' を使う)
-            message: `メールから新しい問い合わせが届きました：${email.subject}`, // 通知文言
-            ticketId, // 紐付けチケット
-            tenantId: tenant.id, // テナントスコープ
-          }),
-        ),
-      );
-      // 通知作成に成功したエージェント ID だけを SSE 配信対象にする (失敗分は DB レコードが無いためスキップ)
-      const succeededIds = notifyTargets
-        .filter((_, i) => notifyResults[i]?.status === 'fulfilled')
-        .map((a) => a.id);
-      const failedCount = notifyTargets.length - succeededIds.length;
-      if (failedCount > 0) {
-        // 失敗件数だけログに残す
-        console.warn(
-          `[POST /api/inbound/email] ${failedCount} notification(s) failed to create for new ticket`,
-          ticketId,
-        );
-      }
-      // 未読カウントを SSE で即時配信して通知ベルに反映させる (成功分のみ)
-      if (succeededIds.length > 0) {
-        await broadcastUnreadCountToMany(succeededIds, tenant.id).catch((err) => {
-          // SSE 配信失敗はバッジ更新が遅れるだけ。ログのみ残して続行する
-          console.warn('[POST /api/inbound/email] failed to broadcast unread count', err);
-        });
-      }
-    }
+    // 通知作成・SSE 配信は LINE 取り込みと共有のヘルパーに委譲する (CLAUDE.md §6 DRY)
+    await notifyAgentsOfNewTicket({
+      tenantId: tenant.id, // テナントスコープ
+      ticketId, // 紐付けチケット
+      message: `メールから新しい問い合わせが届きました：${email.subject}`, // 通知文言
+      targets: notifyTargets, // 通知対象エージェント一覧
+      logPrefix: '[POST /api/inbound/email]', // ログの識別子
+    });
   } catch (notifyErr) {
     // 通知失敗はログのみ (チケット起票は完了しているため応答は成功扱いのまま)
     console.warn(

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -59,8 +59,8 @@ import {
   looksLikeLineLinkCode,
   normalizeLineLinkCode,
 } from '@/lib/line-link';
-// 未読カウントを SSE で即時配信するヘルパー (新規起票後に担当者のバッジをリアルタイム更新する)
-import { broadcastUnreadCountToMany } from '@/features/notifications/notify';
+// 新規起票の担当者通知ヘルパー (メール取り込みと共有。通知作成 + SSE 配信を内包する)
+import { notifyAgentsOfNewTicket } from '@/features/notifications/notify';
 // LINE 連携機能のプランゲート (§6.1 料金プラン: Pro / Enterprise のみ利用可能)
 import { isLineIntegrationAllowed, resolveEffectivePlan } from '@/lib/plan-guard';
 // Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (Web フォーム・メール取り込み・CSV インポートと共有)
@@ -526,42 +526,14 @@ async function processLineEvent(
       const notifyTargets = linkedMember
         ? agents.filter((a) => a.id !== creatorId) // 本人起票: 他担当者のみ
         : agents; // プロキシ起票: 全担当者に通知
-      if (notifyTargets.length > 0) {
-        // 各担当者へ通知を作成する。allSettled で 1 件失敗しても他を止めない
-        const notifyResults = await Promise.allSettled(
-          notifyTargets.map((a) =>
-            repos.notifications.create({
-              userId: a.id, // 通知受信者: 各担当者
-              type: 'imported', // LINE からの取り込みによる新規起票通知 (inbound チャネルは 'imported' を使う)
-              message: `LINE から新しい問い合わせが届きました：${title}`, // 通知文言
-              ticketId, // 紐付けチケット
-              tenantId: targetTenantId, // テナントスコープ
-            }),
-          ),
-        );
-        // 通知作成に成功した担当者 ID だけを SSE 配信対象にする (失敗分は DB レコードが無いためスキップ)
-        const succeededIds = notifyTargets
-          .filter((_, i) => notifyResults[i]?.status === 'fulfilled')
-          .map((a) => a.id);
-        const failedCount = notifyTargets.length - succeededIds.length;
-        if (failedCount > 0) {
-          // 失敗件数だけログに残す
-          console.warn(
-            `[POST /api/inbound/line] ${failedCount} notification(s) failed to create for ticket`,
-            ticketId,
-          );
-        }
-        // 未読カウントを SSE で即時配信して通知ベルに反映させる (成功分のみ)
-        if (succeededIds.length > 0) {
-          await broadcastUnreadCountToMany(
-            succeededIds, // 通知作成に成功した担当者 ID 一覧
-            targetTenantId, // テナントスコープ
-          ).catch((broadcastErr) => {
-            // SSE 配信失敗はバッジ更新が遅れるだけ。ログのみ残して続行する
-            console.warn('[POST /api/inbound/line] failed to broadcast unread count', broadcastErr);
-          });
-        }
-      }
+      // 通知作成・SSE 配信はメール取り込みと共有のヘルパーに委譲する (CLAUDE.md §6 DRY)
+      await notifyAgentsOfNewTicket({
+        tenantId: targetTenantId, // テナントスコープ
+        ticketId, // 紐付けチケット
+        message: `LINE から新しい問い合わせが届きました：${title}`, // 通知文言
+        targets: notifyTargets, // 通知対象担当者一覧
+        logPrefix: '[POST /api/inbound/line]', // ログの識別子
+      });
     } catch (notifyErr) {
       // 通知失敗はログのみ (チケット起票は完了しているため応答は成功扱いのまま)
       console.warn(

--- a/src/features/notifications/notify.ts
+++ b/src/features/notifications/notify.ts
@@ -39,3 +39,50 @@ export async function broadcastUnreadCountToMany(
   // 並列に全ユーザーへ配信 (同じテナントを伝搬)
   await Promise.all(unique.map((uid) => broadcastUnreadCount(uid, tenantId)));
 }
+
+// 「新規チケット 1 件」をエージェント群へアプリ内通知するベストエフォート・ヘルパー。
+// LINE 取り込み・メール取り込みの inbound Webhook が、単一チケットに紐づく
+// 'imported' 通知をエージェント全員へ送る処理を共有する (CLAUDE.md §6 DRY:
+// 2 系統目のメール取り込みを実装した時点でこの形が 2 箇所目の重複になったため抽出)。
+// CSV インポートは複数件をまとめた 1 通のバッチ通知 (ticketId なし) で形が異なるため対象外。
+export async function notifyAgentsOfNewTicket(params: {
+  tenantId: string; // 通知のテナントスコープ
+  ticketId: string; // 紐付ける新規チケット ID
+  message: string; // 通知文言 (呼び出し元でチャネルごとに組み立て済み)
+  targets: ReadonlyArray<{ id: string }>; // 通知対象エージェント一覧 (呼び出し元で自己除外済み)
+  logPrefix: string; // ログの先頭に付ける識別子 (例: '[POST /api/inbound/email]')
+}): Promise<void> {
+  // 分割代入で個々のパラメータを取り出す
+  const { tenantId, ticketId, message, targets, logPrefix } = params;
+  // 通知対象が居なければ何もしない (早期リターン)
+  if (targets.length === 0) return;
+  // 各エージェントへ通知を作成する。allSettled で 1 件失敗しても他を止めない
+  const notifyResults = await Promise.allSettled(
+    targets.map((a) =>
+      repos.notifications.create({
+        userId: a.id, // 通知受信者: 各エージェント
+        type: 'imported', // inbound チャネル (LINE/メール) からの新規起票通知は 'imported' を使う
+        message, // 呼び出し元が組み立てた通知文言
+        ticketId, // 紐付けチケット
+        tenantId, // テナントスコープ
+      }),
+    ),
+  );
+  // 通知作成に成功したエージェント ID だけを SSE 配信対象にする (失敗分は DB レコードが無いためスキップ)
+  const succeededIds = targets
+    .filter((_, i) => notifyResults[i]?.status === 'fulfilled')
+    .map((a) => a.id);
+  // 失敗件数を算出する (成功件数との差分)
+  const failedCount = targets.length - succeededIds.length;
+  if (failedCount > 0) {
+    // 失敗件数だけログに残す (チケット起票自体は完了済みのため処理は継続する)
+    console.warn(`${logPrefix} ${failedCount} notification(s) failed to create for new ticket`, ticketId);
+  }
+  // 未読カウントを SSE で即時配信して通知ベルに反映させる (成功分のみ)
+  if (succeededIds.length > 0) {
+    await broadcastUnreadCountToMany(succeededIds, tenantId).catch((err) => {
+      // SSE 配信失敗はバッジ更新が遅れるだけ。ログのみ残して続行する
+      console.warn(`${logPrefix} failed to broadcast unread count`, err);
+    });
+  }
+}

--- a/tests/features/inbound-email-route.test.ts
+++ b/tests/features/inbound-email-route.test.ts
@@ -206,6 +206,21 @@ describe('POST /api/inbound/email', () => {
     expect(ticket?.firstResponseDueAt).not.toBeNull();
   });
 
+  // 回帰防止: メール起票が Slack 等の外部通知 (オプトイン) にしか頼っておらず、
+  // LINE 取り込み・CSV インポートと違ってエージェントへのアプリ内通知が一切無かった不備の修正確認
+  it('新規起票時にテナント内の全エージェントへ imported 通知を作成する', async () => {
+    const { POST } = await import('@/app/api/inbound/email/route');
+    const res = await POST(makeRequest(VALID_EMAIL));
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { ticketId: string };
+    // エージェント (AGENT_ID) 宛に 'imported' 種別の通知が作成されていること
+    const notifications = [...store.notifications.values()].filter((n) => n.userId === AGENT_ID);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.type).toBe('imported');
+    expect(notifications[0]?.ticketId).toBe(json.ticketId);
+    expect(notifications[0]?.tenantId).toBe(TENANT);
+  });
+
   // シークレット未設定 (env なし) なら fail-closed で 500
   it('シークレット未設定なら 500 を返す', async () => {
     vi.stubEnv('INBOUND_EMAIL_SECRET', '');


### PR DESCRIPTION
## 概要

対応: `docs/smb-dx-pivot-plan.md` §3.5 フォローアップ（Phase 2 — 既存チャネルからの取り込み）

新規問い合わせの入口チャネルは Web フォーム・LINE・CSV インポート・メールの 4 系統があるが、「新規起票をエージェントへ即時に気づかせる」アプリ内通知（`Notification` テーブルへの `type: 'imported'` 書き込み + SSE での未読件数即時配信）は LINE 取り込み（`processLineEvent`）と CSV インポート（`import-tickets.ts`）にしか実装されておらず、メール取り込み（`POST /api/inbound/email`）だけが欠けていた。

メール起票が担当者に伝わる経路は Slack/Teams/Chatwork 通知（`notifyNewTicketOutbound`）だけだったが、これはテナントごとに個別設定が必要な任意のオプトイン機能であり、未設定のテナント（§1 の「町工場の事務員」ペルソナのように最小構成で始める中小企業ほど起こりやすい）では、メールで届いた問い合わせに誰も気づけないまま `/tickets` を手動で開くまで放置され得た。

## 変更内容

- `src/app/api/inbound/email/route.ts`: 新規起票確定後（重複判定の直後、Slack 等の外部通知より前）に `repos.users.listAgents(tenant.id)` でテナント内の全エージェントを取得し、送信者自身がエージェントなら本人以外へ、依頼者からの起票なら全エージェントへ `type: 'imported'` の通知を作成する。LINE 取り込みの `notifyTargets` 判定・`Promise.allSettled` による部分失敗許容・`broadcastUnreadCountToMany` での SSE 即時配信を、そのまま同じ形で踏襲した（通知失敗はログのみでチケット起票自体は成功のまま継続する。§9 fail-safe）。
- `tests/features/inbound-email-route.test.ts`: 新規起票時にエージェント宛の `imported` 通知が作成されることを検証する回帰テストを追加。
- `docs/smb-dx-pivot-plan.md`: §3.5 フォローアップとして本ギャップと修正内容を記録。

## テスト計画

- [x] `npm run typecheck` — エラーなし
- [x] `npm run lint` — エラーなし
- [x] `npx vitest run` — 865 件全て成功（DB 契約テストは Docker 未使用のためスキップ、CI のサービスコンテナで実行される想定）
- [ ] `/code-review ultra`
- [ ] `/security-review ultra`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EmjRYatTYsphq2dFiKhQrs

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmjRYatTYsphq2dFiKhQrs)_