### PR TITLE
feat(billing): Stripeプラン変更監査ログ / fix(tickets): CSV担当割当通知

### DIFF
--- a/prisma/migrations/20260713000000_add_settings_audit_subscription_plan_update/migration.sql
+++ b/prisma/migrations/20260713000000_add_settings_audit_subscription_plan_update/migration.sql
@@ -1,0 +1,5 @@
+-- フォローアップ (2026-07-13): 監査で発見したギャップの解消。
+-- Stripe Webhook 起因のプラン変更 (アップグレード/ダウングレード/解約) は §4.4 の
+-- tenant_mode_update (Pro モード強制解除の副作用のときのみ記録) では捕捉されず、
+-- subscriptionPlan 自体の変更は一度も監査対象になっていなかった。
+ALTER TYPE "SettingsAuditAction" ADD VALUE 'subscription_plan_update';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,10 @@ enum SettingsAuditAction {
   // チケットへアクセスできる権限を与える操作であり、SSO/LINE/通知チャネル設定と同じ「管理者による
   // 設定変更」として監査対象に含める
   invitation_issue // メンバー招待リンクの発行 (単発・一括まとめて 1 回)
+  // フォローアップ (2026-07-13): Stripe 起因のプラン変更 (アップグレード/ダウングレード/解約) は
+  // §4.4 の tenant_mode_update (Pro モード強制解除の副作用のみ) では捕捉されず、
+  // subscriptionPlan 自体の変更は一度も監査対象になっていなかった
+  subscription_plan_update // サブスクリプションプランの変更 (Stripe Webhook 起因)
 }
 
 // FAQ 候補の状態

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -160,7 +160,10 @@ async function applyPlanChange(
       // Pro 専用機能を使えなくする (Lite モードへ強制的に戻す)
       await tx.tenants.updateMode(tenantId, 'lite');
     }
-    return { shouldResetMode: shouldReset, planChanged: previousPlan !== stripeFields.subscriptionPlan };
+    return {
+      shouldResetMode: shouldReset,
+      planChanged: previousPlan !== stripeFields.subscriptionPlan,
+    };
   });
 
   // §4.3 フォローアップ (2026-07-10): モードが強制的に戻された場合は監査ログにも記録する。
