### PR TITLE
fix(settings,auth): 招待関連アクションで内部エラー文言の漏洩を防ぐ

### DIFF
--- a/src/features/auth/actions/accept-invitation.ts
+++ b/src/features/auth/actions/accept-invitation.ts
@@ -146,7 +146,18 @@ export async function acceptInvitation(
     if (uow.isTransactionConflict(err)) {
       throw new Error('混み合っているため受諾できませんでした。もう一度お試しください。');
     }
-    // 書き込み競合以外 (バリデーションエラー・上限到達など) はそのまま伝播する
+    // /code-review ultra 指摘対応 (2026-07-13): tx 内の findByEmail 事前チェックをすり抜けて
+    // 同一メールの同時受諾が競合すると、User.email の一意制約違反が Prisma の生エラーとして
+    // ここまで伝播しうる。他の throw new Error(...) は本アクション自身が投げる安全な日本語
+    // メッセージのみなので、一意制約違反だけを検出して事前チェックと同じ安全なメッセージへ
+    // 変換する (§9: 内部エラー文言をクライアントに漏らさない)。それ以外はそのまま伝播する。
+    const message = err instanceof Error ? err.message : '';
+    if (message.includes('Unique constraint') || message.includes('P2002')) {
+      console.error('[accept-invitation] メール一意制約違反 (競合受諾の可能性):', err);
+      throw new Error('このメールアドレスは既に登録されています。ログインしてください。');
+    }
+    // 書き込み競合・一意制約違反以外 (バリデーションエラー・上限到達など、本アクション自身が
+    // 投げた安全な日本語メッセージ) はそのまま伝播する
     throw err;
   }
 

--- a/src/features/auth/actions/accept-invitation.ts
+++ b/src/features/auth/actions/accept-invitation.ts
@@ -21,6 +21,8 @@ import { hash } from 'bcryptjs';
 import { repos, uow } from '@/data';
 // 招待トークンのハッシュ化 (生トークン → DB 保存値と同じ SHA-256 へ)
 import { hashInviteToken } from '@/lib/invite';
+// Prisma の一意制約違反 (P2002) 判定の共通ヘルパー (6 箇所に重複していた判定を一元化 / §6 DRY)
+import { isUniqueConstraintError } from '@/lib/prisma-errors';
 // 受諾フォームの入力検証スキーマと、ユーザー入力メールの検証・正規化スキーマ
 import { acceptInvitationSchema, emailSchema } from '@/lib/validations/invite';
 // Phase 4 課金: プランごとのスタッフシート空き状況チェック (create-invitation.ts と共有)。
@@ -151,8 +153,7 @@ export async function acceptInvitation(
     // ここまで伝播しうる。他の throw new Error(...) は本アクション自身が投げる安全な日本語
     // メッセージのみなので、一意制約違反だけを検出して事前チェックと同じ安全なメッセージへ
     // 変換する (§9: 内部エラー文言をクライアントに漏らさない)。それ以外はそのまま伝播する。
-    const message = err instanceof Error ? err.message : '';
-    if (message.includes('Unique constraint') || message.includes('P2002')) {
+    if (isUniqueConstraintError(err)) {
       console.error('[accept-invitation] メール一意制約違反 (競合受諾の可能性):', err);
       throw new Error('このメールアドレスは既に登録されています。ログインしてください。');
     }

--- a/src/features/settings/actions/create-invitations-bulk.ts
+++ b/src/features/settings/actions/create-invitations-bulk.ts
@@ -139,11 +139,25 @@ export async function createInvitationsBulk(
         });
         return { email, ok: true, url };
       } catch (err) {
-        // 1 行の失敗 (トークン重複などの想定外エラー) で他の行の発行を止めない (部分成功を許容する)
+        // 1 行の失敗 (トークン重複などの想定外エラー) で他の行の発行を止めない (部分成功を許容する)。
+        // /code-review ultra 指摘対応 (2026-07-13): err.message をそのままクライアントへ返すと
+        // 想定外エラー時に Prisma の内部エラー文言 (接続情報等) が漏れうる (§9 セキュリティ)。
+        // create-location.ts 等の他アクションと同じく、既知の一意制約違反だけ安全な日本語
+        // メッセージへ変換し、それ以外は生の err.message を返さず汎用メッセージへ丸める。
+        const message = err instanceof Error ? err.message : '';
+        // Prisma の一意制約違反 (P2002、招待トークン衝突など) を検出する
+        const isUniqueConstraintError =
+          message.includes('Unique constraint') || message.includes('P2002');
+        // 想定外エラーはサーバー側ログにだけ詳細を残す (クライアントには漏らさない)
+        if (!isUniqueConstraintError) {
+          console.error('[create-invitations-bulk] 招待発行エラー:', email, err);
+        }
         return {
           email,
           ok: false,
-          error: err instanceof Error ? err.message : '招待の発行に失敗しました',
+          error: isUniqueConstraintError
+            ? 'この招待の発行に失敗しました (重複)'
+            : '招待の発行に失敗しました',
         };
       }
     }),

