### PR TITLE
fix(tickets): 新規起票の通知・CSVインポート往復性のギャップを解消

### DIFF
--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -32,6 +32,12 @@ import {
 // Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (失敗してもチケット作成は止めない。
 // メール取り込み・LINE 取り込み・CSV インポートと共有する)
 import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
+// 監査で発見したギャップ: メール/LINE 取り込みは新規起票をエージェントへアプリ内通知するが、
+// 最も利用頻度が高い Web フォーム経由の起票だけがこの通知を送っていなかった。
+// メール取り込みと共有するヘルパーを使い、同じ形で通知する (CLAUDE.md §6 DRY)
+import { notifyAgentsOfNewTicket } from '@/features/notifications/notify';
+// エージェント判定 (通知対象からの起票者自身の除外に使用)
+import { isAgent } from '@/lib/role';
 // 新規作成されたチケットの型 (通知本文の組み立てに使う最小限のフィールドのみ参照)
 import type { Ticket } from '@/domain/types';
 // Route Handler 向け共通レート制限ラッパー (ticket-comment 等と同じ 429 契約)
@@ -42,6 +48,36 @@ import { checkRouteRateLimit } from '@/lib/route-rate-limit';
 // 最も利用頻度が高くファイル添付・外部通知まで引き起こすチケット作成だけが未対応だった
 // (CLAUDE.md §8/§9 DoS・スパム防止)。コメント投稿と同じ閾値 (60 秒 20 件) に揃える
 const TICKET_CREATE_RATE_LIMIT = { limit: 20, windowMs: 60_000 } as const;
+
+// Web フォーム経由の新規起票をテナント内の全エージェントへアプリ内通知するベストエフォート・ヘルパー。
+// 添付なし/添付ありの 2 経路から同じ形で呼べるよう共通化する (CLAUDE.md §6 DRY)。
+// 失敗してもチケット作成自体は完了済みのため、ログのみ残して続行する (§9 fail-safe)
+async function notifyAgentsOfWebTicket(
+  tenantId: string,
+  ticket: Ticket,
+  creatorId: string,
+  creatorRole: string | null | undefined,
+): Promise<void> {
+  try {
+    // テナント内のエージェント/管理者一覧を取得する (メール/LINE 取り込みと同じヘルパー)
+    const agents = await repos.users.listAgents(tenantId);
+    // 通知対象: 起票者自身がエージェントなら本人以外、依頼者からの起票なら全エージェントへ通知する
+    const notifyTargets = isAgent(creatorRole)
+      ? agents.filter((a) => a.id !== creatorId)
+      : agents;
+    // 通知作成・SSE 配信はメール/LINE 取り込みと共有のヘルパーに委譲する
+    await notifyAgentsOfNewTicket({
+      tenantId,
+      ticketId: ticket.id,
+      message: `新しい問い合わせが届きました：${ticket.title}`,
+      targets: notifyTargets,
+      logPrefix: '[POST /api/tickets]',
+    });
+  } catch (notifyErr) {
+    // 通知失敗はログのみ (チケット起票は完了しているため応答は成功扱いのまま)
+    console.error('[POST /api/tickets] failed to notify agents of new ticket', notifyErr);
+  }
+}
 
 // 422 (バリデーションエラー) を共通フォーマットで返すヘルパー
 function validationError(message: string, path: (string | number)[]) {
@@ -235,6 +271,8 @@ export async function POST(req: Request) {
     });
     // Phase 4: 外部チャネルへ新規問い合わせを通知する (ベストエフォート、失敗してもレスポンスには影響しない)
     await notifyNewTicketOutbound(tenantId, ticket);
+    // テナント内エージェントへアプリ内通知 (ベストエフォート、失敗してもレスポンスには影響しない)
+    await notifyAgentsOfWebTicket(tenantId, ticket, userId, session.user.role);
     return NextResponse.json(ticket, { status: 201 });
   }
 
@@ -311,6 +349,8 @@ export async function POST(req: Request) {
   // ここに到達するのはチケット + 添付の作成が完全に成功した場合のみ。
   // 外部通知は try/catch の外で行い、添付ロールバック処理と失敗要因を混同しない
   await notifyNewTicketOutbound(tenantId, createdTicket);
+  // テナント内エージェントへアプリ内通知 (ベストエフォート、失敗してもレスポンスには影響しない)
+  await notifyAgentsOfWebTicket(tenantId, createdTicket, userId, session.user.role);
   // 成功: 作成された行を 201 で返す
   return NextResponse.json(createdTicket, { status: 201 });
 }

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -38,8 +38,9 @@ import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
 import { notifyAgentsOfNewTicket } from '@/features/notifications/notify';
 // エージェント判定 (通知対象からの起票者自身の除外に使用)
 import { isAgent } from '@/lib/role';
-// 新規作成されたチケットの型 (通知本文の組み立てに使う最小限のフィールドのみ参照)
-import type { Ticket } from '@/domain/types';
+// 新規作成されたチケットの型 (通知本文の組み立てに使う最小限のフィールドのみ参照)。
+// Role は正準のロール型 (session.user.role と同じ型を使い、typo をコンパイル時に検出できるようにする)
+import type { Ticket, Role } from '@/domain/types';
 // Route Handler 向け共通レート制限ラッパー (ticket-comment 等と同じ 429 契約)
 import { checkRouteRateLimit } from '@/lib/route-rate-limit';
 
@@ -56,7 +57,7 @@ async function notifyAgentsOfWebTicket(
   tenantId: string,
   ticket: Ticket,
   creatorId: string,
-  creatorRole: string | null | undefined,
+  creatorRole: Role | null | undefined,
 ): Promise<void> {
   try {
     // テナント内のエージェント/管理者一覧を取得する (メール/LINE 取り込みと同じヘルパー)
@@ -74,8 +75,11 @@ async function notifyAgentsOfWebTicket(
       logPrefix: '[POST /api/tickets]',
     });
   } catch (notifyErr) {
-    // 通知失敗はログのみ (チケット起票は完了しているため応答は成功扱いのまま)
-    console.error('[POST /api/tickets] failed to notify agents of new ticket', notifyErr);
+    // /code-review ultra 指摘対応 (2026-07-13): 通知失敗はベストエフォート (チケット起票自体は
+    // 完了済みで応答は成功扱いのまま) であり、同じ性質の失敗を warn で扱うメール/LINE 取り込み
+    // (notifyAgentsOfNewTicket 呼び出し元) とログレベルを揃える。error だとアラート監視が
+    // 本来ページする必要のない非致命的な失敗にまで反応しうるため
+    console.warn('[POST /api/tickets] failed to notify agents of new ticket', notifyErr);
   }
 }
 
@@ -269,10 +273,13 @@ export async function POST(req: Request) {
       resolutionDueAt,
       firstResponseDueAt,
     });
-    // Phase 4: 外部チャネルへ新規問い合わせを通知する (ベストエフォート、失敗してもレスポンスには影響しない)
-    await notifyNewTicketOutbound(tenantId, ticket);
-    // テナント内エージェントへアプリ内通知 (ベストエフォート、失敗してもレスポンスには影響しない)
-    await notifyAgentsOfWebTicket(tenantId, ticket, userId, session.user.role);
+    // Phase 4: 外部チャネルへ新規問い合わせを通知する (ベストエフォート、失敗してもレスポンスには影響しない)。
+    // テナント内エージェントへのアプリ内通知とは互いに独立した I/O なので Promise.all で並行実行する
+    // (§8 パフォーマンス。§5.4.1 フォローアップで同種の直列積み上がりを解消した方針を踏襲する)
+    await Promise.all([
+      notifyNewTicketOutbound(tenantId, ticket),
+      notifyAgentsOfWebTicket(tenantId, ticket, userId, session.user.role),
+    ]);
     return NextResponse.json(ticket, { status: 201 });
   }
 
@@ -347,10 +354,12 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: '添付ファイルの保存に失敗しました' }, { status: 500 });
   }
   // ここに到達するのはチケット + 添付の作成が完全に成功した場合のみ。
