### PR TITLE
feat(inbound,tickets): LINE画像添付とCSV担当割当メール通知

### DIFF
--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -398,6 +398,51 @@ async function findDuplicateLineTicket(
   return existingTicketId;
 }
 
+// 画像メッセージの添付を取得・検証し、検証済みファイル一覧を返す (取得・検証に失敗すれば空配列)。
+// /code-review ultra 指摘対応 (2026-07-13): processLineEvent 内に「取得 → 検証 → 上限チェック」の
+// 3 段ネストで書かれていて読みづらかったため、早期 return で平坦化した専用ヘルパーへ抽出した。
+// 呼び出し元は取得・検証の失敗を例外ではなく空配列で受け取り、添付なしで起票を継続する (§9 fail-safe)。
+async function resolveLineImageAttachment(
+  channelAccessToken: string, // Content API 取得に使うテナントの長期アクセストークン
+  attachmentMessageId: string, // Content API の取得キー (画像メッセージの ID)
+  targetTenantId: string, // 添付累計サイズ上限チェックのスコープ
+  subscriptionPlan: SubscriptionPlan, // 添付累計サイズ上限チェックに使う契約プラン
+): Promise<ValidatedAttachment[]> {
+  // Content API から画像本体を取得する。失敗 (HTTP エラー・タイムアウト・サイズ超過等) なら
+  // fetchLineMessageContent 自身がログを残して null を返すので、ここでは空配列で早期リターンする
+  const content = await fetchLineMessageContent(channelAccessToken, attachmentMessageId);
+  if (!content) return [];
+
+  // Content API が返す実際の Content-Type を申告 MIME として渡し、既存の検証パイプライン
+  // (許可 MIME 判定 + マジックバイト整合チェック) をそのまま再利用する (§6 DRY)。
+  // Uint8Array のコピーコンストラクタを経由して ArrayBuffer 裏付けの型にする
+  // (TS の lib.dom 型定義上、素の Uint8Array<ArrayBufferLike> は BlobPart に直接代入できないため。
+  // src/app/api/attachments/[id]/route.ts の配信時と同じ回避策)
+  const file = new File([new Uint8Array(content.bytes)], `line-${attachmentMessageId}`, {
+    type: content.contentType,
+  });
+  const attachmentValidation = await validateUploadedFilesLenient([file]);
+  if (attachmentValidation.droppedCount > 0) {
+    console.warn('[POST /api/inbound/line] image attachment rejected by validation', {
+      messageId: attachmentMessageId,
+    });
+  }
+  const validatedAttachments = attachmentValidation.files;
+  // 検証を通過した添付が無ければ、上限チェックするまでもなくここで終える
+  if (validatedAttachments.length === 0) return [];
+
+  // 添付累計サイズ上限チェック (Web フォーム・メール取り込みと共有 §6.1 料金プラン)
+  const totalBytes = validatedAttachments.reduce((sum, f) => sum + f.size, 0);
+  const quotaCheck = await checkAttachmentQuota(targetTenantId, totalBytes, subscriptionPlan);
+  if (!quotaCheck.ok) {
+    console.warn('[POST /api/inbound/line] image attachment exceeds quota, continuing without it', {
+      reason: quotaCheck.message,
+    });
+    return [];
+  }
+  return validatedAttachments;
+}
+
 // LINE Webhook イベント 1 件を処理する。起票 (または重複判定) できた場合はチケット ID を返し、
 // スタンプ/空メッセージ/連携コード処理/起票失敗など「起票しない」イベントは null を返す。
 // POST から呼び出す前提の内部ヘルパーのため export しない。
@@ -567,43 +612,16 @@ async function processLineEvent(
 
   // 画像添付があれば、チケット起票より前に取得・検証しておく (メール取り込みと同じ順序)。
   // 取得・検証に失敗しても添付なしで起票を継続する (§9 fail-safe)。
-  let validatedAttachments: ValidatedAttachment[] = [];
-  if (attachmentMessageId) {
-    const content = await fetchLineMessageContent(ctx.channelAccessToken, attachmentMessageId);
-    if (content) {
-      // Content API が返す実際の Content-Type を申告 MIME として渡し、既存の検証パイプライン
-      // (許可 MIME 判定 + マジックバイト整合チェック) をそのまま再利用する (§6 DRY)
-      // Uint8Array のコピーコンストラクタを経由して ArrayBuffer 裏付けの型にする
-      // (TS の lib.dom 型定義上、素の Uint8Array<ArrayBufferLike> は BlobPart に直接代入できないため。
-      // src/app/api/attachments/[id]/route.ts の配信時と同じ回避策)
-      const file = new File([new Uint8Array(content.bytes)], `line-${attachmentMessageId}`, {
-        type: content.contentType,
-      });
-      const attachmentValidation = await validateUploadedFilesLenient([file]);
-      if (attachmentValidation.droppedCount > 0) {
-        console.warn('[POST /api/inbound/line] image attachment rejected by validation', {
-          messageId: attachmentMessageId,
-        });
-      }
-      validatedAttachments = attachmentValidation.files;
-      // 添付累計サイズ上限チェック (Web フォーム・メール取り込みと共有 §6.1 料金プラン)
-      if (validatedAttachments.length > 0) {
-        const totalBytes = validatedAttachments.reduce((sum, f) => sum + f.size, 0);
-        const quotaCheck = await checkAttachmentQuota(
-          targetTenantId,
-          totalBytes,
-          ctx.subscriptionPlan,
-        );
-        if (!quotaCheck.ok) {
-          console.warn(
-            '[POST /api/inbound/line] image attachment exceeds quota, continuing without it',
-            { reason: quotaCheck.message },
-          );
-          validatedAttachments = [];
-        }
-      }
-    }
-  }
+  // /code-review ultra 指摘対応 (2026-07-13): 取得 → 検証 → 上限チェックの 3 段ネストが深く
+  // 読みづらかったため、早期 return で平坦化した専用ヘルパーへ抽出した
+  const validatedAttachments = attachmentMessageId
+    ? await resolveLineImageAttachment(
+        ctx.channelAccessToken,
+        attachmentMessageId,
+        targetTenantId,
+        ctx.subscriptionPlan,
+      )
+    : [];
 
   // Phase 4 課金: 月間チケット上限チェック (Web フォーム・CSV インポート・メール取り込みと共有)。
   // tenant-plan.ts のコメントで「全ての起票入口で共有する」と明記されているにもかかわらず、

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -65,8 +65,27 @@ import { notifyAgentsOfNewTicket } from '@/features/notifications/notify';
 import { isLineIntegrationAllowed, resolveEffectivePlan } from '@/lib/plan-guard';
 // Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (Web フォーム・メール取り込み・CSV インポートと共有)
 import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
-// Phase 4 課金: 月間チケット上限チェック (Web フォーム・CSV インポートと共有)
-import { getMonthlyTicketQuota, type MonthlyTicketQuota } from '@/lib/tenant-plan';
+// Phase 4 課金: 月間チケット上限チェック (Web フォーム・CSV インポートと共有)。
+// フォローアップ (2026-07-13): 添付累計サイズ上限チェックも Web フォーム・メール取り込みと共有する
+import {
+  getMonthlyTicketQuota,
+  checkAttachmentQuota,
+  type MonthlyTicketQuota,
+} from '@/lib/tenant-plan';
+// フォローアップ (2026-07-13): 監査で発見したギャップの解消。LINE の画像メッセージ (スマホで
+// 撮った写真) を Messaging API の Content エンドポイントから取得するヘルパー
+import { fetchLineMessageContent } from '@/lib/line-content';
+// 添付ファイルの寛容版検証ヘルパー (メール取り込みと共有。1 件でも違反があっても全体を失敗させない。
+// この Webhook にはユーザーへ即座にフィードバックして再送信させられる画面が無いため)
+import {
+  validateUploadedFilesLenient,
+  type ValidatedAttachment,
+} from '@/lib/validations/attachment';
+// 添付ファイルのストレージ保存 / 失敗時クリーンアップの共通ヘルパー (POST /api/tickets・
+// POST /api/inbound/email と共有)
+import { persistAttachments, cleanupWrittenAttachments } from '@/lib/attachment-persistence';
+// 課金プランの型 (添付累計サイズ上限チェック checkAttachmentQuota に渡す)
+import type { SubscriptionPlan } from '@/domain/types';
 // このルートは Node ランタイムで動かす (node:crypto / Prisma を使うため Edge では動かない)
 export const runtime = 'nodejs';
 
@@ -106,6 +125,17 @@ interface LineTextMessage {
   text: string; // メッセージ本文
 }
 
+// LINE Webhook が送ってくる画像メッセージの型 (フォローアップ 2026-07-13)。
+// バイト列は含まれず、id を使って Messaging API の Content エンドポイントから別途取得する。
+// contentProvider.type が 'external' の場合は LINE がホストしていない画像 (LIFF 等からの外部 URL)
+// のため、Content エンドポイントでは取得できず対象外にする (任意の外部 URL を fetch すると
+// SSRF の懸念があるため、固定ホストの Content API 経由で取得できるものだけをサポート範囲にする)
+interface LineImageMessage {
+  type: 'image'; // 画像メッセージであることを示す種別
+  id: string; // メッセージ ID (Content API の取得キーにもなる)
+  contentProvider?: { type?: string }; // 'line' (既定) | 'external'
+}
+
 // LINE Webhook のイベント 1 件分の型。
 // 署名検証済みでも JSON の構造は信用しないため (§9)、各フィールドは任意 (optional) として扱い、
 // 実行時に存在チェックしてから参照する。follow / unfollow / postback 等の非メッセージイベントや、
@@ -119,7 +149,8 @@ interface LineMessageEvent {
     groupId?: string; // グループ ID (group タイプの場合のみ存在)
     roomId?: string; // ルーム ID (room タイプの場合のみ存在)
   };
-  message?: LineTextMessage | { type?: string }; // メッセージの中身 (テキスト以外は type だけ参照)
+  // メッセージの中身 (テキスト/画像以外はスタンプ等なので type だけ参照してスキップする)
+  message?: LineTextMessage | LineImageMessage | { type?: string };
   timestamp?: number; // Unix ミリ秒のイベント発生時刻
 }
 
@@ -143,6 +174,8 @@ interface LineEventContext {
   resolutionDueAt: ReturnType<typeof calculateResolutionDueAt>; // 優先度 Medium ベースの解決期限
   firstResponseDueAt: ReturnType<typeof calculateFirstResponseDueAt>; // 優先度 Medium ベースの初回応答期限
   quota: MonthlyTicketQuota; // 月間チケット上限の残枠 (イベントごとに消費するミュータブルなカウンタ)
+  channelAccessToken: string; // フォローアップ (2026-07-13): 画像添付を Content API から取得するために使う
+  subscriptionPlan: SubscriptionPlan; // 添付累計サイズ上限チェック (checkAttachmentQuota) に使う
 }
 
 // LINE Webhook の署名を検証する関数 (LINE Developers ドキュメント準拠)
