### PR TITLE
fix(tickets): 担当者・カテゴリ・拠点プルダウンの未処理エラーを解消

### DIFF
--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -931,6 +931,40 @@ Phase 2 の差別化の本丸であるメール/LINE 取り込みチャネルを
   対応状況が不揃いになるため、別途 5 種まとめて対応するフォローアップ課題として残す
   （§7 accessibility の `<label>`/`aria-labelledby` 要件）。
 
+#### 4.9 フォローアップ（2026-07-16）: 担当者・カテゴリ・拠点プルダウンの未処理エラー
+
+コードベース監査（既存フォローアップ群と同じ「済マーク済みの機能を実装から再点検する」観点）で
+発見したギャップの修正。§1.4/§1.5 で `FaqStatusButton`/`StatusSelect`/`PrioritySelect` に
+導入した「送信中は無効化し、失敗はその場にエラー表示、競合時は `router.refresh()` で最新化する」
+契約が、§4.8 で追加した `EntitySelect`（`AssigneeSelect`/`CategorySelect`/`LocationSelect` が
+共有する汎用プルダウン。`src/features/tickets/components/EntitySelect.tsx`）には一度も
+適用されていなかった。
+
+- **問題**: `EntitySelect` は `startTransition(() => onChange(val || null))` という形で、
+  非同期の `onChange`（実体は `updateTicketAssignee`/`updateTicketCategory`/
+  `updateTicketLocation`）が返す `Promise` を誰も `await` も `catch` もしていなかった。
+  これらのサーバーアクションはレート制限超過・チケット消失（削除との競合）・指定先の不在
+  （他エージェントによる担当者/カテゴリ/拠点の削除・退職処理との競合）で `Error` を throw する
+  正常な失敗系路を持つが、`EntitySelect` 側で拒否 (`reject`) が誰にも処理されないため未処理の
+  Promise 拒否になり、ユーザーには何も表示されないまま操作が黙って失敗していた
+  （§6 エラーを握り潰さない、に反する）。`StatusSelect`/`PrioritySelect`（§1.5）・
+  `FaqStatusButton`（§1.4）は同種の問題を既に解消済みだったが、`EntitySelect` は §4.8 で
+  それらより後に追加されたにもかかわらず、この契約を踏襲していなかった。
+- **修正**: `EntitySelect` に `useState` によるエラー表示と `useRouter().refresh()` を追加し、
+  `handleChange` を `StatusSelect`/`FaqStatusButton` と同じ
+  `startTransition(async () => { try { await onChange(...) } catch (err) { ... } })` の形に
+  変更した。失敗時は `role="alert"` のメッセージをその場に表示し、`router.refresh()` で
+  サーバーの最新状態を取り直す（エラー時は `revalidatePath` に到達しないため、担当者/カテゴリ/
+  拠点の表示が古いまま残り続けるのを防ぐ）。`onChange` の型を `void` から `void | Promise<void>`
+  に修正し、非同期であることを型シグネチャにも明示した。`AssigneeSelect`/`CategorySelect`/
+  `LocationSelect` 側の変更は不要（`EntitySelect` への配線はそのまま）。
+- 本修正は UI イベントハンドラのみの変更であり、`updateTicketAssignee`/`updateTicketCategory`/
+  `updateTicketLocation`（サーバー側の検証・RBAC・tenantId スコープ）自体には変更がない。
+  リポジトリに React コンポーネント向けのユニットテスト基盤（jsdom / Testing Library 等）が
+  無く、Vitest は `environment: 'node'` で `tests/**/*.test.ts` のみを対象とする構成のため
+  （`vitest.config.ts`）、`FaqStatusButton`/`StatusSelect`/`PrioritySelect` の同種の修正
+  （§1.4/§1.5）と同じく、この UI 層の変更にも専用のコンポーネント単体テストは追加していない。
+
 ### スケジュール感
 
 ```

--- a/src/features/tickets/components/EntitySelect.tsx
+++ b/src/features/tickets/components/EntitySelect.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-// 非ブロッキングで状態更新を扱う React フック
-import { useTransition } from 'react';
+// React フック (送信中トランジション/エラー表示用ローカル状態)
+import { useState, useTransition } from 'react';
+// 失敗時にサーバーの最新状態を取り直すためのルーター
+import { useRouter } from 'next/navigation';
 
 // プルダウン項目の型 (ID と表示名のみを要求する)
 export interface EntityOption {
@@ -14,7 +16,9 @@ interface Props {
   currentId: string | null;
   options: EntityOption[];
   emptyLabel: string; // 空文字 (未選択) のときに表示するラベル (例: '未割当' '未分類' '未指定')
-  onChange: (newId: string | null) => void; // 選択変更時に呼ばれる (空文字は null に正規化済み)
+  // 選択変更時に呼ばれる (空文字は null に正規化済み)。呼び出し先のサーバーアクション
+  // (updateTicketAssignee 等) は Promise を返す非同期関数なので、戻り値の型に Promise<void> も許容する
+  onChange: (newId: string | null) => void | Promise<void>;
 }
 
 // チケット詳細ページの各種プルダウン (担当者/カテゴリ/拠点) が共有する汎用セレクト。
@@ -23,32 +27,66 @@ interface Props {
 // プルダウンを個別に複製していた (3 箇所目の重複) ため、表示ロジックだけを共通化する
 // (§6 DRY)。呼び出すサーバーアクションはフィールドごとに異なるため、呼び出し自体は
 // 各ラッパーコンポーネント (AssigneeSelect 等) の責務として残す。
+//
+// フォローアップ (2026-07-16): update-ticket.ts の updateTicketAssignee/Category/Location は
+// レート制限超過・チケット消失・指定先の不在 (他エージェントによる削除等) で Error を throw するが、
+// このセレクトは startTransition に渡すコールバックの戻り値 (onChange が返す Promise) を
+// 誰も待たず・捕捉していなかったため未処理の Promise 拒否になっていた。StatusSelect/PrioritySelect
+// (フォローアップ 2026-07-15 #3) と FaqStatusButton (フォローアップ 2026-07-15) で先に直した
+// 「送信中は無効化し、エラーはその場に表示、競合時は router.refresh() で最新化する」パターンを
+// ここにも適用する。
 export function EntitySelect({ currentId, options, emptyLabel, onChange }: Props) {
+  // 失敗時にサーバーの最新状態を取り直すためのルーター
+  const router = useRouter();
   // 送信中フラグ + トランジション関数
   const [isPending, startTransition] = useTransition();
+  // サーバーアクションから返ったエラーを表示する
+  const [error, setError] = useState<string | null>(null);
 
-  // 選択変更時に onChange を呼ぶ (空文字は null に正規化する)
+  // 選択変更時に onChange を呼ぶ (空文字は null に正規化する)。失敗時はその場にエラー表示する
   function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
     const val = e.target.value;
-    startTransition(() => onChange(val || null));
+    // 直前のエラー表示をクリア
+    setError(null);
+    startTransition(async () => {
+      try {
+        // onChange が返す Promise を待ち、拒否 (throw) を確実に捕捉する
+        await onChange(val || null);
+      } catch (err) {
+        // 失敗時 (競合・レート制限・指定先の不在等) はエラーメッセージを画面表示 (§6 エラーを握り潰さない)
+        setError(err instanceof Error ? err.message : 'エラーが発生しました');
+        // 競合エラーは「画面の表示が古い」ことを意味するため、サーバーの最新状態を取り直して
+        // 古いプルダウンの値が残り続けるのを防ぐ (エラー時は revalidatePath に到達しないため
+        // クライアント側で再取得する)
+        router.refresh();
+      }
+    });
   }
 
   return (
-    // 現在値を表示しつつ、変更で更新するセレクト
-    <select
-      value={currentId ?? ''}
-      onChange={handleChange}
-      disabled={isPending}
-      className="rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none disabled:opacity-50"
-    >
-      {/* 空文字 = 未選択 */}
-      <option value="">{emptyLabel}</option>
-      {/* 候補一覧 */}
-      {options.map((o) => (
-        <option key={o.id} value={o.id}>
-          {o.name}
-        </option>
-      ))}
-    </select>
+    <div>
+      {/* 現在値を表示しつつ、変更で更新するセレクト */}
+      <select
+        value={currentId ?? ''}
+        onChange={handleChange}
+        disabled={isPending}
+        className="rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none disabled:opacity-50"
+      >
+        {/* 空文字 = 未選択 */}
+        <option value="">{emptyLabel}</option>
+        {/* 候補一覧 */}
+        {options.map((o) => (
+          <option key={o.id} value={o.id}>
+            {o.name}
+          </option>
+        ))}
+      </select>
+      {/* エラー表示 (ある場合のみ。role="alert" でスクリーンリーダーにも即時に伝える。§7 a11y) */}
+      {error && (
+        <p role="alert" className="mt-1 text-xs text-red-600">
+          {error}
+        </p>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Context

定例コードレビュールーチン（直近マージ済み #219 / #220 / #221 と同じ「既存フォローアップで確立したパターンが、後から追加された同種の実装に一貫して適用されているか」を再点検する観点）での監査。対応する正本の項目は `docs/smb-dx-pivot-plan.md` §4.9（新規追加）。

`src/features/faq/actions/faq-actions.ts` の `updateFaqStatus`（§1.4 / #220）と `src/features/tickets/actions/update-ticket.ts` の `updateTicketStatus`/`updateTicketPriority`（§1.5 / #221）は、check-then-act 競合・レート制限超過時に `Error` を throw する契約に統一されており、呼び出し元の `FaqStatusButton.tsx`/`StatusSelect.tsx`/`PrioritySelect.tsx` も「送信中は無効化、失敗はその場に `role="alert"` で表示、競合時は `router.refresh()` で最新化する」パターンで throw を捕捉するよう既に修正済みでした。

しかし §4.8（#216 相当）で追加された `EntitySelect`（`AssigneeSelect`/`CategorySelect`/`LocationSelect` が共有する汎用プルダウン、`src/features/tickets/components/EntitySelect.tsx`）だけはこのパターンが適用されておらず、`startTransition(() => onChange(val || null))` という形で非同期の `onChange`（実体は `updateTicketAssignee`/`updateTicketCategory`/`updateTicketLocation`）が返す `Promise` を誰も `await`/`catch` していませんでした。これらのサーバーアクションはレート制限超過・チケット消失（削除との競合）・指定先の不在（他エージェントによる担当者/カテゴリ/拠点の削除との競合）で正常に `Error` を throw しますが、`EntitySelect` 側では未処理の Promise 拒否になり、ユーザーには何も表示されないまま操作が黙って失敗していました（CLAUDE.md §6 の「エラーを握り潰さない」に反する）。

## 変更内容

- `src/features/tickets/components/EntitySelect.tsx`
  - `handleChange` を `StatusSelect`/`FaqStatusButton` と同じ `startTransition(async () => { try { await onChange(...) } catch (err) { ... } })` の形に変更。
  - `useState` によるエラー表示（`role="alert"`）と `useRouter().refresh()`（競合時にサーバーの最新状態を取り直す）を追加。
  - `onChange` の型を `void` から `void | Promise<void>` に修正し、非同期であることを型シグネチャにも明示。
  - `AssigneeSelect`/`CategorySelect`/`LocationSelect` 側の変更は不要（`EntitySelect` への配線はそのまま）。
- `docs/smb-dx-pivot-plan.md` §4.9 にフォローアップとして経緯を記録。

サーバー側 (`updateTicketAssignee`/`updateTicketCategory`/`updateTicketLocation` の検証・RBAC・tenantId スコープ) には変更なし。UI イベントハンドラのみの最小スコープの修正です。

## 検証方法

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run test`（Vitest, DB 不要なユニットテスト）— 1002 passed / 146 skipped (contract tests)
- `npm run test:contract` — このサンドボックス環境に PostgreSQL / Docker が無いためスキップ（本 PR はサーバー側ロジック・Prisma スキーマを一切変更していないため契約テストへの影響なし）
- `npm run test:e2e` — dev サーバー起動環境が無いためスキップ

本修正は UI イベントハンドラのみの変更で、リポジトリに React コンポーネント向けの単体テスト基盤（jsdom / Testing Library 等）が無く（`vitest.config.ts` は `environment: 'node'` で `tests/**/*.test.ts` のみが対象）、同種の過去修正（`FaqStatusButton`/`StatusSelect`/`PrioritySelect`、§1.4/§1.5）でも専用のコンポーネント単体テストは追加されていないため、本 PR でも追加していません。

/code-review ultra・/security-review ultra を実行し、指摘があれば反映します。

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_0161KtDKxzBFvVkRicsrYG9Y)_