### PR TITLE
docs: リポジトリ層の状態遷移ガード前提をコメントで明記

### DIFF
--- a/src/data/adapters/prisma/ticket-repository.prisma.ts
+++ b/src/data/adapters/prisma/ticket-repository.prisma.ts
@@ -247,6 +247,10 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
     },
 
     // 状態と解決日時を更新 (tenantId スコープ。updateMany で id+tenantId AND 一致のみ更新)
+    // 注意: このメソッド自体は遷移の妥当性を検証しない (Ports & Adapters の層分離により、
+    // ここは純粋な永続化のみを担う)。呼び出し元は必ず src/domain/ticket-status.ts の
+    // isValidTransition() / getAllowedLiteTransitions() でゲートしてから呼ぶこと
+    // (src/features/tickets/actions/update-ticket.ts::updateTicketStatus が唯一の正しい呼び出し元)。
     async updateStatus(id, status, resolvedAt, tenantId) {
       await db.ticket.updateMany({ where: { id, tenantId }, data: { status, resolvedAt } });
     },
@@ -262,6 +266,9 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
     },
 
     // エスカレーション扱いに更新 (tenantId スコープ)
+    // 注意: updateStatus と同じく、ここでは status: 'Escalated' への遷移可否を検証しない。
+    // 呼び出し元 (src/features/tickets/actions/update-ticket.ts::escalateTicket) が
+    // isValidTransition(ticket.status, 'Escalated', mode) を事前にチェック済みであることが前提。
     async markEscalated(id, args, tenantId) {
       await db.ticket.updateMany({
         where: { id, tenantId },


### PR DESCRIPTION
## Summary
- 定期コードレビューの一環として `src/data/adapters/prisma/ticket-repository.prisma.ts` を監査した際の所見。`updateStatus` / `markEscalated` は tenantId スコープの永続化のみを行い、ステータス遷移の妥当性 (`isValidTransition` / `getAllowedLiteTransitions`) は検証しないという Ports & Adapters の層分離が前提になっている。
- 現状は `src/features/tickets/actions/update-ticket.ts` の `updateTicketStatus` / `escalateTicket` が必ず事前にドメイン層で遷移チェックしてから呼んでおり、バイパス経路は存在しない (監査で確認済み)。
- ただし将来別の呼び出し元がこのメソッドを直接叩いた場合、遷移ガードを素通りしてしまうリスクがコメントに明記されていなかったため、実装意図と前提条件をコメントとして追加した。**動作は変更していない (コメントのみ)**。

対応する Phase: `docs/smb-dx-pivot-plan.md` の特定フェーズ項目には該当しない、既存コードの保守性向上 (CLAUDE.md §6「設計判断を残す」「重複を避ける」の一環としての明文化)。

## Test plan
- コメントのみの変更のため挙動に影響なし。`npm run typecheck` / `npm run lint` 影響なし想定。
- [x] 差分は `src/data/adapters/prisma/ticket-repository.prisma.ts` のコメント追加のみであることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01UU5gTQZovWpGdkE44pfQFS)_