### PR TITLE
fix(tickets): CSVインポートの起票者列を解決し閲覧権限・通知の往復性ギャップを解消

### DIFF
--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -370,6 +370,40 @@ LINE・CSV インポート・メールの 4 系統あるが、「新規起票を
 - `tests/features/inbound-email-route.test.ts`: 新規起票時にエージェント宛の `imported` 通知が作成される
   ことを検証する回帰テストを追加した。
 
+#### 3.6 フォローアップ（2026-07-14）: CSV エクスポートの「起票者」列が往復せず、常にインポート実行者に付け替えられていた
+
+監査で発見したギャップ: §3.3/§3.4 フォローアップで「件名」「内容」「カテゴリ」「期限日」の CSV
+往復性を解消したが、CSV エクスポート（`GET /api/tickets/export`）が出力する「起票者」列
+（`t.creator?.name`）に対応する読み取りが CSV インポート（`import-tickets.ts`）側に一切存在せず、
+インポートされる全チケットの `creatorId` は常にインポートを実行した admin のセッション ID に
+ハードコードされていた。これは §3.1/§3.3/§3.4 と同種の CSV 往復性の欠落だが、「起票者」列は
+表示専用の他の列と異なり、依頼者本人がそのチケットを見られるかどうか
+（`src/app/(app)/tickets/[id]/page.tsx` の `!isAgent && ticket.creatorId !== session.user.id`
+による 404）と、ステータス/優先度変更時の通知の宛先（`update-ticket.ts`）の両方を左右するため、
+影響がより深刻だった。admin がバックアップ・見直し・他テナントへの移行目的でチケットを
+エクスポートし、編集して再インポートする（§0 北極星指標「最短で Excel から卒業できる」が
+前提とする往復ワークフロー）と、元の依頼者（例: §1.2 の現場リーダー鈴木さん）が自分の
+問い合わせを一覧・詳細のどちらからも見られなくなり、以後の進捗通知も届かなくなる回帰だった。
+
+- `src/data/ports/user-repository.ts` に `listByTenant(tenantId)` を追加（Prisma + メモリ両
+  Adapter で実装）。起票者はエージェントに限らず依頼者もなり得るため、既存の `listAgents`
+  （agent/admin のみ）では名前解決できず、ロールを問わない一覧取得が別途必要だった。
+- `import-tickets.ts` に「起票者」列（`headers.indexOf('起票者')`）を追加し、拠点/カテゴリ/
+  担当者と同じ名前解決パターンを踏襲した。同姓同名のメンバーが複数存在する場合に Map の
+  キー衝突でどちらか一方へ無言で misassign されるのを防ぐ重複検出ロジックは、担当者列の実装と
+  完全に同型だったため `buildNameToIdMapWithDuplicates` として抽出し両者で共有した（§6 DRY:
+  2 箇所目の重複が生じた時点で共通化する方針）。列が無い/セルが空の行は従来どおりインポート
+  実行者を起票者にする（後方互換）。
+- `CsvImportForm.tsx` のウィザードに「起票者」列マッピングを追加し、`ColumnMapping` /
+  `PreviewRow` / `SYSTEM_FIELDS` / `applyMapping` / `buildPreview` / `buildAutoMapping` を
+  拠点/担当者と同じ形で一貫して拡張した。入力値フォーマットのヒントに「登録済みのメンバー
+  （担当者または依頼者）の氏名と完全一致」「空欄ならインポート実行者が起票者になる」旨を明記した。
+- `tests/features/import-tickets.test.ts` に依頼者名/エージェント名での解決・列/セル省略時の
+  後方互換・存在しない名前のエラー・同姓同名の重複エラー・他テナントの同名ユーザーが解決対象に
+  含まれないことの回帰テストを追加。`listByTenant` 自体のテストも
+  `tests/data/user-repository.memory.test.ts` と `user-repository.contract.prisma.test.ts` に
+  追加した。
+
 ### Phase 4 — マネタイズと運用（継続）
 
 - [x] サブスク課金（Stripe Billing）: Free / Standard / Pro の 3 段階

--- a/src/data/adapters/memory/user-repository.memory.ts
+++ b/src/data/adapters/memory/user-repository.memory.ts
@@ -68,6 +68,22 @@ export function makeUserRepo(store: Store): UserRepository {
       return agents;
     },
 