@@ -168,30 +171,33 @@ async function applyPlanChange(
   // しか対象にしておらず、Stripe イベント起因の自動ダウングレードは監査対象から漏れていた
   // (「誰がいつ Pro モードに切り替えたか」を追えるはずの §4.3 の意図に反する)。
   // ここは操作したユーザーが存在しないシステム操作のため actorId は null (システムアクター) を渡す。
-  // 監査ログの書き込み失敗は本来の処理 (プラン反映) の成否に影響させない (recordSettingsAudit の方針)
-  if (shouldResetMode) {
-    await recordSettingsAudit({
-      tenantId,
-      actorId: null,
-      action: 'tenant_mode_update',
-      logPrefix: '[stripe-webhook]',
-    });
-  }
-
+  // 監査ログの書き込み失敗は本来の処理 (プラン反映) の成否に影響させない (recordSettingsAudit の方針)。
+  //
   // フォローアップ (2026-07-13): 監査で発見したギャップの解消。§4.2-§4.6 が SSO/LINE/通知チャネル/
   // テナントモード/拠点/招待リンクまで監査対象を広げてきた一方、それらより上位の「組織設定」である
   // subscriptionPlan 自体の変更 (アップグレード/ダウングレード/解約) は tenant_mode_update の
   // 副作用としてしか記録されず (Pro モードで運用中のダウングレードのみ)、プラン変更そのものは
   // 一度も監査対象になっていなかった。Enterprise プランが謳う「監査強化」の実態と乖離するため、
-  // プランが実際に変わった場合は常に (mode リセットの有無に関わらず) 記録する
-  if (planChanged) {
-    await recordSettingsAudit({
-      tenantId,
-      actorId: null,
-      action: 'subscription_plan_update',
-      logPrefix: '[stripe-webhook]',
-    });
-  }
+  // プランが実際に変わった場合は常に (mode リセットの有無に関わらず) 記録する。
+  // 2 つの監査ログ書き込みは互いに独立した I/O なので Promise.all で並行実行する (§8 パフォーマンス)
+  await Promise.all([
+    shouldResetMode
+      ? recordSettingsAudit({
+          tenantId,
+          actorId: null,
+          action: 'tenant_mode_update',
+          logPrefix: '[stripe-webhook]',
+        })
+      : Promise.resolve(),
+    planChanged
+      ? recordSettingsAudit({
+          tenantId,
+          actorId: null,
+          action: 'subscription_plan_update',
+          logPrefix: '[stripe-webhook]',
+        })
+      : Promise.resolve(),
+  ]);
 }
 
 // サブスクリプション作成・更新を処理する: テナントのプランと状態を最新に保つ

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -145,11 +145,13 @@ async function applyPlanChange(
     subscriptionPlan: SubscriptionPlan;
   },
 ): Promise<void> {
-  const shouldResetMode = await uow.run(async (tx) => {
+  const { shouldResetMode, planChanged } = await uow.run(async (tx) => {
     // トランザクション内で最新のテナント状態を読み直す (呼び出し元のスナップショットに頼らない)
     const tenant = await tx.tenants.findById(tenantId);
     // 呼び出し元で存在確認済みだが、念のためここでも安全側 (何もしない) に倒す
-    if (!tenant) return false;
+    if (!tenant) return { shouldResetMode: false, planChanged: false };
+    // /code-review ultra 指摘対応 (2026-07-13): 監査ログに残すため、更新前のプランを保持しておく
+    const previousPlan = tenant.subscriptionPlan;
     // Stripe 連携情報とプランを反映する
     await tx.tenants.updateStripeSubscription(tenantId, stripeFields);
     // 現在 Pro モードで運用中かつ、新プランが Pro モードを許可しないときだけモードを戻す
@@ -158,7 +160,7 @@ async function applyPlanChange(
       // Pro 専用機能を使えなくする (Lite モードへ強制的に戻す)
       await tx.tenants.updateMode(tenantId, 'lite');
     }
-    return shouldReset;
+    return { shouldResetMode: shouldReset, planChanged: previousPlan !== stripeFields.subscriptionPlan };
   });
 
   // §4.3 フォローアップ (2026-07-10): モードが強制的に戻された場合は監査ログにも記録する。
@@ -172,6 +174,21 @@ async function applyPlanChange(
       tenantId,
       actorId: null,
       action: 'tenant_mode_update',
+      logPrefix: '[stripe-webhook]',
+    });
+  }
+
+  // フォローアップ (2026-07-13): 監査で発見したギャップの解消。§4.2-§4.6 が SSO/LINE/通知チャネル/
+  // テナントモード/拠点/招待リンクまで監査対象を広げてきた一方、それらより上位の「組織設定」である
+  // subscriptionPlan 自体の変更 (アップグレード/ダウングレード/解約) は tenant_mode_update の
+  // 副作用としてしか記録されず (Pro モードで運用中のダウングレードのみ)、プラン変更そのものは
+  // 一度も監査対象になっていなかった。Enterprise プランが謳う「監査強化」の実態と乖離するため、
+  // プランが実際に変わった場合は常に (mode リセットの有無に関わらず) 記録する
+  if (planChanged) {
+    await recordSettingsAudit({
+      tenantId,
+      actorId: null,
+      action: 'subscription_plan_update',
       logPrefix: '[stripe-webhook]',
     });
   }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -44,7 +44,11 @@ export type SettingsAuditAction =
   // フォローアップ (2026-07-11): SSO/LINE/通知チャネル設定と同じ「管理者による設定変更」でありながら
   // 監査対象から漏れていた操作。招待リンク発行 (特に agent 権限付与) は新しい人物に社内の全チケットへ
   // アクセスできる権限を与える操作であり、SSO 証明書変更等と同等以上にセキュリティ上重要
-  | 'invitation_issue'; // メンバー招待リンクの発行 (単発・一括まとめて 1 回)
+  | 'invitation_issue' // メンバー招待リンクの発行 (単発・一括まとめて 1 回)
+  // フォローアップ (2026-07-13): Stripe 起因のプラン変更 (アップグレード/ダウングレード/解約) は
+  // §4.4 の tenant_mode_update (Pro モード強制解除の副作用のときのみ記録) では捕捉されず、
+  // subscriptionPlan 自体の変更は一度も監査対象になっていなかった
+  | 'subscription_plan_update'; // サブスクリプションプランの変更 (Stripe Webhook 起因)
 
 // メール取り込みが起票せず隔離した理由。
 // prisma/schema.prisma の QuarantineReason enum および src/lib/constants.ts の

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -18,7 +18,7 @@ import { getCurrentTenantMode } from '@/lib/tenant';
 // RFC 4180 準拠の CSV パーサ と共有定数 (サーバー / クライアント共通実装)
 import { parseCsvLine, MAX_CSV_BYTES } from '@/lib/csv';
 // 優先度・ステータス・テナントモードのドメイン型
-import type { Priority, TicketStatus, TenantMode } from '@/domain/types';
+import type { Priority, TicketStatus, TenantMode, NotificationType } from '@/domain/types';
 // モードに応じた初期ステータスを返す共通関数（メール取り込み・LINE 取り込みと同一ロジックを共有し DRY を維持する）。
 // getCompletionStatuses は §3.1 フォローアップ (2026-07-10) で追加: インポート時に「状況」列が
 // 完了系ステータスを指定していた場合、resolvedAt をインポート時刻で設定するために使う
@@ -103,6 +103,55 @@ function resolveNameToId(
     };
   }
   return { ok: true, id };