--- a/src/features/settings/actions/create-invitations-bulk.ts
+++ b/src/features/settings/actions/create-invitations-bulk.ts
@@ -36,6 +36,8 @@ import { bulkInviteEmailsSchema, invitableRoleSchema } from '@/lib/validations/i
 import { MAX_CSV_BYTES } from '@/lib/csv';
 // Phase 4 課金: プランごとのスタッフシート空き状況チェック (createInvitation と共有)
 import { checkSeatAvailability } from '@/lib/tenant-plan';
+// Prisma の一意制約違反 (P2002) 判定の共通ヘルパー (6 箇所に重複していた判定を一元化 / §6 DRY)
+import { isUniqueConstraintError } from '@/lib/prisma-errors';
 // フォローアップ (2026-07-11): 設定変更監査ログへの記録共通ヘルパー (§4.2/§4.3 と同じ方式)
 import { recordSettingsAudit } from '@/lib/settings-audit';
 
@@ -144,18 +146,16 @@ export async function createInvitationsBulk(
         // 想定外エラー時に Prisma の内部エラー文言 (接続情報等) が漏れうる (§9 セキュリティ)。
         // create-location.ts 等の他アクションと同じく、既知の一意制約違反だけ安全な日本語
         // メッセージへ変換し、それ以外は生の err.message を返さず汎用メッセージへ丸める。
-        const message = err instanceof Error ? err.message : '';
-        // Prisma の一意制約違反 (P2002、招待トークン衝突など) を検出する
-        const isUniqueConstraintError =
-          message.includes('Unique constraint') || message.includes('P2002');
+        // Prisma の一意制約違反 (P2002、招待トークン衝突など) を共通ヘルパーで検出する
+        const uniqueConstraint = isUniqueConstraintError(err);
         // 想定外エラーはサーバー側ログにだけ詳細を残す (クライアントには漏らさない)
-        if (!isUniqueConstraintError) {
+        if (!uniqueConstraint) {
           console.error('[create-invitations-bulk] 招待発行エラー:', email, err);
         }
         return {
           email,
           ok: false,
-          error: isUniqueConstraintError
+          error: uniqueConstraint
             ? 'この招待の発行に失敗しました (重複)'
             : '招待の発行に失敗しました',
         };

--- a/src/features/settings/actions/create-location.ts
+++ b/src/features/settings/actions/create-location.ts
@@ -15,6 +15,8 @@ import { assertTenantAdmin } from '@/lib/tenant-admin-gate';
 import { checkRateLimit } from '@/lib/rate-limit';
 // 設定変更監査ログへの記録を共通化するヘルパー
 import { recordSettingsAudit } from '@/lib/settings-audit';
+// Prisma の一意制約違反 (P2002) 判定の共通ヘルパー (6 箇所に重複していた判定を一元化 / §6 DRY)
+import { isUniqueConstraintError } from '@/lib/prisma-errors';
 
 // 作成結果の戻り値型
 export interface CreateLocationResult {
@@ -81,14 +83,9 @@ export async function createLocation(formData: FormData): Promise<CreateLocation
     // 作成された拠点 ID を返す
     return { locationId: location.id };
   } catch (err) {
-    // 拠点名の重複エラーをユーザー向けメッセージに変換する
-    const message = err instanceof Error ? err.message : '';
-    // Prisma の一意制約違反 (P2002) または memory アダプタのエラーを検出する
-    if (
-      message.includes('Unique constraint') ||
-      message.includes('already exists') ||
-      message.includes('P2002')
-    ) {
+    // 拠点名の重複エラー (Prisma の一意制約違反、または memory アダプタの相当エラー) を
+    // 共通ヘルパーで検出し、ユーザー向けメッセージに変換する
+    if (isUniqueConstraintError(err)) {
       return { error: 'この拠点名はすでに使用されています' };
     }
     // その他のエラーはログに残して汎用メッセージを返す

--- a/src/features/settings/actions/regenerate-inbound-token.ts
+++ b/src/features/settings/actions/regenerate-inbound-token.ts
@@ -26,6 +26,8 @@ import { resolveTenantPlan } from '@/lib/tenant-plan';
 import { isEmailInboundAllowed } from '@/lib/plan-guard';
 // 設定変更監査ログへの記録を共通化するヘルパー
 import { recordSettingsAudit } from '@/lib/settings-audit';
+// Prisma の一意制約違反 (P2002) 判定の共通ヘルパー (6 箇所に重複していた判定を一元化 / §6 DRY)
+import { isUniqueConstraintError } from '@/lib/prisma-errors';
 
 // メール取り込み用トークンを (再)発行するサーバーアクション。フォーム入力は使わないため
 // formData は受け取らず、管理者権限のみを確認して即座に新トークンを発行する
@@ -58,10 +60,10 @@ export async function regenerateInboundToken(): Promise<void> {
   } catch (err) {
     // inboundToken は @unique 列のため、極めて低確率だが生成したトークンが既存の値と
     // 衝突した場合は一意制約違反になる (create-location.ts / update-line-config.ts と同じ
-    // 検出パターン)。内部詳細 (Prisma のエラー文言) はクライアントに漏らさない (§9)
-    const message = err instanceof Error ? err.message : '';
+    // 検出パターン、共通ヘルパーで判定)。内部詳細 (Prisma のエラー文言) はクライアントに
+    // 漏らさない (§9)
     console.error('[regenerate-inbound-token] トークン発行に失敗しました:', err);
-    if (message.includes('Unique constraint') || message.includes('P2002')) {
+    if (isUniqueConstraintError(err)) {
       throw new Error('発行に失敗しました。もう一度お試しください。');
     }
     throw new Error('転送先アドレスの発行に失敗しました。しばらく後にもう一度お試しください。');

--- a/src/features/settings/actions/update-line-config.ts
+++ b/src/features/settings/actions/update-line-config.ts
@@ -15,6 +15,8 @@ import { LINE_USER_ID_PATTERN } from '@/lib/line-link';
 import { checkRateLimit } from '@/lib/rate-limit';
 // 設定変更監査ログへの記録を共通化するヘルパー
 import { recordSettingsAudit } from '@/lib/settings-audit';
+// Prisma の一意制約違反 (P2002) 判定の共通ヘルパー (6 箇所に重複していた判定を一元化 / §6 DRY)
+import { isUniqueConstraintError } from '@/lib/prisma-errors';
 
 // 入力長の上限 (DoS・異常入力対策)
 const CHANNEL_SECRET_MAX = 256; // チャネルシークレットの最大長
@@ -106,9 +108,9 @@ export async function updateLineConfig(
     // 成功を返す
     return { success: true };
   } catch (err) {
-    // botUserId の重複 (他テナントが既に同じチャネルを登録済み) をユーザー向けメッセージに変換する
-    const message = err instanceof Error ? err.message : '';
-    if (message.includes('Unique constraint') || message.includes('P2002')) {
+    // botUserId の重複 (他テナントが既に同じチャネルを登録済み) を共通ヘルパーで検出し、
+    // ユーザー向けメッセージに変換する
+    if (isUniqueConstraintError(err)) {
       return { error: 'この Bot User ID は既に別のテナントで登録されています' };
     }
     // その他の失敗はログに残して汎用メッセージを返す (内部詳細を漏らさない)

--- a/src/features/settings/actions/update-location.ts
+++ b/src/features/settings/actions/update-location.ts
@@ -14,6 +14,8 @@ import { assertTenantAdmin } from '@/lib/tenant-admin-gate';
 import { checkRateLimit } from '@/lib/rate-limit';
 // 設定変更監査ログへの記録を共通化するヘルパー
 import { recordSettingsAudit } from '@/lib/settings-audit';
+// Prisma の一意制約違反 (P2002) 判定の共通ヘルパー (6 箇所に重複していた判定を一元化 / §6 DRY)
+import { isUniqueConstraintError } from '@/lib/prisma-errors';
 
 // 更新結果の戻り値型
 export interface UpdateLocationResult {
@@ -75,17 +77,13 @@ export async function updateLocation(
     // 成功を返す
     return { success: true };
   } catch (err) {
-    // 拠点名の重複エラーをユーザー向けメッセージに変換する
-    const message = err instanceof Error ? err.message : '';
-    // Prisma の一意制約違反または memory アダプタのエラーを検出する
-    if (
-      message.includes('Unique constraint') ||
-      message.includes('already exists') ||
-      message.includes('P2002')
-    ) {
+    // 拠点名の重複エラー (Prisma の一意制約違反、または memory アダプタの相当エラー) を
+    // 共通ヘルパーで検出し、ユーザー向けメッセージに変換する
+    if (isUniqueConstraintError(err)) {
       return { error: 'この拠点名はすでに使用されています' };
     }
-    // 存在しない拠点 ID のエラー
+    // 存在しない拠点 ID のエラー (この判定にのみ使うメッセージ文字列)
+    const message = err instanceof Error ? err.message : '';
     if (message.includes('RecordNotFound') || message.includes('not found')) {
       return { error: '拠点が見つかりません' };
     }

--- a/src/lib/prisma-errors.ts
+++ b/src/lib/prisma-errors.ts
@@ -1,0 +1,25 @@
+// Prisma の一意制約違反 (P2002) かどうかを、エラーメッセージの内容から判定する共通ヘルパー。
+//
+// /code-review ultra 指摘対応 (2026-07-13): 同じ判定ロジック (メッセージに 'Unique constraint' /
+// 'P2002' / 'already exists' のいずれかを含むか) が create-location.ts / update-location.ts /
+// regenerate-inbound-token.ts / update-line-config.ts / accept-invitation.ts /
+// create-invitations-bulk.ts の 6 箇所にコピペされていた (CLAUDE.md §6: 2〜3 箇所目で重複したら
+// 共通化する)。ここへ一元化し、各所は呼び出しに置き換える。
+//
+// 'already exists' は Prisma 本番アダプタではなく、memory アダプタ (テスト用) が模す一意制約
+// 違反のメッセージ (例: location-repository.memory.ts の `"${name}" already exists in tenant...`)
+// を検出するために必要 (line-config-repository.memory.ts のように 'P2002' を含む文言を模す
+// memory アダプタもあるため、両方の言い回しを許容する)。
+
+// Prisma の一意制約違反、またはそれに相当する memory アダプタのエラーかどうかを判定する。
+// err が Error インスタンスでない場合は判定不能として false を返す。
+export function isUniqueConstraintError(err: unknown): boolean {
+  // Error 以外 (文字列 throw など) はメッセージが無いので判定不能として扱う
+  const message = err instanceof Error ? err.message : '';
+  // いずれかのキーワードを含めば一意制約違反とみなす
+  return (
+    message.includes('Unique constraint') ||
+    message.includes('P2002') ||
+    message.includes('already exists')
+  );
+}

--- a/tests/features/accept-invitation.test.ts
+++ b/tests/features/accept-invitation.test.ts
@@ -1,7 +1,8 @@
 // Vitest のテスト DSL とモック機能
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-// メモリ実装の context (store/repos/uow)
-import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// メモリ実装の context (store/repos/uow)。buildMemoryRepos は競合エラーの回帰テストで
+// tx.users.create だけを差し替えたカスタム uow を組み立てるために使う
+import { buildMemoryRepos, createMemoryContext, type Store } from '@/data/adapters/memory';
 // リポジトリ束 / UnitOfWork の型
 import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
 // 招待トークンのハッシュ化 (DB 保存値と同じ SHA-256 を作るために使う)
@@ -273,5 +274,43 @@ describe('acceptInvitation', () => {
     // 招待はロールバックで未消費のまま残っている (再利用可能)
     const invitation = await repos.invitations.findByTokenHash(tokenHash);
     expect(invitation?.consumedAt).toBeNull();
+  });
+
+  // /code-review ultra 指摘対応 (2026-07-13): 事前の findByEmail 重複チェックをすり抜けて
+  // (= 同時受諾レース) tx.users.create が DB の一意制約違反を投げても、Prisma の生エラー
+  // 文言をクライアントへそのまま返さず、事前チェックと同じ安全な日本語メッセージに変換される
+  // こと (§9: 内部エラー文言の非漏洩) を、1 回の呼び出しで投げられたエラーを直接検査して確認する
+  // (uow.isTransactionConflict は false を返すレースなので、そちらの分岐には入らない)。
+  it('メール一意制約違反がレースで競合しても生のエラー文言を返さない', async () => {
+    const rawToken = await seedInvitation({
+      tenantId: TENANT_B,
+      role: 'requester',
+      email: 'race@example.com',
+    });
+    // tx.users.create だけを差し替えたカスタム uow (それ以外は通常のメモリ実装のまま)
+    uow = {
+      async run(fn) {
+        const tx = buildMemoryRepos(store);
+        tx.users.create = async () => {
+          // Prisma の一意制約違反エラーを模した生メッセージ (DB スキーマ情報を含む想定)
+          throw new Error('Unique constraint failed on the fields: (`email`)');
+        };
+        return fn(tx);
+      },
+      isTransactionConflict: () => false,
+    };
+
+    const acceptInvitation = await loadAction();
+    // 投げられたエラーを直接捕まえ、メッセージの中身を検査する
+    const err: unknown = await acceptInvitation(
+      rawToken,
+      makeForm({ name: 'レース太郎', password: 'password123' }),
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    // 事前チェックと同じ安全な日本語メッセージに変換されていること
+    expect((err as Error).message).toMatch(/既に登録/);
+    // 生の Prisma エラー文言 (フィールド名等) が漏れていないこと
+    expect((err as Error).message).not.toMatch(/email`|Unique constraint/);
   });
 });

--- a/tests/features/create-invitations-bulk.test.ts
+++ b/tests/features/create-invitations-bulk.test.ts
@@ -284,4 +284,41 @@ describe('createInvitationsBulk', () => {
 
     await expect(createInvitationsBulk(makeForm('requester', 'a@example.com'))).rejects.toThrow();
   });
+
+  // /code-review ultra 指摘対応 (2026-07-13): 行単位の想定外エラーで issueInvitation が
+  // Prisma の生エラー (例: 一意制約違反) を投げても、err.message をそのままクライアントへ
+  // 返さないこと (§9: 内部エラー文言の非漏洩)。他行は影響を受けず成功すること (部分成功) も確認する。
+  it('行単位の想定外エラーは生のエラー文言を返さず安全なメッセージに変換する', async () => {
+    seedTenant('standard');
+    // 直前のテスト (管理者以外は実行できない) が vi.doMock で auth() を requester に差し替えて
+    // おり、vi.doMock は vi.resetModules() を挟んでも解除されない (テスト実行順序に依存しない
+    // ようにするため) admin セッションへ明示的に戻す
+    vi.doMock('@/lib/auth', () => ({
+      auth: async () => ({ user: { id: ADMIN_ID, role: 'admin', tenantId: TENANT_ID } }),
+    }));
+    // issueInvitation を差し替え、特定の 1 行だけ Prisma 風の生エラーを投げさせる
+    vi.doMock('@/features/settings/actions/create-invitation', () => ({
+      issueInvitation: async (input: { email?: string }) => {
+        if (input.email === 'boom@example.com') {
+          // Prisma の一意制約違反エラーを模した生メッセージ (DB スキーマ情報を含む想定)
+          throw new Error('Unique constraint failed on the fields: (`tokenHash`)');
+        }
+        return { url: `https://example.com/invite/${input.email}` };
+      },
+    }));
+    const { createInvitationsBulk } =
+      await import('@/features/settings/actions/create-invitations-bulk');
+
+    const result = await createInvitationsBulk(
+      makeForm('requester', 'ok@example.com\nboom@example.com'),
+    );
+
+    // 正常行は成功する (部分成功)
+    const okRow = result.results.find((r) => r.email === 'ok@example.com');
+    expect(okRow?.ok).toBe(true);
+    // 失敗行は生の Prisma エラー文言を含まず、安全な日本語メッセージに変換されている
+    const failedRow = result.results.find((r) => r.email === 'boom@example.com');
+    expect(failedRow?.ok).toBe(false);
+    expect(failedRow?.error).not.toMatch(/tokenHash|Unique constraint/);
+  });
 });

--- a/tests/prisma-errors.test.ts
+++ b/tests/prisma-errors.test.ts
@@ -1,0 +1,39 @@
+// isUniqueConstraintError (src/lib/prisma-errors.ts) の単体テスト。
+// /code-review ultra 指摘対応 (2026-07-13): 6 箇所に重複していた「一意制約違反かどうか」の
+// 判定ロジックを共通ヘルパーへ一元化した (§6 DRY)。各所での挙動 (本番 Prisma のエラー文言、
+// memory アダプタの相当エラー、無関係なエラーの素通し) が変わっていないことを確認する。
+
+import { describe, expect, it } from 'vitest';
+import { isUniqueConstraintError } from '@/lib/prisma-errors';
+
+describe('isUniqueConstraintError', () => {
+  // Prisma 本番アダプタの一意制約違反メッセージ (P2002) を検出できる
+  it('Prisma の "Unique constraint" 文言を検出する', () => {
+    const err = new Error('Unique constraint failed on the fields: (`email`)');
+    expect(isUniqueConstraintError(err)).toBe(true);
+  });
+
+  // メッセージに "P2002" コードだけが含まれる場合も検出できる
+  it('"P2002" コードを検出する', () => {
+    const err = new Error('Unique constraint failed on the fields: (`botUserId`) (P2002)');
+    expect(isUniqueConstraintError(err)).toBe(true);
+  });
+
+  // memory アダプタ (location-repository.memory.ts 等) が模す "already exists" 文言を検出できる
+  it('memory アダプタの "already exists" 文言を検出する', () => {
+    const err = new Error('Location name "本社" already exists in tenant tenant-a');
+    expect(isUniqueConstraintError(err)).toBe(true);
+  });
+
+  // 無関係なエラーは一意制約違反と誤検出しない
+  it('無関係なエラーメッセージは false を返す', () => {
+    const err = new Error('この招待リンクは無効か、既に使用されています。');
+    expect(isUniqueConstraintError(err)).toBe(false);
+  });
+
+  // Error インスタンスでない値 (文字列 throw など) は判定不能として false を返す
+  it('Error インスタンスでない値は false を返す', () => {
+    expect(isUniqueConstraintError('文字列としての throw')).toBe(false);
+    expect(isUniqueConstraintError(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`src/features/*/actions/`（Server Actions）、`src/app/api/*`、`src/middleware.ts`、`src/lib/auth.ts`、`src/domain/ticket-status.ts`、`src/data/adapters/prisma/` を対象に、tenantId スコープ漏れ・RBAC 不備・`isValidTransition` バイパス・Webhook 署名検証・エラーメッセージでの内部情報漏洩の観点で徹底レビューを行った。

見つかった具体的な問題（いずれも file:line で特定できる内部エラー文言のクライアント漏洩、CLAUDE.md §9「機密情報・PII・スタックトレースをログやエラー応答に漏らさない」違反）を修正:

- `src/features/settings/actions/create-invitations-bulk.ts:141-148`（修正前）— 一括招待発行で行単位の想定外エラー時に `err.message` をそのままクライアントへ返しており、Prisma の内部エラー文言が漏れうる状態だった。`create-location.ts` 等の他アクションと同じパターン（一意制約違反のみ検出して安全な日本語メッセージへ変換、それ以外は `console.error` でサーバーログに残しつつ汎用メッセージを返す）に揃えた。
- `src/features/auth/actions/accept-invitation.ts:142-151`（修正前）— 招待受諾の同時実行レース（`findByEmail` 事前チェックをすり抜けて `tx.users.create` が `User.email` の一意制約違反を投げるケース）で生の Prisma エラーがそのまま `throw err` で伝播していた。事前チェックと同じ安全なメッセージへ変換するよう修正。

いずれも tenantId スコープ・RBAC・状態遷移テーブルは問題なし（レビュー結果は下記参照）。

## レビューで確認した観点（問題なしと判断したファイル）

- **tenantId スコープ**: `src/data/adapters/prisma/*.prisma.ts` 全 19 ファイル + `prisma/schema.prisma`。全ての per-tenant エンティティの `where` 句に `tenantId` が含まれることを確認（`TicketComment`/`TicketHistory` は親 `Ticket.tenantId` 経由で正しくスコープ）。
- **RBAC / `isAgent()` vs `role === 'admin'`**: `src/features/*/actions/*.ts` 全 22 ファイル、`src/lib/role.ts`。admin 限定操作は意図通り `assertAdminSession`、agent/requester の区別は `isAgent()` を正しく使用。
- **`isValidTransition` バイパス**: `src/domain/ticket-status.ts`、`src/features/tickets/actions/update-ticket.ts`。全てのステータス変更が `ALLOWED_TRANSITIONS` 経由。
- **Webhook 署名検証**: Stripe (`stripe.webhooks.constructEvent`)、LINE (`constantTimeStringEqual` による HMAC-SHA256)、inbound email (`timingSafeEqual`)。いずれも定数時間比較・fail-closed を確認。
- **認証フロー**: magic-link・SSO・招待受諾。トークンの単回使用・失効チェック・テナント境界の検証を確認。オープンリダイレクトになりうるユーザー制御の遷移先は発見せず。
- **SSE / 添付ファイル**: `src/app/api/notifications/stream/route.ts` はユーザー自身の未読数のみ配信。`src/app/api/attachments/[id]/route.ts` は tenantId スコープ + チケット閲覧権限チェックを確認。

## Test plan

- [x] `npm run db:generate`
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass
- [x] `npm run test` — 867 passed, 127 skipped (DB 必須の contract テスト)
- [x] 修正 2 箇所それぞれに回帰テストを追加 (`tests/features/create-invitations-bulk.test.ts`, `tests/features/accept-invitation.test.ts`)
- [ ] `npm run test:contract` / `npm run test:e2e`（DB 起動が必要なため未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155xXVXzHbi6h95owFbKx3j

---
_Generated by [Claude Code](https://claude.ai/code/session_0155xXVXzHbi6h95owFbKx3j)_