### PR TITLE
fix(faq): FAQ一覧取得(list/listPublished)に上限を追加

### DIFF
--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -1033,6 +1033,35 @@ Phase 2 の差別化の本丸であるメール/LINE 取り込みチャネルを
     （`<dt id="...">` と対応する select の `labelledBy="..."`）も、ページ内の
     `FIELD_LABEL_IDS` 定数にまとめ、リテラル文字列の重複を解消した。
 
+#### 4.11 フォローアップ（2026-07-16 #3）: FAQ 一覧取得に上限が無かった
+
+監査で発見したギャップ: `FaqRepository.list`（エージェント向け管理ビュー）と `listPublished`
+（依頼者向け閲覧ビュー、§1.2 フォローアップ）はどちらも `db.faqCandidate.findMany()` を
+上限・ページネーション無しで呼んでおり、テナントの FAQ 候補が何件あっても全件を 1 度に取得して
+いた。CLAUDE.md §8「一覧取得は必ず上限・ページネーションを持たせる（既定件数・最大件数は定数で
+一元管理する）」に反する。他の一覧系メソッド（`TicketRepository`・`NotificationRepository`・
+`SettingsAuditLogRepository`・`TicketHistoryRepository` 等）はいずれも `take`/`limit` を
+持つのに対し、FAQ だけが唯一の例外だった。FAQ 候補は解決済みチケットから継続的に生成される
+性質上（Phase 3 業種テンプレの自動投入も含む）、カテゴリ/拠点のような小規模な管理者設定データとは
+異なり、テナントの運用期間に応じて際限なく増え得るため、実害のある省略だった。
+
+- `FaqRepository`（`src/data/ports/faq-repository.ts`）に `FAQ_LIST_LIMIT`（200 件。
+  `/audit` の `PAGE_LIMIT` と同じ規模感）を追加し、`list`/`listPublished` の契約に
+  `opts: { limit: number }` を追加した（`NotificationRepository.list` と同じ形）。
+- Prisma アダプタ（`take: opts.limit`）・メモリアダプタ（`.slice(0, opts.limit)`、ソート後に
+  適用して「新しい順の先頭 N 件」を保証）の両方に実装した。
+- `/faq` ページ（`src/app/(app)/faq/page.tsx`）の 2 箇所の呼び出しに
+  `{ limit: FAQ_LIST_LIMIT }` を渡すよう変更した。
+- 本フォローアップは「必ず上限を持たせる」という §8 の核を満たす最小限の対応とし、`/audit`・
+  `/quarantine` のようなキーセットページネーション（「さらに読み込む」）は追加していない
+  （`/notifications` ページの既存の「上限付き一覧・追加ページ無し」という設計と同じ扱い。
+  200 件を超えた FAQ 候補・公開済み FAQ にどちらの立場からも到達できなくなるが、
+  それ自体はチケット一覧・監査ログほど高頻度に発生しない性質のデータであるため、まず
+  上限を設けることを優先した。必要性が高まれば `/audit` と同様のページネーションを
+  別途フォローアップとして追加する）。
+- 回帰テスト: `tests/data/faq-repository.memory.test.ts` / `faq-repository.contract.prisma.test.ts`
+  に、`limit` が新しい順に件数を上限化することを検証するテストを追加した。
+
 ### スケジュール感
 
 ```

--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -1061,6 +1061,28 @@ Phase 2 の差別化の本丸であるメール/LINE 取り込みチャネルを
   別途フォローアップとして追加する）。
 - 回帰テスト: `tests/data/faq-repository.memory.test.ts` / `faq-repository.contract.prisma.test.ts`
   に、`limit` が新しい順に件数を上限化することを検証するテストを追加した。
+- `/code-review ultra` 指摘対応: 複数の独立レビューエージェントが収斂して指摘した以下 3 件を追加修正した。
+  - **アダプタ層に多層防御のクランプが無かった**: 現状の唯一の呼び出し元（`/faq` ページ）は常に
+    `FAQ_LIST_LIMIT` そのものを渡すため実害は無いが、`audit`/`quarantine` の
+    `resolveAuditLimit`（`src/data/adapters/audit-pagination.ts`）が「呼び出し元の指定値を
+    アダプタ側でも上限クランプする」多層防御を持つのに対し、`FaqRepository` の両アダプタは
+    `opts.limit` を無条件に `take`/`slice` へ渡すのみだった。`resolveFaqListLimit(requested)`
+    （`src/data/ports/faq-repository.ts`）を追加し、Prisma/メモリ両アダプタで
+    `take: resolveFaqListLimit(opts.limit)` / `.slice(0, resolveFaqListLimit(opts.limit))`
+    に変更した。将来 Server Action や API がユーザー入力由来の limit をそのまま渡すように
+    なっても、アダプタ層で上限を超えないことを保証する。
+  - **テストが `FAQ_LIST_LIMIT` を使わずリテラル `200` を直書きしていた**: §6「マジック数値を
+    避け単一の参照元に置く」に反し、`audit`/`quarantine` のテストが `AUDIT_MAX_LIMIT` を
+    import する既存の慣習からも外れていた。3 テストファイル（`faq-repository.memory.test.ts`・
+    `faq-repository.contract.prisma.test.ts`・`faq-actions.test.ts`）すべてで
+    `FAQ_LIST_LIMIT` を import して使うよう修正した（新設の limit 上限化テスト自体が使う
+    `{ limit: 1 }` は意図的に小さい値を検証するためのものなので対象外）。
+  - **新設の Prisma 契約テストに createdAt タイの潜在的なフレーキーさがあった**: 新しい順の
+    上限化を検証するテストが、実 DB へ複数のチケット/FAQ 候補を明示的な間隔なしで連続作成して
+    おり、`createdAt`（ミリ秒精度）が同一ミリ秒に揃うと順序アサーションが不安定になり得た。
+    同ファイルの兄弟テスト（メモリアダプタ版）は `setTimeout` で明示的に間隔を空けていたのに対し、
+    この契約テストだけ同種のガードが無い非対称があった。作成のたびに 5ms の間隔を空けるよう
+    修正した。
 
 ### スケジュール感
 

--- a/src/app/(app)/faq/page.tsx
+++ b/src/app/(app)/faq/page.tsx
@@ -14,6 +14,8 @@ import { FaqEditForm } from '@/features/faq/components/FaqEditForm';
 import { FaqStatusButton } from '@/features/faq/components/FaqStatusButton';
 // テナントの動作モード (lite | pro) を取得するヘルパー
 import { getCurrentTenantMode } from '@/lib/tenant';
+// FAQ 一覧取得の既定件数上限 (フォローアップ 2026-07-16 #3: §8 一覧取得の上限必須化)
+import { FAQ_LIST_LIMIT } from '@/data/ports/faq-repository';
 
 // 状態変更ボタン (却下/非公開にする) 共通の outlined スタイル (§6: 同一文字列の重複を避ける)
 const SECONDARY_STATUS_BUTTON_CLASS =
@@ -64,8 +66,8 @@ export default async function FaqPage() {
   // 依頼者 (非エージェント) 向け: 公開済み FAQ のみを閲覧専用で表示する
   // (元チケット・作成者・ステータスバッジ・公開/却下操作は含めない)
   if (!agent) {
-    // 公開済み FAQ 一覧を取得 (質問/回答のみ。§9 最小権限・最小公開)
-    const publishedFaqs = await repos.faq.listPublished(tenantId);
+    // 公開済み FAQ 一覧を取得 (質問/回答のみ。§9 最小権限・最小公開。新しい順に上限 FAQ_LIST_LIMIT 件)
+    const publishedFaqs = await repos.faq.listPublished(tenantId, { limit: FAQ_LIST_LIMIT });
     return (
       <div className="space-y-6">
         {/* ページヘッダー: タイトル + サブテキスト */}
@@ -99,8 +101,8 @@ export default async function FaqPage() {
   }
 
   // エージェント以上向け: 従来どおりの候補管理ビュー (公開/却下操作を含む)
-  // 当該テナントの FAQ 一覧を取得 (元チケットと作成者名を含む、全ステータス)
-  const faqs = await repos.faq.list(tenantId);
+  // 当該テナントの FAQ 一覧を取得 (元チケットと作成者名を含む、全ステータス。新しい順に上限 FAQ_LIST_LIMIT 件)
+  const faqs = await repos.faq.list(tenantId, { limit: FAQ_LIST_LIMIT });
 
   return (
     <div className="space-y-6">

--- a/src/data/adapters/memory/faq-repository.memory.ts
+++ b/src/data/adapters/memory/faq-repository.memory.ts
@@ -1,5 +1,9 @@
 // FAQ リポジトリの契約 (port) と、ドメイン型/ストア関連をインポート
-import type { FaqListItem, FaqRepository } from '@/data/ports/faq-repository';
+import {
+  resolveFaqListLimit,
+  type FaqListItem,
+  type FaqRepository,
+} from '@/data/ports/faq-repository';
 import type { FaqCandidate } from '@/domain/types';
 import { nextId, type Store } from './store';
 
@@ -20,7 +24,7 @@ export function makeFaqRepo(store: Store): FaqRepository {
       const rows = [...store.faq.values()]
         .filter((f) => f.tenantId === tenantId)
         .sort((a, b) => +b.createdAt - +a.createdAt)
-        .slice(0, opts.limit);
+        .slice(0, resolveFaqListLimit(opts.limit)); // 呼び出し元の指定値をさらにクランプ
       // 関連チケットと作成者を引き当てて結合
       return rows.map<FaqListItem>((f) => {
         const ticket = store.tickets.get(f.ticketId); // 元チケット
@@ -44,7 +48,7 @@ export function makeFaqRepo(store: Store): FaqRepository {
       return [...store.faq.values()]
         .filter((f) => f.tenantId === tenantId && f.status === 'Published')
         .sort((a, b) => +b.createdAt - +a.createdAt)
-        .slice(0, opts.limit)
+        .slice(0, resolveFaqListLimit(opts.limit)) // 呼び出し元の指定値をさらにクランプ
         .map((f) => ({ id: f.id, question: f.question, answer: f.answer }));
     },
 

--- a/src/data/adapters/memory/faq-repository.memory.ts
+++ b/src/data/adapters/memory/faq-repository.memory.ts
@@ -13,12 +13,14 @@ export function makeFaqRepo(store: Store): FaqRepository {
       return { ...row }; // 破壊防止のため複製して返す
     },
 
-    // 当該テナントの FAQ 候補を新しい順で一覧化 (関連チケット/作成者名を結合)
-    async list(tenantId) {
-      // Map を配列化し、テナントで絞ったうえで作成日時の降順で並べる
+    // 当該テナントの FAQ 候補を新しい順で一覧化 (関連チケット/作成者名を結合)。
+    // opts.limit で取得件数を上限化する (フォローアップ 2026-07-16 #3: §8 一覧取得の上限必須化)
+    async list(tenantId, opts) {
+      // Map を配列化し、テナントで絞ったうえで作成日時の降順で並べ、上限件数で切り詰める
       const rows = [...store.faq.values()]
         .filter((f) => f.tenantId === tenantId)
-        .sort((a, b) => +b.createdAt - +a.createdAt);
+        .sort((a, b) => +b.createdAt - +a.createdAt)
+        .slice(0, opts.limit);
       // 関連チケットと作成者を引き当てて結合
       return rows.map<FaqListItem>((f) => {
         const ticket = store.tickets.get(f.ticketId); // 元チケット
@@ -36,11 +38,13 @@ export function makeFaqRepo(store: Store): FaqRepository {
     },
 
     // 当該テナントの公開済み (Published) FAQ を新しい順で一覧化 (依頼者含む全メンバー向け。
-    // 元チケット/作成者は含めない範囲最小化のため質問/回答のみ返す)
-    async listPublished(tenantId) {
+    // 元チケット/作成者は含めない範囲最小化のため質問/回答のみ返す)。
+    // opts.limit で取得件数を上限化する (フォローアップ 2026-07-16 #3: §8 一覧取得の上限必須化)
+    async listPublished(tenantId, opts) {
       return [...store.faq.values()]
         .filter((f) => f.tenantId === tenantId && f.status === 'Published')
         .sort((a, b) => +b.createdAt - +a.createdAt)
+        .slice(0, opts.limit)
         .map((f) => ({ id: f.id, question: f.question, answer: f.answer }));
     },
 

--- a/src/data/adapters/prisma/faq-repository.prisma.ts
+++ b/src/data/adapters/prisma/faq-repository.prisma.ts
@@ -12,11 +12,13 @@ export function makeFaqRepo(db: PrismaLike): FaqRepository {
       return row ? toFaq(row) : null;
     },
 
-    // 当該テナントの FAQ 候補一覧を取得 (新しい順、関連チケットと作成者を同梱)
-    async list(tenantId) {
+    // 当該テナントの FAQ 候補一覧を取得 (新しい順、関連チケットと作成者を同梱)。
+    // opts.limit で取得件数を上限化する (フォローアップ 2026-07-16 #3: §8 一覧取得の上限必須化)
+    async list(tenantId, opts) {
       const rows = await db.faqCandidate.findMany({
         where: { tenantId }, // テナントスコープ (必須)
         orderBy: { createdAt: 'desc' }, // 新しい順
+        take: opts.limit, // 件数上限
         include: {
           // 関連チケットの最小情報を JOIN
           ticket: { select: { id: true, title: true } },
@@ -33,12 +35,14 @@ export function makeFaqRepo(db: PrismaLike): FaqRepository {
     },
 
     // 当該テナントの公開済み (Published) FAQ 一覧を取得 (依頼者含む全メンバー向け。
-    // 元チケット/作成者は含めない範囲最小化のため select で question/answer のみに絞る)
-    async listPublished(tenantId) {
+    // 元チケット/作成者は含めない範囲最小化のため select で question/answer のみに絞る)。
+    // opts.limit で取得件数を上限化する (フォローアップ 2026-07-16 #3: §8 一覧取得の上限必須化)
+    async listPublished(tenantId, opts) {
       // select の形が PublishedFaqItem と一致するため中間変数を使わずそのまま返す
       return db.faqCandidate.findMany({
         where: { tenantId, status: 'Published' }, // テナントスコープ + 公開済みのみ
         orderBy: { createdAt: 'desc' }, // 新しい順
+        take: opts.limit, // 件数上限
         select: { id: true, question: true, answer: true }, // 質問/回答/IDのみ取得 (範囲最小化)
       });
     },

--- a/src/data/adapters/prisma/faq-repository.prisma.ts
+++ b/src/data/adapters/prisma/faq-repository.prisma.ts
@@ -1,5 +1,9 @@
 // FAQ リポジトリの契約 (port)、マッパー、Prisma 共通型をインポート
-import type { FaqListItem, FaqRepository } from '@/data/ports/faq-repository';
+import {
+  resolveFaqListLimit,
+  type FaqListItem,
+  type FaqRepository,
+} from '@/data/ports/faq-repository';
 import { toFaq } from './mappers';
 import type { PrismaLike } from './types';
 
@@ -18,7 +22,7 @@ export function makeFaqRepo(db: PrismaLike): FaqRepository {
       const rows = await db.faqCandidate.findMany({
         where: { tenantId }, // テナントスコープ (必須)
         orderBy: { createdAt: 'desc' }, // 新しい順
-        take: opts.limit, // 件数上限
+        take: resolveFaqListLimit(opts.limit), // 件数上限 (呼び出し元の指定値をさらにクランプ)
         include: {
           // 関連チケットの最小情報を JOIN
           ticket: { select: { id: true, title: true } },
@@ -42,7 +46,7 @@ export function makeFaqRepo(db: PrismaLike): FaqRepository {
       return db.faqCandidate.findMany({
         where: { tenantId, status: 'Published' }, // テナントスコープ + 公開済みのみ
         orderBy: { createdAt: 'desc' }, // 新しい順
-        take: opts.limit, // 件数上限
+        take: resolveFaqListLimit(opts.limit), // 件数上限 (呼び出し元の指定値をさらにクランプ)
         select: { id: true, question: true, answer: true }, // 質問/回答/IDのみ取得 (範囲最小化)
       });
     },

--- a/src/data/ports/faq-repository.ts
+++ b/src/data/ports/faq-repository.ts
@@ -1,6 +1,13 @@
 // ドメイン型 (FAQ 候補/FAQ 状態) をインポート
 import type { FaqCandidate, FaqStatus } from '@/domain/types';
 
+// FAQ 一覧 (list/listPublished 共通) の既定件数上限。
+// フォローアップ (2026-07-16 #3): list/listPublished が上限なしで全件取得しており、
+// CLAUDE.md §8「一覧取得は必ず上限・ページネーションを持たせる」に反していた
+// (FAQ 候補は解決済みチケットから継続的に積み上がる性質上、無制限に増え得る)。
+// audit ログの PAGE_LIMIT (200 件) と同じ規模感に揃える
+export const FAQ_LIST_LIMIT = 200;
+
 // FAQ 候補を新規作成するときの入力値
 export interface CreateFaqInput {
   ticketId: string; // 元となったチケット ID
@@ -30,11 +37,13 @@ export interface PublishedFaqItem {
 export interface FaqRepository {
   // ID + tenantId で 1 件取得 (他テナントの ID なら null)
   findById(id: string, tenantId: string): Promise<FaqCandidate | null>;
-  // 当該テナントの FAQ 候補一覧を取得 (エージェント向け管理画面用。全ステータスを含む)
-  list(tenantId: string): Promise<FaqListItem[]>;
+  // 当該テナントの FAQ 候補一覧を取得 (エージェント向け管理画面用。全ステータスを含む)。
+  // opts.limit で新しい順に取得件数を上限化する (フォローアップ 2026-07-16 #3)
+  list(tenantId: string, opts: { limit: number }): Promise<FaqListItem[]>;
   // 当該テナントの公開済み (Published) FAQ 一覧を取得する (依頼者含む全メンバーが閲覧可能。
-  // フォローアップ 2026-07-14 #5)
-  listPublished(tenantId: string): Promise<PublishedFaqItem[]>;
+  // フォローアップ 2026-07-14 #5)。opts.limit で新しい順に取得件数を上限化する
+  // (フォローアップ 2026-07-16 #3)
+  listPublished(tenantId: string, opts: { limit: number }): Promise<PublishedFaqItem[]>;
   // 候補を作成 (input.tenantId 必須)
   create(input: CreateFaqInput): Promise<FaqCandidate>;
   // 公開/却下などの状態更新 (tenantId スコープ。他テナントの ID なら 0 件更新で no-op)。

--- a/src/data/ports/faq-repository.ts
+++ b/src/data/ports/faq-repository.ts
@@ -8,6 +8,16 @@ import type { FaqCandidate, FaqStatus } from '@/domain/types';
 // audit ログの PAGE_LIMIT (200 件) と同じ規模感に揃える
 export const FAQ_LIST_LIMIT = 200;
 
+// 呼び出し側が指定した limit を FAQ_LIST_LIMIT 以下にクランプする。
+// /code-review ultra 指摘対応: 現状の唯一の呼び出し元 (/faq ページ) は常に FAQ_LIST_LIMIT
+// そのものを渡すため実害はないが、audit/quarantine の `resolveAuditLimit`
+// （`src/data/adapters/audit-pagination.ts`）と同じく、将来 Server Action や API が
+// ユーザー入力由来の limit をそのまま渡すようになっても Prisma/メモリ両アダプタ側で
+// 無制限クエリにならないよう、アダプタ層でも下限として機能させる (fail-closed の多層防御)
+export function resolveFaqListLimit(requested: number): number {
+  return Math.min(requested, FAQ_LIST_LIMIT);
+}
+
 // FAQ 候補を新規作成するときの入力値
 export interface CreateFaqInput {
   ticketId: string; // 元となったチケット ID

--- a/tests/data/faq-repository.contract.prisma.test.ts
+++ b/tests/data/faq-repository.contract.prisma.test.ts
@@ -9,6 +9,7 @@
 import { describe, beforeAll, afterAll, beforeEach, expect, it } from 'vitest';
 import { PrismaClient } from '@/generated/prisma';
 import { buildPrismaRepos } from '@/data/adapters/prisma';
+import { FAQ_LIST_LIMIT } from '@/data/ports/faq-repository';
 
 const TENANT_A = 'tenant-a';
 const TENANT_B = 'tenant-b';
@@ -94,7 +95,7 @@ describe.runIf(SHOULD_RUN)('FaqRepository (prisma adapter)', () => {
       answer: 'AA',
       tenantId: TENANT_A,
     });
-    const result = await repos.faq.list(TENANT_A, { limit: 200 });
+    const result = await repos.faq.list(TENANT_A, { limit: FAQ_LIST_LIMIT });
     expect(result).toHaveLength(1);
     expect(result[0].ticket.title).toBe('テナントAのチケット');
     expect(result[0].createdBy.name).toBe('エージェントA');
@@ -130,7 +131,7 @@ describe.runIf(SHOULD_RUN)('FaqRepository (prisma adapter)', () => {
       tenantId: TENANT_A,
     });
 
-    const result = await repos.faq.listPublished(TENANT_A, { limit: 200 });
+    const result = await repos.faq.listPublished(TENANT_A, { limit: FAQ_LIST_LIMIT });
     expect(result).toEqual([
       { id: published.id, question: '公開済みの質問', answer: '公開済みの回答' },
     ]);
@@ -160,6 +161,11 @@ describe.runIf(SHOULD_RUN)('FaqRepository (prisma adapter)', () => {
         answer: `回答${i}`,
         tenantId: TENANT_A,
       });
+      // 実 DB の createdAt はミリ秒精度のため、順序アサーションが同一ミリ秒の
+      // タイに左右されないよう作成タイミングを確実にずらす
+      // (/code-review ultra 指摘対応: memory アダプタ版の同名テストは
+      // setTimeout で明示的にずらしていたが、この契約テストには無かった)
+      await new Promise((r) => setTimeout(r, 5));
     }
     for (let i = 0; i < 2; i++) {
       const ticket = await repos.tickets.create({
@@ -180,6 +186,8 @@ describe.runIf(SHOULD_RUN)('FaqRepository (prisma adapter)', () => {
       });
       await repos.faq.updateStatus(faq.id, { from: 'Candidate', to: 'Published' }, TENANT_A);
       lastPublishedId = faq.id;
+      // 同一ミリ秒の createdAt タイを避けるため作成タイミングをずらす (上と同じ理由)
+      await new Promise((r) => setTimeout(r, 5));
     }
 
     // 全 4 件のうち limit: 1 なら 1 件だけ (最新のもの) が返る

--- a/tests/data/faq-repository.contract.prisma.test.ts
+++ b/tests/data/faq-repository.contract.prisma.test.ts
@@ -94,7 +94,7 @@ describe.runIf(SHOULD_RUN)('FaqRepository (prisma adapter)', () => {
       answer: 'AA',
       tenantId: TENANT_A,
     });
-    const result = await repos.faq.list(TENANT_A);
+    const result = await repos.faq.list(TENANT_A, { limit: 200 });
     expect(result).toHaveLength(1);
     expect(result[0].ticket.title).toBe('テナントAのチケット');
     expect(result[0].createdBy.name).toBe('エージェントA');
@@ -130,10 +130,67 @@ describe.runIf(SHOULD_RUN)('FaqRepository (prisma adapter)', () => {
       tenantId: TENANT_A,
     });
 
-    const result = await repos.faq.listPublished(TENANT_A);
+    const result = await repos.faq.listPublished(TENANT_A, { limit: 200 });
     expect(result).toEqual([
       { id: published.id, question: '公開済みの質問', answer: '公開済みの回答' },
     ]);
+  });
+
+  // list/listPublished: limit で件数が上限化される (実 DB の take が効くことの確認)
+  // フォローアップ (2026-07-16 #3): 監査で発見したギャップ。§8「一覧取得は必ず上限を持たせる」に
+  // 反し、以前は limit 引数自体が存在せず常に全件返していた
+  it('listとlistPublishedはlimitで新しい順に件数を上限化する', async () => {
+    const repos = buildPrismaRepos(prisma);
+    // FaqCandidate.ticketId はユニーク制約 (1 チケット 1 候補) のため、候補ごとに別チケットを使う
+    let lastPublishedId = '';
+    for (let i = 0; i < 2; i++) {
+      const ticket = await repos.tickets.create({
+        title: `候補用チケット${i}`,
+        body: '本文',
+        priority: 'Medium',
+        creatorId: AGENT_A,
+        categoryId: null,
+        locationId: null,
+        tenantId: TENANT_A,
+      });
+      await repos.faq.create({
+        ticketId: ticket.id,
+        createdById: AGENT_A,
+        question: `候補${i}`,
+        answer: `回答${i}`,
+        tenantId: TENANT_A,
+      });
+    }
+    for (let i = 0; i < 2; i++) {
+      const ticket = await repos.tickets.create({
+        title: `公開用チケット${i}`,
+        body: '本文',
+        priority: 'Medium',
+        creatorId: AGENT_A,
+        categoryId: null,
+        locationId: null,
+        tenantId: TENANT_A,
+      });
+      const faq = await repos.faq.create({
+        ticketId: ticket.id,
+        createdById: AGENT_A,
+        question: `公開${i}`,
+        answer: `回答${i}`,
+        tenantId: TENANT_A,
+      });
+      await repos.faq.updateStatus(faq.id, { from: 'Candidate', to: 'Published' }, TENANT_A);
+      lastPublishedId = faq.id;
+    }
+
+    // 全 4 件のうち limit: 1 なら 1 件だけ (最新のもの) が返る
+    const listResult = await repos.faq.list(TENANT_A, { limit: 1 });
+    expect(listResult).toHaveLength(1);
+    expect(listResult[0].question).toBe('公開1');
+
+    // 公開済み 2 件のうち limit: 1 なら 1 件だけ (最新のもの) が返る
+    const publishedResult = await repos.faq.listPublished(TENANT_A, { limit: 1 });
+    expect(publishedResult).toHaveLength(1);
+    expect(publishedResult[0].id).toBe(lastPublishedId);
   });
 
   // updateStatus: 期待状態 (from) が一致していれば tenantId スコープの updateMany が更新し true を返す

--- a/tests/data/faq-repository.memory.test.ts
+++ b/tests/data/faq-repository.memory.test.ts
@@ -6,6 +6,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createMemoryContext, type Store } from '@/data/adapters/memory';
 import type { Repos } from '@/data/ports/unit-of-work';
+import { FAQ_LIST_LIMIT } from '@/data/ports/faq-repository';
 
 const TENANT_A = 'tenant-a';
 const TENANT_B = 'tenant-b';
@@ -94,7 +95,7 @@ describe('FaqRepository (memory)', () => {
       tenantId: TENANT_B,
     });
 
-    const result = await repos.faq.list(TENANT_A, { limit: 200 });
+    const result = await repos.faq.list(TENANT_A, { limit: FAQ_LIST_LIMIT });
     expect(result).toHaveLength(1);
     expect(result[0].ticket.title).toBe('テナントAの問い合わせ');
     expect(result[0].createdBy.name).toBe(AGENT_A);
@@ -119,7 +120,7 @@ describe('FaqRepository (memory)', () => {
       answer: 'A2',
       tenantId: TENANT_A,
     });
-    const result = await repos.faq.list(TENANT_A, { limit: 200 });
+    const result = await repos.faq.list(TENANT_A, { limit: FAQ_LIST_LIMIT });
     expect(result.map((f) => f.id)).toEqual([second.id, first.id]);
   });
 
@@ -194,7 +195,7 @@ describe('FaqRepository (memory)', () => {
     });
     await repos.faq.updateStatus(publishedB.id, { from: 'Candidate', to: 'Published' }, TENANT_B);
 
-    const result = await repos.faq.listPublished(TENANT_A, { limit: 200 });
+    const result = await repos.faq.listPublished(TENANT_A, { limit: FAQ_LIST_LIMIT });
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
       id: published.id,

--- a/tests/data/faq-repository.memory.test.ts
+++ b/tests/data/faq-repository.memory.test.ts
@@ -94,7 +94,7 @@ describe('FaqRepository (memory)', () => {
       tenantId: TENANT_B,
     });
 
-    const result = await repos.faq.list(TENANT_A);
+    const result = await repos.faq.list(TENANT_A, { limit: 200 });
     expect(result).toHaveLength(1);
     expect(result[0].ticket.title).toBe('テナントAの問い合わせ');
     expect(result[0].createdBy.name).toBe(AGENT_A);
@@ -119,8 +119,47 @@ describe('FaqRepository (memory)', () => {
       answer: 'A2',
       tenantId: TENANT_A,
     });
-    const result = await repos.faq.list(TENANT_A);
+    const result = await repos.faq.list(TENANT_A, { limit: 200 });
     expect(result.map((f) => f.id)).toEqual([second.id, first.id]);
+  });
+
+  // list/listPublished: limit で件数が上限化される
+  // フォローアップ (2026-07-16 #3): 監査で発見したギャップ。§8「一覧取得は必ず上限を持たせる」に
+  // 反し、以前は limit 引数自体が存在せず常に全件返していた
+  it('listとlistPublishedはlimitで新しい順に件数を上限化する', async () => {
+    const ticket = await seedTicketAndAgent(TENANT_A, 'チケット', AGENT_A);
+    // Candidate 2 件 + Published 2 件を作成日時をずらして作る
+    for (let i = 0; i < 2; i++) {
+      await repos.faq.create({
+        ticketId: ticket.id,
+        createdById: AGENT_A,
+        question: `候補${i}`,
+        answer: `回答${i}`,
+        tenantId: TENANT_A,
+      });
+      await new Promise((r) => setTimeout(r, 2));
+    }
+    for (let i = 0; i < 2; i++) {
+      const faq = await repos.faq.create({
+        ticketId: ticket.id,
+        createdById: AGENT_A,
+        question: `公開${i}`,
+        answer: `回答${i}`,
+        tenantId: TENANT_A,
+      });
+      await repos.faq.updateStatus(faq.id, { from: 'Candidate', to: 'Published' }, TENANT_A);
+      await new Promise((r) => setTimeout(r, 2));
+    }
+
+    // 全 4 件のうち limit: 1 なら 1 件だけ (最新のもの) が返る
+    const listResult = await repos.faq.list(TENANT_A, { limit: 1 });
+    expect(listResult).toHaveLength(1);
+    expect(listResult[0].question).toBe('公開1');
+
+    // 公開済み 2 件のうち limit: 1 なら 1 件だけ (最新のもの) が返る
+    const publishedResult = await repos.faq.listPublished(TENANT_A, { limit: 1 });
+    expect(publishedResult).toHaveLength(1);
+    expect(publishedResult[0].question).toBe('公開1');
   });
 
   // listPublished: 公開済み (Published) のみを返し、Candidate/Rejected は含めない
@@ -155,7 +194,7 @@ describe('FaqRepository (memory)', () => {
     });
     await repos.faq.updateStatus(publishedB.id, { from: 'Candidate', to: 'Published' }, TENANT_B);
 
-    const result = await repos.faq.listPublished(TENANT_A);
+    const result = await repos.faq.listPublished(TENANT_A, { limit: 200 });
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
       id: published.id,

--- a/tests/features/faq-actions.test.ts
+++ b/tests/features/faq-actions.test.ts
@@ -134,7 +134,7 @@ describe('createFaqCandidate', () => {
 
     await createFaqCandidate(ticketId, '質問', '回答');
 
-    const faqs = await repos.faq.list(TENANT);
+    const faqs = await repos.faq.list(TENANT, { limit: 200 });
     expect(faqs).toHaveLength(1);
   });
 
@@ -155,7 +155,7 @@ describe('createFaqCandidate', () => {
 
     await createFaqCandidate(ticketId, '質問', '回答');
 
-    const faqs = await repos.faq.list(TENANT);
+    const faqs = await repos.faq.list(TENANT, { limit: 200 });
     expect(faqs).toHaveLength(1);
   });
 
@@ -166,7 +166,7 @@ describe('createFaqCandidate', () => {
 
     await createFaqCandidate(ticketId, '質問', '回答');
 
-    const faqs = await repos.faq.list(TENANT);
+    const faqs = await repos.faq.list(TENANT, { limit: 200 });
     expect(faqs).toHaveLength(1);
   });
 

--- a/tests/features/faq-actions.test.ts
+++ b/tests/features/faq-actions.test.ts
@@ -6,6 +6,8 @@ import { createMemoryContext, type Store } from '@/data/adapters/memory';
 import type { Repos } from '@/data/ports/unit-of-work';
 // レート制限の履歴をテスト間でクリアする内部用関数
 import { __resetRateLimits } from '@/lib/rate-limit';
+// FAQ 一覧取得の既定件数上限 (フォローアップ 2026-07-16 #3)
+import { FAQ_LIST_LIMIT } from '@/data/ports/faq-repository';
 
 // 各テスト前に書き換える "可変" な依存。Action import 前に値を入れる必要がある。
 let store: Store;
@@ -134,7 +136,7 @@ describe('createFaqCandidate', () => {
 
     await createFaqCandidate(ticketId, '質問', '回答');
 
-    const faqs = await repos.faq.list(TENANT, { limit: 200 });
+    const faqs = await repos.faq.list(TENANT, { limit: FAQ_LIST_LIMIT });
     expect(faqs).toHaveLength(1);
   });
 
@@ -155,7 +157,7 @@ describe('createFaqCandidate', () => {
 
     await createFaqCandidate(ticketId, '質問', '回答');
 
-    const faqs = await repos.faq.list(TENANT, { limit: 200 });
+    const faqs = await repos.faq.list(TENANT, { limit: FAQ_LIST_LIMIT });
     expect(faqs).toHaveLength(1);
   });
 
@@ -166,7 +168,7 @@ describe('createFaqCandidate', () => {
 
     await createFaqCandidate(ticketId, '質問', '回答');
 
-    const faqs = await repos.faq.list(TENANT, { limit: 200 });
+    const faqs = await repos.faq.list(TENANT, { limit: FAQ_LIST_LIMIT });
     expect(faqs).toHaveLength(1);
   });
 


### PR DESCRIPTION
## Context

定例コードレビュールーチン（既存フォローアップ群と同じ「済マーク済みの機能を実装から再点検する」観点）での監査。対応する正本の項目は `docs/smb-dx-pivot-plan.md` §4.11（新規追加）。

`FaqRepository.list`（エージェント向け管理ビュー）と `listPublished`（依頼者向け閲覧ビュー、§1.2 フォローアップ）はどちらも `db.faqCandidate.findMany()` を上限・ページネーション無しで呼んでおり、テナントの FAQ 候補が何件あっても全件を 1 度に取得していました。CLAUDE.md §8「一覧取得は必ず上限・ページネーションを持たせる（既定件数・最大件数は定数で一元管理する）」に反する状態でした。他の一覧系メソッド（`TicketRepository`・`NotificationRepository`・`SettingsAuditLogRepository`・`TicketHistoryRepository` 等）はいずれも `take`/`limit` を持つのに対し、FAQ だけが唯一の例外でした。FAQ 候補は解決済みチケットから継続的に生成される性質上（Phase 3 業種テンプレの自動投入も含む）、カテゴリ/拠点のような小規模な管理者設定データとは異なり、テナントの運用期間に応じて際限なく増え得るため、実害のある省略でした。

## 変更内容

- `FaqRepository`（`src/data/ports/faq-repository.ts`）に `FAQ_LIST_LIMIT`（200 件。`/audit` の `PAGE_LIMIT` と同じ規模感）を追加し、`list`/`listPublished` の契約に `opts: { limit: number }` を追加しました（`NotificationRepository.list` と同じ形）。
- Prisma アダプタ（`take: opts.limit`）・メモリアダプタ（`.slice(0, opts.limit)`、ソート後に適用して「新しい順の先頭 N 件」を保証）の両方に実装しました。
- `/faq` ページ（`src/app/(app)/faq/page.tsx`）の 2 箇所の呼び出しに `{ limit: FAQ_LIST_LIMIT }` を渡すよう変更しました。
- 本フォローアップは「必ず上限を持たせる」という §8 の核を満たす最小限の対応とし、`/audit`・`/quarantine` のようなキーセットページネーション（「さらに読み込む」）は追加していません（`/notifications` ページの既存の「上限付き一覧・追加ページ無し」という設計と同じ扱い。200 件を超えた FAQ 候補・公開済み FAQ にどちらの立場からも到達できなくなりますが、それ自体はチケット一覧・監査ログほど高頻度に発生しない性質のデータであるため、まず上限を設けることを優先しました。必要性が高まれば `/audit` と同様のページネーションを別途フォローアップとして追加します）。
- 回帰テスト: `tests/data/faq-repository.memory.test.ts` / `faq-repository.contract.prisma.test.ts` に、`limit` が新しい順に件数を上限化することを検証するテストを追加しました。既存の呼び出し箇所（`tests/features/faq-actions.test.ts` を含む）もすべて新しいシグネチャに更新しています。

## 検証方法

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run test`（Vitest, DB 不要なユニットテスト）— 1003 passed / 147 skipped (contract tests)
- `npm run test:contract` — このサンドボックス環境に PostgreSQL / Docker が無いためスキップ。新設した Prisma 契約テストは実 DB 環境の CI で実行されます
- `npm run test:e2e` — dev サーバー起動環境が無いためスキップ（本 PR は Server Action・画面表示ロジック自体は変更していないため既存 e2e への影響は無い想定）

/code-review ultra・/security-review ultra を実行し、指摘があれば反映します。

Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_0148WCDcDHBejSBtS1wcfSKw)_