### PR TITLE
fix(inbound): メール取り込みで添付画像を保存する

### DIFF
--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -16,26 +16,25 @@
 
 // JSON レスポンスヘルパー
 import { NextResponse } from 'next/server';
-// 共有シークレットの定数時間比較 / 添付ファイルの保存先キー組み立てに使う (Node ランタイム前提のルート)
-import { timingSafeEqual, randomUUID } from 'node:crypto';
+// 共有シークレットの定数時間比較に使う (Node ランタイム前提のルート)
+import { timingSafeEqual } from 'node:crypto';
 // ページキャッシュ無効化 (スレッド継続でコメント追記したチケット詳細を再描画させる)
 import { revalidatePath } from 'next/cache';
 // データ層 (テナント / ユーザー / チケットのリポジトリ束 + トランザクション境界)
 import { repos, uow } from '@/data';
-// 添付ファイル本体の StoragePort (Edge runtime 汚染回避のため別モジュールから取り込む)
-import { storage } from '@/data/storage';
 // Webhook 再送に対する冪等起票の共通ヘルパー (LINE/メールで共有)。フォローアップ (2026-07-13):
 // 添付ファイルをチケット起票と同一トランザクションで保存するための onCreated フックを追加した
 import {
   createTicketIdempotent,
   emailMessageIdempotencyOps,
 } from '@/lib/idempotent-ticket-creation';
-// 添付ファイル検証ヘルパー (件数/MIME/サイズ/マジックバイト。Web フォーム・コメント投稿と共有)
-import { validateUploadedFiles, type ValidatedAttachment } from '@/lib/validations/attachment';
-// MIME → 拡張子の対応表 (storageKey の組み立てで使用)
-import { MIME_TO_EXTENSION } from '@/domain/attachment';
-// リポジトリ束の型 (トランザクション内 tx / 非トランザクション repos 共通。添付保存ヘルパーの引数に使う)
-import type { Repos } from '@/data/ports/unit-of-work';
+// 添付ファイルの寛容版検証ヘルパー (件数/MIME/サイズ/マジックバイト。Web フォーム・コメント投稿の
+// 全件一括版 validateUploadedFiles とは異なり、1 件でも違反があっても全体を失敗させない。
+// この Webhook にはユーザーへ即座にフィードバックして再送信させられる画面が無いため)
+import { validateUploadedFilesLenient } from '@/lib/validations/attachment';
+// 添付ファイルのストレージ保存 / 失敗時クリーンアップの共通ヘルパー (POST /api/tickets・
+// POST /api/tickets/[id]/comments と共有。/code-review ultra 指摘対応: 3 箇所目の重複を解消)
+import { persistAttachments, cleanupWrittenAttachments } from '@/lib/attachment-persistence';
 // 新規起票時の初期ステータスを mode から決める共通ルール (Web フォーム起票と単一の源を共有)
 import { initialStatusForMode } from '@/domain/ticket-status';
 // コメント通知の宛先決定 (Web フォーム経由コメントと共有するヘルパー)
@@ -362,59 +361,6 @@ async function recordQuarantine(
   }
 }
 