+}
+
+// CSV インポート完了後、対象ユーザー群へバッチ通知 (1 通ずつ) を送るベストエフォート・ヘルパー。
+// /code-review ultra 指摘対応 (2026-07-13): 「全エージェントへの追加通知 ('imported')」と
+// 「担当者への割当通知 ('assigned')」が、DB 書き込み → 失敗のエージェント別詳細ログ → SSE
+// 未読件数配信、という同型の処理をそれぞれ個別に実装しており 2 箇所目の重複になっていたため、
+// ここに共通化する (§6 DRY)。通知書き込み・SSE 配信の失敗はいずれもチケット作成の成否に
+// 影響させないベストエフォートとして扱う (呼び出し元と同じ方針)。
+async function notifyImportBatch(
+  recipientIds: string[], // 通知対象ユーザー ID 一覧 (呼び出し元で自己除外済み)
+  tenantId: string, // テナントスコープ
+  type: NotificationType, // 通知種別 ('imported' | 'assigned')
+  messageFor: (recipientId: string) => string, // 受信者ごとの通知文言を組み立てる関数
+  logPrefix: string, // ログの先頭に付ける識別子 (例: '[importTickets] 担当割当通知')
+): Promise<void> {
+  // 対象が居なければ何もしない (早期リターン)
+  if (recipientIds.length === 0) return;
+  // 各ユーザーへの通知を並列で DB に書き込む。Promise.allSettled を使い、1 件の書き込み失敗が
+  // 他ユーザーへの通知配信や SSE broadcast をブロックしないようにする
+  const results = await Promise.allSettled(
+    recipientIds.map((userId) =>
+      repos.notifications.create({
+        userId,
+        type,
+        message: messageFor(userId),
+        ticketId: null, // バッチ通知は単一チケットに紐づかないため null
+        tenantId,
+      }),
+    ),
+  );
+  // 失敗した通知件数と、ユーザーごとの失敗理由をサーバーログに記録する
+  // (チケット作成の成否には影響しない。CLAUDE.md §6: エラーを握り潰さない)
+  const failedCount = results.filter((r) => r.status === 'rejected').length;
+  if (failedCount > 0) {
+    console.warn(`${logPrefix} ${failedCount} 件の通知書き込みに失敗しました`);
+    results.forEach((r, i) => {
+      if (r.status === 'rejected') {
+        console.warn(`${logPrefix} ユーザー ${recipientIds[i]} への通知書き込みに失敗:`, r.reason);
+      }
+    });
+  }
+  // 未読件数を SSE で即時配信して通知ベルに反映させる。
+  // broadcast は通知 DB 書き込みより後に行う必要があるため、上の Promise.allSettled を待ってから実行する。
+  // ここで例外が発生してもチケット作成は完了済みなので、ユーザーに失敗として返さず警告ログに留める。
+  try {
+    await broadcastUnreadCountToMany(recipientIds, tenantId);
+  } catch (err) {
+    console.warn(`${logPrefix} SSE broadcast に失敗しました（チケット作成は成功）:`, err);
+  }
 }
 
 // YYYY-MM-DD 形式の日付文字列をローカル時刻の Date に変換する純粋関数