-  // 外部通知は try/catch の外で行い、添付ロールバック処理と失敗要因を混同しない
-  await notifyNewTicketOutbound(tenantId, createdTicket);
-  // テナント内エージェントへアプリ内通知 (ベストエフォート、失敗してもレスポンスには影響しない)
-  await notifyAgentsOfWebTicket(tenantId, createdTicket, userId, session.user.role);
+  // 外部通知は try/catch の外で行い、添付ロールバック処理と失敗要因を混同しない。
+  // 2 つの通知は互いに独立した I/O なので Promise.all で並行実行する (§8 パフォーマンス)
+  await Promise.all([
+    notifyNewTicketOutbound(tenantId, createdTicket),
+    notifyAgentsOfWebTicket(tenantId, createdTicket, userId, session.user.role),
+  ]);
   // 成功: 作成された行を 201 で返す
   return NextResponse.json(createdTicket, { status: 201 });
 }

--- a/src/data/adapters/memory/ticket-repository.memory.ts
+++ b/src/data/adapters/memory/ticket-repository.memory.ts
@@ -262,13 +262,15 @@ export function makeTicketRepo(store: Store): TicketRepository {
         updatedAt: now,
         firstResponseDueAt: input.firstResponseDueAt ?? null,
         resolutionDueAt: input.resolutionDueAt ?? null,
-        firstRespondedAt: null,
+        // フォローアップ (2026-07-13): CSV インポートで初期状態以外を指定時の初回応答日時 (未指定なら null)
+        firstRespondedAt: input.firstRespondedAt ?? null,
         // §3.1 フォローアップ: CSV インポートで完了系ステータス指定時の解決日時 (未指定なら null)
         resolvedAt: input.resolvedAt ?? null,
         escalatedAt: null,
         escalationReason: null,
         creatorId: input.creatorId,
-        assigneeId: null, // 初期は未アサイン
+        // フォローアップ (2026-07-13): CSV インポートで担当者名を解決した ID (未指定なら未アサイン)
+        assigneeId: input.assigneeId ?? null,
         categoryId: input.categoryId,
         locationId: input.locationId ?? null, // 拠点 ID (Phase 4 多拠点。未指定なら null)
         tenantId: input.tenantId, // 所属テナントを必ず保存

--- a/src/data/adapters/memory/ticket-repository.memory.ts
+++ b/src/data/adapters/memory/ticket-repository.memory.ts
@@ -250,7 +250,10 @@ export function makeTicketRepo(store: Store): TicketRepository {
 
     // 新規チケットを作成 (初期状態は 'New')
     async create(input) {
-      const now = new Date(); // 作成時刻
+      // /code-review ultra 指摘対応 (2026-07-13): CSV インポートは resolvedAt/firstRespondedAt が
+      // createdAt より前にならないよう、同じ取り込み時刻を明示的に渡す (Prisma アダプタと同じ方針)。
+      // 未指定なら通常どおりこの呼び出し時点の時刻を作成日時にする
+      const now = input.createdAt ?? new Date(); // 作成時刻
       // 新規チケット行を組み立て
       const ticket: Ticket = {
         id: nextId(store, 'tkt'), // 'tkt_...' 形式の一意 ID

--- a/src/data/adapters/prisma/ticket-repository.prisma.ts
+++ b/src/data/adapters/prisma/ticket-repository.prisma.ts
@@ -235,6 +235,10 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
           resolvedAt: input.resolvedAt ?? null,
           // フォローアップ (2026-07-13): CSV インポートで初期状態以外を指定時の初回応答日時 (未指定なら null)
           firstRespondedAt: input.firstRespondedAt ?? null,
+          // /code-review ultra 指摘対応 (2026-07-13): 未指定なら undefined を渡して Prisma 既定
+          // (@default(now())) に任せる。CSV インポートは resolvedAt/firstRespondedAt が createdAt
+          // より前にならないよう、同じ取り込み時刻を明示的に渡す (下記コメント参照)
+          createdAt: input.createdAt ?? undefined,
         },
         include: REFS_INCLUDE, // 作成直後に関連情報も取得
       });

--- a/src/data/adapters/prisma/ticket-repository.prisma.ts
+++ b/src/data/adapters/prisma/ticket-repository.prisma.ts
@@ -225,12 +225,16 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
           priority: input.priority,
           categoryId: input.categoryId,
           locationId: input.locationId ?? null, // 拠点 ID (Phase 4 多拠点。未指定なら null)
+          // フォローアップ (2026-07-13): CSV インポートで担当者名を解決した ID (未指定なら未アサイン)
+          assigneeId: input.assigneeId ?? null,
           creatorId: input.creatorId,
           tenantId: input.tenantId, // テナント所属を必ず保存
           firstResponseDueAt: input.firstResponseDueAt ?? null,
           resolutionDueAt: input.resolutionDueAt ?? null,
           // §3.1 フォローアップ: CSV インポートで完了系ステータス指定時の解決日時 (未指定なら null)
           resolvedAt: input.resolvedAt ?? null,
+          // フォローアップ (2026-07-13): CSV インポートで初期状態以外を指定時の初回応答日時 (未指定なら null)
+          firstRespondedAt: input.firstRespondedAt ?? null,
         },
         include: REFS_INCLUDE, // 作成直後に関連情報も取得
       });

