### PR TITLE
feat(inbound): LINE取り込みの隔離記録をメールと共有し admin から可視化する

### DIFF
--- a/prisma/migrations/20260713010000_add_quarantine_channel_and_line_fields/migration.sql
+++ b/prisma/migrations/20260713010000_add_quarantine_channel_and_line_fields/migration.sql
@@ -1,0 +1,17 @@
+-- フォローアップ (2026-07-13): 監査で発見したギャップの解消。LINE 取り込みも
+-- 「console.warn のサーバーログにしか残らず admin から確認できない」不備を抱えていたため、
+-- QuarantinedEmail テーブルをチャネル共通の隔離記録として拡張する。
+
+-- AlterEnum: LINE 専用の隔離理由 (テナントに担当者が 1 人もいない) を追加する
+ALTER TYPE "QuarantineReason" ADD VALUE 'no_agents';
+
+-- CreateEnum: 隔離記録の発生元チャネル
+CREATE TYPE "QuarantineChannel" AS ENUM ('email', 'line');
+
+-- AlterTable: channel を追加 (既存行は全てメール由来なので既定値 'email' を設定)し、
+-- LINE 専用の lineUserId を追加。メール専用だった senderAddress/subject は
+-- LINE 記録では埋まらないため NOT NULL 制約を外す
+ALTER TABLE "QuarantinedEmail" ADD COLUMN "channel" "QuarantineChannel" NOT NULL DEFAULT 'email';
+ALTER TABLE "QuarantinedEmail" ADD COLUMN "lineUserId" TEXT;
+ALTER TABLE "QuarantinedEmail" ALTER COLUMN "senderAddress" DROP NOT NULL;
+ALTER TABLE "QuarantinedEmail" ALTER COLUMN "subject" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -117,18 +117,30 @@ enum AttachmentStorage {
   s3 // 互換オブジェクトストレージ (Phase 2 以降に予定)
 }
 
-// メール取り込み (POST /api/inbound/email) が起票せず隔離した理由。
+// メール/LINE 取り込みが起票せず隔離した理由。
 // docs/smb-dx-pivot-plan.md §3.2 フォローアップ (2026-07-09): 未登録送信者からのメールは
 // 「システムが受け取り、担当者が確認の上で処理する場合がある」とヘルプセンターで案内していたが、
 // 実装は console.warn を残すだけで永続化・admin 向け一覧が存在せず、案内どおりに機能していなかった
 // ギャップを解消するための隔離理由の列挙。追加時はここと QUARANTINE_REASON_LABELS
-// (src/lib/constants.ts) を必ず両方更新する
+// (src/lib/constants.ts) を必ず両方更新する。
+// フォローアップ (2026-07-13): 監査で発見したギャップの解消。LINE 取り込みも同じ「console.warn の
+// サーバーログにしか残らず admin から確認できない」不備を抱えていたため、QuarantinedEmail
+// テーブルをチャネル共通の隔離記録として再利用する (下の channel フィールド参照)。no_agents は
+// LINE 特有の理由 (テナントに担当者が 1 人もいないため代理起票者を決められない) として追加した
 enum QuarantineReason {
-  plan_gate // メール取り込みが契約プランで許可されていない (Free プラン等)
-  auth_fail // 送信元ドメイン認証 (SPF/DKIM/DMARC) が enforce ポリシーで明示 fail
-  unknown_sender // 宛先テナントに所属しない送信者
-  thread_forbidden // 既知メンバーだが他人のチケットへの追記権限がない
-  quota_exceeded // 月間チケット上限に到達済み
+  plan_gate // 取り込みが契約プランで許可されていない (Free プラン等。メール/LINE 共通)
+  auth_fail // 送信元ドメイン認証 (SPF/DKIM/DMARC) が enforce ポリシーで明示 fail (メール専用)
+  unknown_sender // 宛先テナントに所属しない送信者 (メール専用)
+  thread_forbidden // 既知メンバーだが他人のチケットへの追記権限がない (メール専用)
+  quota_exceeded // 月間チケット上限に到達済み (メール/LINE 共通)
+  no_agents // テナントに担当者が 1 人もおらず代理起票者を決められない (LINE 専用)
+}
+
+// 隔離記録がどの取り込みチャネル由来かを示す種別。フォローアップ (2026-07-13):
+// QuarantinedEmail テーブルをメール専用からチャネル共通の隔離記録へ拡張する際に追加した
+enum QuarantineChannel {
+  email
+  line
 }
 
 // ─────────────────────────────────────────────