@@ -659,51 +708,7 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     // それを再利用し、同一リクエスト内で listAgents を二重に呼ばないようにする (§8 パフォーマンス)
     const agents = agentsForAssignee ?? (await repos.users.listAgents(tenantId));
     // インポート実行者自身への通知は不要なので除外する (自分が実施したことは知っているため)
-    const otherAgents = agents.filter((a) => a.id !== creatorId);
-    if (otherAgents.length > 0) {
-      // 各エージェントへの通知を並列で DB に書き込む。
-      // Promise.allSettled を使い、1 件の書き込み失敗が他エージェントへの通知配信や
-      // SSE broadcast をブロックしないようにする。チケット作成は完了済みなので
-      // 通知書き込みの一部失敗はエラーとして呼び出し元に返さずログに留める。
-      const notifyResults = await Promise.allSettled(
-        otherAgents.map((agent) =>
-          repos.notifications.create({
-            userId: agent.id, // 受信者: 各エージェント
-            type: 'imported', // CSV 一括インポート通知 (NotificationType.imported)
-            message: `${imported} 件のチケットが CSV インポートで追加されました`, // 表示文言
-            ticketId: null, // バッチインポートは単一チケットに紐づかないため null
-            tenantId, // テナントスコープ
-          }),
-        ),
-      );
-      // 失敗した通知件数をサーバーログに記録する（チケット作成の成否には影響しない）
-      const failedCount = notifyResults.filter((r) => r.status === 'rejected').length;
-      if (failedCount > 0) {
-        // 失敗件数をサマリーとして出力する (何件失敗したか数が把握できるようにする)
-        console.warn(`[importTickets] ${failedCount} 件の通知書き込みに失敗しました`);
-        // 失敗内容の詳細もログに残す (CLAUDE.md §6: エラーを握り潰さない)
-        notifyResults.forEach((r, i) => {
-          if (r.status === 'rejected') {
-            console.warn(
-              `[importTickets] エージェント ${otherAgents[i].id} への通知書き込みに失敗:`,
-              r.reason,
-            );
-          }
-        });
-      }
-      // 未読件数を SSE で即時配信して通知ベルに反映させる。
-      // broadcast は通知 DB 書き込みより後に行う必要があるため、上の Promise.all を待ってから実行する。
-      // ここで例外が発生してもチケット作成は完了済みなので、ユーザーに失敗として返さず警告ログに留める。
-      try {
-        await broadcastUnreadCountToMany(
-          otherAgents.map((a) => a.id), // 通知対象の agent ID 一覧
-          tenantId, // テナントスコープ
-        );
-      } catch (err) {
-        // SSE broadcast の失敗はチケット作成の成否に影響しない。通知ベルの更新が遅れるだけなのでログのみ。
-        console.warn('[importTickets] SSE broadcast に失敗しました（チケット作成は成功）:', err);
-      }
-    }
+    const otherAgentIds = agents.map((a) => a.id).filter((id) => id !== creatorId);
 
     // フォローアップ (2026-07-13): 監査で発見したギャップの解消。「担当者」列で割り当てた
     // エージェントには、上の「N件のチケットが追加されました」という全エージェント向けの汎用通知
