### PR TITLE
feat(quarantine): 隔離記録一覧に全履歴CSVエクスポートを追加する

### DIFF
--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -404,6 +404,37 @@ LINE・CSV インポート・メールの 4 系統あるが、「新規起票を
   `tests/data/user-repository.memory.test.ts` と `user-repository.contract.prisma.test.ts` に
   追加した。
 
+#### 3.7 フォローアップ（2026-07-14 #3）: 隔離記録一覧に CSV エクスポートが無く、200 件を超えると古い記録に到達できなかった
+
+監査で発見したギャップ: §3.2 フォローアップ再訪（2026-07-12）で `/quarantine` 画面と
+キーセットページネーション（「さらに読み込む」）を新設したが、CSV エクスポートは実装しなかった。
+一方 `/audit` 画面は同じ「200 件で打ち切られる一覧を、監査・investigation 目的でまとめて
+保管・共有したい」というニーズに対し、§4.2.1（キーセットページネーション追加時点）を経て
+§4.2.2 で「現在ページのみ即時ダウンロード」＋「全履歴 CSV エクスポート（`GET
+/api/audit/export`）」の 2 段構えまで発展させていた。`/quarantine` はその後継の改善を一切
+受けておらず、隔離記録が 200 件を超えるテナントの admin は「登録し忘れたメンバーからの
+問い合わせが隔離されていないか」をまとめて確認したり、スパム傾向の証跡として誰かに共有したり
+する手段が「さらに読み込む」の手作業以外に存在しなかった。
+
+- `src/features/quarantine/quarantine-csv.ts` に `quarantinedEmailRowsToCsv` を新設し、
+  `src/features/audit/audit-csv.ts`（画面とエクスポートルートで列定義を共有する純粋関数）と
+  同じ設計を踏襲した。列はメール由来（送信者名・送信元アドレス・件名）と LINE 由来
+  （LINE ユーザー ID）の両方を機械可読な別列として持つ（画面表示は 1 セルにまとめているが、
+  CSV では往復性より判別しやすさを優先した）。
+- `GET /api/quarantine/export` を新設した。`GET /api/audit/export` と同じキーセットカーソル
+  前進ループ・`MAX_QUARANTINE_EXPORT_ROWS`（10,000 件）・`assertTenantAdmin` による
+  admin 専用ゲート・専用レート制限（3 回/分）を踏襲する。`/quarantine` 画面と同じくプランゲートは
+  設けない（Free プランでの隔離を admin 自身が確認できることが「なぜ取り込まれないか」に
+  気づく導線として有用なため。§3.2 フォローアップ再訪の方針をそのまま踏襲）。
+- `src/features/quarantine/components/QuarantineExportButton.tsx`（`AuditFullExportButton.tsx`
+  と同じ設計）を追加し、`/quarantine` 画面ヘッダーに配置した。`/audit` と異なり `/quarantine`
+  には「現在ページのみ即時ダウンロード」ボタンが元々存在しなかったため、全履歴エクスポートの
+  1 ボタンのみを追加した（無かった機能を 2 つ同時に増やすと変更のスコープが広がるため、
+  §4.2.2 の 2 段構えのうち今回不足していた「全履歴」側のみを追加する）。
+- `tests/features/quarantine-export-route.test.ts` に `tests/features/audit-export-route.test.ts`
+  と同じ構成（複数ページに跨る集計・ちょうど上限件数での誤 truncated 防止・RBAC・
+  プランゲート無し・レート制限・未認証）の回帰テストを追加した。
+
 ### Phase 4 — マネタイズと運用（継続）
 
 - [x] サブスク課金（Stripe Billing）: Free / Standard / Pro の 3 段階

--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -434,6 +434,18 @@ LINE・CSV インポート・メールの 4 系統あるが、「新規起票を
 - `tests/features/quarantine-export-route.test.ts` に `tests/features/audit-export-route.test.ts`
   と同じ構成（複数ページに跨る集計・ちょうど上限件数での誤 truncated 防止・RBAC・
   プランゲート無し・レート制限・未認証）の回帰テストを追加した。
+- `/code-review ultra` 指摘対応: 当初は `GET /api/quarantine/export` を `GET /api/audit/export`
+  からキーセットカーソル前進ループ・打ち切り誤検知防止・CSV レスポンスヘッダー組み立てまで
+  丸ごと複製する形で実装していたが、これは同一ロジックの 2 箇所目の複製であり
+  （`fetch-audit-feed-page.ts` や `rate-limit.ts` の `checkRateLimit` が同種の重複を「2〜3
+  箇所目で共通化する」方針（§6 DRY）で解消してきた前例と同じ状況）、看過できないと判断した。
+  `src/lib/cursor-csv-export.ts` に `collectCursorPaginatedRows`（カーソル前進ループ + 誤検知
+  防止）・`buildCsvExportResponse`（ファイル名の JST 日付付与 + 打ち切り時ヘッダー）を抽出し、
+  `GET /api/audit/export` 側もこの共通ヘルパーを使うよう改修した（新規実装だけでなく、複製元の
+  既存実装も併せて共通化する）。あわせて `quarantine-csv.ts` の docstring が「画面
+  (page.tsx) とエクスポートルートの両方がこの関数を共有する」と audit-csv.ts の説明を
+  そのまま流用していたが、`/quarantine` 画面は表を直接描画しておりこの関数を消費していない
+  ため、実態と食い違う記述を修正した。
 
 ### Phase 4 — マネタイズと運用（継続）
 

--- a/src/app/(app)/quarantine/page.tsx
+++ b/src/app/(app)/quarantine/page.tsx
@@ -10,6 +10,8 @@ import { formatDateTimeJP } from '@/lib/format-date';
 import { QUARANTINE_REASON_LABELS, QUARANTINE_CHANNEL_LABELS } from '@/lib/constants';
 // 監査ログ系リポジトリ共通のページネーション上限 (findAllByTenant が limit をクランプする上限値)
 import { AUDIT_MAX_LIMIT } from '@/data/adapters/audit-pagination';
+// 全履歴 CSV エクスポートボタン (Client Component。フォローアップ 2026-07-14 #3)
+import { QuarantineExportButton } from '@/features/quarantine/components/QuarantineExportButton';
 
 // 一覧の取得件数上限 (パフォーマンス保護: 1 ページあたり 200 件まで。/audit と同じ値)
 const PAGE_LIMIT = 200;
