### PR TITLE
fix(a11y): プルダウンのlabel関連付け・絞り込みバー・遷移後フォーカスを解消

### DIFF
--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -965,6 +965,41 @@ Phase 2 の差別化の本丸であるメール/LINE 取り込みチャネルを
   （`vitest.config.ts`）、`FaqStatusButton`/`StatusSelect`/`PrioritySelect` の同種の修正
   （§1.4/§1.5）と同じく、この UI 層の変更にも専用のコンポーネント単体テストは追加していない。
 
+#### 4.10 フォローアップ（2026-07-16 #2）: プルダウンの label 関連付け欠如・一覧の絞り込みバー・ページ遷移後のフォーカス移動という 3 件の a11y ギャップ
+
+定例コードレビュールーチンでの監査（CLAUDE.md §7 a11y の要件と実装を再点検する観点）で発見した、
+これまで「別途対応」として明記されたまま残っていたギャップ、および新たに見つかったギャップの解消。
+
+- **§4.8 が「別途 5 種まとめて対応する」と明記していた label 関連付けの欠如**: チケット詳細画面
+  （`src/app/(app)/tickets/[id]/page.tsx`）のステータス/優先度/担当者/カテゴリ/拠点の 5 種プルダウン
+  （`StatusSelect`/`PrioritySelect`/`EntitySelect` が共有する `AssigneeSelect`/`CategorySelect`/
+  `LocationSelect`）は、いずれも隣接する `<dt>` の可視テキストとプログラム的に関連付けられておらず、
+  スクリーンリーダー利用者にはこのプルダウンが何を変更する操作か伝わらなかった（CLAUDE.md §7
+  「フォーム入力に対応する `<label>`（または `aria-labelledby`）を付ける」に反する）。各 `<dt>` に
+  id（`ticket-detail-{status,priority,assignee,category,location}-label`）を振り、対応する
+  select に `aria-labelledby` として渡すよう、5 コンポーネント全てに `labelledBy` prop を追加した。
+  可視テキストを唯一の源としたかったため、ラベル文言を select 側に複製する `aria-label` ではなく
+  `aria-labelledby` を選んだ。
+- **チケット一覧の絞り込みバーにも同種のギャップがあった**: `TicketFilters.tsx`
+  のキーワード検索欄・ステータス/優先度/カテゴリ/担当者/拠点の 5 種絞り込みプルダウンは、
+  対応する可視ラベル要素（`<dt>` のような）自体が存在しない設計のため、`aria-labelledby` ではなく
+  `aria-label`（例:「ステータスで絞り込む」）を直接付与した。キーワード入力の `placeholder`
+  はアクセシブルネームの正式な代替にはならないため、同じく `aria-label="キーワード検索"` を追加した。
+- **ページ遷移後にフォーカスが本文へ移らず、本文へ飛ぶスキップリンクも無かった**: CLAUDE.md §7 は
+  「SPA でページ遷移したらフォーカスを新ページの先頭（`main` 等）へ移し、本文へ飛ぶスキップリンクも
+  用意する」ことを求めるが、`(app)/layout.tsx` はどちらも実装していなかった。Next.js App Router の
+  `Link` によるクライアントサイド遷移は通常のブラウザ遷移と異なりフォーカスを暗黙にリセットしない
+  ため、遷移後もフォーカスが遷移前の要素（サイドバーのリンク等）に残り続け、スクリーンリーダー
+  利用者は新しいページの内容に気づけなかった。`<main>` に `id="main-content"`/`tabIndex={-1}`
+  を付与し、`SkipLink`（`src/components/layout/SkipLink.tsx`。通常は `sr-only` で視覚的に隠し
+  Tab フォーカスを受けたときのみ表示する定番パターン）と `RouteFocusManager`
+  （`src/components/layout/RouteFocusManager.tsx`。`usePathname()` の変化を検知し、初回マウント
+  時を除いて `#main-content` へ `focus()` する副作用専用コンポーネント）を新設して `(app)/layout.tsx`
+  に配線した。
+- 3 件とも UI 層（マークアップ/属性/新規の副作用専用コンポーネント）のみの変更であり、
+  サーバー側の Server Action・RBAC・tenantId スコープには影響しない。§4.9 と同じ理由
+  （コンポーネント単体テスト基盤が無い）により、専用テストは追加していない。
+
 ### スケジュール感
 
 ```

--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -999,6 +999,39 @@ Phase 2 の差別化の本丸であるメール/LINE 取り込みチャネルを
 - 3 件とも UI 層（マークアップ/属性/新規の副作用専用コンポーネント）のみの変更であり、
   サーバー側の Server Action・RBAC・tenantId スコープには影響しない。§4.9 と同じ理由
   （コンポーネント単体テスト基盤が無い）により、専用テストは追加していない。
+- `/code-review ultra` 指摘対応: 上記の初回実装に対する複数の独立レビューエージェントが
+  収斂して指摘した 4 件を追加修正した。
+  - **`focus:outline-none` に代替の見た目が無かった**: `<main>` はスキップリンク/
+    `RouteFocusManager` からの `focus()` を実際に受け取る要素になったにもかかわらず、
+    デフォルトのフォーカスアウトラインを消すクラスのみを追加し代替の見た目を用意していな
+    かった（CLAUDE.md §7 自身が明記する「`outline` を消す場合は代替の見た目を用意する」に
+    反する）。`focus-visible:ring-2 focus-visible:ring-teal-500`（キーボード操作/
+    programmatic focus 時のみ表示され、マウス操作では出ない）を追加した。
+  - **`RouteFocusManager` が開発時の React Strict Mode 二重実行で初回ロード時にもフォーカス
+    を奪っていた**: 「初回マウントか」を `useEffect` 内で書き換えるフラグ (`isFirstRender`)
+    で判定していたが、Strict Mode（Next.js App Router は既定で有効）は副作用を
+    マウント→クリーンアップ→再マウントの順で 2 回連続実行するため、1 回目でフラグが
+    false に書き換わった直後の 2 回目の実行で「初回マウントではない」と誤判定し、
+    ページの初回ロード時にも `main.focus()` が呼ばれていた。副作用側で状態を書き換える
+    方式をやめ、マウント時点のパスを `useRef` に 1 度だけ記憶し、以降は「現在のパスが
+    記憶した初期パスと異なるか」のみで判定する方式に変更した（Strict Mode の 2 回実行でも
+    判定結果が変わらない）。
+  - **Safari/VoiceOver でスキップリンクがフォーカスを移さない**: Safari には、同一ページ内
+    フラグメントリンクのクリックでスクロールはしてもフォーカスは移動しない既知の挙動が
+    あり（対象要素が `tabIndex={-1}` でも）、`href` によるネイティブなフラグメント遷移だけ
+    に頼ると Safari/VoiceOver 利用者だけスキップリンクが機能しなかった。`SkipLink` を
+    Client Component 化し、`onClick` で明示的に `document.getElementById(...)?.focus()`
+    を呼ぶことで、Chromium/Firefox/Safari のいずれでも確実にフォーカスが移るようにした。
+  - **DOM id `"main-content"` が 3 箇所に直書きされていた**: `SkipLink` の `href`・
+    `(app)/layout.tsx` の `<main id="...">`・`RouteFocusManager` の
+    `getElementById(...)` の 3 箇所に同じ文字列が独立して直書きされており、CLAUDE.md §6
+    「マジック文字列を避ける・単一の参照元に置く」に反していた（将来どれか 1 箇所だけ
+    リネームし忘れると、コンパイルエラーも lint エラーも出ないまま静かに壊れる）。
+    `MAIN_CONTENT_ID`（`src/components/layout/main-content-id.ts`）に集約し、3 箇所とも
+    そこから import するよう変更した。同種の懸念があったチケット詳細画面の
+    `ticket-detail-{status,priority,assignee,category,location}-label` の 5 ペア
+    （`<dt id="...">` と対応する select の `labelledBy="..."`）も、ページ内の
+    `FIELD_LABEL_IDS` 定数にまとめ、リテラル文字列の重複を解消した。
 
 ### スケジュール感
 

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -6,6 +6,10 @@ import { Header } from '@/components/layout/Header';
 import { Sidebar } from '@/components/layout/Sidebar';
 // モバイル時のサイドバードロワー開閉状態を Header / Sidebar 間で共有する Provider
 import { MobileNavProvider } from '@/components/layout/MobileNavProvider';
+// 本文へ飛ぶスキップリンク (§7 a11y)
+import { SkipLink } from '@/components/layout/SkipLink';
+// クライアントサイド遷移のたびに本文へフォーカスを移す (§7 a11y)
+import { RouteFocusManager } from '@/components/layout/RouteFocusManager';
 // 現在テナントの動作モード(lite | pro)を取得するヘルパー
 import { getCurrentTenantMode } from '@/lib/tenant';
 // §6.1 料金プラン「Free: ロゴ表示」の判定用。トライアル中の実効プランを返す
@@ -30,6 +34,10 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     // Provider は client コンポーネントだが、async な Header/Sidebar の親に置けるため
     // children のレンダリング順序や Server Action 利用を妨げない
     <MobileNavProvider>
+      {/* 本文へ飛ぶスキップリンク (§7 a11y)。通常は視覚的に隠れており、Tab で最初にフォーカスされたときのみ表示 */}
+      <SkipLink />
+      {/* クライアントサイド遷移のたびに #main-content へフォーカスを移す (画面には何も描画しない) */}
+      <RouteFocusManager />
       {/* 画面全体: 左右レイアウト + 縦スクロール抑止 (背景は新トークン surface) */}
       <div className="bg-surface flex h-screen overflow-hidden">
         {/* サイドバー (権限とモードに応じてメニューを出し分け。md 未満は Provider 状態でドロワー化) */}
@@ -37,8 +45,17 @@ export default async function AppLayout({ children }: { children: React.ReactNod
         {/* 右側: ヘッダー + メインコンテンツ */}
         <div className="flex flex-1 flex-col overflow-hidden">
           <Header />
-          {/* 各ページの内容 (縦スクロール可) ─ モバイルは余白を控えめにする */}
-          <main className="flex-1 overflow-y-auto p-4 sm:p-6 md:p-8">{children}</main>
+          {/* 各ページの内容 (縦スクロール可) ─ モバイルは余白を控えめにする。
+              id="main-content"/tabIndex={-1} はスキップリンクの遷移先 + ページ遷移後の
+              フォーカス移動先 (RouteFocusManager) として使う。tabIndex={-1} なので
+              通常の Tab 移動では選択されず、programmatic focus() でのみフォーカス可能 */}
+          <main
+            id="main-content"
+            tabIndex={-1}
+            className="flex-1 overflow-y-auto p-4 focus:outline-none sm:p-6 md:p-8"
+          >
+            {children}
+          </main>
           {/* §6.1 料金プラン「Free: ロゴ表示」。Free プラン (トライアル中を除く) のテナントにのみ表示する。
               text-slate-500 (背景 white 比でコントラスト比 約4.6:1) で WCAG AA (通常文 4.5:1) を満たす
               (slate-400 は約2.56:1 で未達だったため修正) */}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -10,6 +10,8 @@ import { MobileNavProvider } from '@/components/layout/MobileNavProvider';
 import { SkipLink } from '@/components/layout/SkipLink';
 // クライアントサイド遷移のたびに本文へフォーカスを移す (§7 a11y)
 import { RouteFocusManager } from '@/components/layout/RouteFocusManager';
+// <main> に振る id の単一の参照元 (§6 マジック文字列を避ける)
+import { MAIN_CONTENT_ID } from '@/components/layout/main-content-id';
 // 現在テナントの動作モード(lite | pro)を取得するヘルパー
 import { getCurrentTenantMode } from '@/lib/tenant';
 // §6.1 料金プラン「Free: ロゴ表示」の判定用。トライアル中の実効プランを返す
@@ -46,13 +48,20 @@ export default async function AppLayout({ children }: { children: React.ReactNod
         <div className="flex flex-1 flex-col overflow-hidden">
           <Header />
           {/* 各ページの内容 (縦スクロール可) ─ モバイルは余白を控えめにする。
-              id="main-content"/tabIndex={-1} はスキップリンクの遷移先 + ページ遷移後の
+              id=MAIN_CONTENT_ID/tabIndex={-1} はスキップリンクの遷移先 + ページ遷移後の
               フォーカス移動先 (RouteFocusManager) として使う。tabIndex={-1} なので
-              通常の Tab 移動では選択されず、programmatic focus() でのみフォーカス可能 */}
+              通常の Tab 移動では選択されず、programmatic focus() でのみフォーカス可能。
+              フォローアップ (2026-07-16 #2 レビュー対応): 当初 focus:outline-none のみで
+              代替の見た目を用意しておらず、スキップリンク/遷移後にフォーカスが移っても
+              画面上に何も変化が見えなかった (CLAUDE.md §7 の「outline を消す場合は
+              代替の見た目を用意する」に反する)。既定のブラウザアウトラインの代わりに
+              focus-visible:ring-2 (TicketFilters 等と同じ teal 系のフォーカスリング) を
+              明示的に用意した。focus-visible を使うのは、programmatic focus() やキーボード
+              操作時にのみ視覚的に表示し、マウス操作の副作用で毎回リングが出ないようにするため */}
           <main
-            id="main-content"
+            id={MAIN_CONTENT_ID}
             tabIndex={-1}
-            className="flex-1 overflow-y-auto p-4 focus:outline-none sm:p-6 md:p-8"
+            className="flex-1 overflow-y-auto p-4 focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 sm:p-6 md:p-8"
           >
             {children}
           </main>

--- a/src/app/(app)/tickets/[id]/page.tsx
+++ b/src/app/(app)/tickets/[id]/page.tsx
@@ -219,9 +219,14 @@ export default async function TicketDetailPage({ params }: Props) {
             <h2 className="mb-4 text-sm font-semibold text-gray-500">詳細</h2>
 
             <dl className="space-y-3 text-sm">
-              {/* ステータス (エージェントは変更プルダウン付き、ラベルはテナント mode で切替) */}
+              {/* ステータス (エージェントは変更プルダウン付き、ラベルはテナント mode で切替)
+                  フォローアップ (2026-07-16 #2): §4.8 で残していた a11y ギャップ (プルダウンが
+                  どの dt の値を変更するかプログラム的に伝わっていなかった) の解消。dt に id を
+                  振り、対応する select から aria-labelledby で参照する */}
               <div>
-                <dt className="font-medium text-gray-500">ステータス</dt>
+                <dt id="ticket-detail-status-label" className="font-medium text-gray-500">
+                  ステータス
+                </dt>
                 <dd className="mt-1">
                   <span
                     className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[ticket.status] ?? ''}`}