@@ -711,36 +716,29 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     // 手動アサイン) が担当者へ 'assigned' 通知を送るのと同じ意図で、担当者ごとに 1 通ずつ
     // (行ごとではなく) まとめて通知する (200 件でも担当者数分の通知で済む)。
     // インポート実行者自身が自分を担当に設定した場合は、既にそれを知っているため対象外にする
-    // (上の otherAgents と同じ「自分の操作を自分に通知しない」方針)。
+    // (上の otherAgentIds と同じ「自分の操作を自分に通知しない」方針)。
     const assignedAgentIds = [...assignedCounts.keys()].filter((id) => id !== creatorId);
-    if (assignedAgentIds.length > 0) {
-      const assignResults = await Promise.allSettled(
-        assignedAgentIds.map((agentId) =>
-          repos.notifications.create({
-            userId: agentId, // 受信者: 割り当てられたエージェント本人
-            type: 'assigned', // 担当割当通知 (NotificationType.assigned)
-            message: `CSV インポートで ${assignedCounts.get(agentId)} 件のチケットが担当者に割り当てられました`,
-            ticketId: null, // 複数チケットにまたがるため null (バッチ通知と同じ扱い)
-            tenantId,
-          }),
-        ),
-      );
-      // 失敗件数をログに残す (チケット作成の成否には影響しない。上の otherAgents と同じ方針)
-      const failedAssignCount = assignResults.filter((r) => r.status === 'rejected').length;
-      if (failedAssignCount > 0) {
-        console.warn(
-          `[importTickets] ${failedAssignCount} 件の担当割当通知の書き込みに失敗しました`,
-        );
-      }
-      try {
-        await broadcastUnreadCountToMany(assignedAgentIds, tenantId);
-      } catch (err) {
-        console.warn(
-          '[importTickets] 担当割当通知の SSE broadcast に失敗しました（チケット作成は成功）:',
-          err,
-        );
-      }
-    }
+
+    // /code-review ultra 指摘対応 (2026-07-13): 上記 2 種類の通知は互いに独立した宛先・内容の
+    // I/O であり、notifyImportBatch 共通ヘルパーへの抽出と合わせて Promise.all で並行実行する
+    // (§8 パフォーマンス)
+    await Promise.all([
+      notifyImportBatch(
+        otherAgentIds,
+        tenantId,
+        'imported', // CSV 一括インポート通知 (NotificationType.imported)
+        () => `${imported} 件のチケットが CSV インポートで追加されました`,
+        '[importTickets] 一括追加通知',
+      ),
+      notifyImportBatch(
+        assignedAgentIds,
+        tenantId,
+        'assigned', // 担当割当通知 (NotificationType.assigned)
+        (agentId) =>
+          `CSV インポートで ${assignedCounts.get(agentId)} 件のチケットが担当者に割り当てられました`,
+        '[importTickets] 担当割当通知',
+      ),
+    ]);
   }
 
   // 成功件数とエラー一覧を返す

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -435,6 +435,11 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
   // 集計用カウンタとエラーリストを初期化する
   let imported = 0;
   const errors: Array<{ row: number; message: string }> = [];
+  // フォローアップ (2026-07-13): 「担当者」列で割り当てた件数をエージェント別に集計する。
+  // updateTicketAssignee (画面からの手動アサイン) は担当者へ 'assigned' 通知を送るが、
+  // CSV インポートで初期担当者を設定してもこれまで一切通知していなかった (監査で発見したギャップ)。
+  // インポート後にまとめて 1 通ずつ送るための集計 (行ごとに送ると 200 件で 200 通になり得る)
+  const assignedCounts = new Map<string, number>();
 
   // ヘッダ列インデックスをまとめてバリデーション関数へ渡す
   const columnIndices: ColumnIndices = {
@@ -608,6 +613,11 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
       });
       // 成功カウンタをインクリメント
       imported += 1;
+      // フォローアップ (2026-07-13): 担当者が割り当てられた行はエージェント別に集計しておく
+      // (通知はインポート後にまとめて 1 通ずつ送る)
+      if (assigneeId) {
+        assignedCounts.set(assigneeId, (assignedCounts.get(assigneeId) ?? 0) + 1);
+      }
       // 上限のあるプランでは残枠を消費する (無制限プランは remaining が Infinity のため減算不要だが、
       // 明示的にガードして意図を示す)
       if (quota.limited) quota.remaining -= 1;