--- a/src/data/ports/ticket-repository.ts
+++ b/src/data/ports/ticket-repository.ts
@@ -72,6 +72,9 @@ export interface CreateTicketInput {
   priority: Priority; // 優先度
   categoryId: string | null; // カテゴリ (無指定は null)
   locationId?: string | null; // 拠点 ID (Phase 4 多拠点。未指定は null)
+  // フォローアップ (2026-07-13): CSV インポートで「担当者」列を名前解決した ID (未指定は null=未アサイン)。
+  // Web フォーム/メール/LINE 取り込みは起票時に担当者を指定できないため常に未指定のままになる
+  assigneeId?: string | null;
   creatorId: string; // 起票者 ID
   tenantId: string; // 所属テナント ID (マルチテナント化のキー)
   status?: TicketStatus; // 初期ステータス (未指定なら DB 既定の New。Lite では 'Open'=未対応 で起票する)
@@ -80,6 +83,12 @@ export interface CreateTicketInput {
   // §3.1 フォローアップ (2026-07-10): CSV インポートで「状況」列が完了系ステータスを指定していた
   // 場合の解決日時 (インポート時刻)。未指定なら null (未解決のまま起票)
   resolvedAt?: Date | null;
+  // フォローアップ (2026-07-13): CSV インポートで「状況」列がモードの初期状態以外を指定していた
+  // 場合の初回応答日時 (インポート時刻)。resolvedAt と対になるフィールドで、既に着手/完了済みの
+  // 行を「未応答」のまま起票してしまうと、Pro モードの SLA バッジ・品質メトリクス
+  // (平均初回応答時間) が永久に不正確になる (§2.1.2 フォローアップと同種の欠落)。
+  // 未指定なら null (未応答のまま起票。Web フォーム/メール/LINE 取り込みの既定動作)
+  firstRespondedAt?: Date | null;
 }
 
 // エスカレーション適用時の入力値

--- a/src/data/ports/ticket-repository.ts
+++ b/src/data/ports/ticket-repository.ts
@@ -89,6 +89,14 @@ export interface CreateTicketInput {
   // (平均初回応答時間) が永久に不正確になる (§2.1.2 フォローアップと同種の欠落)。
   // 未指定なら null (未応答のまま起票。Web フォーム/メール/LINE 取り込みの既定動作)
   firstRespondedAt?: Date | null;
+  // /code-review ultra 指摘対応 (2026-07-13): CSV インポートは resolvedAt/firstRespondedAt に
+  // 取り込みバッチ開始時点の時刻 (now) を使うが、createdAt は DB 側の @default(now()) や
+  // 各行の作成タイミングで個別に決まるため、複数行をループで作成する間に経過した時間の分だけ
+  // createdAt が now より後になり、resolvedAt/firstRespondedAt が createdAt より「前」になって
+  // 品質メトリクス (平均初回応答時間・平均解決時間) の AVG(resolvedAt - createdAt) が負値になり得る。
+  // CSV インポートはこの createdAt を明示的に同じ now で上書きし、常に
+  // resolvedAt/firstRespondedAt >= createdAt を保証する。未指定なら DB 既定 (作成時刻) のまま
+  createdAt?: Date;
 }
 
 // エスカレーション適用時の入力値

--- a/src/domain/ticket-status.ts
+++ b/src/domain/ticket-status.ts
@@ -103,3 +103,15 @@ export function initialStatusForMode(mode: TenantMode): TicketStatus | undefined
 export function getCompletionStatuses(mode: TenantMode): TicketStatus[] {
   return mode === 'lite' ? ['Closed', 'Resolved'] : ['Resolved'];
 }
+
+// フォローアップ (2026-07-13): CSV インポートで「状況」列が初期状態以外を指定していた場合、
+// 既に初回対応が済んでいたとみなせるかどうかの単一ルール（「起票直後」の initialStatusForMode を
+// 裏返した判定）。/code-review ultra 指摘対応: 当初 import-tickets.ts に直書きしていたインライン
+// 三項演算子をここへ抽出し、getCompletionStatuses と同じくドメイン層を唯一の源にする
+// （実際の応答有無を判定する markFirstResponded 系 (コメント投稿ベース) とは別の、
+// CSV インポート専用の近似ルールである点に注意。両者は「初回対応済みか」を異なる入力から
+// 推定する別々の判定であり、意図的に共有していない）。
+export function hasRespondedByImportStatus(status: TicketStatus, mode: TenantMode): boolean {
+  // 初期状態のままなら未応答、それ以外なら既に着手/完了済みとみなす
+  return status !== (initialStatusForMode(mode) ?? 'New');
+}

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -142,6 +142,10 @@ interface ValidatedRow {
   // §3.1 フォローアップ (2026-07-10): 変換済みのステータス (null = 列なし/セル空 → 呼び出し側が
   // initialStatusForMode の既定値にフォールバックする)
   status: TicketStatus | null;
+  // フォローアップ (2026-07-13): 担当者名 (trim 済み。null = 未指定。実在確認は拠点/カテゴリと
+  // 同じく DB を持つ呼び出し側で行う)。CSV エクスポートは「担当者」列を出力するのにインポート側に
+  // 対応する読み取りが無く、エクスポート→編集→再インポートの往復で担当者情報が失われていた
+  assigneeName: string | null;
 }
 
 // CSV ヘッダの列インデックス一覧
@@ -153,6 +157,7 @@ interface ColumnIndices {
   locationIndex: number; // 「拠点」列 (-1 = 未指定)
   categoryIndex: number; // 「カテゴリ」列 (-1 = 未指定。フォローアップ 2026-07-11)
   statusIndex: number; // 「状況」列 (-1 = 未指定。§3.1 フォローアップ)
+  assigneeIndex: number; // 「担当者」列 (-1 = 未指定。フォローアップ 2026-07-13)
 }
 
 // CSV 1 行分のセルを受け取り、バリデーション・型変換を行う純粋関数。
@@ -172,6 +177,7 @@ function validateImportRow(
     locationIndex,
     categoryIndex,
     statusIndex,
+    assigneeIndex,
   } = indices;
 
   // 件名セルを取り出す。前後の空白は除去する (空白だけのセルを「入力あり」と誤判定しないため)
@@ -230,9 +236,10 @@ function validateImportRow(
     }
   }
 
-  // 拠点セル・カテゴリセルを取り出す (未指定なら null。extractOptionalCell を共有)
+  // 拠点セル・カテゴリセル・担当者セルを取り出す (未指定なら null。extractOptionalCell を共有)
   const locationName = extractOptionalCell(cells, locationIndex);
   const categoryName = extractOptionalCell(cells, categoryIndex);
+  const assigneeName = extractOptionalCell(cells, assigneeIndex);
 
   // §3.1 フォローアップ (2026-07-10): 「状況」セルをテナントの現在モードのラベルから TicketStatus へ
   // 変換する。既存の問い合わせ管理 Excel には既に完了済みの行が大量に混ざっているのが実情で、
@@ -282,6 +289,7 @@ function validateImportRow(
       locationName,
       categoryName,
       status,
+      assigneeName,
     },
   };
 }
@@ -361,6 +369,9 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
   // 拠点と同じく名前解決が必要なため列インデックスだけここで取得する)
   const categoryIndex = headers.indexOf('カテゴリ');
   const statusIndex = headers.indexOf('状況'); // 状況 (§3.1 フォローアップ。既存 Excel の完了済み行を再現する)
+  // フォローアップ (2026-07-13): 担当者名 (CSV エクスポートの「担当者」列と対称の項目。
+  // 拠点/カテゴリと同じく名前解決が必要なため列インデックスだけここで取得する)
+  const assigneeIndex = headers.indexOf('担当者');
 
   // データ行 (2 行目以降) を取り出す
   const dataLines = nonEmptyLines.slice(1);
@@ -384,12 +395,16 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
   // 必要。カテゴリは拠点と異なり Pro モード専用の概念 (TicketForm.tsx の `{!isLite && (...)}` /
   // POST /api/tickets の `effectiveCategoryId = mode === 'lite' ? null : ...` 参照) のため、Lite
   // テナントでは列があっても名前解決自体を行わない (categoryId は常に null にする)。
-  // 拠点・カテゴリは互いに独立した取得のため Promise.all で並列化する (§8 パフォーマンス)。
-  const [locationsByName, categoriesByName] = await Promise.all([
+  // フォローアップ (2026-07-13): 「担当者」列も同じ名前解決が必要。拠点と同じく Lite/Pro
+  // どちらのモードでも使える概念 (§3.1 用語表「アサイン→担当を決める」) のため、カテゴリと
+  // 異なり mode によるガードは行わない。
+  // 拠点・カテゴリ・担当者は互いに独立した取得のため Promise.all で並列化する (§8 パフォーマンス)。
+  const [locationsByName, categoriesByName, agentsByName] = await Promise.all([
     buildNameToIdMap(locationIndex !== -1, () => repos.locations.listByTenant(tenantId)),
     buildNameToIdMap(categoryIndex !== -1 && mode !== 'lite', () =>
       repos.categories.list(tenantId),
     ),
+    buildNameToIdMap(assigneeIndex !== -1, () => repos.users.listAgents(tenantId)),
   ]);
 
   // 集計用カウンタとエラーリストを初期化する
@@ -405,6 +420,7 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     locationIndex,
     categoryIndex,
     statusIndex,
+    assigneeIndex,
   };
 
   // データ行を 1 件ずつ処理する (部分成功を許可するため、1 件エラーでも他を続ける)
@@ -454,6 +470,7 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
       locationName,
       categoryName,
       status: parsedStatus,
+      assigneeName,
     } = validation.data;
     // 「状況」列が未指定 (null) ならモードの既定初期ステータスにフォールバックする
     const status = parsedStatus ?? initialStatus;
@@ -461,6 +478,13 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     // インポート時刻を解決日時として記録する (update-ticket.ts の完了判定と同じ getCompletionStatuses
     // を共有し、「完了」の定義が呼び出し箇所ごとに食い違わないようにする)
     const resolvedAt = getCompletionStatuses(mode).includes(status) ? now : null;
+    // フォローアップ (2026-07-13): 「状況」列がモードの初期状態 (Lite: 未対応 / Pro: 新規) 以外を
+    // 指定していた場合、その行は既に着手済み (対応中・完了等) であり、実運用の Excel 台帳では
+    // 既にエージェントの初回対応が済んでいたはずである。CSV には応答者・応答日時の列が無いため
+    // インポート時刻で近似する (resolvedAt と同じ「正確な履歴が無いので取り込み時刻で代替する」方針)。
+    // これを設定しないと、Pro モードの SLA バッジ・品質メトリクス (平均初回応答時間) が
+    // インポートされた履歴チケットを永久に「未応答」として扱ってしまう (§2.1.2 と同種の欠落)
+    const firstRespondedAt = status !== initialStatus ? now : null;
 
     // 拠点名が指定されていれば ID に解決する (resolveNameToId を共有)。テナントに存在しない
     // 拠点名はタイポや削除済み拠点の可能性が高く、無言で「拠点未設定」にすると取り込んだデータの