@@ -230,7 +235,12 @@ export default async function TicketDetailPage({ params }: Props) {
                   </span>
                   {isAgent && (
                     <div className="mt-1">
-                      <StatusSelect ticketId={ticket.id} current={ticket.status} mode={mode} />
+                      <StatusSelect
+                        ticketId={ticket.id}
+                        current={ticket.status}
+                        mode={mode}
+                        labelledBy="ticket-detail-status-label"
+                      />
                     </div>
                   )}
                 </dd>
@@ -238,14 +248,20 @@ export default async function TicketDetailPage({ params }: Props) {
 
               {/* 優先度 (エージェントは変更プルダウン付き) */}
               <div>
-                <dt className="font-medium text-gray-500">優先度</dt>
+                <dt id="ticket-detail-priority-label" className="font-medium text-gray-500">
+                  優先度
+                </dt>
                 <dd className="mt-1">
                   <span className={`text-sm ${PRIORITY_COLORS[ticket.priority] ?? ''}`}>
                     {PRIORITY_LABELS[ticket.priority] ?? ticket.priority}
                   </span>
                   {isAgent && (
                     <div className="mt-1">
-                      <PrioritySelect ticketId={ticket.id} current={ticket.priority} />
+                      <PrioritySelect
+                        ticketId={ticket.id}
+                        current={ticket.priority}
+                        labelledBy="ticket-detail-priority-label"
+                      />
                     </div>
                   )}
                 </dd>
@@ -253,13 +269,16 @@ export default async function TicketDetailPage({ params }: Props) {
 
               {/* 担当者 (エージェントは変更可、それ以外は表示のみ) */}
               <div>
-                <dt className="font-medium text-gray-500">担当者</dt>
+                <dt id="ticket-detail-assignee-label" className="font-medium text-gray-500">
+                  担当者
+                </dt>
                 <dd className="mt-1">
                   {isAgent ? (
                     <AssigneeSelect
                       ticketId={ticket.id}
                       currentAssigneeId={ticket.assigneeId}
                       agents={agents}
+                      labelledBy="ticket-detail-assignee-label"
                     />
                   ) : (
                     <span className="text-gray-700">{ticket.assignee?.name ?? '未割当'}</span>
@@ -271,13 +290,16 @@ export default async function TicketDetailPage({ params }: Props) {
                   フォローアップ 2026-07-14 #4: メール/LINE 取り込みチケットは常にカテゴリ未設定で
                   作成されるため、事後変更できないと永久に未分類のままだった) */}
               <div>
-                <dt className="font-medium text-gray-500">カテゴリ</dt>
+                <dt id="ticket-detail-category-label" className="font-medium text-gray-500">
+                  カテゴリ
+                </dt>
                 <dd className="mt-1">
                   {isAgent && mode === 'pro' ? (
                     <CategorySelect
                       ticketId={ticket.id}
                       currentCategoryId={ticket.categoryId}
                       categories={categories}
+                      labelledBy="ticket-detail-category-label"
                     />
                   ) : (
                     <span className="text-gray-700">{ticket.category?.name ?? '―'}</span>
@@ -289,13 +311,16 @@ export default async function TicketDetailPage({ params }: Props) {
                   それ以外は表示のみ。未指定なら "―"。フォローアップ 2026-07-14 #4: カテゴリと
                   同じくメール/LINE 取り込みチケットの事後変更手段が無かったギャップの解消) */}
               <div>
-                <dt className="font-medium text-gray-500">拠点</dt>
+                <dt id="ticket-detail-location-label" className="font-medium text-gray-500">
+                  拠点
+                </dt>
                 <dd className="mt-1">
                   {isAgent && locations.length > 0 ? (
                     <LocationSelect
                       ticketId={ticket.id}
                       currentLocationId={ticket.locationId}
                       locations={locations}
+                      labelledBy="ticket-detail-location-label"
                     />
                   ) : (
                     <span className="text-gray-700">{ticket.location?.name ?? '―'}</span>

--- a/src/app/(app)/tickets/[id]/page.tsx
+++ b/src/app/(app)/tickets/[id]/page.tsx
@@ -53,6 +53,20 @@ interface Props {
   params: Promise<{ id: string }>;
 }
 
+// サイドバー「詳細」欄の各 <dt> に振る id の単一の参照元。
+// フォローアップ (2026-07-16 #2 レビュー対応): 各 id は元々 <dt id="..."> と
+// 対応する select の labelledBy="..." の 2 箇所に同じ文字列を直書きしていたが、
+// これは §6「マジック文字列を避ける・単一の参照元に置く」に反し、どちらか片方だけ
+// typo した場合にコンパイルエラーも lint エラーも出ないまま aria-labelledby が
+// 静かに壊れる (対応する dt が見つからず読み上げられない) リスクがあった
+const FIELD_LABEL_IDS = {
+  status: 'ticket-detail-status-label',
+  priority: 'ticket-detail-priority-label',
+  assignee: 'ticket-detail-assignee-label',
+  category: 'ticket-detail-category-label',
+  location: 'ticket-detail-location-label',
+} as const;
+
 // /tickets/[id] : チケット詳細ページ
 export default async function TicketDetailPage({ params }: Props) {
   // 動的セグメントを取り出す
@@ -224,7 +238,7 @@ export default async function TicketDetailPage({ params }: Props) {
                   どの dt の値を変更するかプログラム的に伝わっていなかった) の解消。dt に id を
                   振り、対応する select から aria-labelledby で参照する */}
               <div>
-                <dt id="ticket-detail-status-label" className="font-medium text-gray-500">
+                <dt id={FIELD_LABEL_IDS.status} className="font-medium text-gray-500">
                   ステータス
                 </dt>
                 <dd className="mt-1">
@@ -239,7 +253,7 @@ export default async function TicketDetailPage({ params }: Props) {
                         ticketId={ticket.id}
                         current={ticket.status}
                         mode={mode}
-                        labelledBy="ticket-detail-status-label"
+                        labelledBy={FIELD_LABEL_IDS.status}
                       />
                     </div>
                   )}
@@ -248,7 +262,7 @@ export default async function TicketDetailPage({ params }: Props) {
 
               {/* 優先度 (エージェントは変更プルダウン付き) */}
               <div>
-                <dt id="ticket-detail-priority-label" className="font-medium text-gray-500">
+                <dt id={FIELD_LABEL_IDS.priority} className="font-medium text-gray-500">
                   優先度
                 </dt>
                 <dd className="mt-1">
@@ -260,7 +274,7 @@ export default async function TicketDetailPage({ params }: Props) {
                       <PrioritySelect
                         ticketId={ticket.id}
                         current={ticket.priority}
-                        labelledBy="ticket-detail-priority-label"
+                        labelledBy={FIELD_LABEL_IDS.priority}
                       />
                     </div>
                   )}
@@ -269,7 +283,7 @@ export default async function TicketDetailPage({ params }: Props) {
 
               {/* 担当者 (エージェントは変更可、それ以外は表示のみ) */}
               <div>
-                <dt id="ticket-detail-assignee-label" className="font-medium text-gray-500">
+                <dt id={FIELD_LABEL_IDS.assignee} className="font-medium text-gray-500">
                   担当者
                 </dt>
                 <dd className="mt-1">
@@ -278,7 +292,7 @@ export default async function TicketDetailPage({ params }: Props) {
                       ticketId={ticket.id}
                       currentAssigneeId={ticket.assigneeId}
                       agents={agents}
-                      labelledBy="ticket-detail-assignee-label"
+                      labelledBy={FIELD_LABEL_IDS.assignee}
                     />
                   ) : (
                     <span className="text-gray-700">{ticket.assignee?.name ?? '未割当'}</span>
@@ -290,7 +304,7 @@ export default async function TicketDetailPage({ params }: Props) {
                   フォローアップ 2026-07-14 #4: メール/LINE 取り込みチケットは常にカテゴリ未設定で
                   作成されるため、事後変更できないと永久に未分類のままだった) */}
               <div>
-                <dt id="ticket-detail-category-label" className="font-medium text-gray-500">
+                <dt id={FIELD_LABEL_IDS.category} className="font-medium text-gray-500">
                   カテゴリ
                 </dt>
                 <dd className="mt-1">
@@ -299,7 +313,7 @@ export default async function TicketDetailPage({ params }: Props) {
                       ticketId={ticket.id}
                       currentCategoryId={ticket.categoryId}
                       categories={categories}
-                      labelledBy="ticket-detail-category-label"
+                      labelledBy={FIELD_LABEL_IDS.category}
                     />
                   ) : (
                     <span className="text-gray-700">{ticket.category?.name ?? '―'}</span>
@@ -311,7 +325,7 @@ export default async function TicketDetailPage({ params }: Props) {
                   それ以外は表示のみ。未指定なら "―"。フォローアップ 2026-07-14 #4: カテゴリと
                   同じくメール/LINE 取り込みチケットの事後変更手段が無かったギャップの解消) */}
               <div>
-                <dt id="ticket-detail-location-label" className="font-medium text-gray-500">
+                <dt id={FIELD_LABEL_IDS.location} className="font-medium text-gray-500">
                   拠点
                 </dt>
                 <dd className="mt-1">
@@ -320,7 +334,7 @@ export default async function TicketDetailPage({ params }: Props) {
                       ticketId={ticket.id}
                       currentLocationId={ticket.locationId}
                       locations={locations}
-                      labelledBy="ticket-detail-location-label"
+                      labelledBy={FIELD_LABEL_IDS.location}
                     />
                   ) : (
                     <span className="text-gray-700">{ticket.location?.name ?? '―'}</span>

--- a/src/components/layout/RouteFocusManager.tsx
+++ b/src/components/layout/RouteFocusManager.tsx
@@ -1,28 +1,46 @@
 'use client';
 
-// 現在パスの変化を検知するための Next.js フックと、初回マウント判定用の ref フック
+// 現在パスの変化を検知するための Next.js フックと、初回パス記憶用の ref フック
 import { usePathname } from 'next/navigation';
 import { useEffect, useRef } from 'react';
+// (app) レイアウトの <main> に振った id の単一の参照元 (§6 マジック文字列を避ける)
+import { MAIN_CONTENT_ID } from '@/components/layout/main-content-id';
 
 // CLAUDE.md §7 a11y: 「SPA でページ遷移したらフォーカスを新ページの先頭 (main 等) へ移す」。
 // Next.js App Router のクライアントサイド遷移 (Link 経由) はブラウザの通常のページ遷移と異なり、
 // フォーカスを暗黙にリセットしない。ページ遷移後もフォーカスが遷移前の要素 (例: サイドバーの
 // リンク) に残り続け、スクリーンリーダー利用者は新しいページの内容に気づけない。
 // 遷移のたびに #main-content (SkipLink の遷移先と共通) へフォーカスを移す。
+//
+// 対象範囲について: usePathname() はクエリ文字列 (検索パラメータ) の変化には反応しない
+// (パス部分のみを返す)。TicketFilters.tsx の絞り込みプルダウンはクエリ文字列のみを書き換える
+// 遷移のため、この副作用は発火しない。これは意図的な範囲限定であり不具合ではない ―
+// 絞り込み操作は利用者自身がその場でセレクトを操作した直後であり、そこからフォーカスを
+// 本文へ強制的に奪うことは WCAG 3.2.1/3.2.2 が禁じる「利用者の入力による予期しない
+// コンテキスト変化」に該当しうるため、ここでは実際のページ遷移 (パス変化) のみを対象にする。
 export function RouteFocusManager() {
   // 現在の URL パス (クライアントサイド遷移のたびに変わる)
   const pathname = usePathname();
-  // 初回マウント (＝実際のページロード。ブラウザが自然にフォーカスを扱うため対象外) かどうかの判定用
-  const isFirstRender = useRef(true);
+  // マウント時点のパスを 1 度だけ記憶する ref。
+  // フォローアップ (2026-07-16 #2 レビュー対応): 当初は useEffect 内で
+  // `isFirstRender.current = false` と代入するフラグ方式だったが、React の
+  // Strict Mode (開発時、Next.js App Router は既定で有効) は副作用を
+  // マウント→クリーンアップ→再マウントの順で 2 回連続実行するため、
+  // 1 回目の実行でフラグが false に書き換わった直後に 2 回目が実行され、
+  // 「初回マウント時はフォーカスを奪わない」という意図に反して初回ロード時にも
+  // focus() が呼ばれてしまっていた。ref の初期値としてマウント時のパスをそのまま
+  // 記憶し、以降は「現在のパスが記憶した初期パスと異なるか」だけで判定することで、
+  // 副作用側で状態を書き換えない (Strict Mode の 2 回実行でも判定結果が変わらない)
+  // 実装に変更した。
+  const initialPathname = useRef(pathname);
 
   useEffect(() => {
-    // 初回マウント時はフォーカスを奪わない (通常のページロードの挙動を尊重する)
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
+    // 現在のパスが初期パスと同じ (＝まだ実際のページ遷移が起きていない) ならフォーカスを奪わない
+    if (pathname === initialPathname.current) {
       return;
     }
-    // 2 回目以降 (＝クライアントサイド遷移) はメインコンテンツの先頭にフォーカスを移す
-    document.getElementById('main-content')?.focus();
+    // パスが変わった (＝クライアントサイド遷移が起きた) 場合のみメインコンテンツへフォーカスを移す
+    document.getElementById(MAIN_CONTENT_ID)?.focus();
   }, [pathname]);
 
   // 画面には何も描画しない (副作用のみのコンポーネント)

--- a/src/components/layout/RouteFocusManager.tsx
+++ b/src/components/layout/RouteFocusManager.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+// 現在パスの変化を検知するための Next.js フックと、初回マウント判定用の ref フック
+import { usePathname } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+// CLAUDE.md §7 a11y: 「SPA でページ遷移したらフォーカスを新ページの先頭 (main 等) へ移す」。
+// Next.js App Router のクライアントサイド遷移 (Link 経由) はブラウザの通常のページ遷移と異なり、
+// フォーカスを暗黙にリセットしない。ページ遷移後もフォーカスが遷移前の要素 (例: サイドバーの
+// リンク) に残り続け、スクリーンリーダー利用者は新しいページの内容に気づけない。
+// 遷移のたびに #main-content (SkipLink の遷移先と共通) へフォーカスを移す。
+export function RouteFocusManager() {
+  // 現在の URL パス (クライアントサイド遷移のたびに変わる)
+  const pathname = usePathname();
+  // 初回マウント (＝実際のページロード。ブラウザが自然にフォーカスを扱うため対象外) かどうかの判定用
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    // 初回マウント時はフォーカスを奪わない (通常のページロードの挙動を尊重する)
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    // 2 回目以降 (＝クライアントサイド遷移) はメインコンテンツの先頭にフォーカスを移す
+    document.getElementById('main-content')?.focus();
+  }, [pathname]);
+
+  // 画面には何も描画しない (副作用のみのコンポーネント)
+  return null;
+}

--- a/src/components/layout/SkipLink.tsx
+++ b/src/components/layout/SkipLink.tsx
@@ -1,12 +1,32 @@
+'use client';
+
+// (app) レイアウトの <main> に振った id の単一の参照元 (§6 マジック文字列を避ける)
+import { MAIN_CONTENT_ID } from '@/components/layout/main-content-id';
+
 // CLAUDE.md §7 a11y: 「本文へ飛ぶスキップリンク」。キーボード利用者がヘッダー/サイドバーの
 // ナビゲーションを毎ページ読み上げ/Tab移動せずに本文 (#main-content) へ直接移動できるようにする。
 // 通常は視覚的に隠し (sr-only)、フォーカスを受けたときだけ表示する定番パターン。
 export function SkipLink() {
+  // クリック時に本文へ明示的にフォーカスを移す関数
+  // (Safari/VoiceOver はページ内フラグメントリンクのクリックでスクロールはするが、
+  // 対象要素が tabIndex={-1} でもフォーカスは移動しない既知の挙動があるため、
+  // href によるネイティブなフラグメント遷移だけに頼らず、明示的に focus() を呼んで
+  // Chromium/Firefox/Safari のいずれでも確実にフォーカスが移るようにする)
+  function handleClick() {
+    // 本文要素を id で取得する (見つからない場合は何もしない)
+    document.getElementById(MAIN_CONTENT_ID)?.focus();
+  }
+
+  // スキップリンク本体を返す
   return (
+    // href は通常のフラグメント遷移として残しつつ (JS 無効時のフォールバック)、
+    // onClick で明示的な focus() も併用する
     <a
-      href="#main-content"
+      href={`#${MAIN_CONTENT_ID}`}
+      onClick={handleClick}
       className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-teal-700 focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-white focus:ring-2 focus:ring-teal-500/30 focus:outline-none"
     >
+      {/* リンクの可視テキスト (通常は sr-only で隠れる) */}
       本文へスキップ
     </a>
   );

--- a/src/components/layout/SkipLink.tsx
+++ b/src/components/layout/SkipLink.tsx
@@ -1,0 +1,13 @@
+// CLAUDE.md §7 a11y: 「本文へ飛ぶスキップリンク」。キーボード利用者がヘッダー/サイドバーの
+// ナビゲーションを毎ページ読み上げ/Tab移動せずに本文 (#main-content) へ直接移動できるようにする。
+// 通常は視覚的に隠し (sr-only)、フォーカスを受けたときだけ表示する定番パターン。
+export function SkipLink() {
+  return (
+    <a
+      href="#main-content"
+      className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-teal-700 focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-white focus:ring-2 focus:ring-teal-500/30 focus:outline-none"
+    >
+      本文へスキップ
+    </a>
+  );
+}

--- a/src/components/layout/main-content-id.ts
+++ b/src/components/layout/main-content-id.ts
@@ -1,0 +1,6 @@
+// (app) レイアウトの <main> に振る DOM id の単一の参照元。
+// SkipLink (遷移先の href)・(app)/layout.tsx (<main> 本体の id)・RouteFocusManager
+// (document.getElementById での取得先) の 3 箇所で同じ文字列を直書きすると、
+// 将来どれか 1 箇所だけリネームし忘れた場合にコンパイルエラーも lint エラーも出ないまま
+// スキップリンク/フォーカス移動が静かに壊れる (§6 マジック文字列を避ける・単一の参照元に置く)
+export const MAIN_CONTENT_ID = 'main-content';

--- a/src/features/tickets/components/AssigneeSelect.tsx
+++ b/src/features/tickets/components/AssigneeSelect.tsx
@@ -8,21 +8,23 @@ import { updateTicketAssignee } from '@/features/tickets/actions/update-ticket';
 // 共通化した (§6 DRY)。挙動 (value/onChange/disabled/クラス名) は変更していない。
 import { EntitySelect, type EntityOption } from '@/features/tickets/components/EntitySelect';
 
-// 受け取る props (チケット ID/現担当者 ID/候補一覧)
+// 受け取る props (チケット ID/現担当者 ID/候補一覧/紐付け先ラベルの id)
 interface Props {
   ticketId: string;
   currentAssigneeId: string | null;
   agents: EntityOption[];
+  labelledBy: string;
 }
 
 // 担当者を切り替えるプルダウン (空文字 = 未割当)
-export function AssigneeSelect({ ticketId, currentAssigneeId, agents }: Props) {
+export function AssigneeSelect({ ticketId, currentAssigneeId, agents, labelledBy }: Props) {
   return (
     <EntitySelect
       currentId={currentAssigneeId}
       options={agents}
       emptyLabel="未割当"
       onChange={(newId) => updateTicketAssignee(ticketId, newId)}
+      labelledBy={labelledBy}
     />
   );
 }

--- a/src/features/tickets/components/CategorySelect.tsx
+++ b/src/features/tickets/components/CategorySelect.tsx
@@ -5,21 +5,23 @@ import { updateTicketCategory } from '@/features/tickets/actions/update-ticket';
 // チケット詳細ページの各種プルダウンが共有する汎用セレクト (§6 DRY)
 import { EntitySelect, type EntityOption } from '@/features/tickets/components/EntitySelect';
 
-// 受け取る props (チケット ID/現カテゴリ ID/候補一覧)
+// 受け取る props (チケット ID/現カテゴリ ID/候補一覧/紐付け先ラベルの id)
 interface Props {
   ticketId: string;
   currentCategoryId: string | null;
   categories: EntityOption[];
+  labelledBy: string;
 }
 
 // カテゴリを切り替えるプルダウン (空文字 = 未分類)
-export function CategorySelect({ ticketId, currentCategoryId, categories }: Props) {
+export function CategorySelect({ ticketId, currentCategoryId, categories, labelledBy }: Props) {
   return (
     <EntitySelect
       currentId={currentCategoryId}
       options={categories}
       emptyLabel="未分類"
       onChange={(newId) => updateTicketCategory(ticketId, newId)}
+      labelledBy={labelledBy}
     />
   );
 }

--- a/src/features/tickets/components/EntitySelect.tsx
+++ b/src/features/tickets/components/EntitySelect.tsx
@@ -19,6 +19,9 @@ interface Props {
   // 選択変更時に呼ばれる (空文字は null に正規化済み)。呼び出し先のサーバーアクション
   // (updateTicketAssignee 等) は Promise を返す非同期関数なので、戻り値の型に Promise<void> も許容する
   onChange: (newId: string | null) => void | Promise<void>;
+  // このセレクトの意味を伝える可視ラベル (呼び出し元ページの dt 要素) の id。
+  // フォローアップ (2026-07-16 #2): §4.8 で残していた a11y ギャップ (label 関連付け欠如) の解消
+  labelledBy: string;
 }
 
 // チケット詳細ページの各種プルダウン (担当者/カテゴリ/拠点) が共有する汎用セレクト。
@@ -35,7 +38,12 @@ interface Props {
 // (フォローアップ 2026-07-15 #3) と FaqStatusButton (フォローアップ 2026-07-15) で先に直した
 // 「送信中は無効化し、エラーはその場に表示、競合時は router.refresh() で最新化する」パターンを
 // ここにも適用する。
-export function EntitySelect({ currentId, options, emptyLabel, onChange }: Props) {
+//
+// フォローアップ (2026-07-16 #2): §4.8 のこの直前のコメントブロックが「別途 5 種まとめて対応する」と
+// 明記して残していた a11y ギャップ (この select がどの dt の値を表すか、プログラム的な関連付けが
+// 無かった) の解消。呼び出し元ページの dt に振った id を labelledBy として受け取り、
+// aria-labelledby として select に渡す。
+export function EntitySelect({ currentId, options, emptyLabel, onChange, labelledBy }: Props) {
   // 失敗時にサーバーの最新状態を取り直すためのルーター
   const router = useRouter();
   // 送信中フラグ + トランジション関数
@@ -70,6 +78,7 @@ export function EntitySelect({ currentId, options, emptyLabel, onChange }: Props
         value={currentId ?? ''}
         onChange={handleChange}
         disabled={isPending}
+        aria-labelledby={labelledBy}
         className="rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none disabled:opacity-50"
       >
         {/* 空文字 = 未選択 */}

--- a/src/features/tickets/components/LocationSelect.tsx
+++ b/src/features/tickets/components/LocationSelect.tsx
@@ -5,21 +5,23 @@ import { updateTicketLocation } from '@/features/tickets/actions/update-ticket';
 // チケット詳細ページの各種プルダウンが共有する汎用セレクト (§6 DRY)
 import { EntitySelect, type EntityOption } from '@/features/tickets/components/EntitySelect';
 
-// 受け取る props (チケット ID/現拠点 ID/候補一覧)
+// 受け取る props (チケット ID/現拠点 ID/候補一覧/紐付け先ラベルの id)
 interface Props {
   ticketId: string;
   currentLocationId: string | null;
   locations: EntityOption[];
+  labelledBy: string;
 }
 
 // 拠点を切り替えるプルダウン (空文字 = 未指定)
-export function LocationSelect({ ticketId, currentLocationId, locations }: Props) {
+export function LocationSelect({ ticketId, currentLocationId, locations, labelledBy }: Props) {
   return (
     <EntitySelect
       currentId={currentLocationId}
       options={locations}
       emptyLabel="未指定"
       onChange={(newId) => updateTicketLocation(ticketId, newId)}
+      labelledBy={labelledBy}
     />
   );
 }

--- a/src/features/tickets/components/PrioritySelect.tsx
+++ b/src/features/tickets/components/PrioritySelect.tsx
@@ -18,13 +18,16 @@ const ALL_PRIORITIES: Priority[] = ['Low', 'Medium', 'High'];
 interface Props {
   ticketId: string;
   current: Priority;
+  // このセレクトの意味を伝える可視ラベル (dt 要素) の id。
+  // フォローアップ (2026-07-16 #2): §4.8 で残していた a11y ギャップ (label 関連付け欠如) の解消
+  labelledBy: string;
 }
 
 // フォローアップ (2026-07-15 #3): updateTicketPriority も updateTicketStatus と同じく
 // check-then-act 競合時に Error を throw するようになったため、StatusSelect と同じく
 // 送信中はセレクトを無効化しエラーはその場に表示する
 // 優先度を切り替えるプルダウン (エージェント向け)
-export function PrioritySelect({ ticketId, current }: Props) {
+export function PrioritySelect({ ticketId, current, labelledBy }: Props) {
   // 失敗時にサーバーの最新状態を取り直すためのルーター
   const router = useRouter();
   // 送信中フラグ + トランジション
@@ -58,6 +61,7 @@ export function PrioritySelect({ ticketId, current }: Props) {
         value={current}
         onChange={handleChange}
         disabled={isPending}
+        aria-labelledby={labelledBy}
         className="rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none disabled:opacity-50"
       >
         {/* 全優先度を順に option として描画 */}

--- a/src/features/tickets/components/StatusSelect.tsx
+++ b/src/features/tickets/components/StatusSelect.tsx
@@ -20,6 +20,10 @@ interface Props {
   ticketId: string;
   current: TicketStatus;
   mode: TenantMode;
+  // このセレクトの意味を伝える可視ラベル (dt 要素) の id。
+  // フォローアップ (2026-07-16 #2): §4.8 で「別途 5 種まとめて対応する」と明記していた
+  // a11y ギャップ (フォーム入力に対応する <label>/aria-labelledby が無い) の解消
+  labelledBy: string;
 }
 
 // フォローアップ (2026-07-15 #3): updateTicketStatus は check-then-act 競合時に
@@ -27,7 +31,7 @@ interface Props {
 // このセレクトは throw を誰も捕捉しておらず未処理の Promise 拒否になっていた
 // (FaqStatusButton と同じく、送信中はセレクトを無効化しエラーはその場に表示する)
 // ステータスを切り替えるプルダウン (許可された遷移のみ表示)
-export function StatusSelect({ ticketId, current, mode }: Props) {
+export function StatusSelect({ ticketId, current, mode, labelledBy }: Props) {
   // 失敗時にサーバーの最新状態を取り直すためのルーター
   const router = useRouter();
   // 送信中フラグ + トランジション
@@ -64,6 +68,7 @@ export function StatusSelect({ ticketId, current, mode }: Props) {
         value={current}
         onChange={handleChange}
         disabled={isPending}
+        aria-labelledby={labelledBy}
         className="rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none disabled:opacity-50"
       >
         {/* 現在値はプレースホルダ的に disabled で表示 (mode に応じて Lite/Pro ラベル) */}

--- a/src/features/tickets/components/TicketFilters.tsx
+++ b/src/features/tickets/components/TicketFilters.tsx
@@ -91,11 +91,15 @@ export function TicketFilters({ categories, agents, isAgent, mode, locations }: 
     >
       {/* 絞り込みコントロール群 (折り返し可能) */}
       <div className="flex flex-wrap items-center gap-2">
-        {/* キーワード入力 (Enter または検索ボタンで反映) */}
+        {/* キーワード入力 (Enter または検索ボタンで反映)
+            a11y: placeholder はスクリーンリーダーの読み上げ対象として label の代わりにならないため
+            aria-label で明示する (この入力欄には対応する可視ラベル要素が無いため aria-labelledby ではなく
+            aria-label を使う。§7 a11y) */}
         <input
           ref={keywordRef}
           type="search"
           placeholder="キーワード検索"
+          aria-label="キーワード検索"
           // クエリ変化時に再マウントして表示値を同期
           key={searchParams.get('q') ?? ''}
           defaultValue={searchParams.get('q') ?? ''}
@@ -115,10 +119,11 @@ export function TicketFilters({ categories, agents, isAgent, mode, locations }: 
         {/* Lite モードではキーワード検索のみに縮約し、以下のプルダウン群は非表示にする */}
         {!isLite && (
           <>
-            {/* ステータス絞り込み */}
+            {/* ステータス絞り込み (a11y: 対応する可視ラベル要素が無いため aria-label を付与。§7) */}
             <select
               value={searchParams.get('status') ?? ''}
               onChange={(e) => update('status', e.target.value)}
+              aria-label="ステータスで絞り込む"
               className={fieldBaseClass}
             >
               <option value="">すべてのステータス</option>
@@ -128,10 +133,11 @@ export function TicketFilters({ categories, agents, isAgent, mode, locations }: 
                 </option>
               ))}
             </select>
-            {/* 優先度絞り込み */}
+            {/* 優先度絞り込み (a11y: aria-label を付与。§7) */}
             <select
               value={searchParams.get('priority') ?? ''}
               onChange={(e) => update('priority', e.target.value)}
+              aria-label="優先度で絞り込む"
               className={fieldBaseClass}
             >
               <option value="">すべての優先度</option>
@@ -141,10 +147,11 @@ export function TicketFilters({ categories, agents, isAgent, mode, locations }: 
                 </option>
               ))}
             </select>
-            {/* カテゴリ絞り込み */}
+            {/* カテゴリ絞り込み (a11y: aria-label を付与。§7) */}
             <select
               value={searchParams.get('categoryId') ?? ''}
               onChange={(e) => update('categoryId', e.target.value)}
+              aria-label="カテゴリで絞り込む"
               className={fieldBaseClass}
             >
               <option value="">すべてのカテゴリ</option>
@@ -154,11 +161,12 @@ export function TicketFilters({ categories, agents, isAgent, mode, locations }: 
                 </option>
               ))}
             </select>
-            {/* 担当者絞り込み (エージェントのみ表示) */}
+            {/* 担当者絞り込み (エージェントのみ表示。a11y: aria-label を付与。§7) */}
             {isAgent && (
               <select
                 value={searchParams.get('assigneeId') ?? ''}
                 onChange={(e) => update('assigneeId', e.target.value)}
+                aria-label="担当者で絞り込む"
                 className={fieldBaseClass}
               >
                 <option value="">すべての担当者</option>
@@ -171,11 +179,12 @@ export function TicketFilters({ categories, agents, isAgent, mode, locations }: 
                 ))}
               </select>
             )}
-            {/* 拠点絞り込み (登録された拠点が 1 件以上ある場合のみ表示) */}
+            {/* 拠点絞り込み (登録された拠点が 1 件以上ある場合のみ表示。a11y: aria-label を付与。§7) */}
             {locations.length > 0 && (
               <select
                 value={searchParams.get('locationId') ?? ''}
                 onChange={(e) => update('locationId', e.target.value)}
+                aria-label="拠点で絞り込む"
                 className={fieldBaseClass}
               >
                 <option value="">すべての拠点</option>


### PR DESCRIPTION
## Context

定例コードレビュールーチン（CLAUDE.md §7 a11y の要件と実装を再点検する観点）での監査。対応する正本の項目は `docs/smb-dx-pivot-plan.md` §4.10（新規追加）。

`docs/smb-dx-pivot-plan.md` §4.8 のフォローアップ（PR #216 相当）は、チケット詳細画面の 5 種プルダウン（ステータス/優先度/担当者/カテゴリ/拠点）がいずれも `<label>`/`aria-labelledby` によるプログラム的な関連付けを持たない a11y ギャップを発見しつつ「別途 5 種まとめて対応するフォローアップ課題として残す」と明記して意図的にスコープ外にしていました。今回の監査でこの積み残しを解消するとともに、同種の未関連付けギャップがチケット一覧の絞り込みバーにも存在すること、および CLAUDE.md §7 が求める「SPA でページ遷移したらフォーカスを新ページの先頭へ移し、本文へ飛ぶスキップリンクも用意する」が未実装であることを新たに発見し、あわせて対応しました。

## 変更内容

1. **§4.8 の積み残し: チケット詳細画面プルダウンの label 関連付け**
   - `StatusSelect`/`PrioritySelect`/`EntitySelect`（`AssigneeSelect`/`CategorySelect`/`LocationSelect` が共有）に `labelledBy` prop を追加し、select に `aria-labelledby` として渡す。
   - `src/app/(app)/tickets/[id]/page.tsx` の各 `<dt>` に id（`ticket-detail-{status,priority,assignee,category,location}-label`）を振り、対応する select へ渡す。可視テキストを唯一の源にするため `aria-label` の複製ではなく `aria-labelledby` を選択。

2. **チケット一覧の絞り込みバー（`TicketFilters.tsx`）**
   - キーワード検索欄・ステータス/優先度/カテゴリ/担当者/拠点の絞り込みプルダウンには対応する可視ラベル要素自体が無いため、`aria-label` を直接付与（例:「ステータスで絞り込む」）。`placeholder` はアクセシブルネームの正式な代替にならないため、検索欄にも `aria-label="キーワード検索"` を追加。

3. **SPA 遷移後のフォーカス移動・スキップリンク（`(app)/layout.tsx`）**
   - `<main>` に `id="main-content"`/`tabIndex={-1}` を付与。
   - `SkipLink`（`src/components/layout/SkipLink.tsx`）: 通常は `sr-only` で隠し、Tab フォーカスを受けたときのみ表示する「本文へスキップ」リンクを新設。
   - `RouteFocusManager`（`src/components/layout/RouteFocusManager.tsx`）: `usePathname()` の変化を検知し、初回マウント時を除いて `#main-content` へ `focus()` する副作用専用コンポーネントを新設。Next.js App Router の `Link` 遷移はブラウザの通常遷移と異なりフォーカスを暗黙にリセットしないため。

3 件ともサーバー側（Server Action・RBAC・tenantId スコープ）には変更なし。UI 層のみの最小スコープの修正です。

## 検証方法

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run test`（Vitest, DB 不要なユニットテスト）— 1002 passed / 146 skipped (contract tests)
- `npm run test:contract` — このサンドボックス環境に PostgreSQL / Docker が無いためスキップ（本 PR はサーバー側ロジック・Prisma スキーマを一切変更していないため契約テストへの影響なし）
- `npm run test:e2e` — dev サーバー起動環境が無いためスキップ

リポジトリに React コンポーネント向けの単体テスト基盤（jsdom / Testing Library 等）が無く（`vitest.config.ts` は `environment: 'node'` で `tests/**/*.test.ts` のみが対象）、同種の過去の UI 層のみの a11y/属性修正（§1.4/§1.5/§4.9 等）でも専用のコンポーネント単体テストは追加されていないため、本 PR でも追加していません。

/code-review ultra・/security-review ultra を実行し、指摘があれば反映します。

Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_0148WCDcDHBejSBtS1wcfSKw)_