+    // 当該テナント内の全ユーザー (ロール問わず) を名前順で一覧取得 (フォローアップ 2026-07-14:
+    // CSV インポートの「起票者」列名解決用。起票者は依頼者もなり得るため listAgents では絞り込めない)
+    async listByTenant(tenantId) {
+      // 結果を入れる配列を準備
+      const out: UserSummary[] = [];
+      // 全ユーザーを走査し、テナント一致だけ抽出 (ロールは問わない)
+      for (const u of store.users.values()) {
+        if (u.tenantId !== tenantId) continue; // 他テナントは除外
+        out.push({ id: u.id, name: u.name });
+      }
+      // 名前でロケール順に並び替え
+      out.sort((a, b) => a.name.localeCompare(b.name));
+      // 結果を返す
+      return out;
+    },
+
     // 当該テナント内の agent または admin の ID だけを一覧取得
     async listAgentIds(tenantId) {
       // 結果 ID 配列

--- a/src/data/adapters/prisma/user-repository.prisma.ts
+++ b/src/data/adapters/prisma/user-repository.prisma.ts
@@ -45,6 +45,18 @@ export function makeUserRepo(db: PrismaLike): UserRepository {
       return rows.map(toUserSummary);
     },
 
+    // 当該テナント内の全ユーザー (ロール問わず) を名前順で取得 (フォローアップ 2026-07-14:
+    // CSV インポートの「起票者」列名解決用。起票者は依頼者もなり得るため listAgents では絞り込めない)
+    async listByTenant(tenantId) {
+      const rows = await db.user.findMany({
+        where: { tenantId }, // テナントのみで絞る (ロール不問)
+        select: { id: true, name: true }, // 必要列のみ
+        orderBy: { name: 'asc' }, // 名前昇順
+      });
+      // 各行を UserSummary に変換
+      return rows.map(toUserSummary);
+    },
+
     // 当該テナント内の agent または admin の ID だけを取得 (通知一斉送信用)
     async listAgentIds(tenantId) {
       const rows = await db.user.findMany({

--- a/src/data/ports/user-repository.ts
+++ b/src/data/ports/user-repository.ts
@@ -29,6 +29,10 @@ export interface UserRepository {
   }): Promise<User>;
   /** Agents and admins in the given tenant. */
   listAgents(tenantId: string): Promise<UserSummary[]>; // 当該テナント内の agent/admin 一覧
+  // 当該テナント内の全ユーザー (agent/admin/requester 問わず) の概要一覧。
+  // フォローアップ (2026-07-14): CSV インポートの「起票者」列名解決用に追加。起票者はエージェントに
+  // 限らず依頼者 (requester) もなり得るため、agent/admin だけを返す listAgents では解決できない。
+  listByTenant(tenantId: string): Promise<UserSummary[]>;
   listAgentIds(tenantId: string): Promise<string[]>; // 当該テナント内の agent/admin の ID だけ
   findSummariesByIds(ids: string[], tenantId: string): Promise<UserSummary[]>; // テナント内 ID 配列から概要
   // エスカレーション一斉メール等、メール送信先として全エージェントの email が必要な場面向け。

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -18,7 +18,13 @@ import { getCurrentTenantMode } from '@/lib/tenant';
 // RFC 4180 準拠の CSV パーサ と共有定数 (サーバー / クライアント共通実装)
 import { parseCsvLine, MAX_CSV_BYTES } from '@/lib/csv';
 // 優先度・ステータス・テナントモードのドメイン型
-import type { Priority, TicketStatus, TenantMode, NotificationType } from '@/domain/types';
+import type {
+  Priority,
+  TicketStatus,
+  TenantMode,
+  NotificationType,
+  UserSummary,
+} from '@/domain/types';
 // モードに応じた初期ステータスを返す共通関数（メール取り込み・LINE 取り込みと同一ロジックを共有し DRY を維持する）。
 // getCompletionStatuses は §3.1 フォローアップ (2026-07-10) で追加: インポート時に「状況」列が
 // 完了系ステータスを指定していた場合、resolvedAt をインポート時刻で設定するために使う
@@ -109,6 +115,29 @@ function resolveNameToId(
     };
   }
   return { ok: true, id };
+}
+
+// 名前 → ID の対応表を作りつつ、同姓同名 (重複名) を集合として検出する共通ヘルパー。
+// 拠点・カテゴリと異なり、担当者・起票者は「チケットの所有権に関わる」列であり、同姓同名を
+// Map のキー衝突でどちらか一方へ無言で misassign すると事故になるため、専用の重複検出が必要になる
+// (buildNameToIdMap は「列が使われるかどうか」の分岐のみを共有する用途なのでここでは使わない)。
+// フォローアップ (2026-07-14): 元々は担当者名解決にインライン実装されていたが、起票者名解決も
+// 同じ形の重複検出を必要とするため、2 箇所目の重複が生じた時点で共通化する (§6 DRY)。
+function buildNameToIdMapWithDuplicates(items: UserSummary[]): {
+  byName: Map<string, string>;
+  duplicateNames: Set<string>;
+} {
+  const byName = new Map<string, string>();
+  const nameCounts = new Map<string, number>();
+  for (const item of items) {
+    nameCounts.set(item.name, (nameCounts.get(item.name) ?? 0) + 1);
+    byName.set(item.name, item.id);
+  }
+  const duplicateNames = new Set<string>();
+  for (const [name, count] of nameCounts) {
+    if (count > 1) duplicateNames.add(name);
+  }
+  return { byName, duplicateNames };
 }
 
 // CSV インポート完了後、対象ユーザー群へバッチ通知 (1 通ずつ) を送るベストエフォート・ヘルパー。
@@ -258,6 +287,13 @@ interface ValidatedRow {
   // 同じく DB を持つ呼び出し側で行う)。CSV エクスポートは「担当者」列を出力するのにインポート側に
   // 対応する読み取りが無く、エクスポート→編集→再インポートの往復で担当者情報が失われていた
   assigneeName: string | null;
+  // フォローアップ (2026-07-14): 起票者名 (trim 済み。null = 未指定。実在確認は担当者と同じく
+  // DB を持つ呼び出し側で行う)。CSV エクスポートは「起票者」列を出力するのにインポート側に
+  // 対応する読み取りが無く、常にインポート実行者が起票者としてハードコードされていたため、
+  // エクスポート→編集→再インポートの往復で元の起票者 (依頼者本人) の情報が失われていた。
+  // これはチケットの閲覧権限 (依頼者は自分の起票したチケットしか見えない) と通知の宛先を
+  // 誤らせる回帰であり、拠点/カテゴリ/担当者よりも影響が大きい
+  creatorName: string | null;
 }
 
 // CSV ヘッダの列インデックス一覧
@@ -270,6 +306,7 @@ interface ColumnIndices {
   categoryIndex: number; // 「カテゴリ」列 (-1 = 未指定。フォローアップ 2026-07-11)
   statusIndex: number; // 「状況」列 (-1 = 未指定。§3.1 フォローアップ)
   assigneeIndex: number; // 「担当者」列 (-1 = 未指定。フォローアップ 2026-07-13)
+  creatorIndex: number; // 「起票者」列 (-1 = 未指定。フォローアップ 2026-07-14)
 }
 
 // CSV 1 行分のセルを受け取り、バリデーション・型変換を行う純粋関数。
@@ -290,6 +327,7 @@ function validateImportRow(
     categoryIndex,
     statusIndex,
     assigneeIndex,
+    creatorIndex,
   } = indices;
 
   // 件名セルを取り出す。前後の空白は除去する (空白だけのセルを「入力あり」と誤判定しないため)
@@ -348,10 +386,11 @@ function validateImportRow(
     }
   }
 
-  // 拠点セル・カテゴリセル・担当者セルを取り出す (未指定なら null。extractOptionalCell を共有)
+  // 拠点セル・カテゴリセル・担当者セル・起票者セルを取り出す (未指定なら null。extractOptionalCell を共有)
   const locationName = extractOptionalCell(cells, locationIndex);
   const categoryName = extractOptionalCell(cells, categoryIndex);
   const assigneeName = extractOptionalCell(cells, assigneeIndex);