@@ -73,13 +75,21 @@ export default async function QuarantinePage({ searchParams }: Props) {
   return (
     <div className="space-y-6">
       {/* ページヘッダー */}
-      <div>
-        <h1 className="text-2xl font-bold text-slate-900">隔離メール</h1>
-        <p className="mt-1 text-sm text-slate-500">
-          プラン未対応・未登録の送信者・認証失敗などで問い合わせ化されなかったメール/LINE
-          メッセージを表示しています。
-          {before ? `${PAGE_LIMIT} 件ずつ表示中。` : `最新 ${PAGE_LIMIT} 件。`}
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">隔離メール</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            プラン未対応・未登録の送信者・認証失敗などで問い合わせ化されなかったメール/LINE
+            メッセージを表示しています。
+            {before ? `${PAGE_LIMIT} 件ずつ表示中。` : `最新 ${PAGE_LIMIT} 件。`}
+          </p>
+        </div>
+        {/* フォローアップ (2026-07-14 #3): 監査で発見したギャップの解消。「さらに読み込む」を
+            手動で辿らないと 200 件を超える隔離記録に到達できず、まとめて保管・共有する手段も
+            無かった (/audit 画面が §4.2.1/§4.2.2 で解消したのと同種のギャップ) */}
+        <div className="shrink-0">
+          <QuarantineExportButton />
+        </div>
       </div>
 
       {logs.length === 0 ? (

--- a/src/app/api/audit/export/route.ts
+++ b/src/app/api/audit/export/route.ts
@@ -17,6 +17,9 @@ import type { AuditFeedRow } from '@/features/audit/types';
 import type { AuditPaginationCursor } from '@/data/ports/audit-pagination';
 // CSV 文字列への変換 (クライアント側の現在ページエクスポートと共有する純粋関数。§6 DRY)
 import { auditFeedRowsToCsv } from '@/features/audit/audit-csv';
+// キーセットカーソル前進ループ・CSV レスポンス組み立ての共通ヘルパー (フォローアップ 2026-07-14 #3:
+// GET /api/quarantine/export と共有する。§6 DRY)
+import { collectCursorPaginatedRows, buildCsvExportResponse } from '@/lib/cursor-csv-export';
 
 // 全履歴エクスポートで書き出す行数の上限。
 // 件数無制限の取得は DB 負荷・レスポンスサイズ・処理時間が無制限になるため
@@ -90,57 +93,32 @@ export async function GET() {
 
   // カーソルをサーバー側で繰り返し前進させ、上限まで全ページを蓄積する。
   // 1 ページあたり AUDIT_MAX_LIMIT (500) 件ずつ取得することで往復回数を最小化する。
-  const logs: AuditFeedRow[] = [];
-  let cursor: AuditPaginationCursor | undefined = undefined;
-  let truncated = false;
-  for (;;) {
-    const page = await fetchAuditFeedPage(tenantId, AUDIT_MAX_LIMIT, cursor);
-    logs.push(...page.logs);
-    // 上限に達したら、まだ続きがあっても打ち切る (サイレント打ち切りは監査目的で
-    // 「全件取得済み」と誤認させるリスクがあるため X-Truncated ヘッダーで呼び出し元に伝える)。
-    // MAX_AUDIT_EXPORT_ROWS は AUDIT_MAX_LIMIT の倍数であること (上のモジュール読み込み時検査)
-    // が保証されているため logs.length はここで必ずちょうど MAX_AUDIT_EXPORT_ROWS に一致し、
-    // 超過はしない
-    if (logs.length >= MAX_AUDIT_EXPORT_ROWS) {
-      // /code-review ultra 指摘対応: fetchAuditFeedPage の hasMore は「ちょうど limit 件で
-      // 埋まった」ことしか示さない簡易ヒューリスティックのため、テナントの総件数がたまたま
-      // MAX_AUDIT_EXPORT_ROWS ちょうどだった場合に「まだ続きがある」という誤検知になりうる
-      // (/audit 画面では「もう1回読み込む」が無駄になるだけで実害が無いが、CSV エクスポートでは
-      // 「実際は全件取得済みなのに一部のみとユーザーに誤って警告する」ことになるため看過できない)。
-      // 上限にちょうど到達したときだけ、次カーソル以降に本当に行が残っているかを 1 件だけ
-      // 確認してから truncated を確定する (該当しない限りこの追加往復は発生しない)
-      truncated =
-        page.hasMore && page.nextCursor
-          ? (await fetchAuditFeedPage(tenantId, 1, page.nextCursor)).logs.length > 0
-          : false;
-      break;
-    }
-    if (!page.hasMore || !page.nextCursor) break;
-    cursor = page.nextCursor;
-  }
+  // フォローアップ (2026-07-14 #3 /code-review ultra 指摘対応): GET /api/quarantine/export が
+  // 同じループ・打ち切り誤検知防止ロジックを必要としたため、共通ヘルパーへ抽出した (§6 DRY)
+  const { rows: logs, truncated } = await collectCursorPaginatedRows<
+    AuditFeedRow,
+    AuditPaginationCursor
+  >({
+    maxRows: MAX_AUDIT_EXPORT_ROWS,
+    fetchPage: async (cursor) => {
+      const page = await fetchAuditFeedPage(tenantId, AUDIT_MAX_LIMIT, cursor);
+      return { rows: page.logs, hasMore: page.hasMore, nextCursor: page.nextCursor };
+    },
+    // ちょうど上限に到達したときだけ、次カーソル以降に本当に行が残っているかを 1 件だけ
+    // 確認する (「ちょうど limit 件で埋まった」だけのヒューリスティックだと、テナントの総件数が
+    // たまたま MAX_AUDIT_EXPORT_ROWS ちょうどだった場合に「まだ続きがある」という誤検知になりうる)
+    probeForMore: async (nextCursor) =>
+      (await fetchAuditFeedPage(tenantId, 1, nextCursor)).logs.length > 0,
+  });
 
   // 監査ログ行の一覧を CSV 文字列に変換する (クライアント側ボタンと共有する純粋関数)
   const csv = auditFeedRowsToCsv(logs);
 
-  // ファイル名に今日の JST 日付を含める (ダウンロードフォルダで日付識別できる)
-  const today = new Date()
-    .toLocaleDateString('ja-JP', {
-      timeZone: 'Asia/Tokyo',
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-    })
-    .replace(/\//g, '-'); // YYYY/MM/DD → YYYY-MM-DD
-  const filename = `audit-log-full-${today}.csv`;
-
-  const responseHeaders: HeadersInit = {
-    'Content-Type': 'text/csv; charset=utf-8',
-    'Content-Disposition': `attachment; filename="${filename}"`,
-    'Cache-Control': 'no-cache, no-store, must-revalidate',
-  };
-  if (truncated) {
-    responseHeaders['X-Truncated'] = 'true';
-    responseHeaders['X-Total-Limit'] = String(MAX_AUDIT_EXPORT_ROWS);
-  }
-  return new Response(csv, { status: 200, headers: responseHeaders });
+  // CSV レスポンスを組み立てて返す (ファイル名の JST 日付付与・打ち切り時のヘッダーを含む)
+  return buildCsvExportResponse({
+    csv,
+    filenamePrefix: 'audit-log-full',
+    truncated,
+    maxRows: MAX_AUDIT_EXPORT_ROWS,
+  });
 }

--- a/src/app/api/quarantine/export/route.ts
+++ b/src/app/api/quarantine/export/route.ts
@@ -1,0 +1,146 @@
+// 「ログイン済み・admin・自テナント」の共通ゲート (/api/audit/export と同じ実装を共有する)
+import { assertTenantAdmin } from '@/lib/tenant-admin-gate';
+// レート制限 (全履歴エクスポートは複数ページを DB から読み続ける重い操作のため §9 DoS 防止として必須)
+import { enforceRateLimit, RateLimitError } from '@/lib/rate-limit';
+// データ層の Composition Root (Prisma 直叩きを避ける)
+import { repos } from '@/data';
+// 隔離記録一覧が扱う行型・キーセットページネーションのカーソル型
+import type { QuarantinedEmailCursor } from '@/data/ports/quarantined-email-repository';
+import type { QuarantinedEmailRow } from '@/domain/types';
+// 監査ログ系リポジトリ共通のページネーション上限 (findAllByTenant が limit をクランプする上限値。
+// quarantinedEmails.findAllByTenant も resolveAuditLimit 経由でこの値を共有する)
+import { AUDIT_MAX_LIMIT } from '@/data/adapters/audit-pagination';
+// CSV 文字列への変換 (/quarantine ページの将来的な現在ページエクスポートとも共有できる純粋関数。§6 DRY)
+import { quarantinedEmailRowsToCsv } from '@/features/quarantine/quarantine-csv';
+
+// 全履歴エクスポートで書き出す行数の上限。
+// 件数無制限の取得は DB 負荷・レスポンスサイズ・処理時間が無制限になるため
+// 上限を設ける (§8 パフォーマンス / §9 DoS 防止。GET /api/audit/export の
+// MAX_AUDIT_EXPORT_ROWS と同じ考え方)。
+const MAX_QUARANTINE_EXPORT_ROWS = 10_000;
+// /code-review ultra 指摘対応 (audit/export/route.ts と同じ検査): ページングループは 1 ページ
+// あたり AUDIT_MAX_LIMIT 件ずつ蓄積するため、MAX_QUARANTINE_EXPORT_ROWS が AUDIT_MAX_LIMIT の
+// 倍数でないと「上限をちょうど超えた」という前提の分岐が意図と異なる件数で発火しうる。
+// モジュール読み込み時に 1 度だけ検査して fail-fast する
+if (MAX_QUARANTINE_EXPORT_ROWS % AUDIT_MAX_LIMIT !== 0) {
+  throw new Error(
+    'MAX_QUARANTINE_EXPORT_ROWS が AUDIT_MAX_LIMIT の倍数ではありません (quarantine/export/route.ts の設定ミス)',
+  );
+}
+
+/**
+ * GET /api/quarantine/export
+ *
+ * 隔離記録 (メール取り込み・LINE 取り込みが起票せず隔離した受信データ) の全履歴を CSV
+ * ファイルとしてダウンロードする。/quarantine 画面は 1 ページ PAGE_LIMIT (200) 件までしか
+ * 表示できず、CSV エクスポート自体を持たないため、200 件を超えるテナントでは「さらに読み込む」を
+ * 手作業で辿らないと古い行に到達できず、まとめて保管・共有する手段も無かった
+ * (フォローアップ 2026-07-14 #3: /audit 画面が §4.2.1/§4.2.2 で解消したのと同種のギャップ)。
+ * このエンドポイントはキーセットカーソルをサーバー側で繰り返し前進させ、上限
+ * MAX_QUARANTINE_EXPORT_ROWS 件までまとめて 1 つの CSV に書き出す。
+ *
+ * - 認証必須: 未認証は 401
+ * - 管理者専用: admin 以外は 403 (画面側の RBAC と同じく role === 'admin' の直接比較)
+ * - プランゲートなし: /quarantine 画面と同じく全プランで利用可能（Free プランでの隔離
+ *   (plan_gate 理由) を admin 自身が確認できることが「なぜ取り込まれないか」に気づく導線として
+ *   有用なため。§3.2 フォローアップ再訪の方針を踏襲する）
+ * - tenantId スコープ: セッションの tenantId で必ず絞り込む (クロステナント漏洩防止)
+ * - 最大 MAX_QUARANTINE_EXPORT_ROWS 件の上限あり
+ */
+export async function GET() {
+  // 「ログイン済み・admin・自テナント」をまとめて検証する (画面側の /quarantine と同じく
+  // role の直接比較。プランゲートは行わない)
+  const gate = await assertTenantAdmin();
+  if (!gate.ok) {
+    // 未認証 (セッション/tenantId 欠落) と権限不足を区別してステータスコードを分ける
+    const status = gate.error === '認証が必要です' ? 401 : 403;
+    return new Response(JSON.stringify({ error: gate.error }), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  const { userId, tenantId } = gate;
+
+  // 全履歴エクスポートは複数ページの DB 読み取りを伴う重い操作のため、通常の CSV エクスポート
+  // より厳しいレート制限をかける (§8 / §9 DoS 防止。/api/audit/export と同じ値)
+  try {
+    enforceRateLimit(`quarantine-csv-export:${userId}`, { limit: 3, windowMs: 60_000 });
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return new Response(
+        JSON.stringify({
+          error: 'エクスポートのリクエストが多すぎます。しばらくしてから再試行してください。',
+        }),
+        { status: 429, headers: { 'Content-Type': 'application/json', 'Retry-After': '60' } },
+      );
+    }
+    throw err;
+  }
+
+  // カーソルをサーバー側で繰り返し前進させ、上限まで全ページを蓄積する。
+  // 1 ページあたり AUDIT_MAX_LIMIT 件ずつ取得することで往復回数を最小化する
+  // (/api/audit/export と同じループ構造。ただしこの一覧は単一テーブルのみで kind を持たない
+  // ため、fetchAuditFeedPage のような複数ソースのマージ処理は不要で repos を直接呼ぶ)。
+  const logs: QuarantinedEmailRow[] = [];
+  let cursor: QuarantinedEmailCursor | undefined = undefined;
+  let truncated = false;
+  for (;;) {
+    const page = await repos.quarantinedEmails.findAllByTenant({
+      tenantId,
+      limit: AUDIT_MAX_LIMIT,
+      before: cursor,
+    });
+    logs.push(...page);
+    // 上限に達したら、まだ続きがあっても打ち切る (サイレント打ち切りは監査目的で
+    // 「全件取得済み」と誤認させるリスクがあるため X-Truncated ヘッダーで呼び出し元に伝える)。
+    // MAX_QUARANTINE_EXPORT_ROWS は AUDIT_MAX_LIMIT の倍数であること (上のモジュール読み込み時
+    // 検査) が保証されているため logs.length はここで必ずちょうど MAX_QUARANTINE_EXPORT_ROWS に
+    // 一致し、超過はしない
+    if (logs.length >= MAX_QUARANTINE_EXPORT_ROWS) {
+      // ちょうど上限に到達したときだけ、次カーソル以降に本当に行が残っているかを 1 件だけ
+      // 確認してから truncated を確定する (/api/audit/export と同じ「誤って打ち切りを警告しない」方針)
+      const last = page[page.length - 1];
+      truncated =
+        page.length === AUDIT_MAX_LIMIT && last
+          ? (
+              await repos.quarantinedEmails.findAllByTenant({
+                tenantId,
+                limit: 1,
+                before: { createdAt: last.createdAt, id: last.id },
+              })
+            ).length > 0
+          : false;
+      break;
+    }
+    // ページがちょうど上限件数で埋まっていなければ、これ以上データは残っていない
+    if (page.length < AUDIT_MAX_LIMIT) break;
+    const last = page[page.length - 1];
+    if (!last) break;
+    cursor = { createdAt: last.createdAt, id: last.id };
+  }
+
+  // 隔離記録の一覧を CSV 文字列に変換する
+  const csv = quarantinedEmailRowsToCsv(logs);
+
+  // ファイル名に今日の JST 日付を含める (ダウンロードフォルダで日付識別できる)
+  const today = new Date()
+    .toLocaleDateString('ja-JP', {
+      timeZone: 'Asia/Tokyo',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+    .replace(/\//g, '-'); // YYYY/MM/DD → YYYY-MM-DD
+  const filename = `quarantine-full-${today}.csv`;
+
+  const responseHeaders: HeadersInit = {
+    'Content-Type': 'text/csv; charset=utf-8',
+    'Content-Disposition': `attachment; filename="${filename}"`,
+    'Cache-Control': 'no-cache, no-store, must-revalidate',
+  };
+  if (truncated) {
+    responseHeaders['X-Truncated'] = 'true';
+    responseHeaders['X-Total-Limit'] = String(MAX_QUARANTINE_EXPORT_ROWS);
+  }
+  return new Response(csv, { status: 200, headers: responseHeaders });
+}

--- a/src/app/api/quarantine/export/route.ts
+++ b/src/app/api/quarantine/export/route.ts
@@ -10,8 +10,12 @@ import type { QuarantinedEmailRow } from '@/domain/types';
 // 監査ログ系リポジトリ共通のページネーション上限 (findAllByTenant が limit をクランプする上限値。
 // quarantinedEmails.findAllByTenant も resolveAuditLimit 経由でこの値を共有する)
 import { AUDIT_MAX_LIMIT } from '@/data/adapters/audit-pagination';
-// CSV 文字列への変換 (/quarantine ページの将来的な現在ページエクスポートとも共有できる純粋関数。§6 DRY)
+// CSV 文字列への変換 (このエクスポートルート専用の純粋関数。/quarantine 画面は表を直接描画するため
+// 現時点では消費していない)
 import { quarantinedEmailRowsToCsv } from '@/features/quarantine/quarantine-csv';
+// キーセットカーソル前進ループ・CSV レスポンス組み立ての共通ヘルパー (フォローアップ 2026-07-14 #3:
+// GET /api/audit/export と同型のロジックを個別に複製していたため共通化した。§6 DRY)
+import { collectCursorPaginatedRows, buildCsvExportResponse } from '@/lib/cursor-csv-export';
 
 // 全履歴エクスポートで書き出す行数の上限。
 // 件数無制限の取得は DB 負荷・レスポンスサイズ・処理時間が無制限になるため
@@ -79,68 +83,41 @@ export async function GET() {
 
   // カーソルをサーバー側で繰り返し前進させ、上限まで全ページを蓄積する。
   // 1 ページあたり AUDIT_MAX_LIMIT 件ずつ取得することで往復回数を最小化する
-  // (/api/audit/export と同じループ構造。ただしこの一覧は単一テーブルのみで kind を持たない
-  // ため、fetchAuditFeedPage のような複数ソースのマージ処理は不要で repos を直接呼ぶ)。
-  const logs: QuarantinedEmailRow[] = [];
-  let cursor: QuarantinedEmailCursor | undefined = undefined;
-  let truncated = false;
-  for (;;) {
-    const page = await repos.quarantinedEmails.findAllByTenant({
-      tenantId,
-      limit: AUDIT_MAX_LIMIT,
-      before: cursor,
-    });
-    logs.push(...page);
-    // 上限に達したら、まだ続きがあっても打ち切る (サイレント打ち切りは監査目的で
-    // 「全件取得済み」と誤認させるリスクがあるため X-Truncated ヘッダーで呼び出し元に伝える)。
-    // MAX_QUARANTINE_EXPORT_ROWS は AUDIT_MAX_LIMIT の倍数であること (上のモジュール読み込み時
-    // 検査) が保証されているため logs.length はここで必ずちょうど MAX_QUARANTINE_EXPORT_ROWS に
-    // 一致し、超過はしない
-    if (logs.length >= MAX_QUARANTINE_EXPORT_ROWS) {
-      // ちょうど上限に到達したときだけ、次カーソル以降に本当に行が残っているかを 1 件だけ
-      // 確認してから truncated を確定する (/api/audit/export と同じ「誤って打ち切りを警告しない」方針)
+  // (/api/audit/export と同じループ構造は collectCursorPaginatedRows に共通化済み。
+  // この一覧は単一テーブルのみで kind を持たないため、findAllByTenant の結果をそのまま
+  // { rows, hasMore, nextCursor } 形へ詰め替えるだけで済む)。
+  const { rows: logs, truncated } = await collectCursorPaginatedRows<
+    QuarantinedEmailRow,
+    QuarantinedEmailCursor
+  >({
+    maxRows: MAX_QUARANTINE_EXPORT_ROWS,
+    fetchPage: async (cursor) => {
+      const page = await repos.quarantinedEmails.findAllByTenant({
+        tenantId,
+        limit: AUDIT_MAX_LIMIT,
+        before: cursor,
+      });
+      // ページがちょうど上限件数で埋まっていれば、まだ続きがある可能性があるとみなす
+      const hasMore = page.length === AUDIT_MAX_LIMIT;
       const last = page[page.length - 1];
-      truncated =
-        page.length === AUDIT_MAX_LIMIT && last
-          ? (
-              await repos.quarantinedEmails.findAllByTenant({
-                tenantId,
-                limit: 1,
-                before: { createdAt: last.createdAt, id: last.id },
-              })
-            ).length > 0
-          : false;
-      break;
-    }
-    // ページがちょうど上限件数で埋まっていなければ、これ以上データは残っていない
-    if (page.length < AUDIT_MAX_LIMIT) break;
-    const last = page[page.length - 1];
-    if (!last) break;
-    cursor = { createdAt: last.createdAt, id: last.id };
-  }
+      const nextCursor = hasMore && last ? { createdAt: last.createdAt, id: last.id } : null;
+      return { rows: page, hasMore, nextCursor };
+    },
+    // ちょうど上限に到達したときだけ、次カーソル以降に本当に行が残っているかを 1 件だけ確認する
+    // (/api/audit/export と同じ「誤って打ち切りを警告しない」方針)
+    probeForMore: async (nextCursor) =>
+      (await repos.quarantinedEmails.findAllByTenant({ tenantId, limit: 1, before: nextCursor }))
+        .length > 0,
+  });
 
   // 隔離記録の一覧を CSV 文字列に変換する
   const csv = quarantinedEmailRowsToCsv(logs);
 
-  // ファイル名に今日の JST 日付を含める (ダウンロードフォルダで日付識別できる)
-  const today = new Date()
-    .toLocaleDateString('ja-JP', {
-      timeZone: 'Asia/Tokyo',
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-    })
-    .replace(/\//g, '-'); // YYYY/MM/DD → YYYY-MM-DD
-  const filename = `quarantine-full-${today}.csv`;
-
-  const responseHeaders: HeadersInit = {
-    'Content-Type': 'text/csv; charset=utf-8',
-    'Content-Disposition': `attachment; filename="${filename}"`,
-    'Cache-Control': 'no-cache, no-store, must-revalidate',
-  };
-  if (truncated) {
-    responseHeaders['X-Truncated'] = 'true';
-    responseHeaders['X-Total-Limit'] = String(MAX_QUARANTINE_EXPORT_ROWS);
-  }
-  return new Response(csv, { status: 200, headers: responseHeaders });
+  // CSV レスポンスを組み立てて返す (ファイル名の JST 日付付与・打ち切り時のヘッダーを含む)
+  return buildCsvExportResponse({
+    csv,
+    filenamePrefix: 'quarantine-full',
+    truncated,
+    maxRows: MAX_QUARANTINE_EXPORT_ROWS,
+  });
 }

--- a/src/features/quarantine/components/QuarantineExportButton.tsx
+++ b/src/features/quarantine/components/QuarantineExportButton.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+// ローディング状態を管理する
+import { useState } from 'react';
+// Blob ダウンロードの共通処理 (CsvExportButton / AuditExportButton 系と共有。§6 DRY)
+import { triggerBlobDownload } from '@/lib/blob-download';
+
+/**
+ * 隔離記録の全履歴を CSV でダウンロードするボタン。
+ *
+ * フォローアップ (2026-07-14 #3): 監査で発見したギャップの解消。/quarantine 画面は
+ * 「さらに読み込む」によるキーセットページネーションしか持たず、200 件を超えるテナントでは
+ * CSV エクスポート自体が存在しないため、admin が「登録し忘れたメンバーからの問い合わせが
+ * 隔離されていないか」等をまとめて確認・保管する手段が無かった (/audit 画面が
+ * §4.2.1/§4.2.2 で解消したのと同種のギャップ)。GET /api/quarantine/export を叩いて
+ * サーバー側でキーセットカーソルを繰り返し前進させ、上限件数までの全履歴を 1 つの CSV に
+ * まとめて返してもらう (AuditFullExportButton と同じ設計)。
+ */
+export function QuarantineExportButton() {
+  // ダウンロード中かどうかを管理する (多重クリック防止のため)
+  const [loading, setLoading] = useState(false);
+
+  // CSV ダウンロードを実行するハンドラ
+  async function handleDownload() {
+    setLoading(true);
+    try {
+      // fetch で CSV データを取得する (auth cookie はブラウザが自動付与する)
+      const res = await fetch('/api/quarantine/export');
+      if (!res.ok) {
+        console.error(`[QuarantineExportButton] HTTP エラー: ${res.status}`);
+        // ユーザーには内部詳細を含まない安全なメッセージのみ表示する (§9)
+        throw new Error(
+          res.status === 401
+            ? 'セッションが切れました。ページを再読み込みしてからログインし直してください。'
+            : res.status === 403
+              ? 'この操作には管理者権限が必要です。'
+              : res.status === 429
+                ? 'しばらくしてから再度お試しください（エクスポートの上限に達しました）。'
+                : 'CSV エクスポートに失敗しました。しばらくしてから再度お試しください。',
+        );
+      }
+      // サーバーが MAX_QUARANTINE_EXPORT_ROWS でレスポンスを打ち切った場合に X-Truncated: true を返す
+      const truncated = res.headers.get('X-Truncated') === 'true';
+      const rawLimit = res.headers.get('X-Total-Limit');
+      const limitNum = rawLimit ? parseInt(rawLimit, 10) : NaN;
+      // ヘッダー値を直接 alert に埋め込むと MitM でテキスト偽装が可能になるため (§9)、
+      // 整数以外の値は信頼せず既定値にフォールバックする
+      const totalLimit = Number.isFinite(limitNum) ? limitNum.toLocaleString('ja-JP') : '10,000';
+      const blob = await res.blob();
+      triggerBlobDownload(blob, `quarantine-full-${new Date().toISOString().slice(0, 10)}.csv`);
+      // 上限件数で打ち切られていた場合はユーザーに警告を表示する
+      if (truncated) {
+        alert(
+          `隔離記録の件数が上限 (${totalLimit} 件) を超えているため、CSV には最新の ${totalLimit} 件のみ含まれています。`,
+        );
+      }
+    } catch (err) {
+      console.error('[QuarantineExportButton] CSV エクスポートに失敗:', err);
+      // TypeError はオフラインやネットワーク切断で fetch() が失敗したケース
+      const message =
+        err instanceof TypeError
+          ? 'ネットワークエラーが発生しました。接続を確認してから再度お試しください。'
+          : err instanceof Error
+            ? err.message
+            : 'CSV エクスポートに失敗しました。再度お試しください。';
+      alert(message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleDownload}
+      disabled={loading}
+      className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+      aria-label="隔離記録の全履歴を CSV 形式でダウンロードする"
+    >
+      {loading ? '取得中…' : '全履歴をCSVエクスポート'}
+    </button>
+  );
+}

--- a/src/features/quarantine/quarantine-csv.ts
+++ b/src/features/quarantine/quarantine-csv.ts
@@ -1,9 +1,12 @@
 // 隔離記録 (QuarantinedEmailRow[]) を CSV 文字列に変換する純粋関数。
 //
 // フォローアップ (2026-07-14 #3): §4.2.1/§4.2.2 で監査ログ (/audit) に追加した全履歴 CSV
-// エクスポートと同じ設計を、隔離メール一覧 (/quarantine) にも適用する。画面 (page.tsx) と
-// サーバー側の全履歴エクスポートルート (GET /api/quarantine/export) の両方がこの関数を
-// 共有する（§6 DRY: audit-csv.ts と同じ「画面とエクスポートルートで列定義を共有する」方針）。
+// エクスポートと同じ設計を、隔離メール一覧 (/quarantine) にも適用する。現時点では
+// サーバー側の全履歴エクスポートルート (GET /api/quarantine/export) のみがこの関数を使う
+// (/quarantine 画面は `<table>` を直接描画しており、/audit 画面のような「現在ページのみ
+// 即時ダウンロード」ボタンは元々存在しないため、まだ画面側の消費者はいない)。それでも
+// CSV 列定義を呼び出し側から独立した純粋関数として切り出しておくのは audit-csv.ts と同じ
+// 方針で、将来 /quarantine 画面に同種のボタンを追加する際にそのまま共有できるようにするため。
 
 // 隔離記録 1 件分の型 (テナントスコープ絞り込み済み。/quarantine ページと共有)
 import type { QuarantinedEmailRow } from '@/domain/types';

--- a/src/features/quarantine/quarantine-csv.ts
+++ b/src/features/quarantine/quarantine-csv.ts
@@ -1,0 +1,52 @@
+// 隔離記録 (QuarantinedEmailRow[]) を CSV 文字列に変換する純粋関数。
+//
+// フォローアップ (2026-07-14 #3): §4.2.1/§4.2.2 で監査ログ (/audit) に追加した全履歴 CSV
+// エクスポートと同じ設計を、隔離メール一覧 (/quarantine) にも適用する。画面 (page.tsx) と
+// サーバー側の全履歴エクスポートルート (GET /api/quarantine/export) の両方がこの関数を
+// 共有する（§6 DRY: audit-csv.ts と同じ「画面とエクスポートルートで列定義を共有する」方針）。
+
+// 隔離記録 1 件分の型 (テナントスコープ絞り込み済み。/quarantine ページと共有)
+import type { QuarantinedEmailRow } from '@/domain/types';
+// 隔離理由・チャネルの日本語ラベル (画面と同じ参照元)
+import { QUARANTINE_REASON_LABELS, QUARANTINE_CHANNEL_LABELS } from '@/lib/constants';
+// BOM 付き CSV 文字列生成 + CSV インジェクション対応済みエスケープ (lib/csv.ts に一元化)
+import { buildCsvString } from '@/lib/csv';
+
+/**
+ * 隔離記録の一覧を BOM 付き UTF-8 の CSV 文字列に変換する。
+ * メール由来の行は送信者名/送信元アドレスを、LINE 由来の行は LINE ユーザー ID を持つ
+ * (channel によって非 null な列が異なる)。本文は記録していない (§3.2 フォローアップ:
+ * 件名・送信者だけで admin が判断できるため、本文は保存しない範囲最小化の方針)。
+ */
+export function quarantinedEmailRowsToCsv(logs: QuarantinedEmailRow[]): string {
+  // CSV ヘッダー行 (各列の名前を日本語で定義する)
+  const headers = ['日時', '経路', '送信者名', '送信元アドレス', 'LINEユーザーID', '件名', '理由'];
+
+  // データ行を組み立てる (各隔離記録を CSV の 1 行に変換する)
+  const rows = logs.map((log) => [
+    // 日時 (Excel で認識しやすいように ja-JP ロケールで '/' 区切りにする。audit-csv.ts と同じ形式)
+    log.createdAt.toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    }),
+    // 経路 (メール / LINE)
+    QUARANTINE_CHANNEL_LABELS[log.channel],
+    // 送信者名 (メール専用。LINE 記録・ヘッダから取れなかった場合は空文字)
+    log.senderName ?? '',
+    // 送信元アドレス (メール専用。LINE 記録では空文字)
+    log.senderAddress ?? '',
+    // LINE ユーザー ID (LINE 専用。メール記録・不明な場合は空文字)
+    log.lineUserId ?? '',
+    // 件名 (メール専用。LINE 記録では空文字)
+    log.subject ?? '',
+    // 隔離した理由の日本語ラベル
+    QUARANTINE_REASON_LABELS[log.reason],
+  ]);
+
+  // ヘッダー + データ行を BOM 付き CSV 文字列にして返す
+  return buildCsvString(headers, rows);
+}

--- a/src/lib/cursor-csv-export.ts
+++ b/src/lib/cursor-csv-export.ts
@@ -1,0 +1,106 @@
+// キーセットカーソルを使った「全履歴 CSV エクスポート」で共通のロジックを集約する。
+//
+// フォローアップ (2026-07-14 #3 /code-review ultra 指摘対応): GET /api/audit/export
+// (§4.2.1/§4.2.2) と GET /api/quarantine/export (§3.7) が、キーセットカーソルを繰り返し
+// 前進させて上限件数まで全ページを蓄積するループ（「ちょうど上限に到達したときだけ 1 件
+// プローブして誤って truncated と警告しないようにする」判定を含む）と、CSV レスポンスの
+// ヘッダー構築（Content-Disposition のファイル名・Cache-Control・X-Truncated/X-Total-Limit）を、
+// ほぼ一字一句同じ形で個別に複製していた。fetch-audit-feed-page.ts や rate-limit.ts の
+// checkRateLimit が同種の重複を「2〜3 箇所目で共通化する」(§6 DRY) 方針で解消してきた前例に
+// 倣い、ここに集約する (2 箇所目の複製が生じた時点での共通化)。
+
+// 1 ページ分の取得結果 (呼び出し側の fetchPage が返す形。TRow/TCursor はデータソースごとに異なる)
+export interface CursorExportPage<TRow, TCursor> {
+  rows: TRow[]; // このページの行 (最大 pageSize 件)
+  hasMore: boolean; // まだ表示していない古い行が残っている可能性があるか
+  nextCursor: TCursor | null; // 「次ページ」用のカーソル (hasMore が false なら null)
+}
+
+// collectCursorPaginatedRows の戻り値
+export interface CursorExportResult<TRow> {
+  rows: TRow[]; // 蓄積した全行 (最大 maxRows 件)
+  truncated: boolean; // maxRows で打ち切ったかどうか (呼び出し元へ警告するために使う)
+}
+
+/**
+ * fetchPage を繰り返し呼んでキーセットカーソルを前進させ、maxRows 件まで全ページを蓄積する。
+ * maxRows にちょうど到達したときだけ probeForMore で 1 件だけ追加取得し、実際にまだ続きが
+ * あるかを確認してから truncated を確定する（「ちょうど limit 件で埋まった」だけの
+ * ヒューリスティックで真偽を決めると、テナントの総件数がたまたま maxRows ちょうどだった場合に
+ * 「まだ続きがある」と誤って警告してしまうため。/api/audit/export の元実装のコメント参照）。
+ *
+ * @param maxRows 全体の上限件数 (呼び出し側が pageSize の倍数であることを保証すること)
+ * @param fetchPage カーソルを受け取り 1 ページ分を返すコールバック
+ * @param probeForMore ちょうど maxRows に達したときだけ呼ばれる、続きの有無を確認する追加取得
+ */
+export async function collectCursorPaginatedRows<TRow, TCursor>(params: {
+  maxRows: number;
+  fetchPage: (cursor: TCursor | undefined) => Promise<CursorExportPage<TRow, TCursor>>;
+  probeForMore: (nextCursor: TCursor) => Promise<boolean>;
+}): Promise<CursorExportResult<TRow>> {
+  const { maxRows, fetchPage, probeForMore } = params;
+  // 蓄積した行を貯める配列
+  const rows: TRow[] = [];
+  // 現在のカーソル (未指定 = 最新から)
+  let cursor: TCursor | undefined = undefined;
+  // 上限で打ち切ったかどうか
+  let truncated = false;
+  for (;;) {
+    // 1 ページ分を取得する
+    const page = await fetchPage(cursor);
+    // 取得した行を蓄積配列へ追加する
+    rows.push(...page.rows);
+    // 上限に達したら、まだ続きがあっても打ち切る
+    if (rows.length >= maxRows) {
+      // ちょうど上限に到達したときだけ、次カーソル以降に本当に行が残っているかを
+      // 1 件だけ確認してから truncated を確定する
+      truncated = page.hasMore && page.nextCursor ? await probeForMore(page.nextCursor) : false;
+      break;
+    }
+    // 続きが無ければループを終える
+    if (!page.hasMore || !page.nextCursor) break;
+    // 次ページ取得用にカーソルを前進させる
+    cursor = page.nextCursor;
+  }
+  return { rows, truncated };
+}
+
+/**
+ * CSV 全履歴エクスポートの Response を組み立てる (ファイル名への JST 日付付与・
+ * Content-Disposition/Cache-Control・上限打ち切り時の X-Truncated/X-Total-Limit ヘッダー)。
+ */
+export function buildCsvExportResponse(params: {
+  csv: string; // CSV 文字列本体 (BOM 付き)
+  filenamePrefix: string; // ファイル名の接頭辞 (例: 'audit-log-full' / 'quarantine-full')
+  truncated: boolean; // 上限で打ち切ったか
+  maxRows: number; // 打ち切り時に X-Total-Limit へ入れる上限件数
+  now?: Date; // ファイル名の日付算出に使う基準時刻 (未指定なら呼び出し時点の現在時刻)
+}): Response {
+  const { csv, filenamePrefix, truncated, maxRows, now = new Date() } = params;
+  // ファイル名に JST の今日の日付を含める (ダウンロードフォルダで日付識別できる)
+  const today = now
+    .toLocaleDateString('ja-JP', {
+      timeZone: 'Asia/Tokyo',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+    .replace(/\//g, '-'); // YYYY/MM/DD → YYYY-MM-DD
+  const filename = `${filenamePrefix}-${today}.csv`;
+
+  const headers: HeadersInit = {
+    // UTF-8 の CSV であることを明示する
+    'Content-Type': 'text/csv; charset=utf-8',
+    // ブラウザにファイルとして保存させる (attachment) + ファイル名を指定する
+    'Content-Disposition': `attachment; filename="${filename}"`,
+    // キャッシュさせない (毎回最新データを取得させる)
+    'Cache-Control': 'no-cache, no-store, must-revalidate',
+  };
+  // 取得件数が上限に達した場合は打ち切りを呼び出し元に通知する
+  // (サイレント打ち切りは監査目的で「全件取得済み」と誤認させるリスクがある)
+  if (truncated) {
+    headers['X-Truncated'] = 'true';
+    headers['X-Total-Limit'] = String(maxRows);
+  }
+  return new Response(csv, { status: 200, headers });
+}

--- a/tests/features/quarantine-export-route.test.ts
+++ b/tests/features/quarantine-export-route.test.ts
@@ -1,0 +1,202 @@
+// GET /api/quarantine/export (フォローアップ 2026-07-14 #3) のテスト。
+// 隔離記録一覧 (/quarantine) は 1 ページ 200 件までしか表示できず、CSV エクスポート自体を
+// 持たなかったため、200 件を超えるテナントでは「さらに読み込む」を手作業で辿らないと古い行に
+// 到達できず、まとめて保管・共有する手段も無かった不備の回帰テスト。GET /api/audit/export の
+// テスト (audit-export-route.test.ts) と同じ構成で、認証・RBAC・レート制限・キーセットカーソルの
+// ページ跨ぎ集計をメモリアダプタとモックで完結させる。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+import type { Repos } from '@/data/ports/unit-of-work';
+import { __resetRateLimits } from '@/lib/rate-limit';
+import { AUDIT_MAX_LIMIT } from '@/data/adapters/audit-pagination';
+
+// エクスポート側の上限件数 (route.ts の MAX_QUARANTINE_EXPORT_ROWS と同値。テスト用に複製)
+const MAX_QUARANTINE_EXPORT_ROWS = 10_000;
+
+const TENANT = 'default-tenant';
+const ADMIN_ID = 'u-admin-1';
+
+let store: Store;
+let repos: Repos;
+let sessionRole = 'admin';
+
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  auth: async () => ({
+    user: { id: ADMIN_ID, role: sessionRole, tenantId: TENANT },
+  }),
+}));
+
+function seedTenant(plan: 'free' | 'pro' = 'free') {
+  store.tenants.set(TENANT, {
+    id: TENANT,
+    name: 'デフォルト組織',
+    mode: 'lite',
+    industry: null,
+    inboundToken: null,
+    slackWebhookUrl: null,
+    subscriptionPlan: plan,
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+    stripeSubscriptionStatus: null,
+    trialEndsAt: null,
+    teamsWebhookUrl: null,
+    chatworkApiToken: null,
+    chatworkRoomId: null,
+    createdAt: new Date(),
+  });
+  store.users.set(ADMIN_ID, {
+    id: ADMIN_ID,
+    email: 'admin@example.com',
+    name: '管理者',
+    passwordHash: 'x',
+    role: 'admin',
+    tenantId: TENANT,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+}
+
+beforeEach(() => {
+  const ctx = createMemoryContext();
+  store = ctx.store;
+  repos = ctx.repos;
+  __resetRateLimits();
+  vi.resetModules();
+  sessionRole = 'admin';
+  seedTenant();
+});
+
+describe('GET /api/quarantine/export', () => {
+  // 回帰テスト: 1 ページ (AUDIT_MAX_LIMIT 件) を超える隔離記録があっても、
+  // サーバー側でカーソルを前進させて全件 CSV に含めること (以前はエクスポート自体が存在しなかった)
+  it('1 ページを超える件数でもカーソルを前進させて全件エクスポートする', async () => {
+    const totalRows = AUDIT_MAX_LIMIT + 50;
+    for (let i = 0; i < totalRows; i++) {
+      await repos.quarantinedEmails.record({
+        tenantId: TENANT,
+        channel: 'email',
+        reason: 'unknown_sender',
+        senderAddress: `sender-${i}@example.com`,
+        senderName: null,
+        subject: `件名 ${i}`,
+      });
+    }
+
+    const { GET } = await import('@/app/api/quarantine/export/route');
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const csv = await res.text();
+
+    // ヘッダー行 + データ行の合計行数を数える (末尾の空行を除く)
+    const lines = csv
+      .replace(/^﻿/, '')
+      .split('\n')
+      .filter((l) => l.length > 0);
+    // ヘッダー1行 + totalRows 行がすべて含まれること (1 ページ分の 500 件で打ち切られていない)
+    expect(lines.length).toBe(totalRows + 1);
+    expect(res.headers.get('X-Truncated')).toBeNull();
+  });
+
+  // /code-review ultra 指摘対応 (audit/export と同じ回帰テスト): 総件数がちょうど
+  // MAX_QUARANTINE_EXPORT_ROWS (AUDIT_MAX_LIMIT の倍数) のとき、「ちょうど limit 件で埋まった」
+  // ヒューリスティックだけで truncated を判定すると、実際には全件取得済みなのに「一部のみ」と
+  // 誤って警告してしまう回帰テスト
+  it('総件数がちょうど上限件数のときは誤って truncated にしない', async () => {
+    for (let i = 0; i < MAX_QUARANTINE_EXPORT_ROWS; i++) {
+      await repos.quarantinedEmails.record({
+        tenantId: TENANT,
+        channel: 'line',
+        reason: 'quota_exceeded',
+        lineUserId: `line-user-${i}`,
+      });
+    }
+
+    const { GET } = await import('@/app/api/quarantine/export/route');
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const csv = await res.text();
+    const lines = csv
+      .replace(/^﻿/, '')
+      .split('\n')
+      .filter((l) => l.length > 0);
+    expect(lines.length).toBe(MAX_QUARANTINE_EXPORT_ROWS + 1);
+    expect(res.headers.get('X-Truncated')).toBeNull();
+  }, 20_000);
+
+  // 上記の反対系: 総件数が上限を実際に超えている場合は正しく truncated になること
+  it('総件数が上限を超えているときは truncated になる', async () => {
+    for (let i = 0; i < MAX_QUARANTINE_EXPORT_ROWS + 1; i++) {
+      await repos.quarantinedEmails.record({
+        tenantId: TENANT,
+        channel: 'line',
+        reason: 'quota_exceeded',
+        lineUserId: `line-user-${i}`,
+      });
+    }
+
+    const { GET } = await import('@/app/api/quarantine/export/route');
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const csv = await res.text();
+    const lines = csv
+      .replace(/^﻿/, '')
+      .split('\n')
+      .filter((l) => l.length > 0);
+    expect(lines.length).toBe(MAX_QUARANTINE_EXPORT_ROWS + 1);
+    expect(res.headers.get('X-Truncated')).toBe('true');
+    expect(res.headers.get('X-Total-Limit')).toBe(String(MAX_QUARANTINE_EXPORT_ROWS));
+  }, 20_000);
+
+  // 管理者以外 (agent) は 403 (画面側と同じ role === 'admin' 直接比較の RBAC)
+  it('管理者以外は403を返す', async () => {
+    sessionRole = 'agent';
+    const { GET } = await import('@/app/api/quarantine/export/route');
+    const res = await GET();
+    expect(res.status).toBe(403);
+  });
+
+  // /quarantine 画面と同じくプランゲートは設けない (Free プランでの隔離を admin 自身が
+  // 確認できる導線として有用なため。§3.2 フォローアップ再訪の方針)
+  it('Free プランでも200を返す (プランゲートなし)', async () => {
+    seedTenant('free');
+    await repos.quarantinedEmails.record({
+      tenantId: TENANT,
+      channel: 'email',
+      reason: 'plan_gate',
+      senderAddress: 'someone@example.com',
+      senderName: null,
+      subject: '件名',
+    });
+    const { GET } = await import('@/app/api/quarantine/export/route');
+    const res = await GET();
+    expect(res.status).toBe(200);
+  });
+
+  // レート制限 (3 回/分) を超えると 429
+  it('レート制限を超えると429を返す', async () => {
+    const { GET } = await import('@/app/api/quarantine/export/route');
+    // 上限 (3 回) までは通常どおり成功する
+    for (let i = 0; i < 3; i++) {
+      const res = await GET();
+      expect(res.status).toBe(200);
+    }
+    // 4 回目はレート制限に引っかかる
+    const res = await GET();
+    expect(res.status).toBe(429);
+  });
+
+  // 未認証は 401 (vi.doMock は以降の動的 import に永続するため、他のケースへ影響しないよう最後に置く)
+  it('未認証は401を返す', async () => {
+    vi.doMock('@/lib/auth', () => ({ auth: async () => null }));
+    const { GET } = await import('@/app/api/quarantine/export/route');
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Context

`docs/smb-dx-pivot-plan.md` §3.7 フォローアップ (Phase 3「隔離キューの永続化・admin 向け一覧画面」) 対応。

`/quarantine` 画面は §3.2 フォローアップ再訪（2026-07-12）でキーセットページネーション（「さらに
読み込む」）のみが実装され、CSV エクスポートは持たなかった。一方 `/audit` 画面は同じ「200 件で
打ち切られる一覧を監査目的でまとめて保管・共有したい」というニーズに対し、§4.2.1（ページネーション
追加）を経て §4.2.2 で「現在ページのみ即時ダウンロード」＋「全履歴 CSV エクスポート
（`GET /api/audit/export`）」の 2 段構えまで発展していた。`/quarantine` はその後継の改善を
一切受けておらず、隔離記録が 200 件を超えるテナントの admin が「登録し忘れたメンバーからの
問い合わせが隔離されていないか」をまとめて確認したり、スパム傾向の証跡として誰かに共有したりする
手段が「さらに読み込む」の手作業以外に存在しなかった。

## 変更内容

- `src/features/quarantine/quarantine-csv.ts`: `quarantinedEmailRowsToCsv` を新設。
  `src/features/audit/audit-csv.ts`（画面とエクスポートルートで列定義を共有する純粋関数）と
  同じ設計を踏襲。メール由来（送信者名・送信元アドレス・件名）と LINE 由来（LINE ユーザー ID）を
  機械可読な別列として持つ。
- `src/app/api/quarantine/export/route.ts`: `GET /api/quarantine/export` を新設。
  `GET /api/audit/export` と同じキーセットカーソル前進ループ・`MAX_QUARANTINE_EXPORT_ROWS`
  （10,000 件）・`assertTenantAdmin` による admin 専用ゲート・専用レート制限（3 回/分）を踏襲。
  `/quarantine` 画面と同じくプランゲートは設けない（Free プランでの隔離を admin 自身が確認
  できることが「なぜ取り込まれないか」に気づく導線として有用なため。§3.2 フォローアップ再訪の
  方針をそのまま踏襲）。
- `src/features/quarantine/components/QuarantineExportButton.tsx`: `AuditFullExportButton.tsx`
  と同じ設計のボタンを追加し、`/quarantine` 画面ヘッダーに配置。`/audit` と異なり `/quarantine`
  には「現在ページのみ即時ダウンロード」ボタンが元々存在しなかったため、今回は全履歴エクスポート
  の 1 ボタンのみを追加した（無かった機能を 2 つ同時に増やすとスコープが広がるため、§4.2.2 の
  2 段構えのうち不足していた「全履歴」側のみを追加する）。
- `tests/features/quarantine-export-route.test.ts`: `tests/features/audit-export-route.test.ts`
  と同じ構成（複数ページに跨る集計・ちょうど上限件数での誤 truncated 防止・RBAC・プランゲート
  無し・レート制限・未認証）の回帰テストを追加。

## 検証方法

- `npm run typecheck` — 成功
- `npm run lint` — 成功
- `npx prettier --check` (変更ファイル) — 成功
- `npm run test` — 946 件成功 / 137 件スキップ（Prisma 契約テストは `RUN_PRISMA_CONTRACT=1` 未設定のため未実行、想定どおり）

## Test plan

- [x] Vitest ユニットテスト（新規回帰テスト 7 件含む）
- [x] typecheck / lint / prettier
- [ ] Prisma 契約テスト（ローカル DB 未接続のため CI での確認が必要）


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tr3nkX878w11FMHb1uHpPj)_