@@ -692,6 +702,43 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
       } catch (err) {
         // SSE broadcast の失敗はチケット作成の成否に影響しない。通知ベルの更新が遅れるだけなのでログのみ。
         console.warn('[importTickets] SSE broadcast に失敗しました（チケット作成は成功）:', err);
+      }
+    }
+
+    // フォローアップ (2026-07-13): 監査で発見したギャップの解消。「担当者」列で割り当てた
+    // エージェントには、上の「N件のチケットが追加されました」という全エージェント向けの汎用通知
+    // だけでは「自分が担当することになった」ことが伝わらない。updateTicketAssignee (画面からの
+    // 手動アサイン) が担当者へ 'assigned' 通知を送るのと同じ意図で、担当者ごとに 1 通ずつ
+    // (行ごとではなく) まとめて通知する (200 件でも担当者数分の通知で済む)。
+    // インポート実行者自身が自分を担当に設定した場合は、既にそれを知っているため対象外にする
+    // (上の otherAgents と同じ「自分の操作を自分に通知しない」方針)。
+    const assignedAgentIds = [...assignedCounts.keys()].filter((id) => id !== creatorId);
+    if (assignedAgentIds.length > 0) {
+      const assignResults = await Promise.allSettled(
+        assignedAgentIds.map((agentId) =>
+          repos.notifications.create({
+            userId: agentId, // 受信者: 割り当てられたエージェント本人
+            type: 'assigned', // 担当割当通知 (NotificationType.assigned)
+            message: `CSV インポートで ${assignedCounts.get(agentId)} 件のチケットが担当者に割り当てられました`,
+            ticketId: null, // 複数チケットにまたがるため null (バッチ通知と同じ扱い)
+            tenantId,
+          }),
+        ),
+      );
+      // 失敗件数をログに残す (チケット作成の成否には影響しない。上の otherAgents と同じ方針)
+      const failedAssignCount = assignResults.filter((r) => r.status === 'rejected').length;
+      if (failedAssignCount > 0) {
+        console.warn(
+          `[importTickets] ${failedAssignCount} 件の担当割当通知の書き込みに失敗しました`,
+        );
+      }
+      try {
+        await broadcastUnreadCountToMany(assignedAgentIds, tenantId);
+      } catch (err) {
+        console.warn(
+          '[importTickets] 担当割当通知の SSE broadcast に失敗しました（チケット作成は成功）:',
+          err,
+        );
       }
     }
   }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -181,6 +181,8 @@ export const SETTINGS_AUDIT_ACTION_LABELS: Record<SettingsAuditAction, string> =
   inbound_token_regenerate: 'メール転送先アドレスを再発行',
   // フォローアップ (2026-07-11)
   invitation_issue: 'メンバー招待リンクを発行',
+  // フォローアップ (2026-07-13)
+  subscription_plan_update: 'サブスクリプションプランを変更',
 };
 
 // 設定変更監査ログで actorId が null (システムによる自動変更) のときに表示する操作者名。

--- a/tests/features/import-tickets.test.ts
+++ b/tests/features/import-tickets.test.ts
@@ -410,6 +410,39 @@ describe('importTickets', () => {
       expect(ticket?.assigneeId).toBe('u-agt-2');
     });
 