@@ -488,6 +512,20 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
         continue;
       }
       categoryId = resolved.id;
+    }
+
+    // フォローアップ (2026-07-13): 担当者名が指定されていれば ID に解決する (resolveNameToId を
+    // 共有)。拠点と同じく Lite/Pro 両モードで使える概念のため mode によるガードは行わない。
+    // テナントに存在しない担当者名はタイポや退職済みメンバーの可能性が高く、無言で「未アサイン」
+    // にすると取り込んだデータの担当者情報が消えたことに気づけないため、エラー行として記録する。
+    let assigneeId: string | null = null;
+    if (assigneeName !== null) {
+      const resolved = resolveNameToId(assigneeName, agentsByName, '担当者');
+      if (!resolved.ok) {
+        errors.push({ row: rowNum, message: resolved.message });
+        continue;
+      }
+      assigneeId = resolved.id;
     }
 
     // Phase 4 課金: 残枠を使い切っていたらこの行以降は起票せずエラーとして記録する
@@ -518,8 +556,12 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
         // (Web フォーム・メール・LINE 取り込みと同じ SLA ヘルパーを使う)
         firstResponseDueAt: calculateFirstResponseDueAt(priority, now),
         locationId, // 拠点 ID (「拠点」列があれば名前解決済み、無ければ null)
+        // フォローアップ (2026-07-13): 担当者 ID (「担当者」列があれば名前解決済み、無ければ未アサイン)
+        assigneeId,
         // §3.1 フォローアップ: 完了系ステータスで起票する場合はインポート時刻を解決日時にする
         resolvedAt,
+        // フォローアップ (2026-07-13): 初期状態以外で起票する場合はインポート時刻を初回応答日時にする
+        firstRespondedAt,
       });
       // 成功カウンタをインクリメント
       imported += 1;

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -22,7 +22,11 @@ import type { Priority, TicketStatus, TenantMode } from '@/domain/types';
 // モードに応じた初期ステータスを返す共通関数（メール取り込み・LINE 取り込みと同一ロジックを共有し DRY を維持する）。
 // getCompletionStatuses は §3.1 フォローアップ (2026-07-10) で追加: インポート時に「状況」列が
 // 完了系ステータスを指定していた場合、resolvedAt をインポート時刻で設定するために使う
-import { initialStatusForMode, getCompletionStatuses } from '@/domain/ticket-status';
+import {
+  initialStatusForMode,
+  getCompletionStatuses,
+  hasRespondedByImportStatus,
+} from '@/domain/ticket-status';
 // §3.1 フォローアップ (2026-07-10): 「状況」列の日本語ラベルから TicketStatus を逆引きする
 // mode-aware ヘルパー (getStatusLabel の逆写像)、およびエラーメッセージ用の有効ラベル一覧取得
 import { resolveStatusFromLabel, getStatusLabelsForMode } from '@/lib/constants';
@@ -398,14 +402,35 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
   // フォローアップ (2026-07-13): 「担当者」列も同じ名前解決が必要。拠点と同じく Lite/Pro
   // どちらのモードでも使える概念 (§3.1 用語表「アサイン→担当を決める」) のため、カテゴリと
   // 異なり mode によるガードは行わない。