-// フォローアップ (2026-07-13): 検証済み添付ファイル群をストレージへ書き込み、メタ情報を DB へ
-// INSERT する共通ヘルパー (POST /api/tickets・POST /api/tickets/[id]/comments と同じ
-// 「ストレージ書き込み → メタ INSERT」の順で 1 件ずつ処理するパターンを踏襲する)。
-// 必ずトランザクション内 (tx) で呼び、書き込み済みストレージキーを writtenKeys に積むこと。
-// ストレージへの書き込みは DB トランザクション外で観測できる副作用のため、呼び出し元が
-// トランザクション失敗時に writtenKeys を使って best-effort でロールバック (削除) する。
-async function persistAttachments(
-  tx: Repos,
-  files: ValidatedAttachment[],
-  ticketId: string,
-  commentId: string | null, // 新規起票への添付なら null、コメント追記への添付なら該当コメント ID
-  uploaderId: string,
-  tenantId: string,
-  writtenKeys: string[],
-): Promise<void> {
-  for (const v of files) {
-    // 保存先キーを組み立てる (例: tenantId/ticketId/<uuid>.jpg)
-    const ext = MIME_TO_EXTENSION[v.mimeType];
-    const key = `${tenantId}/${ticketId}/${randomUUID()}.${ext}`;
-    // File 本体のバイト列を ArrayBuffer 経由で Uint8Array に変換する
-    const buf = new Uint8Array(await v.file.arrayBuffer());
-    // ストレージへ書き込む (失敗時は呼び出し元が uow のロールバックと writtenKeys で後始末する)
-    await storage.put(key, buf, { contentType: v.mimeType, size: v.size });
-    writtenKeys.push(key);
-    // メタ情報を DB に保存する (storage="local" 固定)
-    await tx.attachments.create({
-      ticketId,
-      commentId,
-      uploaderId,
-      tenantId,
-      mimeType: v.mimeType,
-      size: v.size,
-      originalName: v.originalName,
-      storageKey: key,
-      storage: 'local',
-    });
-  }
-}
-
-// 添付ファイルのストレージ書き込みに失敗した際の後始末 (best-effort)。
-// DB は uow がロールバック済みだが、ストレージへの書き込みはトランザクション外の副作用のため、
-// 既に書き込み済みのファイルを個別に削除する (POST /api/tickets と同じ方針)。
-async function cleanupWrittenAttachments(writtenKeys: string[], logPrefix: string): Promise<void> {
-  await Promise.all(
-    writtenKeys.map((key) =>
-      storage.delete(key).catch((cleanupErr) => {
-        // ストレージ削除失敗はエラーとしてログに残す (warn ではなく error: ロールバック失敗は本物のエラー)
-        console.error(`${logPrefix} failed to clean up storage`, { key, cleanupErr });
-      }),
-    ),
-  );
-}
-
 // POST /api/inbound/email : 受信メールを 1 件の問い合わせに変換する
 export async function POST(req: Request) {
   // 共有シークレットを環境変数から読む。未設定なら fail-closed (無防備な取り込み口を開けない)
@@ -552,18 +498,18 @@ export async function POST(req: Request) {
 
   // フォローアップ (2026-07-13): 監査で発見したギャップの解消。添付ファイルを検証する。
   // Web フォーム/コメント投稿と異なり、この Webhook にはユーザーへ即時フィードバックする画面が無い
-  // (送信者はプロバイダの応答を見ない)。そのため validateUploadedFiles が「1 件でも違反があれば
-  // 全体を失敗扱いにする」設計であっても、ここでは検証失敗時にメール全体 (起票/追記) を止めるのでは
-  // なく、添付なしとして処理を継続する (本文だけでも問い合わせとして残す方が北極星指標 §0 に沿う)。
-  // 件数 0 (添付なし) は常に ok を返す設計のため、この分岐は「1 件以上の添付があり、かつ何かが
-  // 違反していた」場合にのみ発火する。
-  const attachmentValidation = await validateUploadedFiles(fields.attachments);
-  let validatedAttachments: ValidatedAttachment[] = attachmentValidation.ok
-    ? attachmentValidation.files
-    : [];
-  if (!attachmentValidation.ok) {
-    console.warn('[POST /api/inbound/email] attachments rejected, continuing without them', {
-      reason: attachmentValidation.message,
+  // (送信者はプロバイダの応答を見ない)。そのため寛容版 (validateUploadedFilesLenient) を使い、
+  // 1 件でも違反があってもメール全体 (起票/追記) を止めず、違反したファイルだけを除外して処理を
+  // 継続する。/code-review ultra 指摘対応: 当初は全件一括版 (validateUploadedFiles) を使い
+  // 検証失敗時に添付を全て捨てていたが、有効な写真が複数枚あるメールで 1 件でも非対応形式が
+  // 混在すると有効な写真まで巻き添えで消えてしまい、写真添付という本機能の目的を損なっていた。
+  const attachmentValidation = await validateUploadedFilesLenient(fields.attachments);
+  let validatedAttachments = attachmentValidation.files;
+  const { droppedCount } = attachmentValidation;
+  if (droppedCount > 0) {
+    console.warn('[POST /api/inbound/email] some attachments were rejected and dropped', {
+      droppedCount,
+      keptCount: validatedAttachments.length,
     });
   }
   // 添付が残っていれば、テナントの累計サイズ上限 (§6.1 Standard「添付1GB」) も確認する。
@@ -795,9 +741,10 @@ export async function POST(req: Request) {
     ticketId = created.id;
     alreadyExisted = created.alreadyExisted;
   } catch (err) {
-    // DB は自動ロールバック済 (冪等化キーが無い単発起票の場合はトランザクションが無いため、
-    // 添付メタ INSERT 失敗時にチケット行だけが残り得るが、写真無しの問い合わせとして残る方が
-    // 本文ごと消えるより望ましいため許容する。writtenKeys は個別に best-effort で削除する)
+    // /code-review ultra 指摘対応 (2026-07-13): 冪等化キーの有無に関わらず、DB は自動ロールバック
+    // 済み (createTicketIdempotent がキー無し経路もトランザクション化したため、チケット行だけが
+    // 添付無しで残ることは無い)。ストレージへの書き込みだけはトランザクション外の副作用のため、
+    // 書き込み済みキーを個別に best-effort で削除する
     await cleanupWrittenAttachments(writtenKeys, '[POST /api/inbound/email]');
     console.error('[POST /api/inbound/email] ticket creation failed', err);
     return NextResponse.json({ error: '問い合わせの作成に失敗しました' }, { status: 500 });
@@ -807,6 +754,14 @@ export async function POST(req: Request) {
     // 書き込み競合により、別リクエストが既に起票・受領返信済みと判明したケース。
     // 二重にチケットや受領メールを作らないよう、ここでは何もせず既存チケット ID を返す
     console.info('[POST /api/inbound/email] resolved write conflict as duplicate', ticketId);
+    // /code-review ultra 指摘対応 (2026-07-13): このリクエスト自身の (敗れた) トランザクション内で
+    // onCreated が添付ファイルを既にストレージへ書き込んでいた場合、DB 側はロールバックされても
+    // ストレージの書き込みはトランザクション外の副作用のため残ってしまう。writtenKeys にはこの
+    // リクエスト自身が書き込んだキーだけが積まれる (勝者側の書き込みとは無関係) ため、常に
+    // 安全にクリーンアップできる (何も書いていなければ空配列で no-op)
+    if (writtenKeys.length > 0) {
+      await cleanupWrittenAttachments(writtenKeys, '[POST /api/inbound/email]');
+    }
     return NextResponse.json({ status: 'duplicate', ticketId }, { status: 200 });
   }
 

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -16,23 +16,35 @@
 
 // JSON レスポンスヘルパー
 import { NextResponse } from 'next/server';
-// 共有シークレットの定数時間比較に使う (Node ランタイム前提のルート)
-import { timingSafeEqual } from 'node:crypto';
+// 共有シークレットの定数時間比較 / 添付ファイルの保存先キー組み立てに使う (Node ランタイム前提のルート)
+import { timingSafeEqual, randomUUID } from 'node:crypto';
 // ページキャッシュ無効化 (スレッド継続でコメント追記したチケット詳細を再描画させる)
 import { revalidatePath } from 'next/cache';
 // データ層 (テナント / ユーザー / チケットのリポジトリ束 + トランザクション境界)
 import { repos, uow } from '@/data';
-// Webhook 再送に対する冪等起票の共通ヘルパー (LINE/メールで共有)
+// 添付ファイル本体の StoragePort (Edge runtime 汚染回避のため別モジュールから取り込む)
+import { storage } from '@/data/storage';
+// Webhook 再送に対する冪等起票の共通ヘルパー (LINE/メールで共有)。フォローアップ (2026-07-13):
+// 添付ファイルをチケット起票と同一トランザクションで保存するための onCreated フックを追加した
 import {
   createTicketIdempotent,
   emailMessageIdempotencyOps,
 } from '@/lib/idempotent-ticket-creation';
+// 添付ファイル検証ヘルパー (件数/MIME/サイズ/マジックバイト。Web フォーム・コメント投稿と共有)
+import { validateUploadedFiles, type ValidatedAttachment } from '@/lib/validations/attachment';
+// MIME → 拡張子の対応表 (storageKey の組み立てで使用)
+import { MIME_TO_EXTENSION } from '@/domain/attachment';
+// リポジトリ束の型 (トランザクション内 tx / 非トランザクション repos 共通。添付保存ヘルパーの引数に使う)
+import type { Repos } from '@/data/ports/unit-of-work';
 // 新規起票時の初期ステータスを mode から決める共通ルール (Web フォーム起票と単一の源を共有)
 import { initialStatusForMode } from '@/domain/ticket-status';
 // コメント通知の宛先決定 (Web フォーム経由コメントと共有するヘルパー)
 import { resolveCommentRecipients } from '@/lib/comment-recipients';
 // 未読件数を SSE で即時配信するヘルパー (コメント追記時の通知扇形)
-import { broadcastUnreadCountToMany, notifyAgentsOfNewTicket } from '@/features/notifications/notify';
+import {
+  broadcastUnreadCountToMany,
+  notifyAgentsOfNewTicket,
+} from '@/features/notifications/notify';
 // 受信メールの正規化ヘルパー (純粋関数) と生ヘッダ読み取り、送信元認証 (SPF/DKIM/DMARC) の判定
 import {
   parseInboundEmail,
@@ -58,8 +70,9 @@ import { formatTicketRef } from '@/lib/ticket-ref';
 import { isEmailInboundAllowed, resolveEffectivePlan } from '@/lib/plan-guard';
 // Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (Web フォーム・LINE 取り込み・CSV インポートと共有)
 import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
-// Phase 4 課金: 月間チケット上限チェック (Web フォーム・CSV インポートと共有)
-import { getMonthlyTicketQuota } from '@/lib/tenant-plan';
+// Phase 4 課金: 月間チケット上限チェック (Web フォーム・CSV インポートと共有)。
+// フォローアップ (2026-07-13): 添付累計サイズ上限チェックも Web フォーム・コメント投稿と共有する
+import { getMonthlyTicketQuota, checkAttachmentQuota } from '@/lib/tenant-plan';
 // 隔離理由の型 (§3.2 フォローアップ: 隔離記録の永続化に使う)
 import type { QuarantineReason } from '@/domain/types';
 
@@ -121,6 +134,12 @@ interface InboundFields {
   authenticationResults?: string | null; // 送信元認証: 生 Authentication-Results ヘッダ (汎用)
   autoSubmitted?: string | null; // RFC 3834 の Auto-Submitted ヘッダ (自動応答メール判定 = ループ防止)
   precedence?: string | null; // Precedence ヘッダ (bulk/list/junk なら自動配信・メーリングリスト判定)
+  // フォローアップ (2026-07-13): 監査で発見したギャップの解消。SendGrid Inbound Parse は
+  // 添付ファイルを "attachments" (件数) + "attachment1".."attachmentN" (File) フィールドで送るが、
+  // 従来これらを一切読んでおらず、写真を送るだけで済ませたい SMB ペルソナ (§1.2) の主要ユースケース
+  // (問い合わせに画像を添付) がメール経由では実現できていなかった (JSON パスには File 型が無いため
+  // 常に空配列。multipart のみ)
+  attachments: File[];
 }
 
 // 受信メール 1 通分のフィールドを、JSON / multipart のどちらのボディからでも取り出して共通形に揃える。
@@ -173,6 +192,22 @@ async function readInboundFields(req: Request): Promise<InboundFields> {
     // SendGrid 等は個別の Message-ID / In-Reply-To フィールドを持たないことがあるため、
     // 生ヘッダ (headers フィールド) からのフォールバック抽出も用意する (スレッド継続用)。
     const rawHeaders = str(form.get('headers'));
+    // フォローアップ (2026-07-13): 添付ファイルを抽出する。SendGrid Inbound Parse は
+    // "attachments" フィールドに件数を、"attachment1".."attachmentN" に各ファイルを渡す規約。
+    // 件数フィールドの値をそのままループ回数にすると、細工した巨大な値を送られたときに無駄な
+    // ループが走るため、実利用であり得ない上限で頭打ちする (§9 DoS 対策の一環。実際の添付件数
+    // 上限は後段の validateUploadedFiles の MAX_ATTACHMENTS_PER_UPLOAD が別途強制する)。
+    const ATTACHMENT_LOOKUP_MAX = 20;
+    const attachmentCountRaw = parseInt(str(form.get('attachments')) ?? '', 10);
+    const attachmentCount =
+      Number.isFinite(attachmentCountRaw) && attachmentCountRaw > 0
+        ? Math.min(attachmentCountRaw, ATTACHMENT_LOOKUP_MAX)
+        : 0;
+    const attachments: File[] = [];
+    for (let i = 1; i <= attachmentCount; i++) {
+      const entry = form.get(`attachment${i}`);
+      if (entry instanceof File) attachments.push(entry);
+    }
     // 宛先 (ルーティング): envelope の RCPT を優先する (ヘッダ To より実配送先として確実)。
     // 送信者 (本人特定): ヘッダ From を優先する (人間が送った差出人。envelope from=MAIL FROM は
     // 戻り先で本人性が弱い)。本人性は既知メンバー判定に加え、INBOUND_EMAIL_AUTH=enforce のとき
@@ -194,6 +229,7 @@ async function readInboundFields(req: Request): Promise<InboundFields> {
       // 自動応答判定用ヘッダ (multipart では生ヘッダから読む。ループ防止に使う)
       autoSubmitted: readRawHeader(rawHeaders, 'Auto-Submitted'),
       precedence: readRawHeader(rawHeaders, 'Precedence'),
+      attachments, // 添付ファイル (フォローアップ 2026-07-13)
     };
   }
   // それ以外は JSON ボディとして読む (テスト・自前連携向け)。
@@ -237,6 +273,8 @@ async function readInboundFields(req: Request): Promise<InboundFields> {
     // 自動応答判定用ヘッダ (camelCase / ヘッダ表記の両方を受ける)
     autoSubmitted: pick('autoSubmitted') ?? pick('auto-submitted'),
     precedence: pick('precedence') ?? pick('Precedence'),
+    // JSON には File 型が無いため常に空配列 (JSON パスはテスト・内部連携専用。上のコメント参照)
+    attachments: [],
   };
 }
 
@@ -322,6 +360,59 @@ async function recordQuarantine(
     // 記録失敗はログのみ残す (隔離自体は既に確定しているため 202 応答は変えない)
     console.error('[POST /api/inbound/email] 隔離記録の保存に失敗しました', err);
   }
+}
+
+// フォローアップ (2026-07-13): 検証済み添付ファイル群をストレージへ書き込み、メタ情報を DB へ
+// INSERT する共通ヘルパー (POST /api/tickets・POST /api/tickets/[id]/comments と同じ
+// 「ストレージ書き込み → メタ INSERT」の順で 1 件ずつ処理するパターンを踏襲する)。
+// 必ずトランザクション内 (tx) で呼び、書き込み済みストレージキーを writtenKeys に積むこと。
+// ストレージへの書き込みは DB トランザクション外で観測できる副作用のため、呼び出し元が
+// トランザクション失敗時に writtenKeys を使って best-effort でロールバック (削除) する。
+async function persistAttachments(
+  tx: Repos,
+  files: ValidatedAttachment[],
+  ticketId: string,
+  commentId: string | null, // 新規起票への添付なら null、コメント追記への添付なら該当コメント ID
+  uploaderId: string,
+  tenantId: string,
+  writtenKeys: string[],
+): Promise<void> {
+  for (const v of files) {
+    // 保存先キーを組み立てる (例: tenantId/ticketId/<uuid>.jpg)
+    const ext = MIME_TO_EXTENSION[v.mimeType];
+    const key = `${tenantId}/${ticketId}/${randomUUID()}.${ext}`;
+    // File 本体のバイト列を ArrayBuffer 経由で Uint8Array に変換する
+    const buf = new Uint8Array(await v.file.arrayBuffer());
+    // ストレージへ書き込む (失敗時は呼び出し元が uow のロールバックと writtenKeys で後始末する)
+    await storage.put(key, buf, { contentType: v.mimeType, size: v.size });
+    writtenKeys.push(key);
+    // メタ情報を DB に保存する (storage="local" 固定)
+    await tx.attachments.create({
+      ticketId,
+      commentId,
+      uploaderId,
+      tenantId,
+      mimeType: v.mimeType,
+      size: v.size,
+      originalName: v.originalName,
+      storageKey: key,
+      storage: 'local',
+    });
+  }
+}
+
+// 添付ファイルのストレージ書き込みに失敗した際の後始末 (best-effort)。
+// DB は uow がロールバック済みだが、ストレージへの書き込みはトランザクション外の副作用のため、
+// 既に書き込み済みのファイルを個別に削除する (POST /api/tickets と同じ方針)。
+async function cleanupWrittenAttachments(writtenKeys: string[], logPrefix: string): Promise<void> {
+  await Promise.all(
+    writtenKeys.map((key) =>
+      storage.delete(key).catch((cleanupErr) => {
+        // ストレージ削除失敗はエラーとしてログに残す (warn ではなく error: ロールバック失敗は本物のエラー)
+        console.error(`${logPrefix} failed to clean up storage`, { key, cleanupErr });
+      }),
+    ),
+  );
 }
 
 // POST /api/inbound/email : 受信メールを 1 件の問い合わせに変換する
@@ -459,6 +550,40 @@ export async function POST(req: Request) {
     return NextResponse.json({ status: 'quarantined' }, { status: 202 });
   }
 
+  // フォローアップ (2026-07-13): 監査で発見したギャップの解消。添付ファイルを検証する。
+  // Web フォーム/コメント投稿と異なり、この Webhook にはユーザーへ即時フィードバックする画面が無い
+  // (送信者はプロバイダの応答を見ない)。そのため validateUploadedFiles が「1 件でも違反があれば
+  // 全体を失敗扱いにする」設計であっても、ここでは検証失敗時にメール全体 (起票/追記) を止めるのでは
+  // なく、添付なしとして処理を継続する (本文だけでも問い合わせとして残す方が北極星指標 §0 に沿う)。
+  // 件数 0 (添付なし) は常に ok を返す設計のため、この分岐は「1 件以上の添付があり、かつ何かが
+  // 違反していた」場合にのみ発火する。
+  const attachmentValidation = await validateUploadedFiles(fields.attachments);
+  let validatedAttachments: ValidatedAttachment[] = attachmentValidation.ok
+    ? attachmentValidation.files
+    : [];
+  if (!attachmentValidation.ok) {
+    console.warn('[POST /api/inbound/email] attachments rejected, continuing without them', {
+      reason: attachmentValidation.message,
+    });
+  }
+  // 添付が残っていれば、テナントの累計サイズ上限 (§6.1 Standard「添付1GB」) も確認する。
+  // Web フォームと同じ理由で必ず rawPlan (tenant.subscriptionPlan) を渡す (effectivePlan だと
+  // Free trial 中に Free=無制限 → Standard=1GB へ上限が逆に厳しくなってしまう。tenant-plan.ts 参照)
+  if (validatedAttachments.length > 0) {
+    const newAttachmentBytes = validatedAttachments.reduce((sum, f) => sum + f.size, 0);
+    const attachmentQuotaCheck = await checkAttachmentQuota(
+      tenant.id,
+      newAttachmentBytes,
+      tenant.subscriptionPlan,
+    );
+    if (!attachmentQuotaCheck.ok) {
+      console.warn('[POST /api/inbound/email] attachments exceed quota, continuing without them', {
+        reason: attachmentQuotaCheck.message,
+      });
+      validatedAttachments = [];
+    }
+  }
+
   // 冪等性: この受信メールの Message-ID を既に取り込み済みなら、二重起票/二重コメントを避ける。
   // Webhook は at-least-once 配送 (再送あり) なので、同じ Message-ID を見たら過去のチケットを返す。
   // 注意: Message-ID が取れない (null) メールはこの重複判定が効かず、新規起票パスと同じ at-least-once
@@ -506,34 +631,58 @@ export async function POST(req: Request) {
       );
       // 通知メッセージ (Web フォーム経由コメントと同じ文言に揃える)
       const message = `チケット「${ticket.title}」に新しいコメントが追加されました`;
-      // コメント追記 + Message-ID 登録をトランザクションで行う。
+      // フォローアップ (2026-07-13): 添付ファイルのストレージ書き込みはトランザクション外の
+      // 副作用のため、失敗時に後始末できるよう書き込み済みキーを蓄えておく
+      // (POST /api/tickets/[id]/comments と同じ方針)
+      const writtenKeys: string[] = [];
+      // コメント追記 + 添付メタ INSERT + Message-ID 登録をトランザクションで行う。
       // 通知は「最善努力 (best-effort)」なので、トランザクション外で処理する。
       // 通知作成の失敗でコメント本体がロールバックされるのは本末転倒なためここで分離する (§9 fail-safe)。
-      await uow.run(async (r) => {
-        // 受信メール本文を既存チケットへのコメントとして追記する
-        await r.comments.create({
-          ticketId: ticket.id, // 紐づく既存チケット
-          authorId: sender.id, // 追記者 = 送信者 (既知メンバー)
-          body: email.body, // メール本文
-          tenantId: tenant.id, // 親チケットのテナント一致を Adapter が検証する
-        });
-        // SLA: エージェントからのメール返信も初回応答として記録する (comments/route.ts と同じ扱い)。
-        // ここを漏らすと、メール経由で最初に返信したチケットが SLA 上「未応答」のまま扱われ、
-        // 品質メトリクス (平均初回応答時間) からも永久に除外されてしまう。
-        // 依頼者自身の返信は「応答」ではないため対象外。既に記録済みなら上書きしない
-        // (2 回目以降のエージェント返信で初回応答日時が後ろにズレるのを防ぐ)。
-        if (senderIsAgent && !ticket.firstRespondedAt) {
-          await r.tickets.markFirstResponded(ticket.id, now, tenant.id);
-        }
-        // この受信メール自身の Message-ID も対応表へ登録する (返信の連鎖を辿れるように)
-        if (email.messageId) {
-          await r.emailThreads.register({
-            messageId: email.messageId,
-            ticketId: ticket.id,
-            tenantId: tenant.id,
+      try {
+        await uow.run(async (r) => {
+          // 受信メール本文を既存チケットへのコメントとして追記する
+          const comment = await r.comments.create({
+            ticketId: ticket.id, // 紐づく既存チケット
+            authorId: sender.id, // 追記者 = 送信者 (既知メンバー)
+            body: email.body, // メール本文
+            tenantId: tenant.id, // 親チケットのテナント一致を Adapter が検証する
           });
-        }
-      });
+          // SLA: エージェントからのメール返信も初回応答として記録する (comments/route.ts と同じ扱い)。
+          // ここを漏らすと、メール経由で最初に返信したチケットが SLA 上「未応答」のまま扱われ、
+          // 品質メトリクス (平均初回応答時間) からも永久に除外されてしまう。
+          // 依頼者自身の返信は「応答」ではないため対象外。既に記録済みなら上書きしない
+          // (2 回目以降のエージェント返信で初回応答日時が後ろにズレるのを防ぐ)。
+          if (senderIsAgent && !ticket.firstRespondedAt) {
+            await r.tickets.markFirstResponded(ticket.id, now, tenant.id);
+          }
+          // フォローアップ (2026-07-13): 検証済み添付ファイルをこのコメントに紐づけて保存する
+          if (validatedAttachments.length > 0) {
+            await persistAttachments(
+              r,
+              validatedAttachments,
+              ticket.id,
+              comment.id, // コメントへの添付として記録する
+              sender.id,
+              tenant.id,
+              writtenKeys,
+            );
+          }
+          // この受信メール自身の Message-ID も対応表へ登録する (返信の連鎖を辿れるように)
+          if (email.messageId) {
+            await r.emailThreads.register({
+              messageId: email.messageId,
+              ticketId: ticket.id,
+              tenantId: tenant.id,
+            });
+          }
+        });
+      } catch (err) {
+        // DB は自動ロールバック済。ストレージに書き込んだファイルを best-effort で削除する
+        await cleanupWrittenAttachments(writtenKeys, '[POST /api/inbound/email]');
+        // 元のエラーをサーバログに残して 500 を返す (プロバイダは再送する)
+        console.error('[POST /api/inbound/email] thread comment save failed', err);
+        return NextResponse.json({ error: 'コメントの保存に失敗しました' }, { status: 500 });
+      }
       // トランザクション完了後にベストエフォートで通知を作成する。
       // 失敗してもコメント自体は既にコミット済みなので、ログだけ残して続行する。
       // allSettled を使い 1 件の失敗で他の受信者への通知が止まらないようにする。
@@ -603,23 +752,56 @@ export async function POST(req: Request) {
   // 初回応答期限も同じく優先度 Medium ベースで自動算出する
   const firstResponseDueAt = calculateFirstResponseDueAt('Medium', now);
 
-  // 受信メールを 1 件の問い合わせとして作成する (起票 + 対応表登録を原子的に行う)
-  const { id: ticketId, alreadyExisted } = await createTicketIdempotent(
-    emailMessageIdempotencyOps,
-    email.messageId, // 冪等化キー (無い場合は null)
-    tenant.id,
-    {
-      title: email.subject, // 件名 (空メールは既定タイトルに正規化済み)
-      body: email.body, // 本文テキスト
-      priority: 'Medium', // メール取り込みは優先度を Medium 固定 (Lite の既定と揃える)
-      categoryId: null, // メール取り込みではカテゴリ未分類
-      creatorId: sender.id, // 起票者は送信者本人 (既知メンバー)
-      tenantId: tenant.id, // 取り込み先テナント
-      status: initialStatus, // Lite は 'Open'、Pro は undefined (既定 New)
-      resolutionDueAt, // 解決期限 (優先度ベース)
-      firstResponseDueAt, // 初回応答期限 (優先度ベース)
-    },
-  );
+  // フォローアップ (2026-07-13): 添付ファイルのストレージ書き込みはトランザクション外の副作用の
+  // ため、失敗時に後始末できるよう書き込み済みキーを蓄えておく (POST /api/tickets と同じ方針)
+  const writtenKeys: string[] = [];
+  let ticketId: string;
+  let alreadyExisted: boolean;
+  try {
+    // 受信メールを 1 件の問い合わせとして作成する (起票 + 添付メタ INSERT + 対応表登録を
+    // onCreated フック経由で同一トランザクション内で原子的に行う)
+    const created = await createTicketIdempotent(
+      emailMessageIdempotencyOps,
+      email.messageId, // 冪等化キー (無い場合は null)
+      tenant.id,
+      {
+        title: email.subject, // 件名 (空メールは既定タイトルに正規化済み)
+        body: email.body, // 本文テキスト
+        priority: 'Medium', // メール取り込みは優先度を Medium 固定 (Lite の既定と揃える)
+        categoryId: null, // メール取り込みではカテゴリ未分類
+        creatorId: sender.id, // 起票者は送信者本人 (既知メンバー)
+        tenantId: tenant.id, // 取り込み先テナント
+        status: initialStatus, // Lite は 'Open'、Pro は undefined (既定 New)
+        resolutionDueAt, // 解決期限 (優先度ベース)
+        firstResponseDueAt, // 初回応答期限 (優先度ベース)
+      },
+      {
+        // フォローアップ (2026-07-13): 検証済み添付ファイルをこの新規チケットに紐づけて保存する
+        onCreated:
+          validatedAttachments.length > 0
+            ? (tx, newTicketId) =>
+                persistAttachments(
+                  tx,
+                  validatedAttachments,
+                  newTicketId,
+                  null, // 新規起票への添付 (コメントには紐づかない)
+                  sender.id,
+                  tenant.id,
+                  writtenKeys,
+                )
+            : undefined,
+      },
+    );
+    ticketId = created.id;
+    alreadyExisted = created.alreadyExisted;
+  } catch (err) {
+    // DB は自動ロールバック済 (冪等化キーが無い単発起票の場合はトランザクションが無いため、
+    // 添付メタ INSERT 失敗時にチケット行だけが残り得るが、写真無しの問い合わせとして残る方が
+    // 本文ごと消えるより望ましいため許容する。writtenKeys は個別に best-effort で削除する)
+    await cleanupWrittenAttachments(writtenKeys, '[POST /api/inbound/email]');
+    console.error('[POST /api/inbound/email] ticket creation failed', err);
+    return NextResponse.json({ error: '問い合わせの作成に失敗しました' }, { status: 500 });
+  }
 
   if (alreadyExisted) {
     // 書き込み競合により、別リクエストが既に起票・受領返信済みと判明したケース。

--- a/src/app/api/tickets/[id]/comments/route.ts
+++ b/src/app/api/tickets/[id]/comments/route.ts
@@ -1,15 +1,11 @@
 // JSON / 201 レスポンスを返すヘルパー
 import { NextResponse } from 'next/server';
-// crypto ベースの UUID 生成 (保存先キー組み立て用)
-import { randomUUID } from 'node:crypto';
 // ページキャッシュを無効化する Next.js の関数
 import { revalidatePath } from 'next/cache';
 // セッション取得
 import { auth } from '@/lib/auth';
 // リポジトリ束 + UoW (トランザクション境界)
 import { repos, uow } from '@/data';
-// 添付ファイル本体の StoragePort (Edge runtime 汚染回避のため別モジュールから取り込む)
-import { storage } from '@/data/storage';
 // 未読件数を SSE で即時配信するヘルパー
 import { broadcastUnreadCountToMany } from '@/features/notifications/notify';
 // 環境変数で切り替わる EmailSender 実装を取得するファクトリ (依頼者宛メール送信用)
@@ -37,8 +33,9 @@ import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
 import { commentBodySchema } from '@/lib/validations/ticket';
 // 添付ファイル検証ヘルパー
 import { validateUploadedFiles } from '@/lib/validations/attachment';
-// MIME → 拡張子の対応表 (storageKey の組み立てで使う)
-import { MIME_TO_EXTENSION } from '@/domain/attachment';
+// 添付ファイルのストレージ保存 / 失敗時クリーンアップの共通ヘルパー (POST /api/tickets・
+// POST /api/inbound/email と共有。/code-review ultra 指摘対応: 3 箇所目の重複を解消)
+import { persistAttachments, cleanupWrittenAttachments } from '@/lib/attachment-persistence';
 // Phase 4 課金: 添付累計サイズ上限チェック (チケット作成時添付と共有)
 import { checkAttachmentQuota } from '@/lib/tenant-plan';
 // Phase 4: Slack/Teams/Chatwork 外部通知のベストエフォート送信共通ヘルパー
@@ -165,28 +162,17 @@ export async function POST(req: Request, { params }: Params) {
       }
 
       // 添付ファイルがあれば 1 件ずつ「ストレージ書き込み → メタ INSERT」の順に処理する
-      for (const v of attachmentValidation.files) {
-        // 保存先キーを組み立てる (例: tenantId/ticketId/<uuid>.jpg)
-        const ext = MIME_TO_EXTENSION[v.mimeType];
-        const key = `${tenantId}/${ticketId}/${randomUUID()}.${ext}`;
-        // File 本体のバイト列を ArrayBuffer 経由で Uint8Array に変換する
-        const buf = new Uint8Array(await v.file.arrayBuffer());
-        // ストレージへ書き込む (失敗時は uow がロールバック + 後段で削除)
-        await storage.put(key, buf, { contentType: v.mimeType, size: v.size });
-        writtenKeys.push(key);
-        // メタ情報を DB に保存 (commentId をセットしてコメント添付として記録)
-        await r.attachments.create({
-          ticketId,
-          commentId: comment.id,
-          uploaderId: authorId,
-          tenantId,
-          mimeType: v.mimeType,
-          size: v.size,
-          originalName: v.originalName,
-          storageKey: key,
-          storage: 'local',
-        });
-      }
+      // (POST /api/tickets・POST /api/inbound/email と共有するヘルパー。
+      // /code-review ultra 指摘対応: 3 箇所で個別実装されていた重複を解消)
+      await persistAttachments(
+        r,
+        attachmentValidation.files,
+        ticketId,
+        comment.id, // コメントへの添付として記録する
+        authorId,
+        tenantId,
+        writtenKeys,
+      );
 
       // 通知対象に「コメントが追加された」旨を一斉送付する
       await Promise.all(
@@ -203,16 +189,7 @@ export async function POST(req: Request, { params }: Params) {
     });
   } catch (err) {
     // DB は自動ロールバック済。ストレージに書き込んだファイルを best-effort で削除する
-    await Promise.all(
-      writtenKeys.map((key) =>
-        storage.delete(key).catch((cleanupErr) => {
-          console.warn('[POST /api/tickets/[id]/comments] failed to clean up storage', {
-            key,
-            cleanupErr,
-          });
-        }),
-      ),
-    );
+    await cleanupWrittenAttachments(writtenKeys, '[POST /api/tickets/[id]/comments]');
     // 元のエラーをサーバログに残して 500 を返す
     console.error('[POST /api/tickets/[id]/comments] save failed', err);
     return NextResponse.json({ error: 'コメントの保存に失敗しました' }, { status: 500 });

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -1,21 +1,18 @@
 // JSON レスポンスを返すヘルパー
 import { NextResponse } from 'next/server';
-// crypto ベースの UUID 生成 (保存先キー組み立て用)
-import { randomUUID } from 'node:crypto';
 // セッション取得
 import { auth } from '@/lib/auth';
 // リポジトリ束 (tickets/categories/attachments など)
 import { repos, uow } from '@/data';
-// 添付ファイル本体の StoragePort (Edge runtime 汚染回避のため別モジュールから取り込む)
-import { storage } from '@/data/storage';
 // 優先度から解決期限・初回応答期限を計算する SLA ヘルパー
 import { calculateFirstResponseDueAt, calculateResolutionDueAt } from '@/lib/sla';
 // 新規チケット入力の Zod スキーマ
 import { createTicketSchema } from '@/lib/validations/ticket';
 // 添付ファイル検証ヘルパー
 import { validateUploadedFiles } from '@/lib/validations/attachment';
-// MIME → 拡張子の対応表 (storageKey の組み立てで使用)
-import { MIME_TO_EXTENSION } from '@/domain/attachment';
+// 添付ファイルのストレージ保存 / 失敗時クリーンアップの共通ヘルパー (POST /api/tickets/[id]/comments・
+// POST /api/inbound/email と共有。/code-review ultra 指摘対応: 3 箇所目の重複を解消)
+import { persistAttachments, cleanupWrittenAttachments } from '@/lib/attachment-persistence';
 // 新規起票時の初期ステータスを mode から決める共通ルール (メール取り込みと単一の源を共有)
 import { initialStatusForMode } from '@/domain/ticket-status';
 // テナントの動作モード (lite | pro) を取得するヘルパー
@@ -312,43 +309,23 @@ export async function POST(req: Request) {
         firstResponseDueAt,
       });
       // 添付ファイルを 1 件ずつ「ストレージ書き込み → メタ INSERT」の順に処理する
-      for (const v of attachmentValidation.files) {
-        // 保存先キーを組み立てる (例: tenantId/ticketId/<uuid>.jpg)
-        const ext = MIME_TO_EXTENSION[v.mimeType];
-        const key = `${tenantId}/${t.id}/${randomUUID()}.${ext}`;
-        // File 本体のバイト列を ArrayBuffer 経由で Uint8Array に変換する
-        const buf = new Uint8Array(await v.file.arrayBuffer());
-        // ストレージへ書き込む (失敗時は catch でクリーンアップ)
-        await storage.put(key, buf, { contentType: v.mimeType, size: v.size });
-        // ロールバック対象として書き込み済みキーを記録する (DB INSERT 失敗時に削除する)
-        writtenKeys.push(key);
-        // メタ情報を DB に保存する (storage="local" 固定)
-        await r.attachments.create({
-          ticketId: t.id,
-          commentId: null,
-          uploaderId: userId,
-          tenantId,
-          mimeType: v.mimeType,
-          size: v.size,
-          originalName: v.originalName,
-          storageKey: key,
-          storage: 'local',
-        });
-      }
+      // (POST /api/tickets/[id]/comments・POST /api/inbound/email と共有するヘルパー。
+      // /code-review ultra 指摘対応: 3 箇所で個別実装されていた重複を解消)
+      await persistAttachments(
+        r,
+        attachmentValidation.files,
+        t.id,
+        null, // 新規チケットへの添付 (コメントには紐づかない)
+        userId,
+        tenantId,
+        writtenKeys,
+      );
       // チケットを uow の戻り値として返す (呼び出し元で 201 ボディに使う)
       return t;
     });
   } catch (err) {
     // DB は自動ロールバック済。ストレージに書き込んだファイルを best-effort で削除する
-    await Promise.all(
-      writtenKeys.map((key) =>
-        storage.delete(key).catch((cleanupErr) => {
-          // ストレージ削除失敗はエラーとしてログに残す (リトライ用 GC は将来の課題)
-          // warn ではなく error: ロールバック失敗は警告ではなく本物のエラー
-          console.error('[POST /api/tickets] failed to clean up storage', { key, cleanupErr });
-        }),
-      ),
-    );
+    await cleanupWrittenAttachments(writtenKeys, '[POST /api/tickets]');
     // 元のエラーをサーバログに出して 500 を返す
     console.error('[POST /api/tickets] attachment save failed', err);
     return NextResponse.json({ error: '添付ファイルの保存に失敗しました' }, { status: 500 });

--- a/src/lib/attachment-persistence.ts
+++ b/src/lib/attachment-persistence.ts
@@ -1,0 +1,74 @@
+// 検証済み添付ファイル群をストレージへ書き込み、メタ情報を DB へ INSERT する共通ヘルパー。
+//
+// /code-review ultra 指摘対応 (2026-07-13): POST /api/tickets (新規チケット添付)・
+// POST /api/tickets/[id]/comments (コメント添付)・POST /api/inbound/email (メール取り込みの
+// 新規起票/スレッド追記添付) の 3 箇所が「ストレージ書き込み → メタ INSERT」「失敗時は
+// 書き込み済みキーを best-effort で削除」という同型の処理をそれぞれ個別に実装しており、
+// 3 箇所目の重複になっていた (CLAUDE.md §6 DRY: 「実際に 2〜3 箇所目で重複したら共通化する」)。
+// 既存 2 箇所は削除ログのレベル (console.error / console.warn) が食い違っていたため、
+// この共通化にあわせて「ロールバック失敗は警告ではなく本物のエラー」という POST /api/tickets の
+// 方針 (より慎重に検討された判断) に統一した。
+
+// crypto ベースの UUID 生成 (保存先キー組み立て用)
+import { randomUUID } from 'node:crypto';
+// 添付ファイル本体の StoragePort (Edge runtime 汚染回避のため別モジュールから取り込む)
+import { storage } from '@/data/storage';
+// MIME → 拡張子の対応表 (storageKey の組み立てで使用)
+import { MIME_TO_EXTENSION } from '@/domain/attachment';
+// 検証済み添付ファイルの型
+import type { ValidatedAttachment } from '@/lib/validations/attachment';
+// リポジトリ束の型 (トランザクション内 tx / 非トランザクション repos 共通)
+import type { Repos } from '@/data/ports/unit-of-work';
+
+// 検証済み添付ファイル群を 1 件ずつ「ストレージ書き込み → メタ INSERT」の順に処理する。
+// 必ずトランザクション内 (tx) で呼び、書き込み済みストレージキーを writtenKeys に積むこと。
+// ストレージへの書き込みは DB トランザクション外で観測できる副作用のため、呼び出し元が
+// トランザクション失敗時に writtenKeys を使って best-effort でロールバック (削除) する。
+export async function persistAttachments(
+  tx: Repos,
+  files: ValidatedAttachment[],
+  ticketId: string,
+  commentId: string | null, // 新規チケットへの添付なら null、コメントへの添付なら該当コメント ID
+  uploaderId: string,
+  tenantId: string,
+  writtenKeys: string[],
+): Promise<void> {
+  for (const v of files) {
+    // 保存先キーを組み立てる (例: tenantId/ticketId/<uuid>.jpg)
+    const ext = MIME_TO_EXTENSION[v.mimeType];
+    const key = `${tenantId}/${ticketId}/${randomUUID()}.${ext}`;
+    // File 本体のバイト列を ArrayBuffer 経由で Uint8Array に変換する
+    const buf = new Uint8Array(await v.file.arrayBuffer());
+    // ストレージへ書き込む (失敗時は呼び出し元が uow のロールバックと writtenKeys で後始末する)
+    await storage.put(key, buf, { contentType: v.mimeType, size: v.size });
+    writtenKeys.push(key);
+    // メタ情報を DB に保存する (storage="local" 固定)
+    await tx.attachments.create({
+      ticketId,
+      commentId,
+      uploaderId,
+      tenantId,
+      mimeType: v.mimeType,
+      size: v.size,
+      originalName: v.originalName,
+      storageKey: key,
+      storage: 'local',
+    });
+  }
+}
+
+// 添付ファイルのストレージ書き込みに失敗した (または DB ロールバックで無関係になった) 際の
+// 後始末 (best-effort)。既に書き込み済みのファイルを個別に削除する。
+export async function cleanupWrittenAttachments(
+  writtenKeys: string[],
+  logPrefix: string,
+): Promise<void> {
+  await Promise.all(
+    writtenKeys.map((key) =>
+      storage.delete(key).catch((cleanupErr) => {
+        // ストレージ削除失敗はエラーとしてログに残す (warn ではなく error: ロールバック失敗は本物のエラー)
+        console.error(`${logPrefix} failed to clean up storage`, { key, cleanupErr });
+      }),
+    ),
+  );
+}

--- a/src/lib/idempotent-ticket-creation.ts
+++ b/src/lib/idempotent-ticket-creation.ts
@@ -50,10 +50,19 @@ export async function createTicketIdempotent(
   ticketInput: CreateTicketInput,
   options?: CreateTicketIdempotentOptions,
 ): Promise<{ id: string; alreadyExisted: boolean }> {
-  // キーが取れないイベント/メールは突き合わせようがないため、従来どおり単発で起票する
+  // キーが取れないイベント/メールは突き合わせようがないため、従来どおり単発で起票する。
+  // /code-review ultra 指摘対応 (2026-07-13): 以前は tickets.create と onCreated (添付メタ INSERT 等)
+  // が別々の非トランザクション呼び出しだったため、チケット作成が確定した後に onCreated が失敗すると
+  // 「チケットは残るが添付だけ無い中途半端な状態」で例外が伝播し、呼び出し元が 500 を返して
+  // Webhook プロバイダが再送すると (このキー無し経路には重複検知が無いため) 別の重複チケットが
+  // できてしまっていた。両方を 1 トランザクションにまとめ、どちらかが失敗すれば両方ロールバック
+  // されるようにする (キーが無いため Serializable による競合検知は不要で、既定の分離レベルでよい)
   if (!key) {
-    const created = await repos.tickets.create(ticketInput);
-    if (options?.onCreated) await options.onCreated(repos, created.id);
+    const created = await uow.run(async (tx) => {
+      const t = await tx.tickets.create(ticketInput);
+      if (options?.onCreated) await options.onCreated(tx, t.id);
+      return t;
+    });
     return { id: created.id, alreadyExisted: false };
   }
 

--- a/src/lib/idempotent-ticket-creation.ts
+++ b/src/lib/idempotent-ticket-creation.ts
@@ -30,16 +30,30 @@ export interface IdempotencyOps {
   register(tx: Repos, key: string, ticketId: string, tenantId: string): Promise<void>;
 }
 
+// フォローアップ (2026-07-13): メール取り込みの添付ファイル対応で、チケット起票と添付メタ INSERT を
+// 同一トランザクションで原子的に行う必要が生じたため、起票確定直後に追加の副作用を差し込めるフックを
+// 用意する。汎用的なフック名にしているのは、LINE 取り込み等の他チャネルが将来同様の需要を持った際も
+// この仕組みを再利用できるようにするため (添付専用の名前にしない)。
+export interface CreateTicketIdempotentOptions {
+  // チケット起票確定後、同一トランザクション内 (冪等化キーが無い場合は非トランザクションの repos) で
+  // 実行する追加の副作用。ストレージ書き込みのような非トランザクション I/O をここで行う場合、
+  // 失敗時の後始末 (書き込み済みファイルの削除等) は呼び出し側の責務とする
+  // (uow は DB 書き込みをロールバックするだけで、既にストレージへ書き込み済みのファイルは削除しない)。
+  onCreated?: (tx: Repos, ticketId: string) => Promise<void>;
+}
+
 // 冪等性を保ったままチケットを起票する。
 export async function createTicketIdempotent(
   ops: IdempotencyOps, // チャネル固有の対応表操作 (LINE/メールで異なる Port 呼び分け)
   key: string | null, // 冪等化キー。取れなかった場合は null (冪等化なしで単発起票)
   tenantId: string,
   ticketInput: CreateTicketInput,
+  options?: CreateTicketIdempotentOptions,
 ): Promise<{ id: string; alreadyExisted: boolean }> {
   // キーが取れないイベント/メールは突き合わせようがないため、従来どおり単発で起票する
   if (!key) {
     const created = await repos.tickets.create(ticketInput);
+    if (options?.onCreated) await options.onCreated(repos, created.id);
     return { id: created.id, alreadyExisted: false };
   }
 
@@ -53,6 +67,9 @@ export async function createTicketIdempotent(
         // 起票してから対応表に登録する (同一トランザクション内なので原子的)
         const created = await tx.tickets.create(ticketInput);
         await ops.register(tx, key, created.id, tenantId);
+        // 起票確定後の追加副作用 (添付メタ INSERT 等) を同一トランザクション内で実行する。
+        // 重複判定 (already) で早期 return したケースでは呼ばない (別リクエストが既に処理済みのため)
+        if (options?.onCreated) await options.onCreated(tx, created.id);
         return { id: created.id, alreadyExisted: false };
       },
       { isolationLevel: 'Serializable' },

--- a/src/lib/validations/attachment.ts
+++ b/src/lib/validations/attachment.ts
@@ -41,9 +41,57 @@ function formatMb(bytes: number): string {
   return (bytes / (1024 * 1024)).toFixed(1);
 }
 
+// 1 ファイル分の検証本体 (件数チェックは呼び出し側の責務)。
+// 申告 MIME (file.type) と サイズの安価な検査を先に通し、最後に先頭 16 バイトのマジックバイトを
+// 実バイト列で確認する (中身偽装への防御)。validateUploadedFiles (全件一括・1 件でも違反があれば
+// 全体を失敗させる) と validateUploadedFilesLenient (個々に検証し有効なものだけ残す) の両方が
+// この関数を共有することで、検証ルールの定義を 1 か所に保つ (§6 DRY)。
+async function validateSingleFile(
+  file: File,
+): Promise<{ ok: true; value: ValidatedAttachment } | { ok: false; message: string }> {
+  // size === 0 のファイルは空ファイル (フォームから誤って送られたケース) として弾く
+  if (file.size === 0) {
+    return { ok: false, message: '空のファイルは添付できません' };
+  }
+  // サイズ上限を超えるファイルは弾く
+  if (file.size > MAX_ATTACHMENT_SIZE_BYTES) {
+    return {
+      ok: false,
+      message: `1 ファイルあたり ${formatMb(MAX_ATTACHMENT_SIZE_BYTES)}MB までです`,
+    };
+  }
+  // MIME は許可リストにあるものだけ通す (申告ベース)
+  if (!isAllowedImageMimeType(file.type)) {
+    return {
+      ok: false,
+      message: `この形式のファイルは添付できません (許可: ${ALLOWED_IMAGE_MIME_TYPES.join(', ')})`,
+    };
+  }
+  // 中身偽装防御: 先頭 16 バイトを読み、申告 MIME と実マジックバイトの整合を確認する
+  // File.slice は同期、arrayBuffer は async だが既に in-memory のため実 I/O は発生しない
+  const headBuffer = await file.slice(0, MAGIC_BYTES_PEEK_LENGTH).arrayBuffer();
+  const headBytes = new Uint8Array(headBuffer);
+  if (!verifyImageMagicBytes(file.type, headBytes)) {
+    // 申告 MIME と中身が一致しないファイルは保存しない
+    return { ok: false, message: 'ファイルの内容が画像として認識できません' };
+  }
+  // 元ファイル名は trim して空なら "image" にフォールバックする (UI 表示のため)
+  const originalName = file.name.trim() || 'image';
+  // 検証通過: 整理済み情報を返す
+  return {
+    ok: true,
+    value: {
+      file,
+      mimeType: file.type as AllowedImageMimeType, // 直前の isAllowedImageMimeType で絞り込み済み
+      size: file.size,
+      originalName,
+    },
+  };
+}
+
 // アップロードされた File[] を検証する。1 ファイルでも違反があれば全体を失敗扱いにする。
-// 申告 MIME (file.type) と件数 / サイズの安価な検査を先に通し、最後に各ファイル先頭 16 バイトの
-// マジックバイトを実バイト列で確認する (中身偽装への防御)。
+// Web フォーム / コメント投稿のように、失敗時にユーザーへ即座にフィードバックして修正・再送信
+// させられる UI 向け。
 export async function validateUploadedFiles(
   files: File[],
 ): Promise<AttachmentValidationOk | AttachmentValidationError> {
@@ -63,46 +111,36 @@ export async function validateUploadedFiles(
   const validated: ValidatedAttachment[] = [];
   // 各ファイルを順に検査する (1 件でも違反があればすぐ return)
   for (const file of files) {
-    // size === 0 のファイルは空ファイル (フォームから誤って送られたケース) として弾く
-    if (file.size === 0) {
-      return { ok: false, message: '空のファイルは添付できません' };
-    }
-    // サイズ上限を超えるファイルは弾く
-    if (file.size > MAX_ATTACHMENT_SIZE_BYTES) {
-      return {
-        ok: false,
-        message: `1 ファイルあたり ${formatMb(MAX_ATTACHMENT_SIZE_BYTES)}MB までです`,
-      };
-    }
-    // MIME は許可リストにあるものだけ通す (申告ベース)
-    if (!isAllowedImageMimeType(file.type)) {
-      return {
-        ok: false,
-        message: `この形式のファイルは添付できません (許可: ${ALLOWED_IMAGE_MIME_TYPES.join(', ')})`,
-      };
-    }
-    // 中身偽装防御: 先頭 16 バイトを読み、申告 MIME と実マジックバイトの整合を確認する
-    // File.slice は同期、arrayBuffer は async だが既に in-memory のため実 I/O は発生しない
-    const headBuffer = await file.slice(0, MAGIC_BYTES_PEEK_LENGTH).arrayBuffer();
-    const headBytes = new Uint8Array(headBuffer);
-    if (!verifyImageMagicBytes(file.type, headBytes)) {
-      // 申告 MIME と中身が一致しないファイルは保存しない
-      return {
-        ok: false,
-        message: 'ファイルの内容が画像として認識できません',
-      };
-    }
-    // 元ファイル名は trim して空なら "image" にフォールバックする (UI 表示のため)
-    const originalName = file.name.trim() || 'image';
-    // 検証通過: 整理済み情報を蓄える
-    validated.push({
-      file,
-      mimeType: file.type as AllowedImageMimeType, // 直前の isAllowedImageMimeType で絞り込み済み
-      size: file.size,
-      originalName,
-    });
+    const result = await validateSingleFile(file);
+    if (!result.ok) return { ok: false, message: result.message };
+    validated.push(result.value);
   }
 
   // 全件通過: 整理済みリストを返す
   return { ok: true, files: validated };
+}
+
+// 寛容版検証の戻り値型 (常に成功。却下された件数だけログ用に返す)
+export interface LenientAttachmentValidation {
+  files: ValidatedAttachment[]; // 検証を通過した有効なファイルのみ
+  droppedCount: number; // 却下された件数 (呼び出し側のログ用)
+}
+
+// /code-review ultra 指摘対応 (2026-07-13): メール取り込みのように、ユーザーへ即座に
+// フィードバックして修正・再送信させられる画面が無い呼び出し元向けの寛容版。
+// validateUploadedFiles と異なり 1 件でも違反があっても全体を失敗させず、有効なファイルだけを
+// 残す (例: 3 枚の有効な写真 + 1 件の非対応形式ファイルが混在していた場合、写真 3 枚は
+// 問い合わせに残したい。全件一括の validateUploadedFiles だとこの場合も全滅してしまう)。
+// 件数上限を超える分は (どれを優先すべきか判断できないため) 先頭から上限件数だけを対象にし、
+// 超過分は静かに切り捨てる (droppedCount に反映される)。
+export async function validateUploadedFilesLenient(
+  files: File[],
+): Promise<LenientAttachmentValidation> {
+  const capped = files.slice(0, MAX_ATTACHMENTS_PER_UPLOAD);
+  const validated: ValidatedAttachment[] = [];
+  for (const file of capped) {
+    const result = await validateSingleFile(file);
+    if (result.ok) validated.push(result.value);
+  }
+  return { files: validated, droppedCount: files.length - validated.length };
 }

--- a/tests/features/inbound-email-route.test.ts
+++ b/tests/features/inbound-email-route.test.ts
@@ -984,5 +984,98 @@ describe('POST /api/inbound/email', () => {
       expect(store.attachments.size).toBe(0);
       expect(storage.entries.size).toBe(0);
     });
+
+    // /code-review ultra 指摘対応の回帰テスト (2026-07-13): 以前は validateUploadedFiles が
+    // 1 件でも不正な添付があれば全件を切り捨てていたため、有効な画像と無効なファイルが混在した
+    // メールでは有効な写真まで一緒に失われていた。validateUploadedFilesLenient は無効な分だけを
+    // 落とし、有効な添付は保存されることを確認する
+    it('有効な添付と無効な添付が混在していても、有効な分だけ保存される', async () => {
+      const goodFile = makeAttachmentFile('good.png', 'image/png', 'valid-image-bytes');
+      const badFile = makeAttachmentFile('bad.pdf', 'application/pdf', 'not-an-image');
+      const { POST } = await import('@/app/api/inbound/email/route');
+      const res = await POST(
+        makeAttachmentRequest(
+          {
+            to: VALID_EMAIL.to,
+            from: VALID_EMAIL.from,
+            subject: VALID_EMAIL.subject,
+            text: VALID_EMAIL.text,
+          },
+          [goodFile, badFile],
+        ),
+      );
+      expect(res.status).toBe(201);
+      const json = (await res.json()) as { ticketId: string };
+      // 無効な PDF は落とされ、有効な PNG だけが 1 件保存されること
+      const attachments = [...store.attachments.values()].filter(
+        (a) => a.ticketId === json.ticketId,
+      );
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0].originalName).toBe('good.png');
+      expect(storage.entries.size).toBe(1);
+    });
+
+    // /code-review ultra 指摘対応の回帰テスト (2026-07-13): Serializable 分離レベルでの書き込み
+    // 競合は「コミット時点」で検知されるため、敗者側のトランザクションが onCreated (persistAttachments)
+    // で既にストレージへバイト列を書き込み終えた後に競合が発覚するケースがあり得る。DB 側の書き込みは
+    // ロールバックされてもストレージ書き込みはトランザクション外の副作用のため残ってしまっていた不備の
+    // 修正確認 (alreadyExisted 分岐での cleanupWrittenAttachments 呼び出し)
+    it('書き込み競合の敗者側が保存した添付ファイルは重複解決時にクリーンアップされる', async () => {
+      // 「別リクエストが先に確定させた」チケットをあらかじめ用意しておく
+      const winnerTicket = await repos.tickets.create({
+        title: '先勝ちリクエストが作成',
+        body: '本文',
+        priority: 'Medium',
+        categoryId: null,
+        creatorId: MEMBER_ID,
+        tenantId: TENANT,
+      });
+
+      // findTicketIdByMessageIds: 1 回目 (事前チェック) は null、2 回目 (競合後の再確認) は
+      // 先勝ちチケット ID を返す
+      const findTicketIdByMessageIds = vi
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue(winnerTicket.id);
+      repos = {
+        ...repos,
+        emailThreads: { ...repos.emailThreads, findTicketIdByMessageIds },
+      };
+
+      // uow.run は渡されたコールバックを実際に実行してから (= このリクエストの「敗者」
+      // トランザクションが onCreated で添付をストレージへ書き込み終えてから) 書き込み競合で
+      // 失敗させる。実際の Postgres でもコミット時点で初めて競合が検知されるため、
+      // ストレージ書き込みが完了した後に DB 側だけロールバックされる、という順序を再現する
+      const conflictError = new Error('simulated write conflict');
+      uow = {
+        run: vi.fn(async (fn) => {
+          await fn(repos);
+          throw conflictError;
+        }),
+        isTransactionConflict: (err) => err === conflictError,
+      };
+
+      const file = makeAttachmentFile('leak.png', 'image/png', 'leaked-bytes');
+      const { POST } = await import('@/app/api/inbound/email/route');
+      const res = await POST(
+        makeAttachmentRequest(
+          {
+            to: VALID_EMAIL.to,
+            from: VALID_EMAIL.from,
+            subject: VALID_EMAIL.subject,
+            text: VALID_EMAIL.text,
+            'message-id': '<race-attach-1@example.com>',
+          },
+          [file],
+        ),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ticketId: string; status?: string };
+      expect(body.status).toBe('duplicate');
+      expect(body.ticketId).toBe(winnerTicket.id);
+      // 敗者トランザクションが onCreated で書き込んだストレージのバイト列は、重複解決時に
+      // クリーンアップされ残らないこと
+      expect(storage.entries.size).toBe(0);
+    });
   });
 });

--- a/tests/features/inbound-email-route.test.ts
+++ b/tests/features/inbound-email-route.test.ts
@@ -6,6 +6,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // メモリ実装の context (store/repos)
 import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// メモリストレージ (添付バイナリ用。フォローアップ 2026-07-13)
+import { createMemoryStorage, type MemoryStoragePort } from '@/data/adapters/memory/storage.memory';
 // 型のみ
 import type { Repos } from '@/data/ports/unit-of-work';
 
@@ -56,6 +58,8 @@ vi.mock('@/lib/tenant-plan', async (importOriginal) => {
 let store: Store;
 let repos: Repos;
 let uow: UnitOfWork;
+// 添付ファイルのバイナリ本体を保持するメモリストレージ (フォローアップ 2026-07-13)
+let storage: MemoryStoragePort;
 
 // @/data を差し替え (getter で beforeEach の上書きを反映)
 vi.mock('@/data', () => ({
@@ -64,6 +68,13 @@ vi.mock('@/data', () => ({
   },
   get uow() {
     return uow;
+  },
+}));
+
+// storage は別モジュール (Edge runtime 汚染回避のため route.ts が個別 import している)
+vi.mock('@/data/storage', () => ({
+  get storage() {
+    return storage;
   },
 }));
 
@@ -178,6 +189,8 @@ describe('POST /api/inbound/email', () => {
     store = ctx.store;
     repos = ctx.repos;
     uow = ctx.uow;
+    // 添付ファイル用のメモリストレージも毎回作り直す (フォローアップ 2026-07-13)
+    storage = createMemoryStorage();
     seed();
     vi.stubEnv('INBOUND_EMAIL_SECRET', SECRET);
     // 各テストで送信捕捉バッファを空にする (テスト間で送信が混ざらないように)
@@ -839,6 +852,137 @@ describe('POST /api/inbound/email', () => {
       expect(res.status).toBe(202);
       expect(store.quarantinedEmails.size).toBe(1);
       expect(Array.from(store.quarantinedEmails.values())[0].reason).toBe('quota_exceeded');
+    });
+  });
+
+  // フォローアップ (2026-07-13): 監査で発見したギャップの解消。SendGrid Inbound Parse の
+  // 添付ファイル (attachments 件数 + attachment1..N) を一切読んでおらず、スマホで撮った写真を
+  // メールに添付して送るだけで済ませたい SMB ペルソナ (§1.2) の主要ユースケースがメール経由では
+  // 実現できていなかった不備の回帰テスト。
+  describe('添付ファイル (フォローアップ 2026-07-13)', () => {
+    // 既知のマジックバイト (validateUploadedFiles の整合チェックを通すため必要。
+    // tests/features/attachments/post-comment-route.test.ts と同じ方式)
+    const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+    // 申告 MIME に対応するマジックバイトを先頭に置いた File を作る
+    function makeAttachmentFile(name: string, type: string, body: string): File {
+      const text = new TextEncoder().encode(body);
+      const data = type === 'image/png' ? new Uint8Array([...PNG_MAGIC, ...text]) : text;
+      return new File([data], name, { type });
+    }
+
+    // SendGrid Inbound Parse 形式 (attachments 件数 + attachment1..N) の multipart Request を組み立てる
+    function makeAttachmentRequest(fields: Record<string, string>, files: File[]): Request {
+      const form = new FormData();
+      for (const [k, v] of Object.entries(fields)) form.set(k, v);
+      if (files.length > 0) {
+        form.set('attachments', String(files.length));
+        files.forEach((f, i) => form.set(`attachment${i + 1}`, f, f.name));
+      }
+      return new Request('http://localhost/api/inbound/email', {
+        method: 'POST',
+        headers: { 'x-inbound-secret': SECRET },
+        body: form,
+      });
+    }
+
+    // 新規起票 + 有効な画像添付 1 枚 → チケット作成 + 添付メタ INSERT (commentId は null) +
+    // バイト列が storage に書かれること
+    it('新規起票時に有効な画像添付があれば保存される', async () => {
+      const file = makeAttachmentFile('photo.png', 'image/png', 'fake-image-bytes');
+      const { POST } = await import('@/app/api/inbound/email/route');
+      const res = await POST(
+        makeAttachmentRequest(
+          {
+            to: VALID_EMAIL.to,
+            from: VALID_EMAIL.from,
+            subject: VALID_EMAIL.subject,
+            text: VALID_EMAIL.text,
+          },
+          [file],
+        ),
+      );
+      expect(res.status).toBe(201);
+      const json = (await res.json()) as { ticketId: string };
+      // チケットに紐づく添付が 1 件、commentId は null (新規起票への添付) で記録される
+      const attachments = [...store.attachments.values()].filter(
+        (a) => a.ticketId === json.ticketId,
+      );
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0].commentId).toBeNull();
+      expect(attachments[0].originalName).toBe('photo.png');
+      // storage にバイト列が実際に書き込まれていること
+      expect(storage.entries.size).toBe(1);
+    });
+
+    // スレッド追記 (既存チケットへのコメント) + 有効な画像添付 → コメントに紐づけて保存されること
+    it('スレッド追記時に有効な画像添付があればコメントに紐づけて保存される', async () => {
+      const { POST } = await import('@/app/api/inbound/email/route');
+      // 1 通目: 新規起票 (添付なし)
+      const first = await POST(
+        makeRequest({ ...VALID_EMAIL, messageId: '<attach-thread-1@example.com>' }),
+      );
+      expect(first.status).toBe(201);
+      const { ticketId } = (await first.json()) as { ticketId: string };
+
+      // 2 通目: 1 通目への返信に画像添付
+      const file = makeAttachmentFile('reply-photo.png', 'image/png', 'reply-bytes');
+      const reply = await POST(
+        makeAttachmentRequest(
+          {
+            to: VALID_EMAIL.to,
+            from: VALID_EMAIL.from,
+            subject: 'Re: プリンターが動きません',
+            text: '追加の写真です',
+            'in-reply-to': '<attach-thread-1@example.com>',
+            'message-id': '<attach-thread-2@example.com>',
+          },
+          [file],
+        ),
+      );
+      expect(reply.status).toBe(200);
+      // コメントに紐づく添付が 1 件記録されていること (commentId が非 null)
+      const attachments = [...store.attachments.values()].filter((a) => a.ticketId === ticketId);
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0].commentId).not.toBeNull();
+      expect(storage.entries.size).toBe(1);
+    });
+
+    // 許可外 MIME の添付があっても、メール全体 (起票) を止めずに添付なしで処理を継続すること。
+    // Web フォーム/コメント投稿と異なりこの Webhook にはユーザーへの即時フィードバック画面が無いため、
+    // 添付だけを黙って落として本文だけは問い合わせとして残す方針 (route.ts のコメント参照)
+    it('許可外 MIME の添付は無視され、本文だけで起票される', async () => {
+      const file = makeAttachmentFile('doc.pdf', 'application/pdf', 'not-an-image');
+      const { POST } = await import('@/app/api/inbound/email/route');
+      const res = await POST(
+        makeAttachmentRequest(
+          {
+            to: VALID_EMAIL.to,
+            from: VALID_EMAIL.from,
+            subject: VALID_EMAIL.subject,
+            text: VALID_EMAIL.text,
+          },
+          [file],
+        ),
+      );
+      // 添付が拒否されても起票自体は成功する
+      expect(res.status).toBe(201);
+      const json = (await res.json()) as { ticketId: string };
+      expect(store.tickets.get(json.ticketId)?.body).toBe(VALID_EMAIL.text);
+      // 添付は 1 件も記録されない (無言で落とす)
+      expect(
+        [...store.attachments.values()].filter((a) => a.ticketId === json.ticketId),
+      ).toHaveLength(0);
+      expect(storage.entries.size).toBe(0);
+    });
+
+    // 添付が無いメールは従来どおり (回帰なし)
+    it('添付が無いメールは従来どおり起票され、attachments テーブルは空のまま', async () => {
+      const { POST } = await import('@/app/api/inbound/email/route');
+      const res = await POST(makeRequest(VALID_EMAIL));
+      expect(res.status).toBe(201);
+      expect(store.attachments.size).toBe(0);
+      expect(storage.entries.size).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## 対応する Phase / 項目

`docs/smb-dx-pivot-plan.md` は全項目 `[x]` 完了扱いだが、これまでの運用パターンに倣い監査を継続し、新たに見つかったギャップを修正した(前回PR #205, #206の続き)。

- Phase 1（写真添付・スマホ最適化）
- Phase 2（メール取り込み）

## 変更内容

### メール取り込みで添付画像が保存されていなかった

Web フォーム・コメント投稿は添付画像に対応済みだが、メール取り込み（`POST /api/inbound/email`）は SendGrid Inbound Parse が送る添付フィールド（`attachments` 件数 + `attachment1`..`attachmentN`）を一切読んでおらず、新規起票・スレッド追記のどちらでも添付は跡形もなく消えていた。§1.2 のペルソナ「現場リーダー」が最優先とする「写真を撮って送るだけで終わってほしい」というメール経由のユースケースが、最も分かりやすい形で未実装のまま残っていた。

- `src/lib/idempotent-ticket-creation.ts`: チケット起票確定後に同一トランザクション内で追加の副作用（添付メタ INSERT）を実行できる `onCreated` フックを追加した（汎用的なフック名にし、LINE 等の他チャネルが将来同様の需要を持った際も再利用できるようにした）。
- `src/app/api/inbound/email/route.ts`: multipart 経路で添付ファイルを抽出し、Web フォーム/コメント投稿と共有の `validateUploadedFiles` / `checkAttachmentQuota` で検証する。この Webhook にはユーザーへ即時フィードバックする画面が無いため、検証・上限超過で失敗してもメール全体（起票/追記）は止めず、添付なしとして処理を継続する方針にした（北極星指標 §0: 本文だけでも問い合わせとして残す方を優先）。新規起票は `onCreated` フック経由、スレッド追記は既存の `uow.run` 内で、それぞれ「ストレージ書き込み → 添付メタ INSERT」を行い、失敗時は書き込み済みファイルを best-effort で削除する（`POST /api/tickets` と同じ方針）。

## テスト

- `npm run typecheck` — 成功
- `npm run lint` — 成功
- `npx vitest run` — 889件成功
- 追加した回帰テスト（`tests/features/inbound-email-route.test.ts`）:
  - 新規起票への添付保存（storage への書き込み確認込み）
  - スレッド追記（既存チケットへのコメント）への添付保存
  - 許可外 MIME の添付は無視され、本文だけで起票される
  - 添付が無いメールの既存挙動に回帰が無いこと

## 画面確認

UI の見た目に変更はなく、サーバー側の Webhook 処理追加が中心のため、上記の自動テストで検証している。


---
_Generated by [Claude Code](https://claude.ai/code/session_014XnHProPvPHZFdPsE2y9vp)_