+  const creatorName = extractOptionalCell(cells, creatorIndex);
 
   // §3.1 フォローアップ (2026-07-10): 「状況」セルをテナントの現在モードのラベルから TicketStatus へ
   // 変換する。既存の問い合わせ管理 Excel には既に完了済みの行が大量に混ざっているのが実情で、
@@ -402,6 +441,7 @@ function validateImportRow(
       categoryName,
       status,
       assigneeName,
+      creatorName,
     },
   };
 }
@@ -484,6 +524,9 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
   // フォローアップ (2026-07-13): 担当者名 (CSV エクスポートの「担当者」列と対称の項目。
   // 拠点/カテゴリと同じく名前解決が必要なため列インデックスだけここで取得する)
   const assigneeIndex = headers.indexOf('担当者');
+  // フォローアップ (2026-07-14): 起票者名 (CSV エクスポートの「起票者」列と対称の項目。
+  // 担当者と同じく名前解決が必要なため列インデックスだけここで取得する)
+  const creatorIndex = headers.indexOf('起票者');
 
   // データ行 (2 行目以降) を取り出す
   const dataLines = nonEmptyLines.slice(1);
@@ -515,30 +558,31 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
   // ここで取得したものを再利用して二重取得を避ける (§8 パフォーマンス)。(2) 拠点/カテゴリと異なり
   // 担当者名はチケットの所有権 (誰が対応するか) を左右するため、同姓同名のエージェントが存在する
   // 場合に Map のキー衝突でどちらか一方へ無言で misassign されるのを防ぐ重複検出が必要。
-  // 拠点・カテゴリ・エージェント一覧は互いに独立した取得のため Promise.all で並列化する (§8)。
-  const [locationsByName, categoriesByName, agentsForAssignee] = await Promise.all([
-    buildNameToIdMap(locationIndex !== -1, () => repos.locations.listByTenant(tenantId)),
-    buildNameToIdMap(categoryIndex !== -1 && mode !== 'lite', () =>
-      repos.categories.list(tenantId),
-    ),
-    assigneeIndex !== -1 ? repos.users.listAgents(tenantId) : Promise.resolve(null),
-  ]);
+  // フォローアップ (2026-07-14): 起票者も同じ理由で重複検出が必要。ただし起票者はエージェントに
+  // 限らず依頼者もなり得るため、agentsForAssignee (listAgents) ではなく listByTenant (全ロール) を
+  // 別途取得する。同一テナント内で対象が重なっても listAgents とは目的の異なる独立した取得のため、
+  // 拠点・カテゴリ・エージェント一覧と合わせて Promise.all で並列化する (§8 パフォーマンス)。
+  const [locationsByName, categoriesByName, agentsForAssignee, usersForCreator] = await Promise.all(
+    [
+      buildNameToIdMap(locationIndex !== -1, () => repos.locations.listByTenant(tenantId)),
+      buildNameToIdMap(categoryIndex !== -1 && mode !== 'lite', () =>
+        repos.categories.list(tenantId),
+      ),
+      assigneeIndex !== -1 ? repos.users.listAgents(tenantId) : Promise.resolve(null),
+      creatorIndex !== -1 ? repos.users.listByTenant(tenantId) : Promise.resolve(null),
+    ],
+  );
 
-  // 「担当者」列の名前 → ID マップと、同姓同名 (重複名) の集合を作る。
+  // 「担当者」「起票者」列それぞれの名前 → ID マップと、同姓同名 (重複名) の集合を作る。
   // 拠点/カテゴリの resolveNameToId と異なり、同名が複数存在する場合はどちらか一方を無言で
-  // 選ばず、後続のループでエラー行として記録できるよう duplicateAgentNames に集める。
-  const agentsByName = new Map<string, string>();
-  const duplicateAgentNames = new Set<string>();
-  if (agentsForAssignee) {
-    const nameCounts = new Map<string, number>();
-    for (const a of agentsForAssignee) {
-      nameCounts.set(a.name, (nameCounts.get(a.name) ?? 0) + 1);
-      agentsByName.set(a.name, a.id);
-    }
-    for (const [name, count] of nameCounts) {
-      if (count > 1) duplicateAgentNames.add(name);
-    }
-  }
+  // 選ばず、後続のループでエラー行として記録できるよう duplicateNames に集める
+  // (buildNameToIdMapWithDuplicates を共有。§6 DRY: 担当者・起票者の 2 箇所目で共通化した)。
+  const { byName: agentsByName, duplicateNames: duplicateAgentNames } = agentsForAssignee
+    ? buildNameToIdMapWithDuplicates(agentsForAssignee)
+    : { byName: new Map<string, string>(), duplicateNames: new Set<string>() };
+  const { byName: usersByName, duplicateNames: duplicateCreatorNames } = usersForCreator
+    ? buildNameToIdMapWithDuplicates(usersForCreator)
+    : { byName: new Map<string, string>(), duplicateNames: new Set<string>() };
 
   // 集計用カウンタとエラーリストを初期化する
   let imported = 0;
@@ -559,6 +603,7 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     categoryIndex,
     statusIndex,
     assigneeIndex,
+    creatorIndex,
   };
 
   // データ行を 1 件ずつ処理する (部分成功を許可するため、1 件エラーでも他を続ける)
@@ -609,6 +654,7 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
       categoryName,
       status: parsedStatus,
       assigneeName,
+      creatorName,
     } = validation.data;
     // 「状況」列が未指定 (null) ならモードの既定初期ステータスにフォールバックする
     const status = parsedStatus ?? initialStatus;
@@ -679,6 +725,31 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
       assigneeId = resolved.id;
     }
 