-  // 拠点・カテゴリ・担当者は互いに独立した取得のため Promise.all で並列化する (§8 パフォーマンス)。
-  const [locationsByName, categoriesByName, agentsByName] = await Promise.all([
+  // /code-review ultra 指摘対応 (2026-07-13): 担当者は buildNameToIdMap を使わず、生のエージェント
+  // 一覧をここで取得する。理由は 2 つ: (1) 後段のインポート後通知 (§ 下部) でも同じ一覧が必要なため、
+  // ここで取得したものを再利用して二重取得を避ける (§8 パフォーマンス)。(2) 拠点/カテゴリと異なり
+  // 担当者名はチケットの所有権 (誰が対応するか) を左右するため、同姓同名のエージェントが存在する
+  // 場合に Map のキー衝突でどちらか一方へ無言で misassign されるのを防ぐ重複検出が必要。
+  // 拠点・カテゴリ・エージェント一覧は互いに独立した取得のため Promise.all で並列化する (§8)。
+  const [locationsByName, categoriesByName, agentsForAssignee] = await Promise.all([
     buildNameToIdMap(locationIndex !== -1, () => repos.locations.listByTenant(tenantId)),
     buildNameToIdMap(categoryIndex !== -1 && mode !== 'lite', () =>
       repos.categories.list(tenantId),
     ),
-    buildNameToIdMap(assigneeIndex !== -1, () => repos.users.listAgents(tenantId)),
+    assigneeIndex !== -1 ? repos.users.listAgents(tenantId) : Promise.resolve(null),
   ]);
+
+  // 「担当者」列の名前 → ID マップと、同姓同名 (重複名) の集合を作る。
+  // 拠点/カテゴリの resolveNameToId と異なり、同名が複数存在する場合はどちらか一方を無言で
+  // 選ばず、後続のループでエラー行として記録できるよう duplicateAgentNames に集める。
+  const agentsByName = new Map<string, string>();
+  const duplicateAgentNames = new Set<string>();
+  if (agentsForAssignee) {
+    const nameCounts = new Map<string, number>();
+    for (const a of agentsForAssignee) {
+      nameCounts.set(a.name, (nameCounts.get(a.name) ?? 0) + 1);
+      agentsByName.set(a.name, a.id);
+    }
+    for (const [name, count] of nameCounts) {
+      if (count > 1) duplicateAgentNames.add(name);
+    }
+  }
 
   // 集計用カウンタとエラーリストを初期化する
   let imported = 0;
@@ -483,8 +508,10 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     // 既にエージェントの初回対応が済んでいたはずである。CSV には応答者・応答日時の列が無いため
     // インポート時刻で近似する (resolvedAt と同じ「正確な履歴が無いので取り込み時刻で代替する」方針)。
     // これを設定しないと、Pro モードの SLA バッジ・品質メトリクス (平均初回応答時間) が
-    // インポートされた履歴チケットを永久に「未応答」として扱ってしまう (§2.1.2 と同種の欠落)
-    const firstRespondedAt = status !== initialStatus ? now : null;
+    // インポートされた履歴チケットを永久に「未応答」として扱ってしまう (§2.1.2 と同種の欠落)。
+    // /code-review ultra 指摘対応 (2026-07-13): 判定ロジックを ticket-status.ts の
+    // hasRespondedByImportStatus に抽出し、getCompletionStatuses と同じくドメイン層を唯一の源にした
+    const firstRespondedAt = hasRespondedByImportStatus(status, mode) ? now : null;
 
     // 拠点名が指定されていれば ID に解決する (resolveNameToId を共有)。テナントに存在しない
     // 拠点名はタイポや削除済み拠点の可能性が高く、無言で「拠点未設定」にすると取り込んだデータの
@@ -520,6 +547,17 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     // にすると取り込んだデータの担当者情報が消えたことに気づけないため、エラー行として記録する。
     let assigneeId: string | null = null;
     if (assigneeName !== null) {
+      // /code-review ultra 指摘対応 (2026-07-13): 同姓同名のエージェントが複数存在する場合、
+      // Map のキー衝突でどちらか一方へ無言で misassign されてしまう (拠点/カテゴリの誤りより
+      // 「チケットの所有権を誤らせる」ため深刻)。resolveNameToId を呼ぶ前に重複を検出し、
+      // 曖昧な名前は起票者が手動で判断できるようエラー行として記録する。
+      if (duplicateAgentNames.has(assigneeName)) {
+        errors.push({
+          row: rowNum,
+          message: `担当者名が重複しています: "${assigneeName}"（同じ名前のエージェントが複数存在するため一意に特定できません。取り込み後に画面から担当者を設定してください）`,
+        });
+        continue;
+      }
       const resolved = resolveNameToId(assigneeName, agentsByName, '担当者');
       if (!resolved.ok) {
         errors.push({ row: rowNum, message: resolved.message });
@@ -562,6 +600,11 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
         resolvedAt,
         // フォローアップ (2026-07-13): 初期状態以外で起票する場合はインポート時刻を初回応答日時にする
         firstRespondedAt,
+        // /code-review ultra 指摘対応 (2026-07-13): 作成日時を明示的に取り込み時刻 (now) に揃える。
+        // DB 既定 (実際の INSERT 時刻) に任せると、複数行をループで作成する間に経過した時間の分だけ
+        // createdAt が now より後になり、上の resolvedAt/firstRespondedAt (どちらも now) が
+        // createdAt より「前」になって品質メトリクスの平均時間が負値になり得るため
+        createdAt: now,
       });
       // 成功カウンタをインクリメント
       imported += 1;
@@ -602,7 +645,9 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
 
     // 同テナントの他エージェント (インポート実行者を除く) に一括追加を通知する。
     // 個別チケットごとではなく 1 通にまとめることで通知の過多を防ぐ (200 件追加でも通知は 1 通)。
-    const agents = await repos.users.listAgents(tenantId); // 当該テナントの全エージェント一覧を取得
+    // /code-review ultra 指摘対応 (2026-07-13): 「担当者」列の名前解決で既に取得済みの場合は
+    // それを再利用し、同一リクエスト内で listAgents を二重に呼ばないようにする (§8 パフォーマンス)
+    const agents = agentsForAssignee ?? (await repos.users.listAgents(tenantId));
     // インポート実行者自身への通知は不要なので除外する (自分が実施したことは知っているため)
     const otherAgents = agents.filter((a) => a.id !== creatorId);
     if (otherAgents.length > 0) {

--- a/src/features/tickets/components/CsvImportForm.tsx
+++ b/src/features/tickets/components/CsvImportForm.tsx
@@ -38,6 +38,9 @@ type ColumnMapping = {
   拠点: string; // 「拠点」フィールドに対応する CSV 列名 (任意。空文字は使わない。Phase 4 多拠点)
   // §3.1 フォローアップ (2026-07-10): 既存 Excel に混在する完了済み行をそのまま取り込めるようにする
   状況: string; // 「状況」フィールドに対応する CSV 列名 (任意。空文字は使わない)
+  // フォローアップ (2026-07-13): CSV エクスポートの「担当者」列と対称にし、エクスポート→
+  // 再インポートの往復で担当者情報が失われないようにする
+  担当者: string; // 「担当者」フィールドに対応する CSV 列名 (任意。空文字は使わない)
 };
 
 // プレビューテーブルの 1 行を表す型 (マッピング後の固定システムフィールド)
@@ -49,6 +52,7 @@ interface PreviewRow {
   カテゴリ: string; // カテゴリセル (省略可。フォローアップ 2026-07-11)
   拠点: string; // 拠点セル (省略可)
   状況: string; // 状況セル (省略可。§3.1 フォローアップ)
+  担当者: string; // 担当者セル (省略可。フォローアップ 2026-07-13)
 }
 
 // マッピング設定フォームに表示するシステムフィールドの定義一覧
@@ -61,6 +65,7 @@ const SYSTEM_FIELDS = [
   { key: 'カテゴリ' as const, label: 'カテゴリ（任意）', required: false }, // 任意フィールド (フォローアップ 2026-07-11)
   { key: '拠点' as const, label: '拠点（任意）', required: false }, // 任意フィールド
   { key: '状況' as const, label: '状況（任意）', required: false }, // 任意フィールド (§3.1 フォローアップ)
+  { key: '担当者' as const, label: '担当者（任意）', required: false }, // 任意フィールド (フォローアップ 2026-07-13)
 ] as const;
 
 // ウィザードのステップ情報一覧 (ステップインジケーターの表示に使う)
@@ -104,8 +109,9 @@ function applyMapping(csvText: string, mapping: ColumnMapping): string {
   const catIdx = mapping.カテゴリ ? headers.indexOf(mapping.カテゴリ) : -1; // カテゴリ列のインデックス (フォローアップ 2026-07-11)
   const locIdx = mapping.拠点 ? headers.indexOf(mapping.拠点) : -1; // 拠点列のインデックス
   const statusIdx = mapping.状況 ? headers.indexOf(mapping.状況) : -1; // 状況列のインデックス (§3.1 フォローアップ)
+  const assigneeIdx = mapping.担当者 ? headers.indexOf(mapping.担当者) : -1; // 担当者列のインデックス (フォローアップ 2026-07-13)
   // 出力 CSV のヘッダ行: サーバーアクションが期待する固定列名で上書きする
-  const outLines: string[] = ['件名,内容,期限日,優先度,カテゴリ,拠点,状況'];
+  const outLines: string[] = ['件名,内容,期限日,優先度,カテゴリ,拠点,状況,担当者'];
   // データ行を 1 行ずつ変換する
   for (const line of lines.slice(1)) {
     // RFC 4180 パーサで元のセル値を取り出す
@@ -126,6 +132,7 @@ function applyMapping(csvText: string, mapping: ColumnMapping): string {
       escapeCsvCell(catIdx !== -1 ? (cells[catIdx] ?? '') : ''), // カテゴリセル (フォローアップ 2026-07-11)
       escapeCsvCell(locIdx !== -1 ? (cells[locIdx] ?? '') : ''), // 拠点セル
       escapeCsvCell(statusIdx !== -1 ? (cells[statusIdx] ?? '') : ''), // 状況セル (§3.1 フォローアップ)
+      escapeCsvCell(assigneeIdx !== -1 ? (cells[assigneeIdx] ?? '') : ''), // 担当者セル (フォローアップ 2026-07-13)
     ];
     // カンマ区切りで 1 行にして出力リストに追加する
     outLines.push(row.join(','));
@@ -147,7 +154,7 @@ function buildPreview(mappedCsvText: string): PreviewRow[] {
   return dataLines.map((line) => {
     // RFC 4180 パーサで各セルを取り出す
     const cells = parseCsvLine(line);
-    // applyMapping が出力した列順: 件名[0], 内容[1], 期限日[2], 優先度[3], カテゴリ[4], 拠点[5], 状況[6]
+    // applyMapping が出力した列順: 件名[0], 内容[1], 期限日[2], 優先度[3], カテゴリ[4], 拠点[5], 状況[6], 担当者[7]
     return {
       件名: cells[0] ?? '', // 件名セル
       内容: cells[1] ?? '', // 内容セル
@@ -156,6 +163,7 @@ function buildPreview(mappedCsvText: string): PreviewRow[] {
       カテゴリ: cells[4] ?? '', // カテゴリセル (フォローアップ 2026-07-11)
       拠点: cells[5] ?? '', // 拠点セル
       状況: cells[6] ?? '', // 状況セル (§3.1 フォローアップ)
+      担当者: cells[7] ?? '', // 担当者セル (フォローアップ 2026-07-13)
     };
   });
 }
@@ -174,6 +182,7 @@ function buildAutoMapping(headers: string[]): ColumnMapping {
     カテゴリ: find('カテゴリ'), // 「カテゴリ」列が CSV にあれば自動対応 (フォローアップ 2026-07-11)
     拠点: find('拠点'), // 「拠点」列が CSV にあれば自動対応 (自社の CSV エクスポート結果をそのまま再取込しやすくする)
     状況: find('状況'), // 「状況」列が CSV にあれば自動対応 (§3.1 フォローアップ)
+    担当者: find('担当者'), // 「担当者」列が CSV にあれば自動対応 (フォローアップ 2026-07-13)
   };
 }
 
@@ -195,6 +204,7 @@ export function CsvImportForm(_props: CsvImportFormProps) {
     カテゴリ: '',
     拠点: '',
     状況: '',
+    担当者: '',
   });
   // マッピングを適用した変換後の CSV テキスト (サーバーアクションへ渡す)
   const [mappedCsvText, setMappedCsvText] = useState<string | null>(null);
@@ -215,7 +225,7 @@ export function CsvImportForm(_props: CsvImportFormProps) {
     if (!file) {
       setCsvText(null); // 生 CSV テキストをクリア
       setCsvHeaders([]); // ヘッダ一覧をクリア
-      setMapping({ 件名: '', 内容: '', 期限日: '', 優先度: '', カテゴリ: '', 拠点: '', 状況: '' }); // マッピングをクリア
+      setMapping({ 件名: '', 内容: '', 期限日: '', 優先度: '', カテゴリ: '', 拠点: '', 状況: '', 担当者: '' }); // マッピングをクリア
       setMappedCsvText(null); // 変換後 CSV をクリア
       setPreview([]); // プレビューをクリア
       setResult(null); // 結果をクリア
@@ -228,7 +238,7 @@ export function CsvImportForm(_props: CsvImportFormProps) {
       // エラーを表示しつつ、以前のファイルに由来する状態をすべてリセットして不整合を防ぐ
       setCsvText(null); // 前回の生 CSV テキストをクリア
       setCsvHeaders([]); // 前回のヘッダ一覧をクリア
-      setMapping({ 件名: '', 内容: '', 期限日: '', 優先度: '', カテゴリ: '', 拠点: '', 状況: '' }); // 前回のマッピングをクリア
+      setMapping({ 件名: '', 内容: '', 期限日: '', 優先度: '', カテゴリ: '', 拠点: '', 状況: '', 担当者: '' }); // 前回のマッピングをクリア
       setMappedCsvText(null); // 前回の変換後 CSV をクリア
       setPreview([]); // 前回のプレビューをクリア
       setResult(null); // 前回の結果をクリア
@@ -466,6 +476,12 @@ export function CsvImportForm(_props: CsvImportFormProps) {
               <span className="font-medium">状況:</span> 画面に表示されている状況の日本語表記（例:
               「未対応」「対応中」「完了」）と完全に一致する文字列を入力してください。空欄の場合は既定の状況で取り込まれます。一致しない場合はエラーになります。
             </p>
+            {/* 担当者のフォーマット説明: 拠点と同じく、既存の担当者名と完全一致させる必要がある
+                (フォローアップ 2026-07-13) */}
+            <p>
+              <span className="font-medium">担当者:</span>{' '}
+              登録済みの担当者（エージェント）の氏名と完全に一致する文字列を入力してください。空欄の場合は未アサインで取り込まれます。一致しない場合はエラーになります。
+            </p>
           </div>
 
           {/* 件名未選択時などのマッピングエラー */}
@@ -539,6 +555,10 @@ export function CsvImportForm(_props: CsvImportFormProps) {
                     <th className="px-4 py-2 text-left text-xs font-semibold text-slate-500">
                       状況
                     </th>
+                    {/* ヘッダセル: 担当者 (フォローアップ 2026-07-13) */}
+                    <th className="px-4 py-2 text-left text-xs font-semibold text-slate-500">
+                      担当者
+                    </th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-slate-100">
@@ -561,6 +581,8 @@ export function CsvImportForm(_props: CsvImportFormProps) {
                       <td className="px-4 py-2 text-slate-500">{row.拠点 || '―'}</td>
                       {/* 状況セル: 未設定は「―」で表示する (既定の状況が反映される。§3.1 フォローアップ) */}
                       <td className="px-4 py-2 text-slate-500">{row.状況 || '―'}</td>
+                      {/* 担当者セル: 未設定は「―」で表示する (フォローアップ 2026-07-13) */}
+                      <td className="px-4 py-2 text-slate-500">{row.担当者 || '―'}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/tests/data/ticket-repository.contract.ts
+++ b/tests/data/ticket-repository.contract.ts
@@ -106,6 +106,44 @@ export function runTicketRepositoryContract(
       expect(found?.status).toBe('Open');
     });
 
+    // フォローアップ (2026-07-13, /code-review ultra 指摘対応): CSV インポートが追加した
+    // assigneeId / firstRespondedAt / createdAt の明示指定が、Prisma / メモリ両アダプタで
+    // 同じように永続化されることを確認する (この契約テストは runTicketRepositoryContract 経由で
+    // 両アダプタに対して実行されるため、片方の adapter だけが実装を怠っても検出できる)。
+    it('create honors explicit assigneeId / firstRespondedAt / createdAt', async () => {
+      const { requester, agentA, categoryId } = await ctx.seedBasicFixture();
+      // 明示的に過去の時刻を作成日時として指定する
+      const explicitCreatedAt = new Date('2026-01-01T00:00:00.000Z');
+      const created = await ctx.repos.tickets.create({
+        title: 'CSV インポートされたチケット',
+        body: '既に対応中だった問い合わせ',
+        priority: 'Medium',
+        creatorId: requester.id,
+        categoryId,
+        tenantId: TENANT_ID,
+        status: 'InProgress',
+        assigneeId: agentA.id,
+        firstRespondedAt: explicitCreatedAt,
+        createdAt: explicitCreatedAt,
+      });
+      // 指定した担当者・初回応答日時・作成日時がそのまま保存されること
+      expect(created.assignee?.id).toBe(agentA.id);
+      expect(created.firstRespondedAt?.toISOString()).toBe(explicitCreatedAt.toISOString());
+      expect(created.createdAt.toISOString()).toBe(explicitCreatedAt.toISOString());
+      // firstRespondedAt が createdAt より前にならないこと (回帰防止)
+      expect(created.firstRespondedAt!.getTime()).toBeGreaterThanOrEqual(
+        created.createdAt.getTime(),
+      );
+
+      // 取り直しても同じ値のまま永続化されていること
+      // (findById は関連情報を含まない素の Ticket を返すため assigneeId で確認する。
+      // 関連込みの確認は上の created.assignee?.id で既に行っている)
+      const found = await ctx.repos.tickets.findById(created.id, TENANT_ID);
+      expect(found?.assigneeId).toBe(agentA.id);
+      expect(found?.firstRespondedAt?.toISOString()).toBe(explicitCreatedAt.toISOString());
+      expect(found?.createdAt.toISOString()).toBe(explicitCreatedAt.toISOString());
+    });
+
     // list の creatorId フィルタと並び順 (新しい順) が正しいこと
     it('list applies creatorId filter and returns most-recent first', async () => {
       const { requester, agentA, categoryId } = await ctx.seedBasicFixture();

--- a/tests/features/create-ticket-outbound-notify.test.ts
+++ b/tests/features/create-ticket-outbound-notify.test.ts
@@ -6,6 +6,8 @@
 //   1. Slack Webhook 設定済みテナントで起票すると fetch が 1 回呼ばれる
 //   2. 外部通知未設定テナントで起票しても fetch は呼ばれない (無駄打ちしない)
 //   3. 外部通知の送信失敗はチケット作成のレスポンスに影響しない (ベストエフォート)
+//   4. 回帰防止: メール/LINE 取り込みと違い、Web フォーム経由の起票だけがエージェントへの
+//      アプリ内通知 (imported) を送っていなかった不備の修正確認
 
 // Vitest の DSL とモック機能
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -17,6 +19,8 @@ import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
 // 主に使うテナント ID と依頼者 ID
 const TENANT = 'default-tenant';
 const REQUESTER = 'u-req-1';
+// アプリ内通知テスト用のエージェント ID
+const AGENT = 'u-agent-1';
 // テスト用 Slack Webhook URL (実際には送信されない。SSRF ガードを通す公開ホスト)
 const SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/xxx';
 
@@ -83,6 +87,17 @@ async function seedTenant(slackWebhookUrl: string | null) {
     name: '山田 太郎',
     passwordHash: 'x',
     role: 'requester',
+    tenantId: TENANT,
+    createdAt: now,
+    updatedAt: now,
+  });
+  // エージェントユーザーを投入 (アプリ内通知の宛先確認用)
+  store.users.set(AGENT, {
+    id: AGENT,
+    email: 'agent@example.com',
+    name: '佐藤 担当',
+    passwordHash: 'x',
+    role: 'agent',
     tenantId: TENANT,
     createdAt: now,
     updatedAt: now,
@@ -177,5 +192,30 @@ describe('POST /api/tickets (外部通知)', () => {
     expect(res.status).toBe(201);
     const created = await res.json();
     expect(created.title).toBe('ネットワークに繋がらない');
+  });
+});
+
+describe('POST /api/tickets (アプリ内通知)', () => {
+  it('新規起票時にテナント内の全エージェントへ imported 通知を作成する', async () => {
+    // 外部通知は未設定のテナントでも、アプリ内通知は独立して送られることを確認する
+    await seedTenant(null);
+    const { POST } = await import('@/app/api/tickets/route');
+
+    const res = await POST(
+      buildJsonRequest({
+        title: '複合機が印刷できない',
+        body: '朝から紙詰まりが続く',
+        priority: 'Medium',
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const created = await res.json();
+    // エージェント (AGENT) 宛に 'imported' 種別の通知が作成されていること
+    const notifications = [...store.notifications.values()].filter((n) => n.userId === AGENT);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.type).toBe('imported');
+    expect(notifications[0]?.ticketId).toBe(created.id);
+    expect(notifications[0]?.tenantId).toBe(TENANT);
   });
 });

--- a/tests/features/import-tickets.test.ts
+++ b/tests/features/import-tickets.test.ts
@@ -445,6 +445,33 @@ describe('importTickets', () => {
       const ticket = [...store.tickets.values()][0];
       expect(ticket?.assigneeId).toBeNull();
     });
+
+    // /code-review ultra 指摘対応 (2026-07-13): 同姓同名のエージェントが複数存在する場合、
+    // 名前 → ID の Map で無言でどちらか一方に misassign されてしまうと、拠点/カテゴリの
+    // 誤りより深刻 (チケットの所有権を誤らせる) な回帰になる。エラー行として記録され、
+    // どちらのエージェントにも起票されないことを確認する。
+    it('同姓同名のエージェントが複数いる場合はエラーとして記録され起票されない', async () => {
+      // u-agt-2 (エージェント2) と同じ表示名を持つ 3 人目のエージェントを追加する
+      const now = new Date();
+      store.users.set('u-agt-3', {
+        id: 'u-agt-3',
+        email: 'agent3@example.com',
+        name: 'エージェント2', // u-agt-2 と同じ表示名 (同姓同名)
+        passwordHash: 'x',
+        role: 'agent',
+        tenantId: TENANT,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const importTickets = await loadAction();
+      const csv = `件名,担当者\n複合機の紙詰まり,エージェント2`;
+      const result = await importTickets(csv);
+
+      expect(result.imported).toBe(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('担当者名が重複しています');
+      expect(store.tickets.size).toBe(0);
+    });
   });
 
   // §3.1 フォローアップ (2026-07-10): 既存 Excel の完了済み行をそのまま取り込めるかを検証する
@@ -469,6 +496,13 @@ describe('importTickets', () => {
       // フォローアップ (2026-07-13): 完了系ステータスは初回応答も済んでいるはずなので
       // firstRespondedAt もインポート時刻でセットされる (SLA バッジ・品質メトリクスの回帰防止)
       expect(ticket?.firstRespondedAt).toBeInstanceOf(Date);
+      // /code-review ultra 指摘対応 (2026-07-13): resolvedAt/firstRespondedAt は createdAt と
+      // 同じ取り込み時刻を明示的に使うため、createdAt より前になってはいけない
+      // (前になると平均解決時間・平均初回応答時間の AVG(x - createdAt) が負値になる回帰)
+      expect(resolvedAtMs).toBeGreaterThanOrEqual(ticket!.createdAt.getTime());
+      expect(ticket!.firstRespondedAt!.getTime()).toBeGreaterThanOrEqual(
+        ticket!.createdAt.getTime(),
+      );
     });
 
     // 未完了系だが初期状態ではないラベル (「対応中」) を指定すると、resolvedAt は null のままだが
@@ -483,6 +517,10 @@ describe('importTickets', () => {
       expect(ticket?.status).toBe('InProgress');
       expect(ticket?.resolvedAt).toBeNull();
       expect(ticket?.firstRespondedAt).toBeInstanceOf(Date);
+      // /code-review ultra 指摘対応 (2026-07-13): firstRespondedAt が createdAt より前にならないこと
+      expect(ticket!.firstRespondedAt!.getTime()).toBeGreaterThanOrEqual(
+        ticket!.createdAt.getTime(),
+      );
     });
 
     // 「状況」列自体が無ければ従来どおりモードの既定初期ステータス (Lite: Open) で起票される (後方互換)。

--- a/tests/features/import-tickets.test.ts
+++ b/tests/features/import-tickets.test.ts
@@ -392,11 +392,66 @@ describe('importTickets', () => {
     });
   });
 
+  // フォローアップ (2026-07-13): 「担当者」列の名前解決
+  // CSV エクスポート (GET /api/tickets/export) が「担当者」列を出力するのに、インポート側には
+  // 対応する読み取りが存在せず、エクスポート→編集→再インポートの往復で担当者情報が消えて
+  // いた不備の回帰テスト (拠点列の回帰テストと同じ構成)。担当者は拠点と同じく Lite/Pro
+  // 両モードで使える概念のため、Lite テナント (seed() の既定) のまま検証する。
+  describe('担当者列 (フォローアップ 2026-07-13)', () => {
+    // 「担当者」列の値が既存のエージェント名と一致すれば assigneeId が解決されて保存される
+    it('担当者名が一致すれば assigneeId が解決されて保存される', async () => {
+      const importTickets = await loadAction();
+      const csv = `件名,担当者\n複合機の紙詰まり,エージェント2`;
+      const result = await importTickets(csv);
+
+      expect(result.imported).toBe(1);
+      expect(result.errors).toHaveLength(0);
+      const ticket = [...store.tickets.values()][0];
+      expect(ticket?.assigneeId).toBe('u-agt-2');
+    });
+
+    // テナントに存在しない担当者名 (タイポ・退職済み等) はエラーとして記録され、
+    // 無言で未アサインにはならない
+    it('存在しない担当者名はエラーとして記録され起票されない', async () => {
+      const importTickets = await loadAction();
+      const csv = `件名,担当者\n複合機の紙詰まり,存在しない担当者`;
+      const result = await importTickets(csv);
+
+      expect(result.imported).toBe(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('担当者が見つかりません');
+      expect(store.tickets.size).toBe(0);
+    });
+
+    // 「担当者」列自体が無ければ従来どおり assigneeId は null (未アサイン) のまま (後方互換)
+    it('担当者列が無ければ assigneeId は null のまま取り込まれる', async () => {
+      const importTickets = await loadAction();
+      const csv = `件名\n複合機の紙詰まり`;
+      const result = await importTickets(csv);
+
+      expect(result.imported).toBe(1);
+      const ticket = [...store.tickets.values()][0];
+      expect(ticket?.assigneeId).toBeNull();
+    });
+
+    // 担当者列があっても空セルなら未指定として扱い、エラーにはしない
+    it('担当者セルが空なら未指定として扱いエラーにしない', async () => {
+      const importTickets = await loadAction();
+      const csv = `件名,担当者\n複合機の紙詰まり,`;
+      const result = await importTickets(csv);
+
+      expect(result.imported).toBe(1);
+      expect(result.errors).toHaveLength(0);
+      const ticket = [...store.tickets.values()][0];
+      expect(ticket?.assigneeId).toBeNull();
+    });
+  });
+
   // §3.1 フォローアップ (2026-07-10): 既存 Excel の完了済み行をそのまま取り込めるかを検証する
   describe('状況列 (§3.1 フォローアップ)', () => {
     // Lite テナント (seed() の既定) で「完了」を指定すると Closed で起票され、resolvedAt が
     // インポート時刻でセットされる (getCompletionStatuses(mode) との整合を確認)
-    it('Lite テナントで「完了」を指定すると Closed かつ resolvedAt 付きで起票される', async () => {
+    it('Lite テナントで「完了」を指定すると Closed かつ resolvedAt / firstRespondedAt 付きで起票される', async () => {
       const importTickets = await loadAction();
       const csv = `件名,状況\n複合機の紙詰まり,完了`;
       const before = Date.now();
@@ -411,10 +466,14 @@ describe('importTickets', () => {
       const resolvedAtMs = ticket!.resolvedAt!.getTime();
       expect(resolvedAtMs).toBeGreaterThanOrEqual(before);
       expect(resolvedAtMs).toBeLessThanOrEqual(after);
+      // フォローアップ (2026-07-13): 完了系ステータスは初回応答も済んでいるはずなので
+      // firstRespondedAt もインポート時刻でセットされる (SLA バッジ・品質メトリクスの回帰防止)
+      expect(ticket?.firstRespondedAt).toBeInstanceOf(Date);
     });
 
-    // 未完了系のラベル (「対応中」) を指定すると、そのステータスで起票されるが resolvedAt は null のまま
-    it('未完了系のラベルを指定すると resolvedAt を設定せずに起票される', async () => {
+    // 未完了系だが初期状態ではないラベル (「対応中」) を指定すると、resolvedAt は null のままだが
+    // firstRespondedAt はインポート時刻でセットされる (既に着手済みの行のため)
+    it('未完了系のラベル (対応中) を指定すると resolvedAt は null のまま firstRespondedAt がセットされる', async () => {
       const importTickets = await loadAction();
       const csv = `件名,状況\n複合機の紙詰まり,対応中`;
       const result = await importTickets(csv);
@@ -423,10 +482,12 @@ describe('importTickets', () => {
       const ticket = [...store.tickets.values()][0];
       expect(ticket?.status).toBe('InProgress');
       expect(ticket?.resolvedAt).toBeNull();
+      expect(ticket?.firstRespondedAt).toBeInstanceOf(Date);
     });
 
-    // 「状況」列自体が無ければ従来どおりモードの既定初期ステータス (Lite: Open) で起票される (後方互換)
-    it('状況列が無ければ既定の初期ステータスで起票される', async () => {
+    // 「状況」列自体が無ければ従来どおりモードの既定初期ステータス (Lite: Open) で起票される (後方互換)。
+    // 初期状態のままなので resolvedAt / firstRespondedAt はどちらも未設定のまま
+    it('状況列が無ければ既定の初期ステータスで起票され、resolvedAt / firstRespondedAt は未設定のまま', async () => {
       const importTickets = await loadAction();
       const csv = `件名\n複合機の紙詰まり`;
       const result = await importTickets(csv);
@@ -435,6 +496,7 @@ describe('importTickets', () => {
       const ticket = [...store.tickets.values()][0];
       expect(ticket?.status).toBe('Open');
       expect(ticket?.resolvedAt).toBeNull();
+      expect(ticket?.firstRespondedAt).toBeNull();
     });
 
     // 状況セルが空なら未指定として扱い、既定の初期ステータスにフォールバックする (エラーにしない)
@@ -487,6 +549,8 @@ describe('importTickets', () => {
       const ticket = [...store.tickets.values()][0];
       expect(ticket?.status).toBe('Resolved');
       expect(ticket?.resolvedAt).toBeInstanceOf(Date);
+      // フォローアップ (2026-07-13): Pro の完了状態 (Resolved) も初回応答済みとして記録される
+      expect(ticket?.firstRespondedAt).toBeInstanceOf(Date);
     });
 
     // /code-review ultra 指摘対応 (2026-07-10): 「エスカレーション」は escalatedAt/理由の記録や

--- a/tests/ticket-status.test.ts
+++ b/tests/ticket-status.test.ts
@@ -6,6 +6,7 @@ import {
   getAllowedLiteTransitions,
   getAllowedTransitions,
   getCompletionStatuses,
+  hasRespondedByImportStatus,
   isLiteStatus,
   isValidLiteTransition,
   isValidTransition,
@@ -201,5 +202,31 @@ describe('getCompletionStatuses', () => {
   // Lite は Closed (Lite の「完了」) と旧 Pro データの Resolved の両方を完了扱いとする
   it('Lite では Closed と旧データの Resolved を完了扱いとする', () => {
     expect(getCompletionStatuses('lite')).toEqual(['Closed', 'Resolved']);
+  });
+});
+
+// hasRespondedByImportStatus: CSV インポート (import-tickets.ts) が「状況」列から
+// 初回応答済みとみなすかを判定する単一定義 (フォローアップ 2026-07-13)
+describe('hasRespondedByImportStatus', () => {
+  // Pro の初期状態 (New) は未応答とみなす
+  it('Pro で初期状態 (New) は未応答とみなす', () => {
+    expect(hasRespondedByImportStatus('New', 'pro')).toBe(false);
+  });
+
+  // Pro で初期状態以外 (Open 等) は応答済みとみなす
+  it('Pro で初期状態以外は応答済みとみなす', () => {
+    expect(hasRespondedByImportStatus('Open', 'pro')).toBe(true);
+    expect(hasRespondedByImportStatus('Resolved', 'pro')).toBe(true);
+  });
+
+  // Lite の初期状態 (Open=未対応) は未応答とみなす
+  it('Lite で初期状態 (Open) は未応答とみなす', () => {
+    expect(hasRespondedByImportStatus('Open', 'lite')).toBe(false);
+  });
+
+  // Lite で初期状態以外 (InProgress/Closed 等) は応答済みとみなす
+  it('Lite で初期状態以外は応答済みとみなす', () => {
+    expect(hasRespondedByImportStatus('InProgress', 'lite')).toBe(true);
+    expect(hasRespondedByImportStatus('Closed', 'lite')).toBe(true);
   });
 });


### PR DESCRIPTION
## 対応する Phase / 項目

`docs/smb-dx-pivot-plan.md` は全項目 `[x]` 完了扱いだが、これまでの運用パターン（ドキュメント内の各「フォローアップ」節）に倣い、「完了扱いだが実装が伴っていないギャップ」の監査を行い、新たに見つかった 2 件を修正した。

- Phase 2 §5.3（入口チャネルの Adapter 化）/ §3.5 フォローアップ
- Phase 3 §3.1 / §3.3 フォローアップ

## 変更内容

### 1. Web フォーム経由の起票でエージェントへのアプリ内通知が欠けていた

新規問い合わせの入口チャネル（Web フォーム・メール・LINE・CSV インポート）のうち、メール取り込み（§3.5）・LINE 取り込み・CSV インポートは新規起票をテナント内の全エージェントへ `imported` 通知するが、最も利用頻度が高い Web フォーム経由の起票だけがこの通知を送っていなかった。Slack/Teams/Chatwork 通知はオプトイン機能のため、未設定のテナントでは Web フォームから届いた問い合わせに誰も気づけないまま放置されうる。

`POST /api/tickets` の添付なし/添付ありの両成功パスに、メール/LINE 取り込みと共有する `notifyAgentsOfNewTicket` ヘルパーを使った通知を追加した。

### 2. CSV インポートの往復性: 初回応答日時・担当者

- §3.1 フォローアップで CSV インポートに `resolvedAt`（解決日時）の設定を追加したが、兄弟フィールドの `firstRespondedAt`（実際の初回応答日時）は設定していなかった。「状況」列がモードの初期状態以外（対応中・完了等）を指定していた場合は初回応答も済んでいるはずだが、これを未設定のままにすると Pro モードの SLA バッジ・品質メトリクス（平均初回応答時間）が、インポートされた履歴チケットを永久に「未応答」として扱ってしまう（§2.1.2 と同種の欠落）。
- §3.3 フォローアップで件名/内容/カテゴリ/期限日の CSV 往復性を修正したが、エクスポートに存在する「担当者」列がインポート側には一切対応しておらず、エクスポート→編集→再インポートの往復で担当者情報が失われていた。拠点/カテゴリと同じ名前解決パターンで「担当者」列を追加した。

## テスト

- `npm run typecheck` — 成功
- `npm run lint` — 成功
- `npx vitest run` — 877 件成功（Prisma 契約テスト 127 件は `RUN_PRISMA_CONTRACT` 未設定のためスキップ、既存挙動と同じ）
- 追加した回帰テスト:
  - `tests/features/create-ticket-outbound-notify.test.ts`
  - `tests/features/import-tickets.test.ts`

## 画面確認

UI の見た目に変更はなく（CSV インポートのマッピングウィザードに列が 1 つ増えたのみ）、サーバー側の挙動追加が中心のため、上記の自動テストで検証している。


---
_Generated by [Claude Code](https://claude.ai/code/session_014XnHProPvPHZFdPsE2y9vp)_