### PR TITLE
feat(inbound): LINE起票時に受領確認をpush

### DIFF
--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -92,11 +92,7 @@ import type { SubscriptionPlan, QuarantineReason } from '@/domain/types';
 import { recordQuarantineSafe } from '@/lib/quarantine';
 // フォローアップ (2026-07-13): 監査で発見したギャップの解消。メール取り込みの受領自動返信と
 // 同等の「受け付けました」確認を LINE 送信者にも push するためのヘルパー
-import {
-  buildTicketReceivedLineMessage,
-  pushLineMessage,
-  resolveLineAccessToken,
-} from '@/lib/line-push';
+import { buildTicketReceivedLineMessage, pushLineMessage } from '@/lib/line-push';
 // メールに埋め込むリンクのベース URL を解決するヘルパー (受領確認 push の URL 組み立てに使う)
 import { resolveAppBaseUrl } from '@/lib/app-url';
 // チケット詳細ページの URL 組み立て・受付番号 (短縮 ID) の表記を揃えるヘルパー
@@ -766,20 +762,22 @@ async function processLineEvent(
     // フォローアップ (2026-07-13): 監査で発見したギャップの解消。メール取り込みの受領自動返信
     // (sendReceivedAck) と同等の「受け付けました」確認を LINE 送信者にも push する。
     // lineUserId が形式検証済み ('不明' でない) 場合のみ送る (プロキシ起票でも LINE ユーザー ID
-    // 自体は分かっているため、メンバー未連携でも受領確認は届けられる)。テナントの LINE 連携有無・
-    // プランゲートは resolveLineAccessToken が判定する (未設定/対象外プランなら null を返し何もしない)
+    // 自体は分かっているため、メンバー未連携でも受領確認は届けられる)。
+    // /code-review ultra 指摘対応 (2026-07-13): テナントの LINE 連携有無・プランゲートは
+    // POST ハンドラが既にこのリクエストの冒頭で判定済み (isLineIntegrationAllowed, ctx 構築前)。
+    // resolveLineAccessToken を呼んで再度 TenantLineConfig を引き直す・プランを再判定するのは
+    // 1 リクエストに複数イベントが含まれるたびに無駄な DB 参照が発生する重複だったため、
+    // 既に ctx へ載せてある channelAccessToken をそのまま使う (ctx.channelAccessToken は
+    // 画像添付の Content API 取得でも同様に再利用している値、line 656 参照)
     if (lineUserId !== '不明') {
       try {
-        const accessToken = await resolveLineAccessToken(targetTenantId);
-        if (accessToken) {
-          const baseUrl = resolveAppBaseUrl();
-          const receivedText = buildTicketReceivedLineMessage({
-            ticketTitle: title,
-            ticketRef: formatTicketRef(ticketId),
-            ticketUrl: buildTicketUrl(baseUrl, ticketId),
-          });
-          await pushLineMessage(accessToken, lineUserId, receivedText);
-        }
+        const baseUrl = resolveAppBaseUrl();
+        const receivedText = buildTicketReceivedLineMessage({
+          ticketTitle: title,
+          ticketRef: formatTicketRef(ticketId),
+          ticketUrl: buildTicketUrl(baseUrl, ticketId),
+        });
+        await pushLineMessage(ctx.channelAccessToken, lineUserId, receivedText);
       } catch (err) {
         // 送信失敗はログのみ (チケット起票は完了しているため応答は成功扱いのまま。
         // sendReceivedAck と同じ fail-safe 方針)

--- a/src/app/api/inbound/line/route.ts
+++ b/src/app/api/inbound/line/route.ts
@@ -90,6 +90,18 @@ import { persistAttachments, cleanupWrittenAttachments } from '@/lib/attachment-
 import type { SubscriptionPlan, QuarantineReason } from '@/domain/types';
 // 隔離記録の書き込み共通ヘルパー (メール取り込みと共有。§6 DRY)
 import { recordQuarantineSafe } from '@/lib/quarantine';
+// フォローアップ (2026-07-13): 監査で発見したギャップの解消。メール取り込みの受領自動返信と
+// 同等の「受け付けました」確認を LINE 送信者にも push するためのヘルパー
+import {
+  buildTicketReceivedLineMessage,
+  pushLineMessage,
+  resolveLineAccessToken,
+} from '@/lib/line-push';
+// メールに埋め込むリンクのベース URL を解決するヘルパー (受領確認 push の URL 組み立てに使う)
+import { resolveAppBaseUrl } from '@/lib/app-url';
+// チケット詳細ページの URL 組み立て・受付番号 (短縮 ID) の表記を揃えるヘルパー
+import { buildTicketUrl } from '@/lib/ticket-email';
+import { formatTicketRef } from '@/lib/ticket-ref';
 // このルートは Node ランタイムで動かす (node:crypto / Prisma を使うため Edge では動かない)
 export const runtime = 'nodejs';
 
@@ -751,6 +763,29 @@ async function processLineEvent(
     // Phase 4: 新規起票を Slack/Teams/Chatwork へ通知する (Web フォーム・メール・CSV と同じ経路)。
     // アプリ内通知とは独立したベストエフォート処理なので、失敗してもここまでの成功を巻き戻さない
     await notifyNewTicketOutbound(targetTenantId, { id: ticketId, title, priority: 'Medium' });
+    // フォローアップ (2026-07-13): 監査で発見したギャップの解消。メール取り込みの受領自動返信
+    // (sendReceivedAck) と同等の「受け付けました」確認を LINE 送信者にも push する。
+    // lineUserId が形式検証済み ('不明' でない) 場合のみ送る (プロキシ起票でも LINE ユーザー ID
+    // 自体は分かっているため、メンバー未連携でも受領確認は届けられる)。テナントの LINE 連携有無・
+    // プランゲートは resolveLineAccessToken が判定する (未設定/対象外プランなら null を返し何もしない)
+    if (lineUserId !== '不明') {
+      try {
+        const accessToken = await resolveLineAccessToken(targetTenantId);
+        if (accessToken) {
+          const baseUrl = resolveAppBaseUrl();
+          const receivedText = buildTicketReceivedLineMessage({
+            ticketTitle: title,
+            ticketRef: formatTicketRef(ticketId),
+            ticketUrl: buildTicketUrl(baseUrl, ticketId),
+          });
+          await pushLineMessage(accessToken, lineUserId, receivedText);
+        }
+      } catch (err) {
+        // 送信失敗はログのみ (チケット起票は完了しているため応答は成功扱いのまま。
+        // sendReceivedAck と同じ fail-safe 方針)
+        console.warn('[POST /api/inbound/line] failed to push received ack', ticketId, err);
+      }
+    }
     return ticketId;
   } catch (err) {
     // DB は自動ロールバック済み (createTicketIdempotent がキー無し経路もトランザクション化して

--- a/src/lib/line-push.ts
+++ b/src/lib/line-push.ts
@@ -58,6 +58,21 @@ export async function resolveLineAccessToken(tenantId: string): Promise<string |
 // 超過しうるためサーバー側でも明示的に切り詰める。
 const LINE_TEXT_MESSAGE_MAX_LENGTH = 5000;
 
+// LINE テキストメッセージの本文を上限文字数に切り詰める共通ヘルパー (副作用なし)。
+// /code-review ultra 指摘対応 (2026-07-13): 同じ切り詰めロジックが buildTicketReplyLineMessage /
+// buildTicketReceivedLineMessage / buildTicketStatusChangedLineMessage /
+// buildTicketPriorityChangedLineMessage の 4 箇所に重複していたため集約する (§6 DRY)。
+// `text.slice()` は UTF-16 コード単位で切るため、絵文字等のサロゲートペア文字の途中で
+// 切断すると壊れた文字が残る。Array.from() はコードポイント単位で反復するため、
+// サロゲートペアを保ったまま安全に切り詰められる。
+function truncateLineText(text: string): string {
+  const codePoints = Array.from(text);
+  // LINE の文字数上限を超える場合は末尾を省略する (上限超過は 400 エラーになるため事前に丸める)
+  return codePoints.length > LINE_TEXT_MESSAGE_MAX_LENGTH
+    ? `${codePoints.slice(0, LINE_TEXT_MESSAGE_MAX_LENGTH - 1).join('')}…`
+    : text;
+}
+
 // 担当者の返信を LINE のテキストメッセージ本文として組み立てる純粋関数 (副作用なし)
 export function buildTicketReplyLineMessage(input: {
   ticketTitle: string; // 問い合わせの件名
@@ -75,10 +90,7 @@ export function buildTicketReplyLineMessage(input: {
     input.ticketUrl,
   ].join('\n');
 
-  // LINE の文字数上限を超える場合は末尾を省略する (上限超過は 400 エラーになるため事前に丸める)
-  return text.length > LINE_TEXT_MESSAGE_MAX_LENGTH
-    ? `${text.slice(0, LINE_TEXT_MESSAGE_MAX_LENGTH - 1)}…`
-    : text;
+  return truncateLineText(text);
 }
 
 // 新規起票の受領確認を LINE のテキストメッセージ本文として組み立てる純粋関数 (副作用なし)。
@@ -101,10 +113,7 @@ export function buildTicketReceivedLineMessage(input: {
     input.ticketUrl,
   ].join('\n');
 
-  // LINE の文字数上限を超える場合は末尾を省略する (buildTicketReplyLineMessage と同じ安全策)
-  return text.length > LINE_TEXT_MESSAGE_MAX_LENGTH
-    ? `${text.slice(0, LINE_TEXT_MESSAGE_MAX_LENGTH - 1)}…`
-    : text;
+  return truncateLineText(text);
 }
 
 // ステータス変更を LINE のテキストメッセージ本文として組み立てる純粋関数 (副作用なし)。
@@ -127,10 +136,7 @@ export function buildTicketStatusChangedLineMessage(input: {
     input.ticketUrl,
   ].join('\n');
 
-  // LINE の文字数上限を超える場合は末尾を省略する (buildTicketReplyLineMessage と同じ安全策)
-  return text.length > LINE_TEXT_MESSAGE_MAX_LENGTH
-    ? `${text.slice(0, LINE_TEXT_MESSAGE_MAX_LENGTH - 1)}…`
-    : text;
+  return truncateLineText(text);
 }
 
 // 優先度変更を LINE のテキストメッセージ本文として組み立てる純粋関数 (副作用なし)。
@@ -153,10 +159,7 @@ export function buildTicketPriorityChangedLineMessage(input: {
     input.ticketUrl,
   ].join('\n');
 
-  // LINE の文字数上限を超える場合は末尾を省略する (buildTicketReplyLineMessage と同じ安全策)
-  return text.length > LINE_TEXT_MESSAGE_MAX_LENGTH
-    ? `${text.slice(0, LINE_TEXT_MESSAGE_MAX_LENGTH - 1)}…`
-    : text;
+  return truncateLineText(text);
 }
 
 // 指定した LINE ユーザーへテキストメッセージを push する。

--- a/src/lib/line-push.ts
+++ b/src/lib/line-push.ts
@@ -81,6 +81,32 @@ export function buildTicketReplyLineMessage(input: {
     : text;
 }
 
+// 新規起票の受領確認を LINE のテキストメッセージ本文として組み立てる純粋関数 (副作用なし)。
+// フォローアップ (2026-07-13): 監査で発見したギャップの解消。メール取り込みは受領自動返信
+// (renderTicketReceivedEmail) で「起票されたこと」を送信元に伝えるが、LINE 取り込みには
+// 同等の確認が無く、問い合わせが届いたかどうかをユーザーが確認できなかった。
+export function buildTicketReceivedLineMessage(input: {
+  ticketTitle: string; // 問い合わせの件名
+  ticketRef: string; // 受付番号 (例: "#ab12cd34" / 画面・受領メールと同じ短縮 ID 表記)
+  ticketUrl: string; // チケット詳細ページの URL (連携済みユーザーのみ開ける導線)
+}): string {
+  // LINE はプレーンテキストのみのため、改行区切りの簡潔な文面にする (受領メールの text 版相当)
+  const text = [
+    'お問い合わせを受け付けました。担当者が確認のうえご連絡します。',
+    '',
+    `受付番号: ${input.ticketRef}`,
+    `件名: ${input.ticketTitle}`,
+    '',
+    '対応状況の確認はこちら:',
+    input.ticketUrl,
+  ].join('\n');
+
+  // LINE の文字数上限を超える場合は末尾を省略する (buildTicketReplyLineMessage と同じ安全策)
+  return text.length > LINE_TEXT_MESSAGE_MAX_LENGTH
+    ? `${text.slice(0, LINE_TEXT_MESSAGE_MAX_LENGTH - 1)}…`
+    : text;
+}
+
 // ステータス変更を LINE のテキストメッセージ本文として組み立てる純粋関数 (副作用なし)。
 // §5.4 フォローアップ: これまで LINE push はコメント返信 (buildTicketReplyLineMessage) にしか
 // 実装されておらず、ステータス変更はメールのみだった。ギャップ分析表 (§2) の「通知」行が

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -168,11 +168,26 @@ describe('POST /api/inbound/line', () => {
     __resetRateLimits();
     // 連携コード冪等化は DB (lineLinkCodeRefs) 永続化に切り替わったため、createMemoryContext() で
     // 毎回新しい空ストアが作られる時点で自動的に初期化される (グローバル Map のリセットは不要)
+
+    // /code-review ultra 指摘対応 (2026-07-13): 受領確認 push (LINE Push API) が起票成功時に
+    // 無条件で発火するようになったため、fetch をスタブしていないテストでも実際に
+    // https://api.line.me へ HTTP リクエストが飛んでしまっていた (CLAUDE.md §11 「外部 API は
+    // モックして実際には呼ばない」違反。push 失敗は fail-safe で握り潰されるためテスト結果には
+    // 現れず、CI のネットワーク制限下での遅延・不安定化にサイレントにつながっていた)。
+    // ファイル全体の既定として無害な成功レスポンスを返す fetch モックをここでインストールし、
+    // 個別の呼び出し内容を検証したい describe ブロックは自身の beforeEach で上書きする。
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve('ok') }),
+    );
   });
 
   afterEach(() => {
     // 次のテストファイルに影響しないよう、このファイルで消費したバケットも初期化しておく
     __resetRateLimits();
+    // 上でインストールした既定の fetch スタブ (および各 describe ブロックが上書きしたもの) を
+    // 次のテストに影響しないよう必ず元に戻す
+    vi.unstubAllGlobals();
   });
 
   // セキュリティ回帰テスト: destination (署名検証前の値) をレート制限のキーに使うと、
@@ -722,6 +737,12 @@ describe('POST /api/inbound/line', () => {
       vi.unstubAllGlobals();
     });
 
+    // Content API 呼び出しだけを抜き出す/数えるヘルパー (受領確認の LINE Push API 呼び出しは
+    // 別 URL なので対象外にする)。/code-review ultra 指摘対応 (2026-07-13): 同じフィルタ条件が
+    // このブロック内の複数テストに書き写されていたため、ここへ集約する (§6 DRY)
+    const contentApiCallsOf = (mock: ReturnType<typeof vi.fn>) =>
+      mock.mock.calls.filter(([url]) => String(url).includes('/content'));
+
     it('画像メッセージから添付ファイルが保存される', async () => {
       const imageBytes = new Uint8Array([...PNG_MAGIC, 1, 2, 3]);
       fetchMock.mockResolvedValue(
@@ -735,10 +756,7 @@ describe('POST /api/inbound/line', () => {
       expect(body.ticketIds).toHaveLength(1);
 
       // Content API を正しい URL・Authorization ヘッダで呼んでいること
-      // (受領確認の LINE Push API 呼び出しは別 URL なので対象外にする)
-      const contentApiCalls = fetchMock.mock.calls.filter(([url]) =>
-        String(url).includes('/content'),
-      );
+      const contentApiCalls = contentApiCallsOf(fetchMock);
       expect(contentApiCalls).toHaveLength(1);
       const [url, init] = contentApiCalls[0];
       expect(url).toBe('https://api-data.line.me/v2/bot/message/img-1/content');
@@ -817,11 +835,7 @@ describe('POST /api/inbound/line', () => {
       const body = (await res.json()) as { ticketIds: string[] };
       expect(body.ticketIds).toHaveLength(1);
       // 外部ホストの画像は SSRF 対策のため Content API を呼ばない
-      // (受領確認の LINE Push API 呼び出しは起票成功時に別途発火するため対象外にする)
-      const contentApiCalls = fetchMock.mock.calls.filter(([url]) =>
-        String(url).includes('/content'),
-      );
-      expect(contentApiCalls).toHaveLength(0);
+      expect(contentApiCallsOf(fetchMock)).toHaveLength(0);
       expect(store.attachments.size).toBe(0);
     });
 
@@ -831,22 +845,18 @@ describe('POST /api/inbound/line', () => {
         new Response(imageBytes, { status: 200, headers: { 'content-type': 'image/png' } }),
       );
 
-      // Content API 呼び出しだけを数えるヘルパー (受領確認の LINE Push API 呼び出しは対象外にする)
-      const countContentApiCalls = () =>
-        fetchMock.mock.calls.filter(([url]) => String(url).includes('/content')).length;
-
       const { POST } = await import('@/app/api/inbound/line/route');
       const res1 = await POST(makeImageRequest(LINE_ID_UNLINKED, 'img-dup-1'));
       const body1 = (await res1.json()) as { ticketIds: string[] };
       expect(body1.ticketIds).toHaveLength(1);
-      expect(countContentApiCalls()).toBe(1);
+      expect(contentApiCallsOf(fetchMock)).toHaveLength(1);
 
       // 同じメッセージ ID で再送 (LINE の at-least-once 配送を模す)
       const res2 = await POST(makeImageRequest(LINE_ID_UNLINKED, 'img-dup-1'));
       const body2 = (await res2.json()) as { ticketIds: string[] };
       expect(body2.ticketIds).toEqual(body1.ticketIds);
       // 重複判定は早期リターンするため Content API を再度呼ばない
-      expect(countContentApiCalls()).toBe(1);
+      expect(contentApiCallsOf(fetchMock)).toHaveLength(1);
       // チケット・添付とも 1 件のまま (二重起票・二重添付なし)
       expect(store.tickets.size).toBe(1);
       expect(store.attachments.size).toBe(1);

--- a/tests/features/inbound-line-route.test.ts
+++ b/tests/features/inbound-line-route.test.ts
@@ -15,6 +15,12 @@ import { __resetRateLimits } from '@/lib/rate-limit';
 // 外部通知 (Slack/Teams/Chatwork) テスト用の Slack Webhook URL (実際には送信されない)
 const SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/xxx';
 
+// フォローアップ (2026-07-13): 受領確認 push (buildTicketReceivedLineMessage) は、seed() の
+// テナントが常に Pro プラン + LINE 連携設定を持つため、このファイルのほぼ全ての起票成功テストで
+// 副次的に発火する。Slack/Content API の fetch モック呼び出し件数を検証するテストでは、
+// この LINE Push API への呼び出しを url で除外してから数える (src/lib/line-push.ts と同じ URL)
+const LINE_PUSH_API_URL = 'https://api.line.me/v2/bot/message/push';
+
 // src/lib/webhook-fetch.ts は SSRF 対策の DNS 検証用 Dispatcher (Agent) を使うため
 // undici の fetch を直接 import している。vi.stubGlobal('fetch', ...) だけでは差し替わらない
 // ため、undici の fetch を globalThis.fetch へ委譲するモックにする (他テストへは影響しない)
@@ -509,18 +515,22 @@ describe('POST /api/inbound/line', () => {
       expect(res.status).toBe(200);
       expect(store.tickets.size).toBe(1);
 
-      // Slack Webhook へ 1 回だけ POST される
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-      const [url, init] = fetchMock.mock.calls[0];
+      // Slack Webhook へ 1 回だけ POST される (受領確認の LINE Push API 呼び出しは対象外にする)
+      const slackCalls = fetchMock.mock.calls.filter(([url]) => url === SLACK_WEBHOOK_URL);
+      expect(slackCalls).toHaveLength(1);
+      const [url, init] = slackCalls[0];
       expect(url).toBe(SLACK_WEBHOOK_URL);
       expect(JSON.stringify(JSON.parse(init.body))).toContain('プリンターが動きません');
     });
 
-    it('外部通知が未設定のテナントで新規起票しても fetch は呼ばれない', async () => {
+    // フォローアップ (2026-07-13): 受領確認 push (LINE Push API) は外部通知の設定有無に
+    // 関わらず発火するため、ここでは「Slack/Teams/Chatwork への外部通知だけが呼ばれないこと」を検証する
+    it('外部通知が未設定のテナントで新規起票しても Slack 等へは fetch されない', async () => {
       const { POST } = await import('@/app/api/inbound/line/route');
       const res = await POST(makeRequest('プリンターが動きません', LINE_ID_UNLINKED));
       expect(res.status).toBe(200);
-      expect(fetchMock).not.toHaveBeenCalled();
+      const nonPushCalls = fetchMock.mock.calls.filter(([url]) => url !== LINE_PUSH_API_URL);
+      expect(nonPushCalls).toHaveLength(0);
     });
 
     // ワンタイムコードでの連携処理は起票を伴わないため、新規起票向け外部通知も送らない
@@ -549,6 +559,80 @@ describe('POST /api/inbound/line', () => {
       expect(res.status).toBe(200);
       expect(store.tickets.size).toBe(0);
       expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // フォローアップ (2026-07-13): 監査で発見したギャップの解消。メール取り込みの受領自動返信
+  // (sendReceivedAck) と同等の「受け付けました」確認を LINE 送信者にも push する機能そのものの回帰テスト。
+  describe('受領確認 push (フォローアップ 2026-07-13)', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+      fetchMock = vi
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve('ok') });
+      vi.stubGlobal('fetch', fetchMock);
+    });
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('起票成功時に送信者本人へ受領確認が push される', async () => {
+      const { POST } = await import('@/app/api/inbound/line/route');
+      const res = await POST(makeRequest('プリンターが動きません', LINE_ID_UNLINKED));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ticketIds: string[] };
+      expect(body.ticketIds).toHaveLength(1);
+
+      const pushCalls = fetchMock.mock.calls.filter(([url]) => url === LINE_PUSH_API_URL);
+      expect(pushCalls).toHaveLength(1);
+      const [url, init] = pushCalls[0];
+      expect(url).toBe(LINE_PUSH_API_URL);
+      expect(init.headers.Authorization).toBe('Bearer test-access-token');
+      const payload = JSON.parse(init.body);
+      // 未連携ユーザーでも LINE ユーザー ID 自体は分かっているため、本人宛てに届く
+      expect(payload.to).toBe(LINE_ID_UNLINKED);
+      expect(payload.messages[0].text).toContain('お問い合わせを受け付けました');
+      // 受付番号は formatTicketRef (src/lib/ticket-ref.ts) と同じ「先頭8文字+#」形式で入る
+      expect(payload.messages[0].text).toContain(`#${body.ticketIds[0].slice(0, 8)}`);
+    });
+
+    // 回帰防止: lineUserId が形式検証済みでない ('不明') 場合は push 先が無いため送らない
+    it('LINE ユーザー ID が形式外 (不明) の場合は push しない', async () => {
+      const { POST } = await import('@/app/api/inbound/line/route');
+      // source.userId を省略した Webhook イベントは lineUserId が '不明' になる
+      const body = JSON.stringify({
+        destination: BOT_USER_ID,
+        events: [
+          {
+            type: 'message',
+            source: { type: 'group' },
+            message: { type: 'text', id: 'm-no-user', text: 'プリンターが動きません' },
+          },
+        ],
+      });
+      const req = new Request('http://localhost/api/inbound/line', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-line-signature': sign(body) },
+        body,
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      expect(store.tickets.size).toBe(1);
+      const pushCalls = fetchMock.mock.calls.filter(([url]) => url === LINE_PUSH_API_URL);
+      expect(pushCalls).toHaveLength(0);
+    });
+
+    // 回帰防止: push 送信が失敗しても起票自体は成功させる (§9 fail-safe)
+    it('push 送信に失敗しても起票レスポンスは 200 のままになる', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('error'),
+      });
+      const { POST } = await import('@/app/api/inbound/line/route');
+      const res = await POST(makeRequest('プリンターが動きません', LINE_ID_UNLINKED));
+      expect(res.status).toBe(200);
+      expect(store.tickets.size).toBe(1);
     });
   });
 
@@ -651,8 +735,12 @@ describe('POST /api/inbound/line', () => {
       expect(body.ticketIds).toHaveLength(1);
 
       // Content API を正しい URL・Authorization ヘッダで呼んでいること
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-      const [url, init] = fetchMock.mock.calls[0];
+      // (受領確認の LINE Push API 呼び出しは別 URL なので対象外にする)
+      const contentApiCalls = fetchMock.mock.calls.filter(([url]) =>
+        String(url).includes('/content'),
+      );
+      expect(contentApiCalls).toHaveLength(1);
+      const [url, init] = contentApiCalls[0];
       expect(url).toBe('https://api-data.line.me/v2/bot/message/img-1/content');
       expect(init.headers.Authorization).toBe('Bearer test-access-token');
 
@@ -729,7 +817,11 @@ describe('POST /api/inbound/line', () => {
       const body = (await res.json()) as { ticketIds: string[] };
       expect(body.ticketIds).toHaveLength(1);
       // 外部ホストの画像は SSRF 対策のため Content API を呼ばない
-      expect(fetchMock).not.toHaveBeenCalled();
+      // (受領確認の LINE Push API 呼び出しは起票成功時に別途発火するため対象外にする)
+      const contentApiCalls = fetchMock.mock.calls.filter(([url]) =>
+        String(url).includes('/content'),
+      );
+      expect(contentApiCalls).toHaveLength(0);
       expect(store.attachments.size).toBe(0);
     });
 
@@ -739,18 +831,22 @@ describe('POST /api/inbound/line', () => {
         new Response(imageBytes, { status: 200, headers: { 'content-type': 'image/png' } }),
       );
 
+      // Content API 呼び出しだけを数えるヘルパー (受領確認の LINE Push API 呼び出しは対象外にする)
+      const countContentApiCalls = () =>
+        fetchMock.mock.calls.filter(([url]) => String(url).includes('/content')).length;
+
       const { POST } = await import('@/app/api/inbound/line/route');
       const res1 = await POST(makeImageRequest(LINE_ID_UNLINKED, 'img-dup-1'));
       const body1 = (await res1.json()) as { ticketIds: string[] };
       expect(body1.ticketIds).toHaveLength(1);
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(countContentApiCalls()).toBe(1);
 
       // 同じメッセージ ID で再送 (LINE の at-least-once 配送を模す)
       const res2 = await POST(makeImageRequest(LINE_ID_UNLINKED, 'img-dup-1'));
       const body2 = (await res2.json()) as { ticketIds: string[] };
       expect(body2.ticketIds).toEqual(body1.ticketIds);
       // 重複判定は早期リターンするため Content API を再度呼ばない
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(countContentApiCalls()).toBe(1);
       // チケット・添付とも 1 件のまま (二重起票・二重添付なし)
       expect(store.tickets.size).toBe(1);
       expect(store.attachments.size).toBe(1);


### PR DESCRIPTION
## Summary

`docs/smb-dx-pivot-plan.md` §3.2 フォローアップ (前回 PR #205-#210 の監査ラウンドで発見済みのギャップの継続実装)。

- メール取り込みは起票成功時に `sendReceivedAck` で送信者へ「受け付けました」の自動返信を送るが、LINE 取り込みは同等の受領確認を一切送っておらず、LINE 経由の問い合わせ主は起票が実際に成立したかを確認する手段が無かった。
- `src/lib/line-push.ts` に `buildTicketReceivedLineMessage()` を追加。受付番号・件名・チケット URL を含む受領確認テキストを組み立てる純粋関数 (`buildTicketReplyLineMessage` / `buildTicketStatusChangedLineMessage` と同じ形式)。
- `src/app/api/inbound/line/route.ts` の `processLineEvent` 起票成功パス末尾で、`lineUserId` が形式検証済み (「不明」でない) 場合のみ `resolveLineAccessToken` → `pushLineMessage` を呼ぶ。プランゲート・LINE 連携未設定は `resolveLineAccessToken` が既存どおり判定する (null なら何もしない)。送信失敗はログのみに留め、起票自体の成功は巻き戻さない (`sendReceivedAck` と同じ fail-safe 方針、§9)。

## Test plan

- [x] `npx vitest run tests/features/inbound-line-route.test.ts` — 新設した「受領確認 push」ブロック (起票成功時に正しい宛先・本文で push / lineUserId 形式外は push しない / push 失敗時も起票レスポンスは 200) を含め全 27 件成功。既存の Slack/Content API 呼び出し件数検証テストは、新しい push が同じグローバル fetch モックを共有するため、LINE Push API 向け呼び出しを URL で除外してから数えるよう修正済み。
- [x] `npx vitest run` — 全 903 件成功 (契約テスト 129 件はローカル DB 無しでスキップ)
- [x] `RUN_PRISMA_CONTRACT=1 npx vitest run --no-file-parallelism` (専用 DB) — 全 1032 件成功 (スキーマ変更なし)
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx eslint` / `npx prettier --write` — 対象ファイルとも問題なし

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014XnHProPvPHZFdPsE2y9vp

---
_Generated by [Claude Code](https://claude.ai/code/session_014XnHProPvPHZFdPsE2y9vp)_