+    // フォローアップ (2026-07-14): 監査で発見したギャップの解消。起票者名が指定されていれば ID に
+    // 解決する (resolveNameToId を共有)。担当者と同じく Lite/Pro 両モードで使える概念のため mode
+    // によるガードは行わない。列が無い/セルが空の場合は既定どおりインポート実行者を起票者にする
+    // (後方互換: 従来の CSV フォーマットのままインポートしても壊れない)。
+    // 起票者はチケットの閲覧権限 (依頼者は自分の起票したチケットしか見えない。
+    // src/app/(app)/tickets/[id]/page.tsx) と通知の宛先 (update-ticket.ts) の両方を左右するため、
+    // 担当者と同じく無言で「インポート実行者に付け替え」ず、解決できない名前はエラー行として記録する。
+    let effectiveCreatorId = creatorId;
+    if (creatorName !== null) {
+      // 担当者と同じ理由 (同姓同名の misassign 防止) で重複検出を先に行う
+      if (duplicateCreatorNames.has(creatorName)) {
+        errors.push({
+          row: rowNum,
+          message: `起票者名が重複しています: "${creatorName}"（同じ名前のメンバーが複数存在するため一意に特定できません。取り込み後に画面から起票者を確認してください）`,
+        });
+        continue;
+      }
+      const resolved = resolveNameToId(creatorName, usersByName, '起票者');
+      if (!resolved.ok) {
+        errors.push({ row: rowNum, message: resolved.message });
+        continue;
+      }
+      effectiveCreatorId = resolved.id;
+    }
+
     // Phase 4 課金: 残枠を使い切っていたらこの行以降は起票せずエラーとして記録する
     // (Web フォーム / メール / LINE 取り込みと同じ上限を CSV インポートにも適用する)
     if (quota.limited && quota.remaining <= 0) {
@@ -698,7 +769,9 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
         priority, // 優先度
         // 「カテゴリ」列があれば名前解決済みの ID、無ければ未分類 (null。後から設定できる)
         categoryId,
-        creatorId, // セッションのユーザーが起票者になる
+        // フォローアップ (2026-07-14): 「起票者」列があれば名前解決済みの ID、無ければ従来どおり
+        // インポート実行者 (セッションのユーザー) が起票者になる
+        creatorId: effectiveCreatorId,
         tenantId, // テナントスコープを必ず付与する (クロステナント防止)
         // 「状況」列があればその値、無ければモードの既定初期ステータス (Lite: Open / Pro: New)
         status,

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -117,6 +117,28 @@ function resolveNameToId(
   return { ok: true, id };
 }
 
+// 「チケットの所有権に関わる」名前解決 (担当者・起票者) の共通ヘルパー。
+// resolveNameToId と異なり、同姓同名がキー衝突でどちらか一方へ無言で misassign されるのを防ぐため、
+// 解決を試みる前に重複チェックを行う「重複チェック → resolveNameToId」という 2 手順をまとめて持つ。
+// フォローアップ (2026-07-14): 元々は担当者名解決の行処理にインライン実装されていたが、起票者名解決も
+// 全く同型の 2 手順を必要とするため、2 箇所目の重複が生じた時点で共通化する (§6 DRY)。
+function resolveOwnedName(
+  name: string,
+  byName: Map<string, string>,
+  duplicateNames: Set<string>,
+  entityLabel: string, // エラーメッセージに使う日本語ラベル (例: '担当者' '起票者')
+  duplicatePopulationLabel: string, // 重複しうる母集団の呼称 (例: 担当者は「エージェント」、起票者は「メンバー」)
+  duplicateGuidance: string, // 重複時のエラーメッセージ末尾に付ける案内文 (例: '担当者を設定してください')
+): { ok: true; id: string } | { ok: false; message: string } {
+  if (duplicateNames.has(name)) {
+    return {
+      ok: false,
+      message: `${entityLabel}名が重複しています: "${name}"（同じ名前の${duplicatePopulationLabel}が複数存在するため一意に特定できません。取り込み後に画面から${duplicateGuidance}）`,
+    };
+  }
+  return resolveNameToId(name, byName, entityLabel);
+}
+
 // 名前 → ID の対応表を作りつつ、同姓同名 (重複名) を集合として検出する共通ヘルパー。
 // 拠点・カテゴリと異なり、担当者・起票者は「チケットの所有権に関わる」列であり、同姓同名を
 // Map のキー衝突でどちらか一方へ無言で misassign すると事故になるため、専用の重複検出が必要になる
@@ -708,16 +730,15 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     if (assigneeName !== null) {
       // /code-review ultra 指摘対応 (2026-07-13): 同姓同名のエージェントが複数存在する場合、
       // Map のキー衝突でどちらか一方へ無言で misassign されてしまう (拠点/カテゴリの誤りより
-      // 「チケットの所有権を誤らせる」ため深刻)。resolveNameToId を呼ぶ前に重複を検出し、
-      // 曖昧な名前は起票者が手動で判断できるようエラー行として記録する。
-      if (duplicateAgentNames.has(assigneeName)) {
-        errors.push({
-          row: rowNum,
-          message: `担当者名が重複しています: "${assigneeName}"（同じ名前のエージェントが複数存在するため一意に特定できません。取り込み後に画面から担当者を設定してください）`,
-        });
-        continue;
-      }
-      const resolved = resolveNameToId(assigneeName, agentsByName, '担当者');
+      // 「チケットの所有権を誤らせる」ため深刻)。resolveOwnedName が重複検出を先に行う。
+      const resolved = resolveOwnedName(
+        assigneeName,
+        agentsByName,
+        duplicateAgentNames,
+        '担当者',
+        'エージェント',
+        '担当者を設定してください',
+      );
       if (!resolved.ok) {
         errors.push({ row: rowNum, message: resolved.message });
         continue;
@@ -734,15 +755,15 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
     // 担当者と同じく無言で「インポート実行者に付け替え」ず、解決できない名前はエラー行として記録する。
     let effectiveCreatorId = creatorId;
     if (creatorName !== null) {
-      // 担当者と同じ理由 (同姓同名の misassign 防止) で重複検出を先に行う
-      if (duplicateCreatorNames.has(creatorName)) {
-        errors.push({
-          row: rowNum,
-          message: `起票者名が重複しています: "${creatorName}"（同じ名前のメンバーが複数存在するため一意に特定できません。取り込み後に画面から起票者を確認してください）`,
-        });
-        continue;
-      }
-      const resolved = resolveNameToId(creatorName, usersByName, '起票者');
+      // 担当者と同じ理由 (同姓同名の misassign 防止) で resolveOwnedName が重複検出を先に行う
+      const resolved = resolveOwnedName(
+        creatorName,
+        usersByName,
+        duplicateCreatorNames,
+        '起票者',
+        'メンバー',
+        '起票者を確認してください',
+      );
       if (!resolved.ok) {
         errors.push({ row: rowNum, message: resolved.message });
         continue;

--- a/src/features/tickets/components/CsvImportForm.tsx
+++ b/src/features/tickets/components/CsvImportForm.tsx
@@ -41,6 +41,9 @@ type ColumnMapping = {
   // フォローアップ (2026-07-13): CSV エクスポートの「担当者」列と対称にし、エクスポート→
   // 再インポートの往復で担当者情報が失われないようにする
   担当者: string; // 「担当者」フィールドに対応する CSV 列名 (任意。空文字は使わない)
+  // フォローアップ (2026-07-14): CSV エクスポートの「起票者」列と対称にし、エクスポート→
+  // 再インポートの往復で起票者 (依頼者本人) 情報が失われないようにする (監査で発見したギャップ)
+  起票者: string; // 「起票者」フィールドに対応する CSV 列名 (任意。空文字は使わない)
 };
 
 // プレビューテーブルの 1 行を表す型 (マッピング後の固定システムフィールド)
@@ -53,6 +56,7 @@ interface PreviewRow {
   拠点: string; // 拠点セル (省略可)
   状況: string; // 状況セル (省略可。§3.1 フォローアップ)
   担当者: string; // 担当者セル (省略可。フォローアップ 2026-07-13)
+  起票者: string; // 起票者セル (省略可。フォローアップ 2026-07-14)
 }
 
 // マッピング設定フォームに表示するシステムフィールドの定義一覧
@@ -66,6 +70,7 @@ const SYSTEM_FIELDS = [
   { key: '拠点' as const, label: '拠点（任意）', required: false }, // 任意フィールド
   { key: '状況' as const, label: '状況（任意）', required: false }, // 任意フィールド (§3.1 フォローアップ)
   { key: '担当者' as const, label: '担当者（任意）', required: false }, // 任意フィールド (フォローアップ 2026-07-13)
+  { key: '起票者' as const, label: '起票者（任意）', required: false }, // 任意フィールド (フォローアップ 2026-07-14)
 ] as const;
 
 // ウィザードのステップ情報一覧 (ステップインジケーターの表示に使う)
@@ -110,8 +115,9 @@ function applyMapping(csvText: string, mapping: ColumnMapping): string {
   const locIdx = mapping.拠点 ? headers.indexOf(mapping.拠点) : -1; // 拠点列のインデックス
   const statusIdx = mapping.状況 ? headers.indexOf(mapping.状況) : -1; // 状況列のインデックス (§3.1 フォローアップ)
   const assigneeIdx = mapping.担当者 ? headers.indexOf(mapping.担当者) : -1; // 担当者列のインデックス (フォローアップ 2026-07-13)
+  const creatorIdx = mapping.起票者 ? headers.indexOf(mapping.起票者) : -1; // 起票者列のインデックス (フォローアップ 2026-07-14)
   // 出力 CSV のヘッダ行: サーバーアクションが期待する固定列名で上書きする
-  const outLines: string[] = ['件名,内容,期限日,優先度,カテゴリ,拠点,状況,担当者'];
+  const outLines: string[] = ['件名,内容,期限日,優先度,カテゴリ,拠点,状況,担当者,起票者'];
   // データ行を 1 行ずつ変換する
   for (const line of lines.slice(1)) {
     // RFC 4180 パーサで元のセル値を取り出す
@@ -133,6 +139,7 @@ function applyMapping(csvText: string, mapping: ColumnMapping): string {
       escapeCsvCell(locIdx !== -1 ? (cells[locIdx] ?? '') : ''), // 拠点セル
       escapeCsvCell(statusIdx !== -1 ? (cells[statusIdx] ?? '') : ''), // 状況セル (§3.1 フォローアップ)
       escapeCsvCell(assigneeIdx !== -1 ? (cells[assigneeIdx] ?? '') : ''), // 担当者セル (フォローアップ 2026-07-13)
+      escapeCsvCell(creatorIdx !== -1 ? (cells[creatorIdx] ?? '') : ''), // 起票者セル (フォローアップ 2026-07-14)
     ];
     // カンマ区切りで 1 行にして出力リストに追加する
     outLines.push(row.join(','));
@@ -154,7 +161,7 @@ function buildPreview(mappedCsvText: string): PreviewRow[] {
   return dataLines.map((line) => {
     // RFC 4180 パーサで各セルを取り出す
     const cells = parseCsvLine(line);
-    // applyMapping が出力した列順: 件名[0], 内容[1], 期限日[2], 優先度[3], カテゴリ[4], 拠点[5], 状況[6], 担当者[7]
+    // applyMapping が出力した列順: 件名[0], 内容[1], 期限日[2], 優先度[3], カテゴリ[4], 拠点[5], 状況[6], 担当者[7], 起票者[8]
     return {
       件名: cells[0] ?? '', // 件名セル
       内容: cells[1] ?? '', // 内容セル
@@ -164,6 +171,7 @@ function buildPreview(mappedCsvText: string): PreviewRow[] {
       拠点: cells[5] ?? '', // 拠点セル
       状況: cells[6] ?? '', // 状況セル (§3.1 フォローアップ)
       担当者: cells[7] ?? '', // 担当者セル (フォローアップ 2026-07-13)
+      起票者: cells[8] ?? '', // 起票者セル (フォローアップ 2026-07-14)
     };
   });
 }
@@ -183,6 +191,7 @@ function buildAutoMapping(headers: string[]): ColumnMapping {
     拠点: find('拠点'), // 「拠点」列が CSV にあれば自動対応 (自社の CSV エクスポート結果をそのまま再取込しやすくする)
     状況: find('状況'), // 「状況」列が CSV にあれば自動対応 (§3.1 フォローアップ)
     担当者: find('担当者'), // 「担当者」列が CSV にあれば自動対応 (フォローアップ 2026-07-13)
+    起票者: find('起票者'), // 「起票者」列が CSV にあれば自動対応 (自社の CSV エクスポート結果をそのまま再取込しやすくする。フォローアップ 2026-07-14)
   };
 }
 
@@ -205,6 +214,7 @@ export function CsvImportForm(_props: CsvImportFormProps) {
     拠点: '',
     状況: '',
     担当者: '',
+    起票者: '',
   });
   // マッピングを適用した変換後の CSV テキスト (サーバーアクションへ渡す)
   const [mappedCsvText, setMappedCsvText] = useState<string | null>(null);
@@ -225,7 +235,17 @@ export function CsvImportForm(_props: CsvImportFormProps) {
     if (!file) {
       setCsvText(null); // 生 CSV テキストをクリア
       setCsvHeaders([]); // ヘッダ一覧をクリア
-      setMapping({ 件名: '', 内容: '', 期限日: '', 優先度: '', カテゴリ: '', 拠点: '', 状況: '', 担当者: '' }); // マッピングをクリア
+      setMapping({
+        件名: '',
+        内容: '',
+        期限日: '',
+        優先度: '',
+        カテゴリ: '',
+        拠点: '',
+        状況: '',
+        担当者: '',
+        起票者: '',
+      }); // マッピングをクリア
       setMappedCsvText(null); // 変換後 CSV をクリア
       setPreview([]); // プレビューをクリア
       setResult(null); // 結果をクリア
@@ -238,7 +258,17 @@ export function CsvImportForm(_props: CsvImportFormProps) {
       // エラーを表示しつつ、以前のファイルに由来する状態をすべてリセットして不整合を防ぐ
       setCsvText(null); // 前回の生 CSV テキストをクリア
       setCsvHeaders([]); // 前回のヘッダ一覧をクリア
-      setMapping({ 件名: '', 内容: '', 期限日: '', 優先度: '', カテゴリ: '', 拠点: '', 状況: '', 担当者: '' }); // 前回のマッピングをクリア
+      setMapping({
+        件名: '',
+        内容: '',
+        期限日: '',
+        優先度: '',
+        カテゴリ: '',
+        拠点: '',
+        状況: '',
+        担当者: '',
+        起票者: '',
+      }); // 前回のマッピングをクリア
       setMappedCsvText(null); // 前回の変換後 CSV をクリア
       setPreview([]); // 前回のプレビューをクリア
       setResult(null); // 前回の結果をクリア
@@ -482,6 +512,12 @@ export function CsvImportForm(_props: CsvImportFormProps) {
               <span className="font-medium">担当者:</span>{' '}
               登録済みの担当者（エージェント）の氏名と完全に一致する文字列を入力してください。空欄の場合は未アサインで取り込まれます。一致しない場合はエラーになります。
             </p>
+            {/* 起票者のフォーマット説明: 拠点/担当者と同じく、既存のメンバー名と完全一致させる必要がある
+                (フォローアップ 2026-07-14)。指定が無い場合の既定動作も明記し、意図しない付け替えを防ぐ */}
+            <p>
+              <span className="font-medium">起票者:</span>{' '}
+              登録済みのメンバー（担当者または依頼者）の氏名と完全に一致する文字列を入力してください。空欄の場合はこのインポートを実行した担当者が起票者になります。一致しない場合はエラーになります。
+            </p>
           </div>
 
           {/* 件名未選択時などのマッピングエラー */}
@@ -559,6 +595,10 @@ export function CsvImportForm(_props: CsvImportFormProps) {
                     <th className="px-4 py-2 text-left text-xs font-semibold text-slate-500">
                       担当者
                     </th>
+                    {/* ヘッダセル: 起票者 (フォローアップ 2026-07-14) */}
+                    <th className="px-4 py-2 text-left text-xs font-semibold text-slate-500">
+                      起票者
+                    </th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-slate-100">
@@ -583,6 +623,8 @@ export function CsvImportForm(_props: CsvImportFormProps) {
                       <td className="px-4 py-2 text-slate-500">{row.状況 || '―'}</td>
                       {/* 担当者セル: 未設定は「―」で表示する (フォローアップ 2026-07-13) */}
                       <td className="px-4 py-2 text-slate-500">{row.担当者 || '―'}</td>
+                      {/* 起票者セル: 未設定は「―」で表示する (インポート実行者が起票者になる。フォローアップ 2026-07-14) */}
+                      <td className="px-4 py-2 text-slate-500">{row.起票者 || '―'}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/tests/data/user-repository.contract.prisma.test.ts
+++ b/tests/data/user-repository.contract.prisma.test.ts
@@ -126,6 +126,33 @@ describe.runIf(SHOULD_RUN)('UserRepository (prisma adapter)', () => {
     expect(agentEmails).toEqual([{ id: agentA.id, email: 'agent-a@example.com' }]);
   });
 
+  // listByTenant はロール問わず全ユーザーをテナントスコープで返す (フォローアップ 2026-07-14:
+  // CSV インポートの「起票者」列名解決用。requester も含む点が listAgents との違い)
+  it('listByTenantはrequesterも含む全ユーザーをテナントスコープで返す', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const agentA = await createUser(repos, {
+      email: 'agent-a3@example.com',
+      name: 'エージェントA3',
+      role: 'agent',
+      tenantId: TENANT_A,
+    });
+    const requesterA = await createUser(repos, {
+      email: 'req-a3@example.com',
+      name: '依頼者A3',
+      role: 'requester',
+      tenantId: TENANT_A,
+    });
+    await createUser(repos, {
+      email: 'agent-b3@example.com',
+      name: 'エージェントB3',
+      role: 'agent',
+      tenantId: TENANT_B,
+    });
+    const users = await repos.users.listByTenant(TENANT_A);
+    // requester も含めてテナント A の 2 件だけが返り、テナント B のユーザーは含まれない
+    expect(users.map((u) => u.id).sort()).toEqual([agentA.id, requesterA.id].sort());
+  });
+
   // listAdminEmails は admin のみを返す (agent は含まない)
   it('listAdminEmailsはadminのみを返す', async () => {
     const repos = buildPrismaRepos(prisma);

--- a/tests/data/user-repository.memory.test.ts
+++ b/tests/data/user-repository.memory.test.ts
@@ -84,6 +84,19 @@ describe('UserRepository (memory)', () => {
     expect(agents.map((a) => a.id)).toEqual(['u-agent-a', 'u-agent-b']);
   });
 
+  // listByTenant: ロール問わず全ユーザーを名前順で返す (フォローアップ 2026-07-14:
+  // CSV インポートの「起票者」列名解決用。requester も含む点が listAgents との違い)
+  it('listByTenantはrequesterも含む全ユーザーを名前順で返しテナント分離する', async () => {
+    putUser(store, 'u-req', TENANT, { role: 'requester', name: 'requester太郎' });
+    putUser(store, 'u-agent-b', TENANT, { role: 'agent', name: 'ぶらぼー' });
+    putUser(store, 'u-agent-a', TENANT, { role: 'admin', name: 'あいうえお' });
+    putUser(store, 'u-other-tenant-agent', OTHER_TENANT, { role: 'agent', name: 'あ他テナント' });
+
+    const users = await repos.users.listByTenant(TENANT);
+    // requester (u-req) も含めて 3 件返り、他テナントのユーザーは含まれない
+    expect(users.map((u) => u.id)).toEqual(['u-req', 'u-agent-a', 'u-agent-b']);
+  });
+
   // listAgentIds: ID のみを返す (テナント分離込み)
   it('listAgentIdsはagent/adminのIDのみを返す', async () => {
     putUser(store, 'u-req', TENANT, { role: 'requester' });
@@ -119,7 +132,10 @@ describe('UserRepository (memory)', () => {
   it('listAdminEmailsはadminのみを返しagentは含まない', async () => {
     putUser(store, 'u-agent', TENANT, { role: 'agent', email: 'agent@example.com' });
     putUser(store, 'u-admin', TENANT, { role: 'admin', email: 'admin@example.com' });
-    putUser(store, 'u-other-tenant-admin', OTHER_TENANT, { role: 'admin', email: 'other@example.com' });
+    putUser(store, 'u-other-tenant-admin', OTHER_TENANT, {
+      role: 'admin',
+      email: 'other@example.com',
+    });
 
     const admins = await repos.users.listAdminEmails(TENANT);
     expect(admins).toEqual([{ id: 'u-admin', email: 'admin@example.com' }]);

--- a/tests/features/import-tickets.test.ts
+++ b/tests/features/import-tickets.test.ts
@@ -558,6 +558,144 @@ describe('importTickets', () => {
     });
   });
 
+  // フォローアップ (2026-07-14): 「起票者」列の名前解決
+  // 監査で発見したギャップの回帰テスト。CSV エクスポート (GET /api/tickets/export) が「起票者」列を
+  // 出力するのに、インポート側には対応する読み取りが存在せず、常にインポート実行者が起票者として
+  // ハードコードされていた。起票者はチケットの閲覧権限 (依頼者は自分の起票したチケットしか見えない)
+  // と通知の宛先を左右するため、担当者列と同じ構成の回帰テストに加えて「依頼者 (requester) 名でも
+  // 解決できること」も検証する (担当者はエージェントのみが対象だが、起票者は依頼者もなり得るため)。
+  describe('起票者列 (フォローアップ 2026-07-14)', () => {
+    // 「起票者」列の値が既存の依頼者名と一致すれば creatorId が解決されて保存される
+    // (担当者と異なり、起票者は依頼者 (requester) にもなり得ることを確認する)
+    it('起票者名が依頼者名と一致すれば creatorId が依頼者に解決されて保存される', async () => {
+      const importTickets = await loadAction();
+      const csv = `件名,起票者\n複合機の紙詰まり,依頼者1`;
+      const result = await importTickets(csv);
+
+      expect(result.imported).toBe(1);
+      expect(result.errors).toHaveLength(0);
+      const ticket = [...store.tickets.values()][0];
+      // インポート実行者 (u-agt-1) ではなく、CSV で指定した依頼者 (u-req-1) が起票者になること
+      expect(ticket?.creatorId).toBe('u-req-1');
+    });
+
+    // 起票者名がエージェント名と一致する場合も同様に解決できること
+    it('起票者名がエージェント名と一致すれば creatorId がそのエージェントに解決されて保存される', async () => {
+      const importTickets = await loadAction();
+      const csv = `件名,起票者\n複合機の紙詰まり,エージェント2`;
+      const result = await importTickets(csv);
+
+      expect(result.imported).toBe(1);
+      expect(result.errors).toHaveLength(0);
+      const ticket = [...store.tickets.values()][0];
+      expect(ticket?.creatorId).toBe('u-agt-2');
+    });
+
+    // 「起票者」列自体が無ければ従来どおりインポート実行者が起票者になる (後方互換)
+    it('起票者列が無ければインポート実行者が起票者のまま取り込まれる', async () => {
+      const importTickets = await loadAction();
+      const csv = `件名\n複合機の紙詰まり`;
+      const result = await importTickets(csv);
+
+      expect(result.imported).toBe(1);
+      const ticket = [...store.tickets.values()][0];
+      expect(ticket?.creatorId).toBe('u-agt-1');
+    });
+
+    // 起票者列があっても空セルなら未指定として扱い、インポート実行者のまま取り込まれる
+    it('起票者セルが空ならインポート実行者が起票者のまま取り込まれる', async () => {
+      const importTickets = await loadAction();
+      const csv = `件名,起票者\n複合機の紙詰まり,`;
+      const result = await importTickets(csv);
+
+      expect(result.imported).toBe(1);
+      expect(result.errors).toHaveLength(0);
+      const ticket = [...store.tickets.values()][0];
+      expect(ticket?.creatorId).toBe('u-agt-1');
+    });
+
+    // テナントに存在しない起票者名 (タイポ等) はエラーとして記録され、
+    // 無言でインポート実行者に付け替えられない
+    it('存在しない起票者名はエラーとして記録され起票されない', async () => {
+      const importTickets = await loadAction();
+      const csv = `件名,起票者\n複合機の紙詰まり,存在しない人物`;
+      const result = await importTickets(csv);
+
+      expect(result.imported).toBe(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('起票者が見つかりません');
+      expect(store.tickets.size).toBe(0);
+    });
+
+    // 同姓同名のメンバーが複数存在する場合、Map のキー衝突でどちらか一方へ無言で
+    // misassign されると閲覧権限を誤らせる事故になるため、エラー行として記録され
+    // どちらのメンバーにも起票されないことを確認する (担当者列と同じ設計)
+    it('同姓同名のメンバーが複数いる場合はエラーとして記録され起票されない', async () => {
+      // u-req-1 (依頼者1) と同じ表示名を持つ別ユーザーを追加する
+      const now = new Date();
+      store.users.set('u-req-2', {
+        id: 'u-req-2',
+        email: 'req2@example.com',
+        name: '依頼者1', // u-req-1 と同じ表示名 (同姓同名)
+        passwordHash: 'x',
+        role: 'requester',
+        tenantId: TENANT,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const importTickets = await loadAction();
+      const csv = `件名,起票者\n複合機の紙詰まり,依頼者1`;
+      const result = await importTickets(csv);
+
+      expect(result.imported).toBe(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('起票者名が重複しています');
+      expect(store.tickets.size).toBe(0);
+    });
+
+    // 他テナントに同名のメンバーが存在しても、tenantId スコープにより解決対象に含まれない
+    // (クロステナント漏洩防止。listByTenant の tenantId フィルタが効いていることの確認)
+    it('他テナントの同名ユーザーは起票者として解決されない', async () => {
+      const now = new Date();
+      store.tenants.set('other-tenant', {
+        id: 'other-tenant',
+        name: '別テナント',
+        mode: 'lite',
+        industry: null,
+        inboundToken: null,
+        slackWebhookUrl: null,
+        subscriptionPlan: 'free' as const,
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        stripeSubscriptionStatus: null,
+        trialEndsAt: null,
+        teamsWebhookUrl: null,
+        chatworkApiToken: null,
+        chatworkRoomId: null,
+        createdAt: now,
+      });
+      store.users.set('u-other-1', {
+        id: 'u-other-1',
+        email: 'other1@example.com',
+        name: '田中太郎',
+        passwordHash: 'x',
+        role: 'requester',
+        tenantId: 'other-tenant', // 別テナント所属
+        createdAt: now,
+        updatedAt: now,
+      });
+      const importTickets = await loadAction();
+      const csv = `件名,起票者\n複合機の紙詰まり,田中太郎`;
+      const result = await importTickets(csv);
+
+      // 自テナントに一致するユーザーがいないため、起票者として解決できずエラーになる
+      expect(result.imported).toBe(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('起票者が見つかりません');
+      expect(store.tickets.size).toBe(0);
+    });
+  });
+
   // §3.1 フォローアップ (2026-07-10): 既存 Excel の完了済み行をそのまま取り込めるかを検証する
   describe('状況列 (§3.1 フォローアップ)', () => {
     // Lite テナント (seed() の既定) で「完了」を指定すると Closed で起票され、resolvedAt が


### PR DESCRIPTION
## Context

`docs/smb-dx-pivot-plan.md` §3.6 フォローアップ (Phase 3 「CSV インポート」) 対応。

ロードマップ上は Phase 0〜4 が全て `[x]` 済みだが、この計画書には過去にも「完了扱いだが実際には
機能していない」ギャップを監査で発見して埋めてきた実績（§3.1/§3.3/§3.4 等の CSV 往復性フォローアップ）
があるため、同種のギャップが残っていないか改めて監査した。

見つかったギャップ: CSV エクスポート（`GET /api/tickets/export`）は「起票者」列 (`t.creator?.name`) を
出力するが、CSV インポート（`import-tickets.ts`）側にはこの列を読み取る処理が一切なく、インポートされる
全チケットの `creatorId` は常にインポート実行者（admin）のセッション ID にハードコードされていた。

「起票者」列は他の往復性フォローアップ対象（内容・カテゴリ・期限日）と異なり表示専用ではなく、

- **閲覧権限**: `src/app/(app)/tickets/[id]/page.tsx` の `!isAgent && ticket.creatorId !== session.user.id` により、依頼者は自分が起票したチケットしか見られない
- **通知の宛先**: `update-ticket.ts` がステータス/優先度変更時に `ticket.creatorId` へ通知する

の両方を左右する。§0 北極星指標「最短で Excel から卒業できる」が前提とする「エクスポート→編集→
再インポート」ワークフローを admin が行うと、元の依頼者（例: ペルソナの現場リーダー鈴木さん）が
自分の問い合わせを一覧・詳細のどちらからも見られなくなり、以後の進捗通知も届かなくなる回帰だった。

## 変更内容

- `src/data/ports/user-repository.ts` / `src/data/adapters/{prisma,memory}/user-repository.*.ts`:
  `listByTenant(tenantId)` を追加。起票者はエージェントに限らず依頼者もなり得るため、既存の
  `listAgents`（agent/admin のみ）では名前解決できず、ロール不問の一覧取得が別途必要だった。
- `src/features/tickets/actions/import-tickets.ts`: 「起票者」列を拠点/カテゴリ/担当者と同じ
  名前解決パターンで追加。列が無い/セルが空の場合は従来どおりインポート実行者を起票者にする
  （後方互換）。同姓同名メンバーが複数存在する場合の重複検出ロジックは担当者列の実装と完全に
  同型だったため `buildNameToIdMapWithDuplicates` として抽出し両者で共有（DRY）。
- `src/features/tickets/components/CsvImportForm.tsx`: 列マッピングウィザードに「起票者」を追加
  （`ColumnMapping` / `PreviewRow` / `SYSTEM_FIELDS` / `applyMapping` / `buildPreview` /
  `buildAutoMapping` を一貫して拡張）。
- テスト: `tests/features/import-tickets.test.ts` に依頼者名/エージェント名での解決・列/セル省略時の
  後方互換・存在しない名前のエラー・同姓同名の重複エラー・他テナントの同名ユーザーが解決対象に
  含まれないことの回帰テストを追加。`listByTenant` 自体のテストを
  `tests/data/user-repository.memory.test.ts` と `tests/data/user-repository.contract.prisma.test.ts`
  に追加。
- `docs/smb-dx-pivot-plan.md` に §3.6 フォローアップとして経緯を記録。

## 検証方法

- `npm run typecheck` — 成功
- `npm run lint` — 成功
- `npx prettier --check` (変更ファイル) — 成功
- `npm run test` — 937 件成功 / 137 件スキップ（Prisma 契約テストは `RUN_PRISMA_CONTRACT=1` 未設定のため未実行、想定どおり）

## Test plan

- [x] Vitest ユニットテスト（新規回帰テスト含む）
- [x] typecheck / lint / prettier
- [ ] Prisma 契約テスト（ローカル DB 未接続のため CI での確認が必要）


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tr3nkX878w11FMHb1uHpPj)_