@@ -541,13 +553,19 @@ model SettingsAuditLog {
 // 本文は保存しない (件名・送信者だけで admin が「招待し忘れたメンバーか」「スパムか」を判断できる
 // ため、不要な本文までは保持しない範囲最小化の方針。SettingsAuditLog が値そのものを記録しない
 // 設計と同じ考え方)。
+// フォローアップ (2026-07-13): 監査で発見したギャップの解消。LINE 取り込みの隔離記録も
+// このテーブルへ集約する (channel で判別)。メール専用だった senderAddress/subject は
+// LINE 記録では埋まらないため nullable にし、LINE 専用の lineUserId を追加した
+// (テーブル名・Port 名は移行コストを避けるため据え置くが、実体はチャネル共通の隔離記録)
 model QuarantinedEmail {
-  id            String           @id @default(cuid()) // 主キー
+  id            String            @id @default(cuid()) // 主キー
+  channel       QuarantineChannel @default(email) // 隔離記録の発生元チャネル
   reason        QuarantineReason // 隔離した理由
-  senderAddress String // 送信元メールアドレス (admin がスパムか招待漏れかを判断する材料)
-  senderName    String? // 送信者名 (ヘッダから取れた場合のみ)
-  subject       String // 件名
-  createdAt     DateTime         @default(now()) // 隔離した日時
+  senderAddress String? // 送信元メールアドレス (メール専用。LINE 記録では null)
+  senderName    String? // 送信者名 (ヘッダから取れた場合のみ。メール専用)
+  lineUserId    String? // LINE ユーザー ID (LINE 専用。メール記録では null)
+  subject       String? // 件名 (メール専用。LINE 記録では null。本文同様 LINE には件名概念が無い)
+  createdAt     DateTime          @default(now()) // 隔離した日時
 
   tenantId String // 対象テナント (クロステナント漏洩防止のスコープ)
 

--- a/src/app/(app)/quarantine/page.tsx
+++ b/src/app/(app)/quarantine/page.tsx
@@ -6,8 +6,8 @@ import { redirect } from 'next/navigation';
 import { repos } from '@/data';
 // 日付フォーマットヘルパー (年月日時分秒を JST で表示する)
 import { formatDateTimeJP } from '@/lib/format-date';
-// 隔離理由の日本語ラベル
-import { QUARANTINE_REASON_LABELS } from '@/lib/constants';
+// 隔離理由・チャネルの日本語ラベル
+import { QUARANTINE_REASON_LABELS, QUARANTINE_CHANNEL_LABELS } from '@/lib/constants';
 // 監査ログ系リポジトリ共通のページネーション上限 (findAllByTenant が limit をクランプする上限値)
 import { AUDIT_MAX_LIMIT } from '@/data/adapters/audit-pagination';
 
@@ -27,9 +27,12 @@ interface Props {
   }>;
 }
 
-// 隔離メール一覧ページ (管理者専用)
+// 隔離メール/LINE メッセージ一覧ページ (管理者専用)
 // docs/smb-dx-pivot-plan.md §3.2 フォローアップ: 未登録送信者・プラン未対応・認証失敗等で
 // 起票されなかった受信メールを admin が確認できる一覧を提供する。
+// フォローアップ (2026-07-13): 監査で発見したギャップの解消。LINE 取り込みも同じ「console.warn の
+// サーバーログにしか残らず admin から確認できない」不備を抱えていたため、この一覧に LINE 由来の
+// 隔離記録 (経路列で判別) も表示するようにした。
 export default async function QuarantinePage({ searchParams }: Props) {
   const sp = await searchParams;
   // before/beforeId は URL から来る外部入力なので、不正な値でも落ちないよう検証する
@@ -73,18 +76,19 @@ export default async function QuarantinePage({ searchParams }: Props) {
       <div>
         <h1 className="text-2xl font-bold text-slate-900">隔離メール</h1>
         <p className="mt-1 text-sm text-slate-500">
-          プラン未対応・未登録の送信者・認証失敗などで問い合わせ化されなかった受信メールを表示しています。
+          プラン未対応・未登録の送信者・認証失敗などで問い合わせ化されなかったメール/LINE
+          メッセージを表示しています。
           {before ? `${PAGE_LIMIT} 件ずつ表示中。` : `最新 ${PAGE_LIMIT} 件。`}
         </p>
       </div>
 
       {logs.length === 0 ? (
         <div className="rounded-2xl bg-white py-20 text-center text-slate-400 ring-1 ring-slate-200">
-          <p className="text-sm">隔離されたメールはありません。</p>
+          <p className="text-sm">隔離された記録はありません。</p>
         </div>
       ) : (
         <div className="overflow-x-auto rounded-2xl bg-white shadow-sm ring-1 ring-slate-100">
-          <table className="min-w-full divide-y divide-slate-200" aria-label="隔離メールの一覧">
+          <table className="min-w-full divide-y divide-slate-200" aria-label="隔離記録の一覧">
             <thead className="bg-slate-50">
               <tr>
                 <th
@@ -92,6 +96,12 @@ export default async function QuarantinePage({ searchParams }: Props) {
                   className="px-4 py-3 text-left text-xs font-semibold tracking-wider text-slate-500 uppercase"
                 >
                   日時
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-semibold tracking-wider text-slate-500 uppercase"
+                >
+                  経路
                 </th>
                 <th
                   scope="col"
@@ -121,17 +131,29 @@ export default async function QuarantinePage({ searchParams }: Props) {
                       {formatDateTimeJP(log.createdAt)}
                     </time>
                   </td>
+                  <td className="px-4 py-3 text-sm whitespace-nowrap text-slate-600">
+                    {QUARANTINE_CHANNEL_LABELS[log.channel]}
+                  </td>
                   <td className="px-4 py-3 text-sm text-slate-700">
-                    {/* 送信者名 (取れなかった場合はアドレスのみ) + アドレス */}
-                    {/* 送信者名が取れなかった場合 (null) はアドレスのみでも意味が通るよう
-                        フォールバック文言を表示する (/code-review ultra 指摘対応) */}
-                    <div className="font-medium text-slate-900">
-                      {log.senderName ?? '(送信者名なし)'}
-                    </div>
-                    <div className="text-xs text-slate-500">{log.senderAddress}</div>
+                    {/* フォローアップ (2026-07-13): channel によって送信者の表現が異なる
+                        (メールは senderName/senderAddress、LINE は lineUserId) */}
+                    {log.channel === 'email' ? (
+                      <>
+                        {/* 送信者名が取れなかった場合 (null) はアドレスのみでも意味が通るよう
+                            フォールバック文言を表示する (/code-review ultra 指摘対応) */}
+                        <div className="font-medium text-slate-900">
+                          {log.senderName ?? '(送信者名なし)'}
+                        </div>
+                        <div className="text-xs text-slate-500">{log.senderAddress}</div>
+                      </>
+                    ) : (
+                      <div className="font-medium text-slate-900">
+                        LINE ユーザー ID: {log.lineUserId ?? '(不明)'}
+                      </div>
+                    )}
                   </td>
                   <td className="max-w-xs px-4 py-3 text-sm text-slate-700">
-                    <span className="line-clamp-1">{log.subject}</span>
+                    <span className="line-clamp-1">{log.subject ?? '(件名なし)'}</span>
                   </td>
                   <td className="px-4 py-3 text-sm whitespace-nowrap text-slate-600">
                     {QUARANTINE_REASON_LABELS[log.reason]}

--- a/src/app/(app)/quarantine/page.tsx
+++ b/src/app/(app)/quarantine/page.tsx
@@ -144,7 +144,13 @@ export default async function QuarantinePage({ searchParams }: Props) {
                         <div className="font-medium text-slate-900">
                           {log.senderName ?? '(送信者名なし)'}
                         </div>
-                        <div className="text-xs text-slate-500">{log.senderAddress}</div>
+                        {/* /code-review ultra 指摘対応 (2026-07-13): senderName/subject と同じく
+                            null を安全に表示するフォールバックを付ける (RecordQuarantinedEmailInput
+                            は channel='email' で常に非 null を要求するが、表示側は DB 由来の値を
+                            そのまま信用せず念のため備える) */}
+                        <div className="text-xs text-slate-500">
+                          {log.senderAddress ?? '(送信元アドレスなし)'}
+                        </div>
                       </>
                     ) : (
                       <div className="font-medium text-slate-900">

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -350,6 +350,7 @@ async function recordQuarantine(
   try {
     await repos.quarantinedEmails.record({
       tenantId,
+      channel: 'email', // フォローアップ (2026-07-13): LINE 取り込みとテーブルを共有するため明示する
       reason,
       senderAddress: email.senderAddress,
       senderName: email.senderName,

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -74,6 +74,8 @@ import { notifyNewTicketOutbound } from '@/lib/outbound-notify';
 import { getMonthlyTicketQuota, checkAttachmentQuota } from '@/lib/tenant-plan';
 // 隔離理由の型 (§3.2 フォローアップ: 隔離記録の永続化に使う)
 import type { QuarantineReason } from '@/domain/types';
+// 隔離記録の書き込み共通ヘルパー (LINE 取り込みと共有。§6 DRY)
+import { recordQuarantineSafe } from '@/lib/quarantine';
 
 // このルートは Node ランタイムで動かす (node:crypto / Prisma を使うため Edge では動かない)
 export const runtime = 'nodejs';
@@ -342,24 +344,24 @@ async function sendReceivedAck(args: {
 // 本来の処理に影響させない」方針。§9 fail-safe)。
 // /code-review ultra 指摘対応: 当初「レスポンスを遅延させない」とも書いていたが、実際には
 // await しているため応答は記録の完了を待つ。誤解を招く記述だったため実態に合わせて修正した。
+// フォローアップ (2026-07-13): try/catch + ログの定型部分は LINE 取り込みの recordLineQuarantine と
+// 同型の重複だったため src/lib/quarantine.ts::recordQuarantineSafe へ共通化した (§6 DRY)
 async function recordQuarantine(
   tenantId: string,
   reason: QuarantineReason,
   email: { senderAddress: string; senderName: string; subject: string },
 ): Promise<void> {
-  try {
-    await repos.quarantinedEmails.record({
+  await recordQuarantineSafe(
+    {
       tenantId,
-      channel: 'email', // フォローアップ (2026-07-13): LINE 取り込みとテーブルを共有するため明示する
+      channel: 'email',
       reason,
       senderAddress: email.senderAddress,
       senderName: email.senderName,
       subject: email.subject,
-    });
-  } catch (err) {
-    // 記録失敗はログのみ残す (隔離自体は既に確定しているため 202 応答は変えない)
-    console.error('[POST /api/inbound/email] 隔離記録の保存に失敗しました', err);
-  }
+    },
+    '[POST /api/inbound/email]',
+  );
 }
 
 // POST /api/inbound/email : 受信メールを 1 件の問い合わせに変換する

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -88,6 +88,8 @@ import { persistAttachments, cleanupWrittenAttachments } from '@/lib/attachment-
 // フォローアップ (2026-07-13): 監査で発見したギャップの解消。LINE 取り込みが起票せず隔離した記録も
 // メール取り込みと共有の QuarantinedEmail テーブルへ永続化するため QuarantineReason 型を使う
 import type { SubscriptionPlan, QuarantineReason } from '@/domain/types';
+// 隔離記録の書き込み共通ヘルパー (メール取り込みと共有。§6 DRY)
+import { recordQuarantineSafe } from '@/lib/quarantine';
 // このルートは Node ランタイムで動かす (node:crypto / Prisma を使うため Edge では動かない)
 export const runtime = 'nodejs';
 
@@ -390,22 +392,17 @@ export async function POST(req: Request) {
 // 問い合わせが取り込まれないか」を確認する手段が無かった (メール取り込みの §3.2 フォローアップと
 // 同じ不備)。メール取り込みと共有の QuarantinedEmail テーブルへ channel='line' で記録する
 // (record() 自体は SettingsAuditLog と同じ「記録失敗は本来の処理に影響させない」方針)。
+// フォローアップ (2026-07-13): try/catch + ログの定型部分はメール取り込みの recordQuarantine と
+// 同型の重複だったため src/lib/quarantine.ts::recordQuarantineSafe へ共通化した (§6 DRY)
 async function recordLineQuarantine(
   tenantId: string,
   reason: QuarantineReason,
   lineUserId: string | null, // 特定の送信者に紐づかないバッチ単位の隔離 (プランゲート等) では null
 ): Promise<void> {
-  try {
-    await repos.quarantinedEmails.record({
-      tenantId,
-      channel: 'line',
-      reason,
-      lineUserId,
-    });
-  } catch (err) {
-    // 記録失敗はログのみ残す (隔離自体は既に確定しているため応答は変えない)
-    console.error('[POST /api/inbound/line] 隔離記録の保存に失敗しました', err);
-  }
+  await recordQuarantineSafe(
+    { tenantId, channel: 'line', reason, lineUserId },
+    '[POST /api/inbound/line]',
+  );
 }
 
 // このメッセージ ID を既に取り込み済みなら対応するチケット ID を返す (未処理なら null)。

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -84,8 +84,10 @@ import {
 // 添付ファイルのストレージ保存 / 失敗時クリーンアップの共通ヘルパー (POST /api/tickets・
 // POST /api/inbound/email と共有)
 import { persistAttachments, cleanupWrittenAttachments } from '@/lib/attachment-persistence';
-// 課金プランの型 (添付累計サイズ上限チェック checkAttachmentQuota に渡す)
-import type { SubscriptionPlan } from '@/domain/types';
+// 課金プランの型 (添付累計サイズ上限チェック checkAttachmentQuota に渡す)。
+// フォローアップ (2026-07-13): 監査で発見したギャップの解消。LINE 取り込みが起票せず隔離した記録も
+// メール取り込みと共有の QuarantinedEmail テーブルへ永続化するため QuarantineReason 型を使う
+import type { SubscriptionPlan, QuarantineReason } from '@/domain/types';
 // このルートは Node ランタイムで動かす (node:crypto / Prisma を使うため Edge では動かない)
 export const runtime = 'nodejs';
 
@@ -318,6 +320,7 @@ export async function POST(req: Request) {
     console.warn('[POST /api/inbound/line] ignored: LINE integration not allowed for plan', {
       plan: tenant.subscriptionPlan,
     });
+    await recordLineQuarantine(targetTenantId, 'plan_gate', null);
     return NextResponse.json({ status: 'ignored', reason: 'plan_not_allowed' }, { status: 200 });
   }
 
@@ -329,6 +332,7 @@ export async function POST(req: Request) {
     // 担当者が 1 人もいないテナントは起票者を決められない。再送しても状況は変わらない
     // (設定不備) ため、LINE の再送ループを避けるべく 200 で「受領のみ」して破棄する。
     console.warn('[POST /api/inbound/line] no agents found for tenant:', targetTenantId);
+    await recordLineQuarantine(targetTenantId, 'no_agents', null);
     return NextResponse.json({ status: 'ignored', reason: 'no_agents' }, { status: 200 });
   }
   // 名前順で最初の担当者 (agent/admin) を未紐付けユーザー向けの代理起票者とする
@@ -378,6 +382,30 @@ export async function POST(req: Request) {
   // の Serializable トランザクションで、連携コード処理 (起票を伴わない) は repos.lineLinkCodes
   // (LineLinkCodeRef テーブルへの DB 永続化) でそれぞれ担保している。
   return NextResponse.json({ ticketIds }, { status: 200 });
+}
+
+// 起票せず隔離した LINE メッセージ/バッチを永続化する。
+// フォローアップ (2026-07-13): 監査で発見したギャップの解消。以前はプランゲート・担当者未設定・
+// 月間上限到達のいずれも console.warn のサーバーログにしか残らず、admin が「なぜ LINE の
+// 問い合わせが取り込まれないか」を確認する手段が無かった (メール取り込みの §3.2 フォローアップと
+// 同じ不備)。メール取り込みと共有の QuarantinedEmail テーブルへ channel='line' で記録する
+// (record() 自体は SettingsAuditLog と同じ「記録失敗は本来の処理に影響させない」方針)。
+async function recordLineQuarantine(
+  tenantId: string,
+  reason: QuarantineReason,
+  lineUserId: string | null, // 特定の送信者に紐づかないバッチ単位の隔離 (プランゲート等) では null
+): Promise<void> {
+  try {
+    await repos.quarantinedEmails.record({
+      tenantId,
+      channel: 'line',
+      reason,
+      lineUserId,
+    });
+  } catch (err) {
+    // 記録失敗はログのみ残す (隔離自体は既に確定しているため応答は変えない)
+    console.error('[POST /api/inbound/line] 隔離記録の保存に失敗しました', err);
+  }
 }
 
 // このメッセージ ID を既に取り込み済みなら対応するチケット ID を返す (未処理なら null)。
@@ -631,6 +659,11 @@ async function processLineEvent(
   // ctx.quota (POST 側で 1 度だけ取得) の残枠をイベントごとに消費する簡易カウンタとして扱う。
   if (ctx.quota.limited && ctx.quota.remaining <= 0) {
     console.warn(`[POST /api/inbound/line] ignored: monthly ticket quota reached: ${messageId}`);
+    await recordLineQuarantine(
+      targetTenantId,
+      'quota_exceeded',
+      lineUserId !== '不明' ? lineUserId : null,
+    );
     return null;
   }
 

--- a/src/data/adapters/memory/quarantined-email-repository.memory.ts
+++ b/src/data/adapters/memory/quarantined-email-repository.memory.ts
@@ -21,18 +21,31 @@ function isBeforeCursor(createdAt: Date, id: string, cursor: QuarantinedEmailCur
 // メモリストアを使った隔離済み受信メールリポジトリを生成する関数
 export function makeQuarantinedEmailRepo(store: Store): QuarantinedEmailRepository {
   return {
-    // 隔離記録を 1 件保存する
+    // 隔離記録を 1 件保存する。
+    // input は channel で判別されるユニオン型のため、channel ごとに他方のチャネル専用
+    // フィールドを明示的に null で埋める (Prisma アダプタと同じ方針)
     async record(input) {
       const row: QuarantinedEmail = {
         id: nextId(store, 'qte'), // 'qte_...' 形式の一意 ID
         tenantId: input.tenantId,
-        channel: input.channel,
-        reason: input.reason,
-        senderAddress: input.senderAddress ?? null,
-        senderName: input.senderName ?? null,
-        lineUserId: input.lineUserId ?? null,
-        subject: input.subject ?? null,
         createdAt: new Date(),
+        ...(input.channel === 'email'
+          ? {
+              channel: 'email' as const,
+              reason: input.reason,
+              senderAddress: input.senderAddress,
+              senderName: input.senderName,
+              lineUserId: null,
+              subject: input.subject,
+            }
+          : {
+              channel: 'line' as const,
+              reason: input.reason,
+              senderAddress: null,
+              senderName: null,
+              lineUserId: input.lineUserId,
+              subject: null,
+            }),
       };
       store.quarantinedEmails.set(row.id, row);
     },

--- a/src/data/adapters/memory/quarantined-email-repository.memory.ts
+++ b/src/data/adapters/memory/quarantined-email-repository.memory.ts
@@ -26,10 +26,12 @@ export function makeQuarantinedEmailRepo(store: Store): QuarantinedEmailReposito
       const row: QuarantinedEmail = {
         id: nextId(store, 'qte'), // 'qte_...' 形式の一意 ID
         tenantId: input.tenantId,
+        channel: input.channel,
         reason: input.reason,
-        senderAddress: input.senderAddress,
-        senderName: input.senderName,
-        subject: input.subject,
+        senderAddress: input.senderAddress ?? null,
+        senderName: input.senderName ?? null,
+        lineUserId: input.lineUserId ?? null,
+        subject: input.subject ?? null,
         createdAt: new Date(),
       };
       store.quarantinedEmails.set(row.id, row);
@@ -48,9 +50,11 @@ export function makeQuarantinedEmailRepo(store: Store): QuarantinedEmailReposito
         if (filter.before && !isBeforeCursor(q.createdAt, q.id, filter.before)) continue;
         rows.push({
           id: q.id,
+          channel: q.channel,
           reason: q.reason,
           senderAddress: q.senderAddress,
           senderName: q.senderName,
+          lineUserId: q.lineUserId,
           subject: q.subject,
           createdAt: q.createdAt,
         });

--- a/src/data/adapters/prisma/quarantined-email-repository.prisma.ts
+++ b/src/data/adapters/prisma/quarantined-email-repository.prisma.ts
@@ -12,10 +12,12 @@ export function makeQuarantinedEmailRepo(db: PrismaLike): QuarantinedEmailReposi
       await db.quarantinedEmail.create({
         data: {
           tenantId: input.tenantId,
+          channel: input.channel,
           reason: input.reason,
-          senderAddress: input.senderAddress,
-          senderName: input.senderName,
-          subject: input.subject,
+          senderAddress: input.senderAddress ?? null,
+          senderName: input.senderName ?? null,
+          lineUserId: input.lineUserId ?? null,
+          subject: input.subject ?? null,
         },
       });
     },
@@ -45,9 +47,11 @@ export function makeQuarantinedEmailRepo(db: PrismaLike): QuarantinedEmailReposi
 
       return rows.map((row) => ({
         id: row.id,
+        channel: row.channel,
         reason: row.reason,
         senderAddress: row.senderAddress,
         senderName: row.senderName,
+        lineUserId: row.lineUserId,
         subject: row.subject,
         createdAt: row.createdAt,
       }));

--- a/src/data/adapters/prisma/quarantined-email-repository.prisma.ts
+++ b/src/data/adapters/prisma/quarantined-email-repository.prisma.ts
@@ -7,18 +7,31 @@ import { resolveAuditLimit } from '../audit-pagination';
 // Prisma クライアントを使った隔離済み受信メールリポジトリを生成する関数
 export function makeQuarantinedEmailRepo(db: PrismaLike): QuarantinedEmailRepository {
   return {
-    // 隔離記録を 1 件保存する (戻り値なし)
+    // 隔離記録を 1 件保存する (戻り値なし)。
+    // input は channel で判別されるユニオン型のため、channel ごとに他方のチャネル専用
+    // フィールドを明示的に null で埋める (DB 側は依然としてチャネル非依存の 1 テーブル)
     async record(input) {
       await db.quarantinedEmail.create({
-        data: {
-          tenantId: input.tenantId,
-          channel: input.channel,
-          reason: input.reason,
-          senderAddress: input.senderAddress ?? null,
-          senderName: input.senderName ?? null,
-          lineUserId: input.lineUserId ?? null,
-          subject: input.subject ?? null,
-        },
+        data:
+          input.channel === 'email'
+            ? {
+                tenantId: input.tenantId,
+                channel: 'email',
+                reason: input.reason,
+                senderAddress: input.senderAddress,
+                senderName: input.senderName,
+                lineUserId: null,
+                subject: input.subject,
+              }
+            : {
+                tenantId: input.tenantId,
+                channel: 'line',
+                reason: input.reason,
+                senderAddress: null,
+                senderName: null,
+                lineUserId: input.lineUserId,
+                subject: null,
+              },
       });
     },
 

--- a/src/data/ports/quarantined-email-repository.ts
+++ b/src/data/ports/quarantined-email-repository.ts
@@ -6,19 +6,30 @@
 // (channel で判別。型/Port/Adapter 名は移行コストを避けるため "email" のまま据え置く)。
 
 // 隔離理由・チャネルの型
-import type { QuarantineReason, QuarantineChannel, QuarantinedEmailRow } from '@/domain/types';
+import type { QuarantineReason, QuarantinedEmailRow } from '@/domain/types';
 
-// 隔離記録を 1 件保存する際に渡す入力値。メール専用フィールド (senderAddress/senderName/subject)
-// と LINE 専用フィールド (lineUserId) はどちらも channel に応じて呼び出し側が該当する方だけ渡す
-export interface RecordQuarantinedEmailInput {
-  tenantId: string; // 対象テナント
-  channel: QuarantineChannel; // 隔離記録の発生元チャネル
-  reason: QuarantineReason; // 隔離した理由
-  senderAddress?: string | null; // 送信元メールアドレス (メール専用)
-  senderName?: string | null; // 送信者名 (ヘッダから取れた場合のみ。メール専用)
-  lineUserId?: string | null; // LINE ユーザー ID (LINE 専用)
-  subject?: string | null; // 件名 (メール専用)
-}
+// 隔離記録を 1 件保存する際に渡す入力値。
+// /code-review ultra 指摘対応 (2026-07-13): 全フィールドを独立して optional にする単純な
+// フラット型だと、「channel='email' なのに senderAddress/subject を渡し忘れる」ような呼び出しを
+// コンパイラが検知できなかった (4 つの独立レビュー角度が同じ懸念に収束した)。channel をキーにした
+// 判別可能ユニオンにし、各チャネルが実際に必要とするフィールドだけをコンパイル時に強制する。
+export type RecordQuarantinedEmailInput =
+  | {
+      tenantId: string; // 対象テナント
+      channel: 'email';
+      reason: QuarantineReason; // 隔離した理由
+      senderAddress: string; // 送信元メールアドレス (メール取り込みは必ず送信者を特定できる)
+      senderName: string | null; // 送信者名 (ヘッダから取れた場合のみ)
+      subject: string; // 件名
+    }
+  | {
+      tenantId: string; // 対象テナント
+      channel: 'line';
+      reason: QuarantineReason; // 隔離した理由
+      // LINE ユーザー ID。プランゲート・担当者未設定はリクエスト全体 (バッチ) 単位の隔離のため
+      // 特定の送信者に紐づかず null になりうる (月間上限到達は特定のメッセージ由来なので通常は非 null)
+      lineUserId: string | null;
+    };
 
 // キーセットページネーション用カーソル (この一覧は単一テーブルのみを表示するため、
 // audit-pagination.ts の AuditPaginationCursor と異なり kind を持たない単純な 2 要素カーソル)

--- a/src/data/ports/quarantined-email-repository.ts
+++ b/src/data/ports/quarantined-email-repository.ts
@@ -1,18 +1,23 @@
-// 隔離した受信メール (QuarantinedEmail) リポジトリの契約 (port)。
+// 隔離した受信メール/LINE メッセージ (QuarantinedEmail) リポジトリの契約 (port)。
 // docs/smb-dx-pivot-plan.md §3.2 フォローアップ: 未登録送信者・プラン未対応・認証失敗等で
 // 起票されなかった受信メールが admin から一切確認できなかったギャップを解消するための記録先。
 // SettingsAuditLog (§4.2) と同じ「書き込み専用の監査的な記録 + テナント別一覧」という設計を踏襲する。
+// フォローアップ (2026-07-13): LINE 取り込みも同じ隔離記録テーブルを共有するよう拡張した
+// (channel で判別。型/Port/Adapter 名は移行コストを避けるため "email" のまま据え置く)。
 
-// 隔離理由の型
-import type { QuarantineReason, QuarantinedEmailRow } from '@/domain/types';
+// 隔離理由・チャネルの型
+import type { QuarantineReason, QuarantineChannel, QuarantinedEmailRow } from '@/domain/types';
 
-// 隔離記録を 1 件保存する際に渡す入力値
+// 隔離記録を 1 件保存する際に渡す入力値。メール専用フィールド (senderAddress/senderName/subject)
+// と LINE 専用フィールド (lineUserId) はどちらも channel に応じて呼び出し側が該当する方だけ渡す
 export interface RecordQuarantinedEmailInput {
   tenantId: string; // 対象テナント
+  channel: QuarantineChannel; // 隔離記録の発生元チャネル
   reason: QuarantineReason; // 隔離した理由
-  senderAddress: string; // 送信元メールアドレス
-  senderName: string | null; // 送信者名 (ヘッダから取れた場合のみ)
-  subject: string; // 件名
+  senderAddress?: string | null; // 送信元メールアドレス (メール専用)
+  senderName?: string | null; // 送信者名 (ヘッダから取れた場合のみ。メール専用)
+  lineUserId?: string | null; // LINE ユーザー ID (LINE 専用)
+  subject?: string | null; // 件名 (メール専用)
 }
 
 // キーセットページネーション用カーソル (この一覧は単一テーブルのみを表示するため、

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -50,28 +50,39 @@ export type SettingsAuditAction =
   // subscriptionPlan 自体の変更は一度も監査対象になっていなかった
   | 'subscription_plan_update'; // サブスクリプションプランの変更 (Stripe Webhook 起因)
 
-// メール取り込みが起票せず隔離した理由。
+// メール/LINE 取り込みが起票せず隔離した理由。
 // prisma/schema.prisma の QuarantineReason enum および src/lib/constants.ts の
 // QUARANTINE_REASON_LABELS と常に同期すること。値を追加したら 3 箇所すべてを更新する。
+// フォローアップ (2026-07-13): LINE 取り込みも同じ隔離記録テーブルを共有するようにしたため
+// no_agents (LINE 専用) を追加した
 export type QuarantineReason =
-  | 'plan_gate' // メール取り込みが契約プランで許可されていない
-  | 'auth_fail' // 送信元ドメイン認証 (SPF/DKIM/DMARC) が enforce ポリシーで明示 fail
-  | 'unknown_sender' // 宛先テナントに所属しない送信者
-  | 'thread_forbidden' // 既知メンバーだが他人のチケットへの追記権限がない
-  | 'quota_exceeded'; // 月間チケット上限に到達済み
+  | 'plan_gate' // 取り込みが契約プランで許可されていない (メール/LINE 共通)
+  | 'auth_fail' // 送信元ドメイン認証 (SPF/DKIM/DMARC) が enforce ポリシーで明示 fail (メール専用)
+  | 'unknown_sender' // 宛先テナントに所属しない送信者 (メール専用)
+  | 'thread_forbidden' // 既知メンバーだが他人のチケットへの追記権限がない (メール専用)
+  | 'quota_exceeded' // 月間チケット上限に到達済み (メール/LINE 共通)
+  | 'no_agents'; // テナントに担当者が 1 人もおらず代理起票者を決められない (LINE 専用)
 
-// 隔離した受信メールの記録 1 件分 (DB/メモリストアが保持する完全な形。tenantId を含む)
+// 隔離記録の発生元チャネル。フォローアップ (2026-07-13): QuarantinedEmail をメール専用から
+// チャネル共通の隔離記録へ拡張する際に追加した
+export type QuarantineChannel = 'email' | 'line';
+
+// 隔離した受信メール/LINE メッセージの記録 1 件分 (DB/メモリストアが保持する完全な形。
+// tenantId を含む)。メール専用フィールド (senderAddress/senderName/subject) と LINE 専用
+// フィールド (lineUserId) はどちらも channel に応じて片方だけが埋まる (もう片方は null)
 export interface QuarantinedEmail {
   id: string; // 隔離記録 ID
   tenantId: string; // 対象テナント
+  channel: QuarantineChannel; // 隔離記録の発生元チャネル
   reason: QuarantineReason; // 隔離した理由
-  senderAddress: string; // 送信元メールアドレス
-  senderName: string | null; // 送信者名 (ヘッダから取れた場合のみ)
-  subject: string; // 件名
+  senderAddress: string | null; // 送信元メールアドレス (メール専用。LINE 記録では null)
+  senderName: string | null; // 送信者名 (ヘッダから取れた場合のみ。メール専用)
+  lineUserId: string | null; // LINE ユーザー ID (LINE 専用。メール記録では null)
+  subject: string | null; // 件名 (メール専用。LINE 記録では null)
   createdAt: Date; // 隔離した日時
 }
 
-// 隔離した受信メール 1 件分 (§3.2 フォローアップ: admin 向け一覧画面が表示する行。
+// 隔離した受信メール/LINE メッセージ 1 件分 (§3.2 フォローアップ: admin 向け一覧画面が表示する行。
 // 呼び出し側は既にテナントスコープで絞り込み済みのため tenantId を含まない)
 export type QuarantinedEmailRow = Omit<QuarantinedEmail, 'tenantId'>;
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,6 +6,7 @@ import type {
   Role,
   SettingsAuditAction,
   QuarantineReason,
+  QuarantineChannel,
 } from '@/domain/types';
 // Lite モードの 3 値型と型ガード関数を取り込み、mode-aware ラベル関数で使う
 import { isLiteStatus, type LiteStatus } from '@/domain/ticket-status';
@@ -194,11 +195,20 @@ export const SETTINGS_AUDIT_SYSTEM_ACTOR_NAME = 'システム（自動）';
 // QuarantineReason 型 (src/domain/types.ts) / QuarantineReason enum (prisma/schema.prisma)
 // に値を追加したらここも更新する (§3.2 フォローアップ)
 export const QUARANTINE_REASON_LABELS: Record<QuarantineReason, string> = {
-  plan_gate: 'プラン未対応（メール取り込みが利用できないプラン）',
+  // フォローアップ (2026-07-13): LINE 取り込みも同じ隔離記録を使うため、メール限定の
+  // 文言だったものをチャネル非依存の表現に揃えた
+  plan_gate: 'プラン未対応（この取り込み経路が利用できないプラン）',
   auth_fail: '送信元ドメイン認証（SPF/DKIM/DMARC）に失敗',
   unknown_sender: '未登録の送信者',
   thread_forbidden: '追記権限のない送信者',
   quota_exceeded: '月間の問い合わせ件数上限に到達',
+  no_agents: '担当者が未設定（代理起票者を決められない）',
+};
+
+// 隔離記録の発生元チャネルに対応する日本語表示ラベル (admin 向け隔離記録一覧の「経路」列で使う)
+export const QUARANTINE_CHANNEL_LABELS: Record<QuarantineChannel, string> = {
+  email: 'メール',
+  line: 'LINE',
 };
 
 // 通知種別の英語キーに対応する日本語表示ラベル

--- a/src/lib/quarantine.ts
+++ b/src/lib/quarantine.ts
@@ -1,0 +1,28 @@
+// 隔離記録 (QuarantinedEmail) への記録を共通化するヘルパー。
+//
+// /code-review ultra 指摘対応 (2026-07-13): メール取り込み (POST /api/inbound/email) と
+// LINE 取り込み (POST /api/inbound/line) それぞれの Route Handler が「repos.quarantinedEmails.record
+// を try/catch で囲み、書き込み失敗はログに残すだけで本来の応答 (隔離判定) には影響させない」という
+// 同型のラッパーを個別実装しており 2 箇所目の重複になっていた。src/lib/settings-audit.ts の
+// recordSettingsAudit が全く同じ理由 (「記録失敗が本来の処理に影響してはいけない」書き込みの複製)
+// で共通化された前例に倣い、ここに集約する (§6 DRY)。
+
+// データ層の Composition Root (Prisma 直叩きを避ける)
+import { repos } from '@/data';
+// 隔離記録の入力型 (channel で判別されるユニオン。メール/LINE それぞれの必須フィールドを強制する)
+import type { RecordQuarantinedEmailInput } from '@/data/ports/quarantined-email-repository';
+
+// 隔離記録を 1 件保存する。呼び出し元が既に「起票せず隔離する」と判断した後に呼ぶこと。
+// 記録自体が失敗してもログに残すだけで、呼び出し元の応答 (202/200 等) には一切影響させない
+// (recordSettingsAudit と同じ「非クリティカルな副作用」の扱い方)
+export async function recordQuarantineSafe(
+  input: RecordQuarantinedEmailInput,
+  logPrefix: string, // 記録失敗時のログ接頭辞 (呼び出し元を識別するため。例: '[POST /api/inbound/email]')
+): Promise<void> {
+  try {
+    await repos.quarantinedEmails.record(input);
+  } catch (err) {
+    // 記録自体の失敗は本来の処理の成否に影響させず、ログに残すだけに留める
+    console.error(`${logPrefix} 隔離記録の保存に失敗しました`, err);
+  }
+}

--- a/tests/data/quarantined-email-repository.contract.prisma.test.ts
+++ b/tests/data/quarantined-email-repository.contract.prisma.test.ts
@@ -41,6 +41,7 @@ describe.runIf(SHOULD_RUN)('QuarantinedEmailRepository (prisma adapter)', () => 
     const repos = buildPrismaRepos(prisma);
     await repos.quarantinedEmails.record({
       tenantId: TENANT_A,
+      channel: 'email',
       reason: 'plan_gate',
       senderAddress: 'a@example.com',
       senderName: 'A',
@@ -48,6 +49,7 @@ describe.runIf(SHOULD_RUN)('QuarantinedEmailRepository (prisma adapter)', () => 
     });
     await repos.quarantinedEmails.record({
       tenantId: TENANT_A,
+      channel: 'email',
       reason: 'unknown_sender',
       senderAddress: 'b@example.com',
       senderName: 'B',
@@ -66,6 +68,7 @@ describe.runIf(SHOULD_RUN)('QuarantinedEmailRepository (prisma adapter)', () => 
     const repos = buildPrismaRepos(prisma);
     await repos.quarantinedEmails.record({
       tenantId: TENANT_A,
+      channel: 'email',
       reason: 'auth_fail',
       senderAddress: 'a@example.com',
       senderName: 'A',
@@ -82,6 +85,7 @@ describe.runIf(SHOULD_RUN)('QuarantinedEmailRepository (prisma adapter)', () => 
     for (let i = 0; i < 3; i++) {
       await repos.quarantinedEmails.record({
         tenantId: TENANT_A,
+        channel: 'email',
         reason: 'quota_exceeded',
         senderAddress: `u${i}@example.com`,
         senderName: `U${i}`,
@@ -93,8 +97,9 @@ describe.runIf(SHOULD_RUN)('QuarantinedEmailRepository (prisma adapter)', () => 
     expect(rows).toHaveLength(2);
   });
 
-  // 全 5 種の QuarantineReason が実 DB の enum に対して問題なく書き込み・読み出しできること
-  it('全5種の隔離理由が書き込み・読み出しできる', async () => {
+  // 全 6 種の QuarantineReason が実 DB の enum に対して問題なく書き込み・読み出しできること。
+  // フォローアップ (2026-07-13): LINE 専用の no_agents を追加したため 5 種→6 種になった
+  it('全6種の隔離理由が書き込み・読み出しできる', async () => {
     const repos = buildPrismaRepos(prisma);
     const reasons = [
       'plan_gate',
@@ -102,10 +107,12 @@ describe.runIf(SHOULD_RUN)('QuarantinedEmailRepository (prisma adapter)', () => 
       'unknown_sender',
       'thread_forbidden',
       'quota_exceeded',
+      'no_agents',
     ] as const;
     for (const reason of reasons) {
       await repos.quarantinedEmails.record({
         tenantId: TENANT_A,
+        channel: 'email',
         reason,
         senderAddress: 'a@example.com',
         senderName: 'A',
@@ -122,6 +129,7 @@ describe.runIf(SHOULD_RUN)('QuarantinedEmailRepository (prisma adapter)', () => 
     const repos = buildPrismaRepos(prisma);
     await repos.quarantinedEmails.record({
       tenantId: TENANT_A,
+      channel: 'email',
       reason: 'unknown_sender',
       senderAddress: 'noheader@example.com',
       senderName: null,
@@ -140,6 +148,7 @@ describe.runIf(SHOULD_RUN)('QuarantinedEmailRepository (prisma adapter)', () => 
       data: {
         id: 'qte_b',
         tenantId: TENANT_A,
+        channel: 'email',
         reason: 'plan_gate',
         senderAddress: 'b@example.com',
         senderName: 'B',
@@ -151,6 +160,7 @@ describe.runIf(SHOULD_RUN)('QuarantinedEmailRepository (prisma adapter)', () => 
       data: {
         id: 'qte_a',
         tenantId: TENANT_A,
+        channel: 'email',
         reason: 'plan_gate',
         senderAddress: 'a@example.com',
         senderName: 'A',
@@ -162,6 +172,7 @@ describe.runIf(SHOULD_RUN)('QuarantinedEmailRepository (prisma adapter)', () => 
       data: {
         id: 'qte_c',
         tenantId: TENANT_A,
+        channel: 'email',
         reason: 'plan_gate',
         senderAddress: 'c@example.com',
         senderName: 'C',
@@ -186,6 +197,7 @@ describe.runIf(SHOULD_RUN)('QuarantinedEmailRepository (prisma adapter)', () => 
     const repos = buildPrismaRepos(prisma);
     await repos.quarantinedEmails.record({
       tenantId: TENANT_B,
+      channel: 'email',
       reason: 'plan_gate',
       senderAddress: 'a@example.com',
       senderName: 'A',
@@ -196,5 +208,26 @@ describe.runIf(SHOULD_RUN)('QuarantinedEmailRepository (prisma adapter)', () => 
 
     const remaining = await prisma.quarantinedEmail.findMany({ where: { tenantId: TENANT_B } });
     expect(remaining).toHaveLength(0);
+  });
+
+  // フォローアップ (2026-07-13): 監査で発見したギャップの解消。LINE 取り込みもこのテーブルを
+  // channel='line' で共有する。メール専用の NOT NULL 制約を外した senderAddress/subject が
+  // 実 DB で null のまま書き込み・読み出しできることを確認する
+  it('LINE 由来の隔離記録 (channel=line) を記録・読み出しできる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    await repos.quarantinedEmails.record({
+      tenantId: TENANT_A,
+      channel: 'line',
+      reason: 'no_agents',
+      lineUserId: 'U00000000000000000000000000000001',
+    });
+
+    const rows = await repos.quarantinedEmails.findAllByTenant({ tenantId: TENANT_A });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].channel).toBe('line');
+    expect(rows[0].reason).toBe('no_agents');
+    expect(rows[0].lineUserId).toBe('U00000000000000000000000000000001');
+    expect(rows[0].senderAddress).toBeNull();
+    expect(rows[0].subject).toBeNull();
   });
 });

--- a/tests/data/quarantined-email-repository.memory.test.ts
+++ b/tests/data/quarantined-email-repository.memory.test.ts
@@ -24,6 +24,7 @@ describe('QuarantinedEmailRepository (memory)', () => {
   it('records and reads back a quarantined email', async () => {
     await repos.quarantinedEmails.record({
       tenantId: TENANT_A,
+      channel: 'email',
       reason: 'unknown_sender',
       senderAddress: 'unknown@example.com',
       senderName: '知らない人',
@@ -43,6 +44,7 @@ describe('QuarantinedEmailRepository (memory)', () => {
   it('returns rows newest-first', async () => {
     await repos.quarantinedEmails.record({
       tenantId: TENANT_A,
+      channel: 'email',
       reason: 'plan_gate',
       senderAddress: 'a@example.com',
       senderName: 'A',
@@ -52,6 +54,7 @@ describe('QuarantinedEmailRepository (memory)', () => {
     await new Promise((resolve) => setTimeout(resolve, 2));
     await repos.quarantinedEmails.record({
       tenantId: TENANT_A,
+      channel: 'email',
       reason: 'quota_exceeded',
       senderAddress: 'b@example.com',
       senderName: 'B',
@@ -66,6 +69,7 @@ describe('QuarantinedEmailRepository (memory)', () => {
   it('does not leak rows across tenants', async () => {
     await repos.quarantinedEmails.record({
       tenantId: TENANT_A,
+      channel: 'email',
       reason: 'auth_fail',
       senderAddress: 'a@example.com',
       senderName: 'A',
@@ -85,18 +89,22 @@ describe('QuarantinedEmailRepository (memory)', () => {
     store.quarantinedEmails.set('qte_older', {
       id: 'qte_older',
       tenantId: TENANT_A,
+      channel: 'email',
       reason: 'plan_gate',
       senderAddress: 'a@example.com',
       senderName: 'A',
+      lineUserId: null,
       subject: '古い方',
       createdAt: older,
     });
     store.quarantinedEmails.set('qte_newer', {
       id: 'qte_newer',
       tenantId: TENANT_A,
+      channel: 'email',
       reason: 'quota_exceeded',
       senderAddress: 'b@example.com',
       senderName: 'B',
+      lineUserId: null,
       subject: '新しい方',
       createdAt: newer,
     });
@@ -117,27 +125,33 @@ describe('QuarantinedEmailRepository (memory)', () => {
     store.quarantinedEmails.set('qte_b', {
       id: 'qte_b',
       tenantId: TENANT_A,
+      channel: 'email',
       reason: 'plan_gate',
       senderAddress: 'b@example.com',
       senderName: 'B',
+      lineUserId: null,
       subject: 'B',
       createdAt: sameInstant,
     });
     store.quarantinedEmails.set('qte_a', {
       id: 'qte_a',
       tenantId: TENANT_A,
+      channel: 'email',
       reason: 'plan_gate',
       senderAddress: 'a@example.com',
       senderName: 'A',
+      lineUserId: null,
       subject: 'A',
       createdAt: sameInstant,
     });
     store.quarantinedEmails.set('qte_c', {
       id: 'qte_c',
       tenantId: TENANT_A,
+      channel: 'email',
       reason: 'plan_gate',
       senderAddress: 'c@example.com',
       senderName: 'C',
+      lineUserId: null,
       subject: 'C',
       createdAt: sameInstant,
     });
@@ -152,5 +166,26 @@ describe('QuarantinedEmailRepository (memory)', () => {
       before: { createdAt: sameInstant, id: 'qte_b' },
     });
     expect(page2.map((r) => r.id)).toEqual(['qte_a']);
+  });
+
+  // フォローアップ (2026-07-13): 監査で発見したギャップの解消。LINE 取り込みもこのテーブルを
+  // channel='line' で共有する。メール専用フィールド (senderAddress/senderName/subject) が
+  // 埋まらなくても LINE 専用の lineUserId で記録・読み出しできることを確認する
+  it('LINE 由来の隔離記録 (channel=line) を記録・読み出しできる', async () => {
+    await repos.quarantinedEmails.record({
+      tenantId: TENANT_A,
+      channel: 'line',
+      reason: 'no_agents',
+      lineUserId: 'U00000000000000000000000000000001',
+    });
+
+    const rows = await repos.quarantinedEmails.findAllByTenant({ tenantId: TENANT_A });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].channel).toBe('line');
+    expect(rows[0].reason).toBe('no_agents');
+    expect(rows[0].lineUserId).toBe('U00000000000000000000000000000001');
+    expect(rows[0].senderAddress).toBeNull();
+    expect(rows[0].senderName).toBeNull();
+    expect(rows[0].subject).toBeNull();
   });
 });

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -206,6 +206,13 @@ describe('POST /api/inbound/line', () => {
     const res = await POST(makeRequest('プリンターが動きません', LINE_ID_UNLINKED));
     expect(res.status).toBe(200);
     expect(store.tickets.size).toBe(0);
+    // フォローアップ (2026-07-13): 監査で発見したギャップの解消。以前は console.warn の
+    // サーバーログにしか残らず admin から確認できなかったため、隔離記録が永続化されることを確認する
+    expect(store.quarantinedEmails.size).toBe(1);
+    const record = Array.from(store.quarantinedEmails.values())[0];
+    expect(record.channel).toBe('line');
+    expect(record.reason).toBe('plan_gate');
+    expect(record.tenantId).toBe(TENANT);
   });
 
   // 未連携ユーザーの通常メッセージはプロキシ担当者を起票者にして起票する
@@ -555,6 +562,12 @@ describe('POST /api/inbound/line', () => {
       const res = await POST(makeRequest('プリンターが動きません', LINE_ID_UNLINKED));
       expect(res.status).toBe(200);
       expect(store.tickets.size).toBe(0);
+      // フォローアップ (2026-07-13): 監査で発見したギャップの解消。隔離記録が永続化されること
+      expect(store.quarantinedEmails.size).toBe(1);
+      const record = Array.from(store.quarantinedEmails.values())[0];
+      expect(record.channel).toBe('line');
+      expect(record.reason).toBe('quota_exceeded');
+      expect(record.lineUserId).toBe(LINE_ID_UNLINKED);
     });
 
     it('残枠があれば通常どおり起票する', async () => {
@@ -564,6 +577,22 @@ describe('POST /api/inbound/line', () => {
       expect(res.status).toBe(200);
       expect(store.tickets.size).toBe(1);
     });
+  });
+
+  // フォローアップ (2026-07-13): 監査で発見したギャップの解消。担当者が 1 人もいないテナントの
+  // 隔離記録が永続化されることを確認する (以前は console.warn のサーバーログにしか残らなかった)
+  it('担当者が1人もいないテナントは隔離記録を残して 200 を返す', async () => {
+    // シード済みの唯一の担当者を削除し、代理起票者を決められない状態にする
+    store.users.delete(AGENT_ID);
+    const { POST } = await import('@/app/api/inbound/line/route');
+    const res = await POST(makeRequest('プリンターが動きません', LINE_ID_UNLINKED));
+    expect(res.status).toBe(200);
+    expect(store.tickets.size).toBe(0);
+    expect(store.quarantinedEmails.size).toBe(1);
+    const record = Array.from(store.quarantinedEmails.values())[0];
+    expect(record.channel).toBe('line');
+    expect(record.reason).toBe('no_agents');
+    expect(record.tenantId).toBe(TENANT);
   });
 
   // フォローアップ (2026-07-13): 監査で発見したギャップの解消。§1.2 ペルソナ「現場リーダー」の


### PR DESCRIPTION
## 対応する Phase / 項目

`docs/smb-dx-pivot-plan.md` は全項目 `[x]` 完了扱いだが、前回 PR (#205〜#208) までの運用パターンに倣い監査を継続し、新たに見つかったギャップを修正した。

- Phase 2（LINE 連携）/ §3.2 フォローアップ（隔離記録の永続化・admin 可視化）

## 変更内容

### LINE取り込みの隔離記録をメールと共有し admin から可視化する

メール取り込みはプラン未対応・未登録送信者・認証失敗等で起票できなかった受信メールを `QuarantinedEmail` テーブルへ永続化し、admin 専用の `/quarantine` 画面で確認できる（§3.2 フォローアップで解消済み）。一方 LINE 取り込みは同じ性質の失敗モード（プラン未対応・担当者未設定・月間上限到達）をすべて `console.warn` のサーバーログにしか残しておらず、admin が「なぜ LINE の問い合わせが起票されないか」を確認する手段が一切なかった。

`QuarantinedEmail` テーブルをメール専用からチャネル共通の隔離記録へ拡張した（テーブル名・Port 名は移行コストを避けるため据え置き、実体はチャネル共通）。

- `prisma/schema.prisma`: `QuarantineChannel` enum（email/line）を追加。`QuarantineReason` に LINE 専用の `no_agents` を追加。`senderAddress`/`subject` を nullable にし、LINE 専用の `lineUserId` を追加。
- `src/domain/types.ts`・`src/lib/constants.ts`: 型・日本語ラベルを同期。`plan_gate` のラベル文言をチャネル非依存の表現に揃えた。
- `src/data/ports`・`adapters`（prisma/memory）: `RecordQuarantinedEmailInput` に `channel`/`lineUserId` を追加、メール専用フィールドを省略可にした。
- `src/app/api/inbound/line/route.ts`: `recordLineQuarantine` ヘルパーを追加し、プランゲート・担当者未設定・月間上限到達の 3 箇所で呼ぶ（`too_many_events` はテナント解決前のため対象外）。
- `src/app/(app)/quarantine/page.tsx`: 経路（メール/LINE）列を追加し、送信者欄をチャネルに応じて出し分ける（メールは氏名+アドレス、LINE は LINE ユーザー ID）。

## テスト

- `npm run typecheck` — 成功
- `npm run lint` — 成功
- `npx vitest run` — 900 件成功
- マイグレーションを実 DB（`RUN_PRISMA_CONTRACT=1`）に適用し、Prisma 契約テスト 129 件全て成功を確認済み
- 追加した回帰テスト:
  - `tests/data/quarantined-email-repository.memory.test.ts` / `.contract.prisma.test.ts`: `channel='line'` での記録・読み出し、全 6 種の `QuarantineReason`
  - `tests/features/inbound-line-route.test.ts`: プランゲート・担当者未設定・月間上限到達の 3 経路で隔離記録が永続化されること

## 画面確認

`/quarantine` 画面に「経路」列を追加し、LINE 由来の隔離記録も一覧表示されるようにした（UI の見た目の変更は列追加と送信者欄の出し分けのみ）。DB を伴う画面確認は環境上困難なため、上記の自動テスト（メモリ/Prisma 両アダプタ + ルートレベル）で検証している。

---
_Generated by [Claude Code](https://claude.ai/code/session_014XnHProPvPHZFdPsE2y9vp)_