### PR TITLE
fix(faq): 編集フォーム再展開時の内容巻き戻りレースを解消する

### DIFF
--- a/src/features/faq/components/FaqEditForm.tsx
+++ b/src/features/faq/components/FaqEditForm.tsx
@@ -2,6 +2,8 @@
 
 // 更新後にサーバー側キャッシュを再取得させるためのルーター
 import { useRouter } from 'next/navigation';
+// 再取得 (router.refresh) が完了するまでの「同期中」フラグを得るためのトランジション
+import { useTransition } from 'react';
 // FAQ 候補の本文を編集するサーバーアクション
 import { updateFaqContent } from '@/features/faq/actions/faq-actions';
 // 質問/回答フォームの共通実装 (FaqCandidateForm と共有。§6 DRY)
@@ -19,6 +21,10 @@ interface Props {
 export function FaqEditForm({ faqId, question, answer }: Props) {
   // 更新成功後に FAQ 一覧を再取得させるためのルーター
   const router = useRouter();
+  // router.refresh() が RSC の再取得を終えるまで true になるフラグ (同期中はトグルボタンを無効化する。
+  // 保存直後に間髪入れず再度「編集」を開くと、まだサーバーへ反映されていない古い question/answer で
+  // フォームが再展開され、気付かずそのまま保存すると直前の訂正が巻き戻ってしまうため)
+  const [isRefreshing, startRefresh] = useTransition();
 
   return (
     <FaqInlineForm
@@ -26,14 +32,16 @@ export function FaqEditForm({ faqId, question, answer }: Props) {
       toggleClassName="mt-2 text-xs font-medium text-teal-700 hover:underline"
       // 一覧内に同じ「編集」ボタンが並ぶため、対象の質問文でスクリーンリーダー向けに区別する (§7 a11y)
       toggleAriaLabel={`${question} を編集`}
+      // 再取得中は古い内容での再展開を防ぐため一時的にボタンを無効化する
+      toggleDisabled={isRefreshing}
       fieldIdPrefix={`faq-edit-${faqId}`}
       defaultQuestion={question}
       defaultAnswer={answer}
       submitLabel="保存"
       // 質問/回答の本文を更新する
       onSubmit={(q, a) => updateFaqContent(faqId, q, a)}
-      // 更新後はサーバーから最新の質問/回答を取り直す
-      onSuccess={() => router.refresh()}
+      // 更新後はサーバーから最新の質問/回答を取り直す (完了を isRefreshing で追跡する)
+      onSuccess={() => startRefresh(() => router.refresh())}
     />
   );
 }

--- a/src/features/faq/components/FaqInlineForm.tsx
+++ b/src/features/faq/components/FaqInlineForm.tsx
@@ -14,6 +14,10 @@ interface Props {
   // トグルボタンのアクセシブルネーム (省略時は toggleLabel をそのまま使う。
   // §7 a11y: 一覧内に同名ボタンが並ぶ場合、対象を区別できる文言を渡す)
   toggleAriaLabel?: string;
+  // トグルボタンを一時的に無効化するか (省略時 false。呼び出し元がサーバーの最新値への
+  // 同期中であることを示したい場合に使う。例: FaqEditForm が保存成功後の router.refresh()
+  // 完了を待つ間、古い defaultQuestion/defaultAnswer で再展開されるのを防ぐ)
+  toggleDisabled?: boolean;
   // ラベルと入力欄を紐付ける id の接頭辞 (呼び出し元ごとに一意にすること)
   fieldIdPrefix: string;
   // 質問欄の初期値
@@ -35,6 +39,7 @@ export function FaqInlineForm({
   toggleLabel,
   toggleClassName,
   toggleAriaLabel,
+  toggleDisabled,
   fieldIdPrefix,
   defaultQuestion,
   defaultAnswer,
@@ -90,7 +95,11 @@ export function FaqInlineForm({
       <button
         onClick={() => setOpen(true)}
         aria-label={toggleAriaLabel}
-        className={toggleClassName}
+        // 呼び出し元がサーバーの最新値への同期中は再展開を止める (古い初期値での
+        // remount を防ぐ。§9 fail-safe: 見た目のクリックできなさより、気付かない
+        // 内容巻き戻りの方が実害が大きいため無効化を優先する)
+        disabled={toggleDisabled}
+        className={`${toggleClassName} disabled:pointer-events-none disabled:opacity-50`}
       >
         {toggleLabel}
       </button>


### PR DESCRIPTION
## Context

#218（`公開済みFAQを編集・非公開化できるようにする`、マージ済み）の `/code-review ultra` フォローアップレビューで発見したギャップの修正。

## 変更内容

`FaqEditForm`（`src/features/faq/components/FaqEditForm.tsx`）は保存成功後、`FaqInlineForm` 側で `setOpen(false)` によりフォームを閉じてから `onSuccess` として `router.refresh()` を呼ぶ。この再取得は非同期かつ `await` されないため、完了前にエージェントが「編集」ボタンを間髪入れず再度押すと、まだサーバーに反映されていない古い `question`/`answer` で `FaqInlineForm` が再展開されてしまう。気付かずそのまま「保存」すると、直前の訂正が古い内容で上書きされて巻き戻ってしまい、本機能（公開後の誤りを訂正する手段）の目的そのものを損なう。

- `FaqInlineForm`（`src/features/faq/components/FaqInlineForm.tsx`）に `toggleDisabled` prop を追加し、呼び出し元からトグルボタンを一時的に無効化できるようにした。
- `FaqEditForm` は `useTransition` で `router.refresh()` の完了を `isRefreshing` として追跡し、再取得中は `toggleDisabled` でボタンを無効化して古い内容での再展開を防ぐようにした。
- `FaqCandidateForm`（もう一方の呼び出し元）には影響なし（`toggleDisabled` は省略時 `undefined` で無効化されない）。

## 検証方法

- `npm run typecheck` — 成功
- `npm run lint` — 成功
- `npx prettier --check`（変更ファイル） — 成功
- `npm run test` — 973 件成功 / 140 件スキップ（Prisma 契約テストは `RUN_PRISMA_CONTRACT=1` 未設定のため未実行、想定どおり）

## Test plan

- [x] typecheck / lint / prettier
- [x] Vitest ユニットテスト（既存回帰テスト、全件成功）
- [ ] Playwright E2E（ローカルに dev サーバー/DB が無いため CI での確認が必要。今回の変更は再展開タイミングのみで既存 `e2e/faq.spec.ts` のシナリオを壊すものではない想定）

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdvUMVTG9YPCorNia2PSTt)_