@@ -330,6 +363,8 @@ export async function POST(req: Request) {
     resolutionDueAt, // 優先度 Medium ベースの解決期限
     firstResponseDueAt, // 優先度 Medium ベースの初回応答期限
     quota, // 月間チケット上限の残枠
+    channelAccessToken: lineConfig.channelAccessToken, // 画像添付の Content API 取得に使う
+    subscriptionPlan: tenant.subscriptionPlan, // 添付累計サイズ上限チェックに使う
   };
   const ticketIds: string[] = [];
   for (const event of body.events) {
@@ -343,6 +378,24 @@ export async function POST(req: Request) {
   // の Serializable トランザクションで、連携コード処理 (起票を伴わない) は repos.lineLinkCodes
   // (LineLinkCodeRef テーブルへの DB 永続化) でそれぞれ担保している。
   return NextResponse.json({ ticketIds }, { status: 200 });
+}
+
+// このメッセージ ID を既に取り込み済みなら対応するチケット ID を返す (未処理なら null)。
+// テキスト/画像の両メッセージ種別が同じ冪等化早期チェック (fast path) を必要とするため、
+// processLineEvent 内で 2 箇所目の重複になるより前にここへ共通化する (§6 DRY)。
+async function findDuplicateLineTicket(
+  messageId: string,
+  targetTenantId: string,
+): Promise<string | null> {
+  const existingTicketId = await repos.lineMessages.findTicketIdByMessageId(
+    messageId,
+    targetTenantId,
+  );
+  if (existingTicketId) {
+    // 既知のメッセージ ID: 二重起票を避けて既存チケット ID を返す
+    console.info(`[POST /api/inbound/line] duplicate message id, skipping re-create: ${messageId}`);
+  }
+  return existingTicketId;
 }
 
 // LINE Webhook イベント 1 件を処理する。起票 (または重複判定) できた場合はチケット ID を返し、
@@ -367,87 +420,142 @@ async function processLineEvent(
   if (event?.type !== 'message') return null;
   // メッセージ本体を取り出す (欠落していてもよいよう optional 扱い)
   const message = event.message;
-  // テキストメッセージ以外 (スタンプ / 画像 / 動画 等) や message 欠落イベントはスキップする
-  if (message?.type !== 'text') return null;
+  // テキスト / 画像以外 (スタンプ・動画・音声・ファイル・位置情報等) や message 欠落イベントはスキップする。
+  // フォローアップ (2026-07-13): 監査で発見したギャップの解消。画像 (スマホで撮った写真) は
+  // §1.2 ペルソナ「現場リーダー」の最優先ユースケースであり、メール取り込み (PR #207) で
+  // 実現済みの添付対応を LINE にも揃える
+  if (message?.type !== 'text' && message?.type !== 'image') return null;
 
-  // テキストメッセージとして型を確定させる (type==='text' を確認済み)
-  const textMessage = message as LineTextMessage;
   // LINE ユーザー ID を取得する (source / userId が無い場合は '不明' とする)。
   // LINE の正規形式は 'U' + 32 桁 16 進数。署名検証済みでも形式外の値をそのままチケット本文に
   // 埋め込むと将来の出力経路 (HTML メール等) でインジェクションになりうるため §9 に従い検証する
   const rawUserId = event.source?.userId ?? '';
   // 形式が一致する場合のみ採用し、それ以外は '不明' に置き換える
   const lineUserId = LINE_USER_ID_PATTERN.test(rawUserId) ? rawUserId : '不明';
-  // text が文字列でない (欠落・型不正) イベントは起票できないためスキップする
-  if (typeof textMessage.text !== 'string') return null;
 
-  // 空白のみのメッセージはタイトルが空文字列になるため起票対象外としてスキップする
-  // (LINE は空文字メッセージを送信できる場合があり、Zod min(1) を持たないこのパスでは別途ガードが必要)
-  const trimmedText = textMessage.text.trim();
-  if (!trimmedText) return null;
+  // メッセージ種別 (テキスト/画像) ごとにタイトル・本文・冪等化キー・添付候補を組み立てる。
+  // 重複判定 (findDuplicateLineTicket) はどちらの種別でも同じロジックのため各分岐内で呼び出す。
+  let messageId: string | null;
+  let title: string;
+  let ticketBody: string;
+  // 画像添付の Content API 取得キー (テキストメッセージ、または LINE 以外がホストする画像では
+  // null のまま = 添付なしで起票を続行する)
+  let attachmentMessageId: string | null = null;
 
-  // 冪等化キー (このメッセージが再送かどうかの突き合わせに使う)。
-  // id が欠落/非文字列 (想定外の応答) のときは突き合わせできないため null にする
-  const messageId = typeof textMessage.id === 'string' && textMessage.id ? textMessage.id : null;
+  if (message.type === 'text') {
+    // テキストメッセージとして型を確定させる。message の宣言型は
+    // `LineTextMessage | LineImageMessage | { type?: string }` であり、最後の汎用メンバーの
+    // type が string 型 (リテラルでない) のため、type==='text' の絞り込みだけでは
+    // TypeScript が text/id プロパティの存在を保証できない (絞り込み後も汎用メンバーが残る)
+    const textMessage = message as LineTextMessage;
+    // text が文字列でない (欠落・型不正) イベントは起票できないためスキップする
+    if (typeof textMessage.text !== 'string') return null;
 
-  // 冪等化の早期チェック (fast path): このメッセージ ID を既に取り込み済みなら、
-  // 連携コード判定や起票者解決などの以降の処理を行わずに既存チケット ID を返す。
-  // LINE は Webhook 応答が遅延/未受信だと同一メッセージを 5 分以内に再送する (at-least-once)。
-  // これは事前チェックに過ぎず、実際の二重起票防止は createTicketIdempotent 内の
-  // Serializable トランザクションが保証する (このチェック単体では TOCTOU の窓が残るため)。
-  if (messageId) {
-    const existingTicketId = await repos.lineMessages.findTicketIdByMessageId(
-      messageId,
-      targetTenantId,
-    );
-    if (existingTicketId) {
-      // 既知のメッセージ ID: 二重起票を避けて既存チケット ID を返す
-      console.info(
-        `[POST /api/inbound/line] duplicate message id, skipping re-create: ${messageId}`,
-      );
-      return existingTicketId;
+    // 空白のみのメッセージはタイトルが空文字列になるため起票対象外としてスキップする
+    // (LINE は空文字メッセージを送信できる場合があり、Zod min(1) を持たないこのパスでは別途ガードが必要)
+    const trimmedText = textMessage.text.trim();
+    if (!trimmedText) return null;
+
+    // 冪等化キー (このメッセージが再送かどうかの突き合わせに使う)。
+    // id が欠落/非文字列 (想定外の応答) のときは突き合わせできないため null にする
+    messageId = typeof textMessage.id === 'string' && textMessage.id ? textMessage.id : null;
+
+    // 冪等化の早期チェック (fast path): このメッセージ ID を既に取り込み済みなら、
+    // 連携コード判定や起票者解決などの以降の処理を行わずに既存チケット ID を返す。
+    // LINE は Webhook 応答が遅延/未受信だと同一メッセージを 5 分以内に再送する (at-least-once)。
+    // これは事前チェックに過ぎず、実際の二重起票防止は createTicketIdempotent 内の
+    // Serializable トランザクションが保証する (このチェック単体では TOCTOU の窓が残るため)。
+    if (messageId) {
+      const existingTicketId = await findDuplicateLineTicket(messageId, targetTenantId);
+      if (existingTicketId) return existingTicketId;
     }
-  }
 
-  // メンバー紐付け: テキストが発行済みワンタイムコードなら、起票せず lineUserId をメンバーへ紐付ける。
-  // (lineUserId が取得できないイベントは紐付けようがないので、この処理を飛ばして通常起票へ進む)
-  if (lineUserId !== '不明') {
-    // 受信テキストを正規化 (ハイフン・空白除去 + 大文字化) してコードの形か軽く判定する
-    const normalizedCode = normalizeLineLinkCode(trimmedText);
-    if (looksLikeLineLinkCode(normalizedCode)) {
-      // 連携コード処理は起票を伴わないため lineMessages 対応表の冪等化対象外になる。
-      // この messageId を連携コードとして処理済みなら、再度 linkLineUserByCode を
-      // 呼ばずに即座にスキップする (再送で「コードは消費済み → invalid → 誤起票」になるのを防ぐ)
-      if (messageId && (await repos.lineLinkCodes.wasProcessed(messageId))) {
-        console.info(
-          `[POST /api/inbound/line] duplicate link-code message, skipping: ${messageId}`,
-        );
-        return null;
+    // メンバー紐付け: テキストが発行済みワンタイムコードなら、起票せず lineUserId をメンバーへ紐付ける。
+    // (lineUserId が取得できないイベントは紐付けようがないので、この処理を飛ばして通常起票へ進む)
+    if (lineUserId !== '不明') {
+      // 受信テキストを正規化 (ハイフン・空白除去 + 大文字化) してコードの形か軽く判定する
+      const normalizedCode = normalizeLineLinkCode(trimmedText);
+      if (looksLikeLineLinkCode(normalizedCode)) {
+        // 連携コード処理は起票を伴わないため lineMessages 対応表の冪等化対象外になる。
+        // この messageId を連携コードとして処理済みなら、再度 linkLineUserByCode を
+        // 呼ばずに即座にスキップする (再送で「コードは消費済み → invalid → 誤起票」になるのを防ぐ)
+        if (messageId && (await repos.lineLinkCodes.wasProcessed(messageId))) {
+          console.info(
+            `[POST /api/inbound/line] duplicate link-code message, skipping: ${messageId}`,
+          );
+          return null;
+        }
+        // 形が一致したらハッシュ化し、有効な発行行があれば原子的に紐付ける
+        const codeHash = await hashLineLinkCode(normalizedCode);
+        const link = await repos.users.linkLineUserByCode({
+          codeHash,
+          tenantId: targetTenantId,
+          lineUserId,
+          now,
+        });
+        // 連携成功 / 競合 (コードとして処理済み) のときは、このメッセージを問い合わせにしない
+        if (link.status === 'linked' || link.status === 'conflict') {
+          // 連携結果をログに残す (利用者は Web 設定画面の「連携済み」表示で連携状態を確認する)
+          console.info(
+            `[POST /api/inbound/line] line link ${link.status} for tenant`,
+            targetTenantId,
+          );
+          // この messageId を「連携コードとして処理済み」に記録する (再送時の誤起票防止)。
+          // /code-review ultra 指摘対応: DB 永続化 (lineLinkCodes) に切り替えたことで、
+          // 連携成功直後にプロセス再起動/デプロイが挟まっても記録が失われず、単一インスタンスの
+          // 場合はもちろん、複数インスタンス間でも共有される (水平スケール環境でも安全)
+          if (messageId) await repos.lineLinkCodes.markProcessed(messageId);
+          return null;
+        }
+        // invalid (コードの形だが有効な発行行が無い) は通常の問い合わせとして下の起票へ進む
+        // (typo 等の本来の invalid はメッセージ ID 冪等化の対象になるため再送で二重起票しない)。
       }
-      // 形が一致したらハッシュ化し、有効な発行行があれば原子的に紐付ける
-      const codeHash = await hashLineLinkCode(normalizedCode);
-      const link = await repos.users.linkLineUserByCode({
-        codeHash,
-        tenantId: targetTenantId,
-        lineUserId,
-        now,
-      });
-      // 連携成功 / 競合 (コードとして処理済み) のときは、このメッセージを問い合わせにしない
-      if (link.status === 'linked' || link.status === 'conflict') {
-        // 連携結果をログに残す (利用者は Web 設定画面の「連携済み」表示で連携状態を確認する)
-        console.info(
-          `[POST /api/inbound/line] line link ${link.status} for tenant`,
-          targetTenantId,
-        );
-        // この messageId を「連携コードとして処理済み」に記録する (再送時の誤起票防止)。
-        // /code-review ultra 指摘対応: DB 永続化 (lineLinkCodes) に切り替えたことで、
-        // 連携成功直後にプロセス再起動/デプロイが挟まっても記録が失われず、単一インスタンスの
-        // 場合はもちろん、複数インスタンス間でも共有される (水平スケール環境でも安全)
-        if (messageId) await repos.lineLinkCodes.markProcessed(messageId);
-        return null;
-      }
-      // invalid (コードの形だが有効な発行行が無い) は通常の問い合わせとして下の起票へ進む
-      // (typo 等の本来の invalid はメッセージ ID 冪等化の対象になるため再送で二重起票しない)。
+    }
+
+    // チケットタイトルはメッセージテキストの先頭 MAX_TITLE_LENGTH 文字にする
+    title =
+      trimmedText.length > MAX_TITLE_LENGTH
+        ? `${trimmedText.slice(0, MAX_TITLE_LENGTH)}…`
+        : trimmedText;
+
+    // メッセージ本文をサーバー側でも上限に丸める (LINE の送信上限 5000 文字よりも大きい 10000 文字で守る)
+    // プラットフォーム上限だけに頼らずサーバー側でも明示的に制限して DB への過大な書き込みを防ぐ。
+    // trimmedText を使うことで先頭・末尾の空白を除いてから切り詰める (message.text のままだと
+    // 空白だけのメッセージが上の空白チェックをすり抜けた場合にチケット本文が空白だらけになる)。
+    const safeText =
+      trimmedText.length > MAX_BODY_LENGTH
+        ? `${trimmedText.slice(0, MAX_BODY_LENGTH)}…`
+        : trimmedText;
+
+    // チケット本文: LINE ユーザー ID と全メッセージテキストを含める (担当者が手動連絡できるよう)
+    ticketBody = `[LINE 経由の問い合わせ]\nLINE ユーザー ID: ${lineUserId}\n\n${safeText}`;
+  } else {
+    // 画像メッセージとして型を確定させる (text ブランチの LineTextMessage キャストと同じ理由)
+    const imageMessage = message as LineImageMessage;
+    // 冪等化キーはテキストと同じくメッセージ ID を使う
+    messageId = typeof imageMessage.id === 'string' && imageMessage.id ? imageMessage.id : null;
+
+    // 冪等化の早期チェック (テキストと同じロジック。findDuplicateLineTicket に共通化済み)
+    if (messageId) {
+      const existingTicketId = await findDuplicateLineTicket(messageId, targetTenantId);
+      if (existingTicketId) return existingTicketId;
+    }
+
+    // 画像メッセージには本文テキストが無いため固定のタイトル・本文にする
+    title = 'LINE から画像の問い合わせが届きました';
+    ticketBody = `[LINE 経由の問い合わせ]\nLINE ユーザー ID: ${lineUserId}\n\n(画像が送信されました。添付ファイルをご確認ください)`;
+
+    // contentProvider.type が 'line' (既定/省略時) の画像だけ Content API から取得できる。
+    // 'external' (LIFF 等が外部ホストへアップロードした画像) は取得手段が任意の外部 URL になり
+    // SSRF の懸念があるため対象外とする (固定ホストの Content API 経由で取得できるものだけを
+    // サポート範囲にする)。取得できなくても本文だけで起票を継続する (§9 fail-safe)
+    const providerType = imageMessage.contentProvider?.type;
+    if (messageId && (providerType === undefined || providerType === 'line')) {
+      attachmentMessageId = messageId;
+    } else if (messageId) {
+      console.info(
+        `[POST /api/inbound/line] external content provider image skipped: ${messageId}`,
+      );
     }
   }
 
@@ -457,23 +565,45 @@ async function processLineEvent(
     lineUserId !== '不明' ? await repos.users.findByLineUserId(targetTenantId, lineUserId) : null;
   const creatorId = linkedMember ? linkedMember.id : proxyCreator.id;
 
-  // チケットタイトルはメッセージテキストの先頭 MAX_TITLE_LENGTH 文字にする
-  const title =
-    trimmedText.length > MAX_TITLE_LENGTH
-      ? `${trimmedText.slice(0, MAX_TITLE_LENGTH)}…`
-      : trimmedText;
-
-  // メッセージ本文をサーバー側でも上限に丸める (LINE の送信上限 5000 文字よりも大きい 10000 文字で守る)
-  // プラットフォーム上限だけに頼らずサーバー側でも明示的に制限して DB への過大な書き込みを防ぐ。
-  // trimmedText を使うことで先頭・末尾の空白を除いてから切り詰める (textMessage.text のままだと
-  // 空白だけのメッセージが上の空白チェックをすり抜けた場合にチケット本文が空白だらけになる)。
-  const safeText =
-    trimmedText.length > MAX_BODY_LENGTH
-      ? `${trimmedText.slice(0, MAX_BODY_LENGTH)}…`
-      : trimmedText;
-
-  // チケット本文: LINE ユーザー ID と全メッセージテキストを含める (担当者が手動連絡できるよう)
-  const ticketBody = `[LINE 経由の問い合わせ]\nLINE ユーザー ID: ${lineUserId}\n\n${safeText}`;
+  // 画像添付があれば、チケット起票より前に取得・検証しておく (メール取り込みと同じ順序)。
+  // 取得・検証に失敗しても添付なしで起票を継続する (§9 fail-safe)。
+  let validatedAttachments: ValidatedAttachment[] = [];
+  if (attachmentMessageId) {
+    const content = await fetchLineMessageContent(ctx.channelAccessToken, attachmentMessageId);
+    if (content) {
+      // Content API が返す実際の Content-Type を申告 MIME として渡し、既存の検証パイプライン
+      // (許可 MIME 判定 + マジックバイト整合チェック) をそのまま再利用する (§6 DRY)
+      // Uint8Array のコピーコンストラクタを経由して ArrayBuffer 裏付けの型にする
+      // (TS の lib.dom 型定義上、素の Uint8Array<ArrayBufferLike> は BlobPart に直接代入できないため。
+      // src/app/api/attachments/[id]/route.ts の配信時と同じ回避策)
+      const file = new File([new Uint8Array(content.bytes)], `line-${attachmentMessageId}`, {
+        type: content.contentType,
+      });
+      const attachmentValidation = await validateUploadedFilesLenient([file]);
+      if (attachmentValidation.droppedCount > 0) {
+        console.warn('[POST /api/inbound/line] image attachment rejected by validation', {
+          messageId: attachmentMessageId,
+        });
+      }
+      validatedAttachments = attachmentValidation.files;
+      // 添付累計サイズ上限チェック (Web フォーム・メール取り込みと共有 §6.1 料金プラン)
+      if (validatedAttachments.length > 0) {
+        const totalBytes = validatedAttachments.reduce((sum, f) => sum + f.size, 0);
+        const quotaCheck = await checkAttachmentQuota(
+          targetTenantId,
+          totalBytes,
+          ctx.subscriptionPlan,
+        );
+        if (!quotaCheck.ok) {
+          console.warn(
+            '[POST /api/inbound/line] image attachment exceeds quota, continuing without it',
+            { reason: quotaCheck.message },
+          );
+          validatedAttachments = [];
+        }
+      }
+    }
+  }
 
   // Phase 4 課金: 月間チケット上限チェック (Web フォーム・CSV インポート・メール取り込みと共有)。
   // tenant-plan.ts のコメントで「全ての起票入口で共有する」と明記されているにもかかわらず、
@@ -486,13 +616,18 @@ async function processLineEvent(
     return null;
   }
 
+  // 添付ファイルのストレージ書き込みはトランザクション外の副作用のため、失敗時に後始末できるよう
+  // 書き込み済みキーを蓄えておく (POST /api/tickets・POST /api/inbound/email と同じ方針)
+  const writtenKeys: string[] = [];
+
   // 新規チケットを起票する (Web フォーム・メール取り込みと同じ PORT 経由)。
   // 1 件の起票失敗で全体を 500 にすると LINE がバッチ全体を再送し、既に起票済みのチケットが
   // 重複する。そのため起票は try/catch で囲み、失敗は文脈付きでログに残して null を返す
   // (呼び出し側 POST は必ず 200 を返す。再送そのものは createTicketIdempotent の Serializable
   // トランザクションが二重起票を防ぐ)。
   try {
-    // 起票 (+ メッセージ ID 登録) を 1 トランザクションで原子的に行う。
+    // 起票 (+ 添付メタ INSERT + メッセージ ID 登録) を onCreated フック経由で 1 トランザクションで
+    // 原子的に行う (メールの添付対応 PR #207 で追加済みの仕組みをそのまま再利用する)。
     // alreadyExisted が true のときは、書き込み競合で中断された後の再確認で「他リクエストが
     // 既に起票済み」と判明したケース (通知は既にそちらのリクエストで送られているはず)
     const { id: ticketId, alreadyExisted } = await createTicketIdempotent(
@@ -510,10 +645,33 @@ async function processLineEvent(
         resolutionDueAt, // 優先度 Medium ベースの解決期限
         firstResponseDueAt, // 優先度 Medium ベースの初回応答期限
       },
+      {
+        // フォローアップ (2026-07-13): 検証済み画像添付をこの新規チケットに紐づけて保存する
+        onCreated:
+          validatedAttachments.length > 0
+            ? (tx, newTicketId) =>
+                persistAttachments(
+                  tx,
+                  validatedAttachments,
+                  newTicketId,
+                  null, // 新規起票への添付 (コメントには紐づかない)
+                  creatorId,
+                  targetTenantId,
+                  writtenKeys,
+                )
+            : undefined,
+      },
     );
     if (alreadyExisted) {
       // 既に他リクエストが起票・通知済みのため、通知は送らずチケット ID だけ返す
       console.info(`[POST /api/inbound/line] resolved write conflict as duplicate: ${messageId}`);
+      // /code-review ultra 指摘対応 (2026-07-13): このリクエスト自身の (敗れた) トランザクション内で
+      // onCreated が添付ファイルを既にストレージへ書き込んでいた場合、DB 側はロールバックされても
+      // ストレージの書き込みはトランザクション外の副作用のため残ってしまう (メール取り込みと同じ不備)。
+      // writtenKeys にはこのリクエスト自身が書き込んだキーだけが積まれるため常に安全にクリーンアップできる
+      if (writtenKeys.length > 0) {
+        await cleanupWrittenAttachments(writtenKeys, '[POST /api/inbound/line]');
+      }
       return ticketId;
     }
     // 上限のあるプランでは残枠を消費する (無制限プランは remaining が Infinity のため減算不要だが、
@@ -547,6 +705,10 @@ async function processLineEvent(
     await notifyNewTicketOutbound(targetTenantId, { id: ticketId, title, priority: 'Medium' });
     return ticketId;
   } catch (err) {
+    // DB は自動ロールバック済み (createTicketIdempotent がキー無し経路もトランザクション化して
+    // いるため、チケット行だけが添付無しで残ることは無い)。ストレージへの書き込みだけは
+    // トランザクション外の副作用のため、書き込み済みキーを個別に best-effort で削除する
+    await cleanupWrittenAttachments(writtenKeys, '[POST /api/inbound/line]');
     // 起票失敗は握り潰さずログに残す。再送による重複起票を避けるため呼び出し側は 200 で受領する
     console.error('[POST /api/inbound/line] failed to create ticket from event', err);
     return null;

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -38,6 +38,11 @@ import { getMonthlyTicketQuota } from '@/lib/tenant-plan';
 import { notifyOutboundBestEffort } from '@/lib/outbound-notify';
 // 優先度から初回応答期限を計算する SLA ヘルパー (Web フォーム・メール・LINE 取り込みと共有)
 import { calculateFirstResponseDueAt } from '@/lib/sla';
+// フォローアップ (2026-07-13): 監査で発見したギャップの解消。担当割当メールを
+// updateTicketAssignee (画面からの手動アサイン) と同じ経路で送るためのヘルパー群
+import { getEmailSender } from '@/lib/email';
+import { renderAssignedBatchEmail } from '@/lib/ticket-email';
+import { resolveAppBaseUrl } from '@/lib/app-url';
 
 // 1 インポートあたりの最大行数 (これを超えたらエラー)
 const MAX_ROWS = 200;
@@ -151,6 +156,55 @@ async function notifyImportBatch(
     await broadcastUnreadCountToMany(recipientIds, tenantId);
   } catch (err) {
     console.warn(`${logPrefix} SSE broadcast に失敗しました（チケット作成は成功）:`, err);
+  }
+}
+
+// CSV インポートで担当者に割り当てられたエージェントへメールで通知するベストエフォート・ヘルパー。
+// フォローアップ (2026-07-13): 監査で発見したギャップの解消。画面からの手動アサイン
+// (updateTicketAssignee) は担当者へアプリ内通知に加えてメールも届くのに対し、CSV インポートで
+// 「担当者」列から初期担当者を設定してもアプリ内通知しか届かず、アプリを開かない担当者は
+// 気づけなかった (§2 ギャップ分析表「アプリ開かない前提 → メール通知を主軸に切替」に反する)。
+// 個々のチケットごとには送らず、担当件数をまとめて 1 通にする (notifyImportBatch と同じ方針)。
+async function notifyAssignedAgentsByEmail(
+  assignedAgentIds: string[], // メール送信対象のエージェント ID 一覧 (呼び出し元で自己除外済み)
+  tenantId: string, // テナントスコープ
+  assignedCounts: Map<string, number>, // エージェントごとの割当件数
+): Promise<void> {
+  // 対象が居なければ何もしない (早期リターン)
+  if (assignedAgentIds.length === 0) return;
+  // ベース URL を解決する (production で NEXTAUTH_URL 未設定なら throw される)。
+  // 解決できなければメール本文の URL を組み立てられないため、この時点でログしてスキップする
+  let baseUrl: string;
+  try {
+    baseUrl = resolveAppBaseUrl();
+  } catch (err) {
+    console.error('[importTickets] 担当割当メール送信用のベース URL 解決に失敗しました', err);
+    return;
+  }
+  // メール送信先には email が必要 (agentsForAssignee/listAgents が返す UserSummary には email が
+  // 含まれないため、エスカレーション一斉メールと同じ専用メソッドで id→email を解決する)
+  const agentEmails = await repos.users.listAgentEmails(tenantId);
+  const emailById = new Map(agentEmails.map((a) => [a.id, a.email]));
+  // 各エージェントへのメール送信を並列に行う。Promise.allSettled を使い、1 件の送信失敗が
+  // 他エージェントへの送信をブロックしないようにする (チケット作成は既に完了済みのため)
+  const results = await Promise.allSettled(
+    assignedAgentIds.map((agentId) => {
+      const email = emailById.get(agentId);
+      // 退職・削除等で email が引けない場合は送りようがないためスキップする
+      if (!email) return Promise.resolve();
+      // 担当割当メールの件名 / テキスト / HTML を純粋ヘルパーで生成する (件数をまとめた文面)
+      const { subject, text, html } = renderAssignedBatchEmail({
+        count: assignedCounts.get(agentId) ?? 0,
+        ticketsUrl: `${baseUrl}/tickets`, // 単一チケットに紐づかないため一覧ページへリンクする
+      });
+      // 設定された EmailSender (console / smtp) 経由でメール送信
+      return getEmailSender().send({ to: email, subject, text, html });
+    }),
+  );
+  // 失敗した送信件数をサーバーログに記録する (チケット作成の成否には影響しない)
+  const failedCount = results.filter((r) => r.status === 'rejected').length;
+  if (failedCount > 0) {
+    console.warn(`[importTickets] 担当割当メール送信に ${failedCount} 件失敗しました`);
   }
 }
 
@@ -721,7 +775,9 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
 
     // /code-review ultra 指摘対応 (2026-07-13): 上記 2 種類の通知は互いに独立した宛先・内容の
     // I/O であり、notifyImportBatch 共通ヘルパーへの抽出と合わせて Promise.all で並行実行する
-    // (§8 パフォーマンス)
+    // (§8 パフォーマンス)。フォローアップ (2026-07-13): 監査で発見したギャップの解消。担当割当は
+    // 手動アサインと同じくメールも送る (notifyAssignedAgentsByEmail) ので、これも独立した I/O として
+    // 同じ Promise.all に加える
     await Promise.all([
       notifyImportBatch(
         otherAgentIds,
@@ -738,6 +794,7 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
           `CSV インポートで ${assignedCounts.get(agentId)} 件のチケットが担当者に割り当てられました`,
         '[importTickets] 担当割当通知',
       ),
+      notifyAssignedAgentsByEmail(assignedAgentIds, tenantId, assignedCounts),
     ]);
   }
 

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -39,8 +39,9 @@ import { notifyOutboundBestEffort } from '@/lib/outbound-notify';
 // 優先度から初回応答期限を計算する SLA ヘルパー (Web フォーム・メール・LINE 取り込みと共有)
 import { calculateFirstResponseDueAt } from '@/lib/sla';
 // フォローアップ (2026-07-13): 監査で発見したギャップの解消。担当割当メールを
-// updateTicketAssignee (画面からの手動アサイン) と同じ経路で送るためのヘルパー群
-import { getEmailSender } from '@/lib/email';
+// updateTicketAssignee (画面からの手動アサイン) と同じ経路で送るためのヘルパー群。
+// sendBatchEmail はエスカレーション一斉メール (escalateTicket) と共有する送信共通処理 (§6 DRY)
+import { sendBatchEmail } from '@/lib/batch-email';
 import { renderAssignedBatchEmail } from '@/lib/ticket-email';
 import { resolveAppBaseUrl } from '@/lib/app-url';
 
@@ -172,39 +173,43 @@ async function notifyAssignedAgentsByEmail(
 ): Promise<void> {
   // 対象が居なければ何もしない (早期リターン)
   if (assignedAgentIds.length === 0) return;
-  // ベース URL を解決する (production で NEXTAUTH_URL 未設定なら throw される)。
-  // 解決できなければメール本文の URL を組み立てられないため、この時点でログしてスキップする
-  let baseUrl: string;
+  // /code-review ultra 指摘対応 (2026-07-13): 以前はベース URL 解決だけを try/catch していたため、
+  // 続く listAgentEmails (DB 呼び出し) が失敗すると例外が捕捉されずに importTickets 全体の
+  // Promise.all まで伝播し、チケット作成が既に成功しているにもかかわらず CSV インポート自体が
+  // 失敗したように見えてしまっていた (notifyImportBatch 等、同ファイルの他のベストエフォート
+  // 処理と方針が食い違っていた)。ベース URL 解決から送信完了までをまとめて 1 つの try で囲む。
   try {
-    baseUrl = resolveAppBaseUrl();
+    // ベース URL を解決する (production で NEXTAUTH_URL 未設定なら throw される)
+    const baseUrl = resolveAppBaseUrl();
+    // メール送信先には email が必要 (agentsForAssignee/listAgents が返す UserSummary には email が
+    // 含まれないため、エスカレーション一斉メールと同じ専用メソッドで id→email を解決する)
+    const agentEmails = await repos.users.listAgentEmails(tenantId);
+    const assignedIdSet = new Set(assignedAgentIds);
+    const recipients = agentEmails.filter((a) => assignedIdSet.has(a.id));
+    // 退職・削除等で email が引けなかったエージェントがいればログに残す (CLAUDE.md §6:
+    // エラーを握り潰さない。何件送れなかったかが分かれば十分なので件数のみ記録する)
+    const missingCount = assignedAgentIds.length - recipients.length;
+    if (missingCount > 0) {
+      console.warn(
+        `[importTickets] 担当割当メール: ${missingCount} 件のエージェントの email が見つかりませんでした`,
+      );
+    }
+    // 送信・失敗件数ログはエスカレーション一斉メールと共有の共通ヘルパーに委譲する (§6 DRY)
+    await sendBatchEmail(
+      recipients,
+      (agent) =>
+        renderAssignedBatchEmail({
+          count: assignedCounts.get(agent.id) ?? 0,
+          ticketsUrl: `${baseUrl}/tickets`, // 単一チケットに紐づかないため一覧ページへリンクする
+        }),
+      '[importTickets] 担当割当メール',
+    );
   } catch (err) {
-    console.error('[importTickets] 担当割当メール送信用のベース URL 解決に失敗しました', err);
-    return;
-  }
-  // メール送信先には email が必要 (agentsForAssignee/listAgents が返す UserSummary には email が
-  // 含まれないため、エスカレーション一斉メールと同じ専用メソッドで id→email を解決する)
-  const agentEmails = await repos.users.listAgentEmails(tenantId);
-  const emailById = new Map(agentEmails.map((a) => [a.id, a.email]));
-  // 各エージェントへのメール送信を並列に行う。Promise.allSettled を使い、1 件の送信失敗が
-  // 他エージェントへの送信をブロックしないようにする (チケット作成は既に完了済みのため)
-  const results = await Promise.allSettled(
-    assignedAgentIds.map((agentId) => {
-      const email = emailById.get(agentId);
-      // 退職・削除等で email が引けない場合は送りようがないためスキップする
-      if (!email) return Promise.resolve();
-      // 担当割当メールの件名 / テキスト / HTML を純粋ヘルパーで生成する (件数をまとめた文面)
-      const { subject, text, html } = renderAssignedBatchEmail({
-        count: assignedCounts.get(agentId) ?? 0,
-        ticketsUrl: `${baseUrl}/tickets`, // 単一チケットに紐づかないため一覧ページへリンクする
-      });
-      // 設定された EmailSender (console / smtp) 経由でメール送信
-      return getEmailSender().send({ to: email, subject, text, html });
-    }),
-  );
-  // 失敗した送信件数をサーバーログに記録する (チケット作成の成否には影響しない)
-  const failedCount = results.filter((r) => r.status === 'rejected').length;
-  if (failedCount > 0) {
-    console.warn(`[importTickets] 担当割当メール送信に ${failedCount} 件失敗しました`);
+    // ベース URL 解決失敗・email 一覧取得失敗等はメール送信全体を諦める
+    // (チケット作成の成否には影響しない。呼び出し元は Promise.all で並行実行するため、
+    // ここで例外を伝播させると他のベストエフォート処理まで巻き込んで importTickets 全体が
+    // 失敗したように見えてしまう)
+    console.error('[importTickets] 担当割当メール送信処理に失敗しました', err);
   }
 }
 

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -41,6 +41,8 @@ import {
 } from '@/lib/ticket-email';
 // EmailSender 実装を取得するファクトリ (環境変数で console / smtp を切り替え)
 import { getEmailSender } from '@/lib/email';
+// 複数宛先への一斉メール送信共通ヘルパー (CSV インポートの担当割当メールと共有。§6 DRY)
+import { sendBatchEmail } from '@/lib/batch-email';
 // メールに埋め込むリンクのベース URL を解決するヘルパー
 import { resolveAppBaseUrl } from '@/lib/app-url';
 // Phase 4: Slack/Teams 外部通知ヘルパー (失敗してもチケット操作を止めない)
@@ -680,26 +682,21 @@ export async function escalateTicket(ticketId: string, reason: string) {
     // チケット詳細ページの URL (メール本文・外部通知の両方で使い回す)
     const ticketUrl = buildTicketUrl(baseUrl, ticketId);
     await Promise.allSettled([
-      // 経路 1: 操作者以外の全エージェントへメール送信 (1 通の失敗が他へ波及しないよう内側でも allSettled)
+      // 経路 1: 操作者以外の全エージェントへメール送信 (1 通の失敗が他へ波及しないよう内側でも allSettled)。
+      // /code-review ultra 指摘対応 (2026-07-13): CSV インポートの担当割当メール
+      // (notifyAssignedAgentsByEmail) と同型の「id→email 解決済みの宛先一覧へ Promise.allSettled
+      // で送信し、失敗件数をログに残す」処理だったため、共通ヘルパー sendBatchEmail へ抽出した
+      // (2 箇所目の重複。CLAUDE.md §6 DRY)
       (async () => {
         try {
-          // 件名 / 本文 (Text / HTML) を純粋ヘルパーで構築
-          const { subject, text, html } = renderEscalatedEmail({
-            ticketTitle: title,
-            ticketUrl,
-            reason: trimmedReason,
-          });
           // 操作者本人 (エスカレーションを実行したエージェント) は自分の操作を知っているため除く
           const recipients = agents.filter((a) => a.id !== session.user.id);
-          const results = await Promise.allSettled(
-            recipients.map((a) => getEmailSender().send({ to: a.email, subject, text, html })),
+          // 全員へ同じ文面を送るため render 関数は引数 (宛先) を無視してよい
+          await sendBatchEmail(
+            recipients,
+            () => renderEscalatedEmail({ ticketTitle: title, ticketUrl, reason: trimmedReason }),
+            '[escalateTicket]',
           );
-          const failedCount = results.filter((r) => r.status === 'rejected').length;
-          if (failedCount > 0) {
-            console.warn(
-              `[escalateTicket] ${failedCount} 件のエージェント宛メール送信に失敗しました`,
-            );
-          }
         } catch (err) {
           // 本文組み立て自体に失敗した場合もログのみに留める (アプリ内通知は既に成立している)
           console.error('[escalateTicket] エージェント宛メール送信に失敗しました', err);

--- a/src/lib/batch-email.ts
+++ b/src/lib/batch-email.ts
@@ -1,0 +1,46 @@
+// 複数の宛先へ同種のメールをベストエフォートで送る共通ヘルパー。
+//
+// /code-review ultra 指摘対応 (2026-07-13): エスカレーション一斉メール (update-ticket.ts の
+// escalateTicket) と CSV インポートの担当割当メール (import-tickets.ts の
+// notifyAssignedAgentsByEmail) が、それぞれ「id→email を解決したエージェント一覧へ
+// Promise.allSettled で送信し、失敗件数をログに残す」という同型の処理を個別実装しており
+// 2 箇所目の重複になっていた (CLAUDE.md §6 DRY: 「実際に 2〜3 箇所目で重複したら共通化する」)。
+// 1 件の送信失敗が他の宛先への送信をブロックしないよう Promise.allSettled を使い、失敗件数のみを
+// ログに残す (誰が失敗したかの詳細まで欲しい場合は呼び出し側で個別にラップする)。
+
+// 設定された EmailSender (console / smtp) を取得するファクトリ
+import { getEmailSender } from '@/lib/email';
+
+// 送信先として最低限必要な情報 (呼び出し側の型がこれを満たしていればそのまま渡せる)
+export interface BatchEmailRecipient {
+  id: string; // ログ・呼び出し側の突き合わせ用 (このヘルパー自体は使わない)
+  email: string; // 送信先メールアドレス
+}
+
+// 宛先ごとにメール本文を組み立てる関数。全員へ同一内容を送る場合は引数を無視してよい
+// (escalateTicket のように全員同じ文面の場合と、notifyAssignedAgentsByEmail のように
+// 宛先ごとに件数が異なる場合の両方に対応する)。
+export type RenderBatchEmail<R> = (recipient: R) => { subject: string; text: string; html: string };
+
+// recipients が空なら何もしない。各宛先への送信は並列に行い、1 件の失敗が他をブロックしない。
+export async function sendBatchEmail<R extends BatchEmailRecipient>(
+  recipients: R[],
+  renderEmail: RenderBatchEmail<R>,
+  logPrefix: string, // 失敗ログの先頭に付ける識別子 (例: '[escalateTicket]')
+): Promise<void> {
+  // 対象が居なければ何もしない (早期リターン)
+  if (recipients.length === 0) return;
+  // 各宛先への送信を並列で行う。Promise.allSettled を使い、1 件の送信失敗が
+  // 他の宛先への送信をブロックしないようにする
+  const results = await Promise.allSettled(
+    recipients.map((recipient) => {
+      const { subject, text, html } = renderEmail(recipient);
+      return getEmailSender().send({ to: recipient.email, subject, text, html });
+    }),
+  );
+  // 失敗した送信件数をサーバーログに記録する (CLAUDE.md §6: エラーを握り潰さない)
+  const failedCount = results.filter((r) => r.status === 'rejected').length;
+  if (failedCount > 0) {
+    console.warn(`${logPrefix} ${failedCount} 件のメール送信に失敗しました`);
+  }
+}

--- a/src/lib/line-content.ts
+++ b/src/lib/line-content.ts
@@ -26,9 +26,12 @@ const LINE_CONTENT_API_BASE = 'https://api-data.line.me/v2/bot/message';
 // コンテンツ取得のタイムアウト (ミリ秒)。画像は line-push.ts の push (5秒) より大きいため少し長めにする
 const LINE_CONTENT_FETCH_TIMEOUT_MS = 10_000;
 
-// 読み取りバイト数の上限。添付サイズ上限ちょうどの画像を誤って「超過」と誤判定しないよう、
-// 上限そのものではなく「上限を超える (upperBound+1 バイト目) を読めたか」で超過を確定させる
-const READ_CAP_BYTES = MAX_ATTACHMENT_SIZE_BYTES + 1;
+// 読み取りバイト数の上限。readBodyCappedBytes は「受信済みバイト数が上限を超えたか
+// (received > maxBytes)」で打ち切るため、上限ちょうどのファイルは超過にならず最後まで読み切れ、
+// 1 バイトでも超えた時点で打ち切られる。この比較だけで境界値を正しく扱えるため、上限値自体に
+// +1 等の調整は不要 (以前は +1 していたが、received > (MAX+1) という比較になり実質 MAX+2 バイト
+// まで許してしまう off-by-one だった)
+const READ_CAP_BYTES = MAX_ATTACHMENT_SIZE_BYTES;
 
 // 取得できたコンテンツ (バイト列 + LINE サーバが返す実際の Content-Type)
 export interface LineMessageContent {
@@ -44,9 +47,14 @@ export async function fetchLineMessageContent(
   accessToken: string,
   messageId: string,
 ): Promise<LineMessageContent | null> {
-  let response: Awaited<ReturnType<typeof undiciFetch>>;
+  // /code-review ultra 指摘対応 (2026-07-13): 以前は fetch 呼び出しだけを try/catch していたため、
+  // ヘッダ受信後にボディのストリーム読み取り中 (readBodyCappedBytes 内) でタイムアウト・接続断が
+  // 起きると例外が捕捉されずに呼び出し元 (processLineEvent → POST) まで伝播し、この Webhook が
+  // 常に 200 を返すという契約 (LINE の再送ループを止めるための前提) を破ってしまっていた。
+  // fetch とボディ読み取りの両方をまとめて 1 つの try で囲み、どちらの失敗も「添付なしで
+  // 起票を継続する」フォールバックに正しく合流させる。
   try {
-    response = await undiciFetch(`${LINE_CONTENT_API_BASE}/${messageId}/content`, {
+    const response = await undiciFetch(`${LINE_CONTENT_API_BASE}/${messageId}/content`, {
       method: 'GET',
       // 長期アクセストークンを Bearer 認証で渡す (line-push.ts と同じ LINE API 仕様)
       headers: { Authorization: `Bearer ${accessToken}` },
@@ -57,32 +65,33 @@ export async function fetchLineMessageContent(
       // SSRF 対策: DNS 解決した実際の接続先 IP を検証する (DNS リバインディング対策)
       dispatcher: ssrfSafeDispatcher,
     });
+
+    // redirect: 'manual' のとき、リダイレクト応答は opaqueredirect になる (webhook-fetch.ts と同じ判定)
+    if (response.type === 'opaqueredirect' || (response.status >= 300 && response.status < 400)) {
+      console.warn('[line-content] redirect response rejected (SSRF guard)');
+      return null;
+    }
+    if (!response.ok) {
+      console.warn(`[line-content] failed to fetch message content: HTTP ${response.status}`);
+      return null;
+    }
+
+    // LINE サーバが返す実際の Content-Type (申告ベースではなく実測値なので、後段の
+    // validateUploadedFilesLenient のマジックバイト検証と合わせて二重に信頼性を確認できる)
+    const contentType = response.headers.get('content-type') ?? '';
+    const bytes = await readBodyCappedBytes(response, READ_CAP_BYTES);
+    if (bytes === null) {
+      // 上限超過は「巨大すぎる添付」として添付なしにフォールバックさせる (DoS 対策 §9)
+      console.warn('[line-content] message content exceeds size limit, dropping attachment');
+      return null;
+    }
+    return { bytes, contentType };
   } catch (err) {
-    // タイムアウト・DNS 失敗・接続エラー等はログに残し、添付なしにフォールバックさせる
+    // タイムアウト・DNS 失敗・接続エラー・ボディ読み取り中の切断等をまとめてログに残し、
+    // 添付なしにフォールバックさせる
     console.warn('[line-content] failed to fetch message content', err);
     return null;
   }
-
-  // redirect: 'manual' のとき、リダイレクト応答は opaqueredirect になる (webhook-fetch.ts と同じ判定)
-  if (response.type === 'opaqueredirect' || (response.status >= 300 && response.status < 400)) {
-    console.warn('[line-content] redirect response rejected (SSRF guard)');
-    return null;
-  }
-  if (!response.ok) {
-    console.warn(`[line-content] failed to fetch message content: HTTP ${response.status}`);
-    return null;
-  }
-
-  // LINE サーバが返す実際の Content-Type (申告ベースではなく実測値なので、後段の
-  // validateUploadedFilesLenient のマジックバイト検証と合わせて二重に信頼性を確認できる)
-  const contentType = response.headers.get('content-type') ?? '';
-  const bytes = await readBodyCappedBytes(response, READ_CAP_BYTES);
-  if (bytes === null) {
-    // 上限超過は「巨大すぎる添付」として添付なしにフォールバックさせる (DoS 対策 §9)
-    console.warn('[line-content] message content exceeds size limit, dropping attachment');
-    return null;
-  }
-  return { bytes, contentType };
 }
 
 // undici の Response 型と lib.dom の Response 型は ReadableStream 型が微妙に非互換のため、

--- a/src/lib/line-content.ts
+++ b/src/lib/line-content.ts
@@ -1,0 +1,141 @@
+// LINE Messaging API のコンテンツ取得 (画像添付ダウンロード) 専用ヘルパー。
+//
+// docs/smb-dx-pivot-plan.md §1.2 ペルソナ「現場リーダー」の最優先ユースケース「写真を撮って
+// 送るだけで終わってほしい」は、メール取り込み (PR #207) で実現済みだが、このペルソナが実際に
+// 最も使う LINE 経由では実現できていなかった (監査で発見したギャップ)。LINE の画像メッセージは
+// 本文にバイト列を含まず、別途 Messaging API の Content エンドポイントから取得する必要がある。
+//
+// なぜ webhook-fetch.ts (postWebhook) を再利用しないか:
+// postWebhook は「POST・テキストレスポンス」専用 (Slack/Teams/Chatwork の通知送信向け) だが、
+// ここでは「GET・バイナリレスポンス (画像本体)」が必要なため別モジュールに分離する。
+// ただし「タイムアウト」「レスポンスサイズの上限読み取り (§8/§9 DoS 対策)」
+// 「SSRF 対策 (undici + Dispatcher でリダイレクト非追従・DNS リバインディング対策)」という
+// 設計方針は webhook-fetch.ts と揃える。
+
+// SSRF 対策済みの undici fetch (Dispatcher を差し込める版。webhook-fetch.ts と同じ理由で使う)
+import { fetch as undiciFetch } from 'undici';
+// 接続直前に解決済み IP を検証する Dispatcher (DNS リバインディング対策)
+import { ssrfSafeDispatcher } from '@/lib/ssrf-guard';
+// 添付ファイルのサイズ上限 (Web フォーム/メール取り込みと同じ上限をここでも使う。単一の源)
+import { MAX_ATTACHMENT_SIZE_BYTES } from '@/domain/attachment';
+
+// LINE Messaging API のコンテンツ取得エンドポイント (固定ホスト。messageId は URL パスに
+// 埋め込むが、LINE 側が発行する英数字 ID のみでユーザー入力ではないため SSRF の懸念はない)
+const LINE_CONTENT_API_BASE = 'https://api-data.line.me/v2/bot/message';
+
+// コンテンツ取得のタイムアウト (ミリ秒)。画像は line-push.ts の push (5秒) より大きいため少し長めにする
+const LINE_CONTENT_FETCH_TIMEOUT_MS = 10_000;
+
+// 読み取りバイト数の上限。添付サイズ上限ちょうどの画像を誤って「超過」と誤判定しないよう、
+// 上限そのものではなく「上限を超える (upperBound+1 バイト目) を読めたか」で超過を確定させる
+const READ_CAP_BYTES = MAX_ATTACHMENT_SIZE_BYTES + 1;
+
+// 取得できたコンテンツ (バイト列 + LINE サーバが返す実際の Content-Type)
+export interface LineMessageContent {
+  bytes: Uint8Array; // ファイル本体のバイト列
+  contentType: string; // LINE サーバが返す実際の Content-Type (申告ではなく実測値)
+}
+
+// 指定した LINE メッセージ ID の添付コンテンツ (画像等) を取得する。
+// 取得に失敗した場合 (HTTP エラー・タイムアウト・サイズ超過・リダイレクト等) は null を返し、
+// 呼び出し側は「添付なしで起票を継続する」フォールバックを行う (§9 fail-safe: 添付取得の
+// 失敗だけでチケット本文自体の取り込みを止めない。メール取り込みの検証失敗時と同じ方針)。
+export async function fetchLineMessageContent(
+  accessToken: string,
+  messageId: string,
+): Promise<LineMessageContent | null> {
+  let response: Awaited<ReturnType<typeof undiciFetch>>;
+  try {
+    response = await undiciFetch(`${LINE_CONTENT_API_BASE}/${messageId}/content`, {
+      method: 'GET',
+      // 長期アクセストークンを Bearer 認証で渡す (line-push.ts と同じ LINE API 仕様)
+      headers: { Authorization: `Bearer ${accessToken}` },
+      // SSRF 対策: リダイレクトを自動追従しない (webhook-fetch.ts と同じ方針)
+      redirect: 'manual',
+      // 相手側の障害で起票処理が無限にハングしないよう一定時間で打ち切る
+      signal: AbortSignal.timeout(LINE_CONTENT_FETCH_TIMEOUT_MS),
+      // SSRF 対策: DNS 解決した実際の接続先 IP を検証する (DNS リバインディング対策)
+      dispatcher: ssrfSafeDispatcher,
+    });
+  } catch (err) {
+    // タイムアウト・DNS 失敗・接続エラー等はログに残し、添付なしにフォールバックさせる
+    console.warn('[line-content] failed to fetch message content', err);
+    return null;
+  }
+
+  // redirect: 'manual' のとき、リダイレクト応答は opaqueredirect になる (webhook-fetch.ts と同じ判定)
+  if (response.type === 'opaqueredirect' || (response.status >= 300 && response.status < 400)) {
+    console.warn('[line-content] redirect response rejected (SSRF guard)');
+    return null;
+  }
+  if (!response.ok) {
+    console.warn(`[line-content] failed to fetch message content: HTTP ${response.status}`);
+    return null;
+  }
+
+  // LINE サーバが返す実際の Content-Type (申告ベースではなく実測値なので、後段の
+  // validateUploadedFilesLenient のマジックバイト検証と合わせて二重に信頼性を確認できる)
+  const contentType = response.headers.get('content-type') ?? '';
+  const bytes = await readBodyCappedBytes(response, READ_CAP_BYTES);
+  if (bytes === null) {
+    // 上限超過は「巨大すぎる添付」として添付なしにフォールバックさせる (DoS 対策 §9)
+    console.warn('[line-content] message content exceeds size limit, dropping attachment');
+    return null;
+  }
+  return { bytes, contentType };
+}
+
+// undici の Response 型と lib.dom の Response 型は ReadableStream 型が微妙に非互換のため、
+// readBodyCappedBytes が実際に使うメンバーだけを持つ最小限の構造型で受け取る
+// (webhook-fetch.ts の FetchLikeResponse と同じ考え方)
+interface FetchLikeResponse {
+  body: {
+    getReader(): {
+      read(): Promise<{ done: boolean; value?: Uint8Array }>;
+      cancel(): Promise<void>;
+      releaseLock(): void;
+    };
+  } | null;
+}
+
+// レスポンス本文を上限バイト数まで読み取り、超過したら null を返す (呼び出し側がフォールバックする)。
+// webhook-fetch.ts の readBodyCapped と似た構造だが、あちらは文字列 (通知レスポンス確認用) を
+// 返す用途のため、画像本体のバイト列をそのまま返すこちらとは戻り値の型が異なり共通化しなかった。
+async function readBodyCappedBytes(
+  response: FetchLikeResponse,
+  maxBytes: number,
+): Promise<Uint8Array | null> {
+  const body = response.body;
+  if (!body) return null;
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        chunks.push(value);
+        received += value.length;
+        if (received > maxBytes) {
+          // 上限を超えた時点で以降のバイト列は読まずに接続を閉じる (メモリ保護 §8/§9)
+          await reader.cancel().catch(() => {
+            // cancel 自体の失敗は無視する (既に「超過」の判定は確定している)
+          });
+          return null;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const combined = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return combined;
+}

--- a/src/lib/ticket-email.ts
+++ b/src/lib/ticket-email.ts
@@ -308,3 +308,44 @@ export function renderEscalatedEmail(input: {
   // 3 点セットを返す
   return { subject, text, html };
 }
+
+// CSV インポートのように、複数チケットの担当割当をまとめて 1 通で知らせるメール本文を生成する
+// 純粋関数 (副作用なし)。
+//
+// フォローアップ (2026-07-13): 監査で発見したギャップの解消。画面からの手動アサイン
+// (updateTicketAssignee → renderAssignedEmail) は担当者へメールが届くのに対し、CSV インポートで
+// 「担当者」列から初期担当者を設定してもアプリ内通知しか届かず、アプリを開かない担当者は
+// 気づけなかった。renderAssignedEmail は 1 件のチケットタイトルを前提にした文面のため、
+// 複数チケットをまとめて知らせるこちらでは件数ベースの文面にする (タイトルの二重入れ子を避ける)。
+export function renderAssignedBatchEmail(input: {
+  count: number; // まとめて割り当てられたチケット件数
+  ticketsUrl: string; // 一覧ページの URL (個々のチケットに紐づかないため一覧への導線にする)
+}): { subject: string; text: string; html: string } {
+  // 件名: 接頭辞 + 件数を含めた担当割当の件名 (件数は数値のみのためサニタイズ不要)
+  const subject = `${SUBJECT_PREFIX} CSV インポートで${input.count}件のチケットの担当者に割り当てられました`;
+
+  // テキスト本文 (HTML 非対応クライアント向けフォールバック)
+  const text = [
+    `CSV インポートで ${input.count} 件のチケットの担当者に割り当てられました。`,
+    '',
+    '一覧から内容を確認してください。',
+    `${input.ticketsUrl}`,
+    '',
+    'このメールに心当たりがない場合は破棄してください。',
+  ].join('\n');
+
+  // HTML 本文に差し込む外部由来文字列を個別にエスケープする (XSS / 文面崩れ防止)
+  const escapedBatchUrl = escapeHtml(input.ticketsUrl);
+
+  // HTML 本文 (renderAssignedEmail と同じボタン装飾に揃える)
+  const html = `
+    <p>CSV インポートで ${input.count} 件のチケットの担当者に割り当てられました。</p>
+    <p>一覧を確認し、対応を開始してください。</p>
+    <p><a href="${escapedBatchUrl}" style="display:inline-block;padding:10px 16px;background:#0f766e;color:#ffffff;border-radius:6px;text-decoration:none;font-weight:600;">一覧を開く</a></p>
+    <p style="font-size:13px;color:#475569;">うまく開けない場合はこちらの URL をブラウザに貼り付けてください:<br><span style="word-break:break-all;">${escapedBatchUrl}</span></p>
+    <p style="font-size:13px;color:#64748b;">このメールに心当たりがない場合は破棄してください。</p>
+  `.trim();
+
+  // 3 点セットを返す
+  return { subject, text, html };
+}

--- a/tests/features/import-tickets.test.ts
+++ b/tests/features/import-tickets.test.ts
@@ -449,6 +449,34 @@ describe('importTickets', () => {
       expect(sentEmails[0]?.text).toContain('2 件');
     });
 
+    // /code-review ultra 指摘対応の回帰テスト (2026-07-13): 以前は担当割当メール送信の
+    // listAgentEmails 呼び出しが try/catch で囲まれておらず、DB エラー等が発生すると
+    // importTickets 全体の Promise.all まで例外が伝播し、チケット作成が既に成功しているのに
+    // CSV インポート自体が失敗したように見えてしまっていた。担当割当メール処理が失敗しても
+    // インポート結果 (imported/errors) は正しく返ること (例外が伝播しないこと) を確認する
+    it('担当割当メール送信中にエラーが起きてもインポート結果は正常に返る', async () => {
+      repos = {
+        ...repos,
+        users: {
+          ...repos.users,
+          listAgentEmails: async () => {
+            throw new Error('DB 接続エラー (シミュレーション)');
+          },
+        },
+      };
+      const importTickets = await loadAction();
+      const csv = `件名,担当者\n複合機の紙詰まり,エージェント2`;
+      const result = await importTickets(csv);
+
+      // メール送信処理が失敗しても、チケット作成自体は成功として返ること
+      expect(result.imported).toBe(1);
+      expect(result.errors).toHaveLength(0);
+      const ticket = [...store.tickets.values()][0];
+      expect(ticket?.assigneeId).toBe('u-agt-2');
+      // メールは送られていないこと (送信処理自体が例外で中断したため)
+      expect(sentEmails).toHaveLength(0);
+    });
+
     // インポート実行者が自分自身を担当者に設定した場合は、既に自分の操作だと分かっているため
     // 通知不要 (otherAgents と同じ「自分の操作を自分に通知しない」方針)
     it('インポート実行者が自分自身を担当者に設定しても assigned 通知は送られない', async () => {

--- a/tests/features/import-tickets.test.ts
+++ b/tests/features/import-tickets.test.ts
@@ -41,6 +41,19 @@ const { broadcastMock } = vi.hoisted(() => ({
   broadcastMock: vi.fn().mockResolvedValue(undefined),
 }));
 
+// 担当割当メール (フォローアップ 2026-07-13) の送信を捕捉する。実ファイルへ書き込む console
+// ドライバを避け、送信内容を配列に貯めて検証する (update-ticket.test.ts と同じ方式)。
+const { sentEmails } = vi.hoisted(() => ({
+  sentEmails: [] as Array<{ to: string; subject: string; text: string }>,
+}));
+vi.mock('@/lib/email', () => ({
+  getEmailSender: () => ({
+    send: async (message: { to: string; subject: string; text: string }) => {
+      sentEmails.push(message);
+    },
+  }),
+}));
+
 // @/data を差し替え。getter で参照することでテスト中の上書きが反映される
 vi.mock('@/data', () => ({
   get repos() {
@@ -148,6 +161,8 @@ beforeEach(() => {
   vi.resetModules();
   // SSE ブロードキャスト呼び出しの記録をリセットする
   broadcastMock.mockClear();
+  // 前のテストで貯まった送信済みメールをクリアする (フォローアップ 2026-07-13)
+  sentEmails.length = 0;
   // テナント・ユーザーのフィクスチャを投入する
   seed();
 });
@@ -426,6 +441,12 @@ describe('importTickets', () => {
       expect(assignedNotifications).toHaveLength(1);
       expect(assignedNotifications[0]?.message).toContain('2');
       expect(assignedNotifications[0]?.tenantId).toBe(TENANT);
+      // フォローアップ (2026-07-13): アプリ内通知に加えて、手動アサインと同じくメールも
+      // (件数をまとめて) 1 通だけ届くこと
+      expect(sentEmails).toHaveLength(1);
+      expect(sentEmails[0]?.to).toBe('agent2@example.com');
+      expect(sentEmails[0]?.subject).toContain('2件');
+      expect(sentEmails[0]?.text).toContain('2 件');
     });
 
     // インポート実行者が自分自身を担当者に設定した場合は、既に自分の操作だと分かっているため
@@ -441,6 +462,8 @@ describe('importTickets', () => {
         (n) => n.userId === 'u-agt-1' && n.type === 'assigned',
       );
       expect(assignedNotifications).toHaveLength(0);
+      // 自己割当ではメールも送らない (アプリ内通知と同じ「自分の操作を自分に通知しない」方針)
+      expect(sentEmails).toHaveLength(0);
     });
 
     // テナントに存在しない担当者名 (タイポ・退職済み等) はエラーとして記録され、

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -651,6 +651,32 @@ describe('POST /api/inbound/line', () => {
       expect(storage.entries.size).toBe(0);
     });
 
+    // /code-review ultra 指摘対応の回帰テスト (2026-07-13): 以前は fetch 呼び出しだけを try/catch
+    // していたため、ヘッダ受信後にボディのストリーム読み取り中に接続断・タイムアウトが起きると
+    // 例外が捕捉されずに POST まで伝播し、この Webhook が常に 200 を返すべき契約 (再送ループを
+    // 止めるための前提) を破っていた。ボディ読み取り中の失敗でも 200 + 添付なしで起票を継続すること
+    // (POST が 500 にならないこと) を確認する
+    it('Content API のボディ読み取り中に失敗しても 500 にならず添付なしで起票を継続する', async () => {
+      // ヘッダは正常に受信できたが、ボディのストリーム読み取り中に接続が切れるケースを模す
+      const brokenStream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.error(new Error('simulated mid-stream connection reset'));
+        },
+      });
+      fetchMock.mockResolvedValue(
+        new Response(brokenStream, { status: 200, headers: { 'content-type': 'image/png' } }),
+      );
+
+      const { POST } = await import('@/app/api/inbound/line/route');
+      const res = await POST(makeImageRequest(LINE_ID_UNLINKED, 'img-broken-stream'));
+      // ボディ読み取りが失敗しても 500 にはならず、常に 200 を返す契約が守られること
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ticketIds: string[] };
+      expect(body.ticketIds).toHaveLength(1);
+      expect(store.attachments.size).toBe(0);
+      expect(storage.entries.size).toBe(0);
+    });
+
     it('許可外 MIME の画像は無視され、添付なしで起票される', async () => {
       // PNG マジックバイトを持たない (整合しない) バイト列 = 中身偽装防御に弾かれる
       const bogusBytes = new Uint8Array([1, 2, 3, 4]);

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -5,6 +5,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createHmac } from 'node:crypto';
 import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// メモリストレージ (画像添付バイナリ用。フォローアップ 2026-07-13)
+import { createMemoryStorage, type MemoryStoragePort } from '@/data/adapters/memory/storage.memory';
 import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
 import { hashLineLinkCode, normalizeLineLinkCode } from '@/lib/line-link';
 // レート制限バケットをテスト間で初期化するためのヘルパー (グローバル Map の汚染を防ぐ)
@@ -52,6 +54,8 @@ const LINE_ID_NEW = 'U00000000000000000000000000000003'; // 新規連携対象
 let store: Store;
 let repos: Repos;
 let uow: UnitOfWork;
+// 画像添付のバイナリ本体を保持するメモリストレージ (フォローアップ 2026-07-13)
+let storage: MemoryStoragePort;
 
 // @/data を差し替え (getter で beforeEach の上書きを反映)。
 // ルートは冪等な起票を uow.run (Serializable トランザクション) で行うため uow も必要
@@ -61,6 +65,13 @@ vi.mock('@/data', () => ({
   },
   get uow() {
     return uow;
+  },
+}));
+
+// storage は別モジュール (Edge runtime 汚染回避のため route.ts が個別 import している)
+vi.mock('@/data/storage', () => ({
+  get storage() {
+    return storage;
   },
 }));
 
@@ -144,6 +155,8 @@ describe('POST /api/inbound/line', () => {
     store = ctx.store;
     repos = ctx.repos;
     uow = ctx.uow;
+    // 画像添付用のメモリストレージも毎回作り直す (フォローアップ 2026-07-13)
+    storage = createMemoryStorage();
     seed();
     // レート制限バケットはモジュールグローバルなので、他ファイルのテストの影響を受けないよう初期化する
     __resetRateLimits();
@@ -550,6 +563,142 @@ describe('POST /api/inbound/line', () => {
       const res = await POST(makeRequest('プリンターが動きません', LINE_ID_UNLINKED));
       expect(res.status).toBe(200);
       expect(store.tickets.size).toBe(1);
+    });
+  });
+
+  // フォローアップ (2026-07-13): 監査で発見したギャップの解消。§1.2 ペルソナ「現場リーダー」の
+  // 最優先ユースケース「写真を撮って送るだけで終わってほしい」はメール取り込み (PR #207) で
+  // 実現済みだが、このペルソナが実際に最も使う LINE 経由では画像メッセージを一切取り込んでおらず
+  // 実現できていなかった不備の回帰テスト。
+  describe('画像添付 (フォローアップ 2026-07-13)', () => {
+    // 検証パイプライン (マジックバイト整合チェック) を通すための PNG シグネチャ
+    const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+    // 1 件の画像メッセージイベントを含む署名付きリクエストを組み立てる
+    function makeImageRequest(
+      userId: string,
+      messageId: string,
+      contentProvider?: { type?: string },
+      destination: string = BOT_USER_ID,
+    ): Request {
+      const body = JSON.stringify({
+        destination,
+        events: [
+          {
+            type: 'message',
+            source: { type: 'user', userId },
+            message: { type: 'image', id: messageId, contentProvider },
+          },
+        ],
+      });
+      return new Request('http://localhost/api/inbound/line', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-line-signature': sign(body) },
+        body,
+      });
+    }
+
+    let fetchMock: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+      // Content API 取得 (fetchLineMessageContent) は undici 経由で globalThis.fetch に届く
+      // (ファイル冒頭の undici モック参照)
+      fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+    });
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('画像メッセージから添付ファイルが保存される', async () => {
+      const imageBytes = new Uint8Array([...PNG_MAGIC, 1, 2, 3]);
+      fetchMock.mockResolvedValue(
+        new Response(imageBytes, { status: 200, headers: { 'content-type': 'image/png' } }),
+      );
+
+      const { POST } = await import('@/app/api/inbound/line/route');
+      const res = await POST(makeImageRequest(LINE_ID_UNLINKED, 'img-1'));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ticketIds: string[] };
+      expect(body.ticketIds).toHaveLength(1);
+
+      // Content API を正しい URL・Authorization ヘッダで呼んでいること
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://api-data.line.me/v2/bot/message/img-1/content');
+      expect(init.headers.Authorization).toBe('Bearer test-access-token');
+
+      // チケットに紐づく添付が 1 件、commentId は null (新規起票への添付) で記録される
+      const attachments = [...store.attachments.values()].filter(
+        (a) => a.ticketId === body.ticketIds[0],
+      );
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0].commentId).toBeNull();
+      // storage にバイト列が実際に書き込まれていること
+      expect(storage.entries.size).toBe(1);
+    });
+
+    it('Content API 取得に失敗しても添付なしで起票を継続する', async () => {
+      // HTTP エラー (例: アクセストークン失効) を模す
+      fetchMock.mockResolvedValue(new Response(null, { status: 401 }));
+
+      const { POST } = await import('@/app/api/inbound/line/route');
+      const res = await POST(makeImageRequest(LINE_ID_UNLINKED, 'img-2'));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ticketIds: string[] };
+      // 添付取得に失敗してもチケット自体は起票される (§9 fail-safe)
+      expect(body.ticketIds).toHaveLength(1);
+      expect(store.attachments.size).toBe(0);
+      expect(storage.entries.size).toBe(0);
+    });
+
+    it('許可外 MIME の画像は無視され、添付なしで起票される', async () => {
+      // PNG マジックバイトを持たない (整合しない) バイト列 = 中身偽装防御に弾かれる
+      const bogusBytes = new Uint8Array([1, 2, 3, 4]);
+      fetchMock.mockResolvedValue(
+        new Response(bogusBytes, { status: 200, headers: { 'content-type': 'image/png' } }),
+      );
+
+      const { POST } = await import('@/app/api/inbound/line/route');
+      const res = await POST(makeImageRequest(LINE_ID_UNLINKED, 'img-3'));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ticketIds: string[] };
+      expect(body.ticketIds).toHaveLength(1);
+      expect(store.attachments.size).toBe(0);
+      expect(storage.entries.size).toBe(0);
+    });
+
+    it('外部ホストの画像 (contentProvider=external) は Content API を呼ばず添付なしで起票する', async () => {
+      const { POST } = await import('@/app/api/inbound/line/route');
+      const res = await POST(makeImageRequest(LINE_ID_UNLINKED, 'img-4', { type: 'external' }));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ticketIds: string[] };
+      expect(body.ticketIds).toHaveLength(1);
+      // 外部ホストの画像は SSRF 対策のため Content API を呼ばない
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(store.attachments.size).toBe(0);
+    });
+
+    it('同一メッセージ ID の再送は冪等に処理し、Content API を再度呼ばない', async () => {
+      const imageBytes = new Uint8Array([...PNG_MAGIC, 1, 2, 3]);
+      fetchMock.mockResolvedValue(
+        new Response(imageBytes, { status: 200, headers: { 'content-type': 'image/png' } }),
+      );
+
+      const { POST } = await import('@/app/api/inbound/line/route');
+      const res1 = await POST(makeImageRequest(LINE_ID_UNLINKED, 'img-dup-1'));
+      const body1 = (await res1.json()) as { ticketIds: string[] };
+      expect(body1.ticketIds).toHaveLength(1);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // 同じメッセージ ID で再送 (LINE の at-least-once 配送を模す)
+      const res2 = await POST(makeImageRequest(LINE_ID_UNLINKED, 'img-dup-1'));
+      const body2 = (await res2.json()) as { ticketIds: string[] };
+      expect(body2.ticketIds).toEqual(body1.ticketIds);
+      // 重複判定は早期リターンするため Content API を再度呼ばない
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      // チケット・添付とも 1 件のまま (二重起票・二重添付なし)
+      expect(store.tickets.size).toBe(1);
+      expect(store.attachments.size).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## 対応する Phase / 項目

`docs/smb-dx-pivot-plan.md` は全項目 `[x]` 完了扱いだが、前回 PR (#205〜#207) までの運用パターンに倣い監査を継続し、新たに見つかったギャップを修正した。

- Phase 1（写真添付・スマホ最適化）/ Phase 2（LINE 連携）
- §2 ギャップ分析表「アプリ開かない前提 → メール通知を主軸に切替」

## 変更内容

### 1. LINE メッセージの画像添付をチケットへ保存する

メール取り込み（PR #207）は SendGrid の添付フィールドを読んで画像を保存できるようになった一方、§1.2 ペルソナ「現場リーダー」が実際に最も使う LINE 経由では画像メッセージを一切取り込んでおらず（`message?.type !== 'text'` で無条件にスキップ）、「写真を撮って送るだけで終わってほしい」という最優先ユースケースが実現できていなかった。

- `src/lib/line-content.ts`（新規）: LINE Messaging API の Content エンドポイントから画像本体を取得する専用ヘルパー。`webhook-fetch.ts` と同じ SSRF 対策（undici + Dispatcher、リダイレクト非追従）・タイムアウト・レスポンスサイズ上限読み取りの方針を踏襲する。
- `src/app/api/inbound/line/route.ts`: 画像メッセージ（`message.type === 'image'`）を処理対象に追加。`contentProvider.type` が `'line'`（既定）の画像だけ Content API から取得し（LIFF 等の `'external'` ホストは任意 URL の SSRF リスクがあるため対象外）、既存の `validateUploadedFilesLenient` / `persistAttachments` / `checkAttachmentQuota`（メール取り込みと共有）で検証・保存する。`createTicketIdempotent` の `onCreated` フックで起票と添付メタ INSERT を同一トランザクションにまとめ、Serializable 競合の敗者側が書き込んだストレージも `cleanupWrittenAttachments` で後始末する（メール取り込みの添付対応と同じ設計）。

### 2. CSV 担当割当エージェントへメール通知する

画面からの手動アサイン（`updateTicketAssignee`）はアプリ内通知に加えてメールも届くが、CSV インポートで「担当者」列から初期担当者を設定した場合はアプリ内通知しか届かず、アプリを開いていない担当者は割り当てに気づけなかった。

- `src/lib/ticket-email.ts`: `renderAssignedBatchEmail` を追加（複数チケットの割当を件数でまとめて 1 通にする文面。既存の `renderAssignedEmail` は 1 件のチケットタイトル前提のため流用しない）。
- `src/features/tickets/actions/import-tickets.ts`: `notifyAssignedAgentsByEmail` からエージェントごとに 1 通ずつメール送信する。送信先の解決には `repos.users.listAgentEmails`（エスカレーション一斉メールと共有）を使う。

## テスト

- `npm run typecheck` — 成功
- `npm run lint` — 成功
- `npx vitest run` — 896 件成功
- 追加した回帰テスト:
  - `tests/features/inbound-line-route.test.ts`: 画像保存、Content API 失敗時のフォールバック、許可外 MIME の無視、`external` contentProvider のスキップ、再送の冪等性
  - `tests/features/import-tickets.test.ts`: 担当割当メールの宛先・件名・本文、自己割当では送らないこと

## 画面確認

UI の見た目に変更はなく、サーバー側の Webhook 処理・メール送信追加が中心のため、上記の自動テストで検証している。

---
_Generated by [Claude Code](https://claude.ai/code/session_014XnHProPvPHZFdPsE2y9vp)_