+    // フォローアップ (2026-07-13): 監査で発見したギャップの解消。担当者に割り当てられたエージェントへ
+    // 'assigned' 通知が (行ごとではなく件数をまとめて 1 通) 届くことを確認する
+    it('担当者に割り当てられたエージェントへ assigned 通知が届く', async () => {
+      const importTickets = await loadAction();
+      const csv = `件名,担当者\n複合機の紙詰まり,エージェント2\nPC が起動しない,エージェント2`;
+      const result = await importTickets(csv);
+
+      expect(result.imported).toBe(2);
+      expect(result.errors).toHaveLength(0);
+      // u-agt-2 (エージェント2) 宛に 'assigned' 種別の通知が 1 通だけ作成されていること (2 件まとめて)
+      const assignedNotifications = [...store.notifications.values()].filter(
+        (n) => n.userId === 'u-agt-2' && n.type === 'assigned',
+      );
+      expect(assignedNotifications).toHaveLength(1);
+      expect(assignedNotifications[0]?.message).toContain('2');
+      expect(assignedNotifications[0]?.tenantId).toBe(TENANT);
+    });
+
+    // インポート実行者が自分自身を担当者に設定した場合は、既に自分の操作だと分かっているため
+    // 通知不要 (otherAgents と同じ「自分の操作を自分に通知しない」方針)
+    it('インポート実行者が自分自身を担当者に設定しても assigned 通知は送られない', async () => {
+      const importTickets = await loadAction();
+      // seed() の既定でセッションユーザーは u-agt-1 (エージェント1)
+      const csv = `件名,担当者\n複合機の紙詰まり,エージェント1`;
+      const result = await importTickets(csv);
+
+      expect(result.imported).toBe(1);
+      const assignedNotifications = [...store.notifications.values()].filter(
+        (n) => n.userId === 'u-agt-1' && n.type === 'assigned',
+      );
+      expect(assignedNotifications).toHaveLength(0);
+    });
+
     // テナントに存在しない担当者名 (タイポ・退職済み等) はエラーとして記録され、
     // 無言で未アサインにはならない
     it('存在しない担当者名はエラーとして記録され起票されない', async () => {

--- a/tests/features/stripe-webhook-route.test.ts
+++ b/tests/features/stripe-webhook-route.test.ts
@@ -109,12 +109,16 @@ describe('POST /api/webhooks/stripe', () => {
     expect(tenant.subscriptionPlan).toBe('free');
     expect(tenant.mode).toBe('lite');
     // §4.3 フォローアップ: 自動ダウングレードによる mode 強制変更も監査ログに残ること
-    // (actorId は操作したユーザーが存在しないため null = システムアクター)
+    // (actorId は操作したユーザーが存在しないため null = システムアクター)。
+    // フォローアップ (2026-07-13): プラン自体の変更 (pro→free) も別エントリとして記録されること
     const auditLogs = await repos.settingsAudit.findAllByTenant({ tenantId: TENANT });
-    expect(auditLogs).toHaveLength(1);
-    expect(auditLogs[0].action).toBe('tenant_mode_update');
-    expect(auditLogs[0].actorId).toBeNull();
-    expect(auditLogs[0].actorName).toBe(SETTINGS_AUDIT_SYSTEM_ACTOR_NAME);
+    expect(auditLogs).toHaveLength(2);
+    const actions = auditLogs.map((l) => l.action).sort();
+    expect(actions).toEqual(['subscription_plan_update', 'tenant_mode_update']);
+    for (const log of auditLogs) {
+      expect(log.actorId).toBeNull();
+      expect(log.actorName).toBe(SETTINGS_AUDIT_SYSTEM_ACTOR_NAME);
+    }
   });
 
   // 更新イベント (customer.subscription.updated) で Pro → Standard にダウングレードしても同様
@@ -140,6 +144,12 @@ describe('POST /api/webhooks/stripe', () => {
     const tenant = store.tenants.get(TENANT)!;
     expect(tenant.subscriptionPlan).toBe('standard');
     expect(tenant.mode).toBe('lite');
+    // フォローアップ (2026-07-13): mode 強制変更に加え、プラン変更 (pro→standard) も記録される
+    const auditLogs = await repos.settingsAudit.findAllByTenant({ tenantId: TENANT });
+    expect(auditLogs.map((l) => l.action).sort()).toEqual([
+      'subscription_plan_update',
+      'tenant_mode_update',
+    ]);
   });
 
   // Pro のまま更新される (昇格/継続) 場合は mode を変更しない
@@ -190,6 +200,11 @@ describe('POST /api/webhooks/stripe', () => {
     const tenant = store.tenants.get(TENANT)!;
     expect(tenant.subscriptionPlan).toBe('free');
     expect(tenant.mode).toBe('lite');
+    // フォローアップ (2026-07-13): mode は既に lite のため tenant_mode_update は記録されないが、
+    // プラン自体は standard→free に変わっているため subscription_plan_update は記録される
+    const auditLogs = await repos.settingsAudit.findAllByTenant({ tenantId: TENANT });
+    expect(auditLogs).toHaveLength(1);
+    expect(auditLogs[0].action).toBe('subscription_plan_update');
   });
 
   // Enterprise は Stripe 管理外: 解約イベントが来てもプランを降格せず、mode も変更しない
@@ -213,6 +228,9 @@ describe('POST /api/webhooks/stripe', () => {
     const tenant = store.tenants.get(TENANT)!;
     expect(tenant.subscriptionPlan).toBe('enterprise');
     expect(tenant.mode).toBe('pro');
+    // フォローアップ (2026-07-13): プランも mode も変化していないので監査ログは記録されない
+    // (無関係なイベントで監査ログを埋めない)
+    expect(await repos.settingsAudit.findAllByTenant({ tenantId: TENANT })).toHaveLength(0);
   });
 
   // 署名ヘッダが無いリクエストは 400 で拒否する (なりすまし対策)


### PR DESCRIPTION
## 対応する Phase / 項目

`docs/smb-dx-pivot-plan.md` は全項目 `[x]` 完了扱いだが、これまでの運用パターンに倣い監査を継続し、新たに見つかった2件を修正した(前回PR #205の続き)。

- Phase 4 §4.2〜§4.6（設定変更監査ログ）フォローアップ
- Phase 3 §3.3 フォローアップ（前回PRで追加したCSV担当者列サポートの継続）

## 変更内容

### 1. Stripeプラン変更が監査ログに記録されていなかった

§4.2〜§4.6は SSO/LINE連携/通知チャネル設定・テナントモード切替・拠点CRUD・転送先アドレス再発行・招待リンク発行まで `SettingsAuditLog` の対象を広げてきたが、それらより上位の「組織設定」であるはずの `subscriptionPlan` 自体の変更（アップグレード/ダウングレード/解約）は一度も監査対象になっていなかった。§4.4 の `tenant_mode_update` は「Proモードで運用中のテナントがPro非対応プランへ落ちた」副作用のときにしか記録されないため、(a) アップグレードは常に未記録、(b) Liteモードのまま運用していたテナントのプラン変更（例: standard→free）も未記録だった。Enterpriseプランが謳う「監査強化」の実態と乖離していた。

`SettingsAuditAction` に `subscription_plan_update` を追加し、Stripe Webhookの `applyPlanChange` が「実際に subscriptionPlan が変わった場合」に `tenant_mode_update` とは独立して常に記録するようにした。

### 2. CSVインポートで担当割当されたエージェントへの通知が欠けていた

前回PRで追加した「担当者」列サポートは `assigneeId` を起票時に設定できるが、画面からの手動アサイン（`updateTicketAssignee`）が担当者へ `assigned` 通知を送るのに対し、CSVインポートは全エージェント向けの汎用 `imported` バッチ通知しか送っておらず、割り当てられた本人には「自分が担当することになった」ことを伝える個別の通知が一切なかった。

行ごとにアサインを集計し、インポート完了後にエージェントごとに1通ずつ（200件でも担当者数分の通知で済む）`assigned` 通知を送るようにした。

## テスト

- `npm run typecheck` — 成功
- `npm run lint` — 成功
- `npx vitest run` — 885件成功
- Prisma契約テスト（`RUN_PRISMA_CONTRACT=1`）— 134件成功（ローカルPostgresで実行・確認済み）
- 追加した回帰テスト:
  - `tests/features/stripe-webhook-route.test.ts`
  - `tests/features/import-tickets.test.ts`

## 画面確認

UIの見た目に変更はなく、サーバー側の挙動追加が中心のため、上記の自動テストで検証している。


---
_Generated by [Claude Code](https://claude.ai/code/session_014XnHProPvPHZFdPsE2y9vp)_