### PR TITLE
Add check-then-act conflict protection to assignee/category/location updates

### DIFF
--- a/src/data/adapters/memory/ticket-repository.memory.ts
+++ b/src/data/adapters/memory/ticket-repository.memory.ts
@@ -316,24 +316,34 @@ export function makeTicketRepo(store: Store): TicketRepository {
     },
 
     // 担当者を更新 (tenantId スコープ。null で未アサインに戻す)
-    async updateAssignee(id, assigneeId, tenantId) {
+    // 担当者を更新 (tenantId スコープ。フォローアップ 2026-07-16: Prisma アダプタと同じく
+    // 期待担当者 transition.from と不一致 (競合) なら更新しない)
+    async updateAssignee(id, transition, tenantId) {
       const t = store.tickets.get(id);
-      if (!t || t.tenantId !== tenantId) return;
-      store.tickets.set(id, { ...t, assigneeId, updatedAt: new Date() });
+      if (!t || t.tenantId !== tenantId) return false;
+      if (t.assigneeId !== transition.from) return false;
+      store.tickets.set(id, { ...t, assigneeId: transition.to, updatedAt: new Date() });
+      return true;
     },
 
-    // カテゴリを更新 (tenantId スコープ。null で未分類に戻す。フォローアップ 2026-07-14 #4)
-    async updateCategory(id, categoryId, tenantId) {
+    // カテゴリを更新 (tenantId スコープ。null で未分類に戻す。フォローアップ 2026-07-14 #4)。
+    // フォローアップ 2026-07-16: Prisma アダプタと同じく CAS 保護を追加
+    async updateCategory(id, transition, tenantId) {
       const t = store.tickets.get(id);
-      if (!t || t.tenantId !== tenantId) return;
-      store.tickets.set(id, { ...t, categoryId, updatedAt: new Date() });
+      if (!t || t.tenantId !== tenantId) return false;
+      if (t.categoryId !== transition.from) return false;
+      store.tickets.set(id, { ...t, categoryId: transition.to, updatedAt: new Date() });
+      return true;
     },
 
-    // 拠点を更新 (tenantId スコープ。null で未指定に戻す。フォローアップ 2026-07-14 #4)
-    async updateLocation(id, locationId, tenantId) {
+    // 拠点を更新 (tenantId スコープ。null で未指定に戻す。フォローアップ 2026-07-14 #4)。
+    // フォローアップ 2026-07-16: Prisma アダプタと同じく CAS 保護を追加
+    async updateLocation(id, transition, tenantId) {
       const t = store.tickets.get(id);
-      if (!t || t.tenantId !== tenantId) return;
-      store.tickets.set(id, { ...t, locationId, updatedAt: new Date() });
+      if (!t || t.tenantId !== tenantId) return false;
+      if (t.locationId !== transition.from) return false;
+      store.tickets.set(id, { ...t, locationId: transition.to, updatedAt: new Date() });
+      return true;
     },
 
     // エスカレーション扱いに更新 (tenantId スコープ)。期待する現在状態 expectedStatus が一致する

--- a/src/data/adapters/prisma/ticket-repository.prisma.ts
+++ b/src/data/adapters/prisma/ticket-repository.prisma.ts
@@ -278,19 +278,35 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
       return result.count > 0;
     },
 
-    // 担当者を更新 (tenantId スコープ、null で未アサインに戻す)
-    async updateAssignee(id, assigneeId, tenantId) {
-      await db.ticket.updateMany({ where: { id, tenantId }, data: { assigneeId } });
+    // 担当者を更新 (tenantId スコープ、null で未アサインに戻す)。updateStatus と同じく
+    // 期待する現在担当者 transition.from を where 条件に含めた原子的更新にし、
+    // check-then-act 競合時 (0 件更新) は false を返す (フォローアップ 2026-07-16)
+    async updateAssignee(id, transition, tenantId) {
+      const result = await db.ticket.updateMany({
+        where: { id, tenantId, assigneeId: transition.from }, // 期待担当者が一致するときのみ更新
+        data: { assigneeId: transition.to },
+      });
+      return result.count > 0;
     },
 
-    // カテゴリを更新 (tenantId スコープ、null で未分類に戻す。フォローアップ 2026-07-14 #4)
-    async updateCategory(id, categoryId, tenantId) {
-      await db.ticket.updateMany({ where: { id, tenantId }, data: { categoryId } });
+    // カテゴリを更新 (tenantId スコープ、null で未分類に戻す。フォローアップ 2026-07-14 #4)。
+    // updateAssignee と同じく フォローアップ 2026-07-16 で CAS 保護を追加した
+    async updateCategory(id, transition, tenantId) {
+      const result = await db.ticket.updateMany({
+        where: { id, tenantId, categoryId: transition.from }, // 期待カテゴリが一致するときのみ更新
+        data: { categoryId: transition.to },
+      });
+      return result.count > 0;
     },
 
-    // 拠点を更新 (tenantId スコープ、null で未指定に戻す。フォローアップ 2026-07-14 #4)
-    async updateLocation(id, locationId, tenantId) {
-      await db.ticket.updateMany({ where: { id, tenantId }, data: { locationId } });
+    // 拠点を更新 (tenantId スコープ、null で未指定に戻す。フォローアップ 2026-07-14 #4)。
+    // updateAssignee と同じく フォローアップ 2026-07-16 で CAS 保護を追加した
+    async updateLocation(id, transition, tenantId) {
+      const result = await db.ticket.updateMany({
+        where: { id, tenantId, locationId: transition.from }, // 期待拠点が一致するときのみ更新
+        data: { locationId: transition.to },
+      });
+      return result.count > 0;
     },
 
     // エスカレーション扱いに更新 (tenantId スコープ)。期待する現在状態 expectedStatus を where 条件に

--- a/src/data/ports/ticket-repository.ts
+++ b/src/data/ports/ticket-repository.ts
@@ -208,13 +208,31 @@ export interface TicketRepository {
     dueDates: { firstResponseDueAt: Date | null; resolutionDueAt: Date | null },
     tenantId: string,
   ): Promise<boolean>;
-  // 担当者更新 (tenantId スコープ。null で未アサイン)
-  updateAssignee(id: string, assigneeId: string | null, tenantId: string): Promise<void>;
+  // 担当者更新 (tenantId スコープ。null で未アサイン)。期待する現在担当者 transition.from を
+  // where 条件に含めた原子的更新で、check-then-act 競合時 (0 件更新) は false を返す
+  // (updateStatus/updatePriority/markEscalated と同じ契約。フォローアップ 2026-07-16:
+  // 担当者・カテゴリ・拠点だけこの保護が無く、2 つの変更が競合すると片方が静かに失われた
+  // うえ history の oldValue も不正確になり得たギャップの解消)
+  updateAssignee(
+    id: string,
+    transition: { from: string | null; to: string | null },
+    tenantId: string,
+  ): Promise<boolean>;
   // カテゴリ更新 (tenantId スコープ。null で未分類。フォローアップ 2026-07-14 #4:
-  // メール/LINE 取り込みチケットの事後変更を可能にするために追加)
-  updateCategory(id: string, categoryId: string | null, tenantId: string): Promise<void>;
-  // 拠点更新 (tenantId スコープ。null で未指定。フォローアップ 2026-07-14 #4: 同上)
-  updateLocation(id: string, locationId: string | null, tenantId: string): Promise<void>;
+  // メール/LINE 取り込みチケットの事後変更を可能にするために追加)。updateAssignee と同じく
+  // フォローアップ 2026-07-16 で CAS 保護を追加した
+  updateCategory(
+    id: string,
+    transition: { from: string | null; to: string | null },
+    tenantId: string,
+  ): Promise<boolean>;
+  // 拠点更新 (tenantId スコープ。null で未指定。フォローアップ 2026-07-14 #4: 同上)。
+  // updateAssignee と同じく フォローアップ 2026-07-16 で CAS 保護を追加した
+  updateLocation(
+    id: string,
+    transition: { from: string | null; to: string | null },
+    tenantId: string,
+  ): Promise<boolean>;
   // エスカレーション状態にする (tenantId スコープ)。期待する現在状態 expectedStatus を where 条件に
   // 含めた原子的更新で、check-then-act 競合時は false を返す (updateStatus と同じ契約。
   // フォローアップ 2026-07-15 #2)

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -559,8 +559,19 @@ export async function updateTicketAssignee(ticketId: string, newAssigneeId: stri
 
   // 担当者更新・履歴記録・通知作成を 1 トランザクションで実行
   await uow.run(async (r) => {
-    // 担当者を差し替え (解除は null。tenantId スコープで where に注入)
-    await r.tickets.updateAssignee(ticketId, newAssigneeId, tenantId);
+    // 担当者を差し替え (解除は null。tenantId スコープで where に注入)。読み取り時の担当者
+    // (ticket.assigneeId) を期待値として渡し、直前に別の操作が担当者を変えていた場合は
+    // 0 件更新 (false) になる (check-then-act 競合で古い割当が後勝ちして history の
+    // oldValue も不正確になるのを防ぐ。フォローアップ 2026-07-16: updateTicketStatus 等に
+    // 既に導入済みの契約を担当者変更にも適用した)
+    const updated = await r.tickets.updateAssignee(
+      ticketId,
+      { from: ticket.assigneeId, to: newAssigneeId },
+      tenantId,
+    );
+    if (!updated) {
+      throw new Error(TICKET_CONFLICT_MESSAGE);
+    }
     // 変更履歴を残す
     await r.history.record({
       ticketId,
@@ -707,8 +718,17 @@ export async function updateTicketCategory(ticketId: string, newCategoryId: stri
 
   // カテゴリ更新・履歴記録を 1 トランザクションで実行
   await uow.run(async (r) => {
-    // カテゴリを差し替え (解除は null。tenantId スコープで where に注入)
-    await r.tickets.updateCategory(ticketId, effectiveCategoryId, tenantId);
+    // カテゴリを差し替え (解除は null。tenantId スコープで where に注入)。読み取り時のカテゴリ
+    // (ticket.categoryId) を期待値として渡し、他の操作と競合していれば 0 件更新 (false) になる
+    // (updateTicketAssignee と同じ理由。フォローアップ 2026-07-16)
+    const updated = await r.tickets.updateCategory(
+      ticketId,
+      { from: ticket.categoryId, to: effectiveCategoryId },
+      tenantId,
+    );
+    if (!updated) {
+      throw new Error(TICKET_CONFLICT_MESSAGE);
+    }
     // 変更履歴を残す
     await r.history.record({
       ticketId,
@@ -756,8 +776,17 @@ export async function updateTicketLocation(ticketId: string, newLocationId: stri
 
   // 拠点更新・履歴記録を 1 トランザクションで実行
   await uow.run(async (r) => {
-    // 拠点を差し替え (解除は null。tenantId スコープで where に注入)
-    await r.tickets.updateLocation(ticketId, newLocationId, tenantId);
+    // 拠点を差し替え (解除は null。tenantId スコープで where に注入)。読み取り時の拠点
+    // (ticket.locationId) を期待値として渡し、他の操作と競合していれば 0 件更新 (false) になる
+    // (updateTicketAssignee と同じ理由。フォローアップ 2026-07-16)
+    const updated = await r.tickets.updateLocation(
+      ticketId,
+      { from: ticket.locationId, to: newLocationId },
+      tenantId,
+    );
+    if (!updated) {
+      throw new Error(TICKET_CONFLICT_MESSAGE);
+    }
     // 変更履歴を残す
     await r.history.record({
       ticketId,

--- a/tests/data/ticket-repository.contract.ts
+++ b/tests/data/ticket-repository.contract.ts
@@ -246,7 +246,7 @@ export function runTicketRepositoryContract(
         categoryId,
         tenantId: TENANT_ID,
       });
-      await ctx.repos.tickets.updateAssignee(assigned.id, agentA.id, TENANT_ID);
+      await ctx.repos.tickets.updateAssignee(assigned.id, { from: null, to: agentA.id }, TENANT_ID);
       // 担当者なしのチケット
       const unassigned = await ctx.repos.tickets.create({
         title: 'B',
@@ -355,7 +355,7 @@ export function runTicketRepositoryContract(
         resolutionDueAt: tomorrow,
       });
       await ctx.repos.tickets.updateStatus(t2.id, { from: 'New', to: 'Open' }, null, TENANT_ID);
-      await ctx.repos.tickets.updateAssignee(t2.id, agentA.id, TENANT_ID);
+      await ctx.repos.tickets.updateAssignee(t2.id, { from: null, to: agentA.id }, TENANT_ID);
       // agentA 起票の Resolved 1 件 (ワークロード集計から除外される)
       const t3 = await ctx.repos.tickets.create({
         title: 't3',
@@ -365,7 +365,7 @@ export function runTicketRepositoryContract(
         categoryId,
         tenantId: TENANT_ID,
       });
-      await ctx.repos.tickets.updateAssignee(t3.id, agentB.id, TENANT_ID);
+      await ctx.repos.tickets.updateAssignee(t3.id, { from: null, to: agentB.id }, TENANT_ID);
       await ctx.repos.tickets.updateStatus(
         t3.id,
         { from: 'New', to: 'Resolved' },
@@ -604,7 +604,7 @@ export function runTicketRepositoryContract(
         { firstResponseDueAt: null, resolutionDueAt: null },
         tenantB,
       );
-      await ctx.repos.tickets.updateAssignee(ticketA.id, agentA.id, tenantB);
+      await ctx.repos.tickets.updateAssignee(ticketA.id, { from: null, to: agentA.id }, tenantB);
       await ctx.repos.tickets.markEscalated(
         ticketA.id,
         { reason: 'cross-tenant attempt', at: new Date() },
@@ -949,6 +949,114 @@ export function runTicketRepositoryContract(
         const escalated = await ctx.repos.tickets.findById(ticket.id, TENANT_ID);
         expect(escalated?.status).toBe('Escalated');
         expect(escalated?.escalationReason).toBe('r2');
+      });
+    });
+
+    // フォローアップ (2026-07-16): updateAssignee/updateCategory/updateLocation にも
+    // updateStatus/markEscalated と同じ CAS (check-then-act 競合防止) 契約を追加した回帰テスト
+    describe('updateAssignee / updateCategory / updateLocation の原子的更新 (check-then-act 競合防止)', () => {
+      it('updateAssignee は期待担当者が一致する場合に更新でき true を返す', async () => {
+        const { requester, agentA, categoryId } = await ctx.seedBasicFixture();
+        const ticket = await ctx.repos.tickets.create({
+          title: 't',
+          body: 'b',
+          priority: 'Medium',
+          creatorId: requester.id,
+          categoryId,
+          tenantId: TENANT_ID,
+        });
+
+        const updated = await ctx.repos.tickets.updateAssignee(
+          ticket.id,
+          { from: null, to: agentA.id },
+          TENANT_ID,
+        );
+
+        expect(updated).toBe(true);
+        const after = await ctx.repos.tickets.findById(ticket.id, TENANT_ID);
+        expect(after?.assigneeId).toBe(agentA.id);
+      });
+
+      // 期待担当者 (from) が現在の担当者と異なる場合 (= 別の操作が先に担当者を変えていた) は
+      // 更新せず false を返し、行の担当者も変化しないこと
+      it('updateAssignee は期待担当者が一致しない場合に更新せず false を返す', async () => {
+        const { requester, agentA, agentB, categoryId } = await ctx.seedBasicFixture();
+        const ticket = await ctx.repos.tickets.create({
+          title: 't',
+          body: 'b',
+          priority: 'Medium',
+          creatorId: requester.id,
+          categoryId,
+          tenantId: TENANT_ID,
+        });
+        // 実際は agentA に割当済みだが、期待担当者を誤って未割当 (null) として更新を試みる
+        // (先行する別の操作が担当者を変えたケースの再現)
+        await ctx.repos.tickets.updateAssignee(ticket.id, { from: null, to: agentA.id }, TENANT_ID);
+        const updated = await ctx.repos.tickets.updateAssignee(
+          ticket.id,
+          { from: null, to: agentB.id },
+          TENANT_ID,
+        );
+
+        expect(updated).toBe(false);
+        // 担当者は agentA のまま変化していない
+        const after = await ctx.repos.tickets.findById(ticket.id, TENANT_ID);
+        expect(after?.assigneeId).toBe(agentA.id);
+      });
+
+      it('updateCategory は期待カテゴリが一致しない場合に更新せず false を返す', async () => {
+        const { requester, categoryId } = await ctx.seedBasicFixture();
+        const otherCategory = await ctx.repos.categories.create({
+          tenantId: TENANT_ID,
+          name: '別カテゴリ',
+        });
+        const ticket = await ctx.repos.tickets.create({
+          title: 't',
+          body: 'b',
+          priority: 'Medium',
+          creatorId: requester.id,
+          categoryId,
+          tenantId: TENANT_ID,
+        });
+        // 実際のカテゴリは categoryId のままだが、期待カテゴリを誤って別カテゴリとして更新を試みる
+        const updated = await ctx.repos.tickets.updateCategory(
+          ticket.id,
+          { from: otherCategory.id, to: null },
+          TENANT_ID,
+        );
+
+        expect(updated).toBe(false);
+        const after = await ctx.repos.tickets.findById(ticket.id, TENANT_ID);
+        expect(after?.categoryId).toBe(categoryId);
+      });
+
+      it('updateLocation は期待拠点が一致しない場合に更新せず false を返す', async () => {
+        const { requester, categoryId } = await ctx.seedBasicFixture();
+        const locationA = await ctx.repos.locations.create({ tenantId: TENANT_ID, name: 'A店' });
+        const locationB = await ctx.repos.locations.create({ tenantId: TENANT_ID, name: 'B店' });
+        const ticket = await ctx.repos.tickets.create({
+          title: 't',
+          body: 'b',
+          priority: 'Medium',
+          creatorId: requester.id,
+          categoryId,
+          tenantId: TENANT_ID,
+        });
+        await ctx.repos.tickets.updateLocation(
+          ticket.id,
+          { from: null, to: locationA.id },
+          TENANT_ID,
+        );
+        // 実際は locationA のままだが、期待拠点を誤って未設定 (null) として更新を試みる
+        const updated = await ctx.repos.tickets.updateLocation(
+          ticket.id,
+          { from: null, to: locationB.id },
+          TENANT_ID,
+        );
+
+        expect(updated).toBe(false);
+        const after = await ctx.repos.tickets.findById(ticket.id, TENANT_ID);
+        expect(after?.locationId).toBe(locationA.id);
       });
     });
 

--- a/tests/features/attachments/post-comment-route.test.ts
+++ b/tests/features/attachments/post-comment-route.test.ts
@@ -364,7 +364,7 @@ describe('POST /api/tickets/[id]/comments', () => {
   it('notifies the assignee when a requester comments on an assigned ticket', async () => {
     const { ticketId } = await seed();
     // 担当者を割り当てておく
-    await repos.tickets.updateAssignee(ticketId, AGENT, TENANT);
+    await repos.tickets.updateAssignee(ticketId, { from: null, to: AGENT }, TENANT);
     mockSession = buildSession(REQUESTER, 'requester', TENANT);
     const { POST } = await import('@/app/api/tickets/[id]/comments/route');
     const res = await POST(buildRequest('追加情報です', []), makeParams(ticketId));
@@ -436,7 +436,7 @@ describe('POST /api/tickets/[id]/comments', () => {
       createdAt: now,
       updatedAt: now,
     });
-    await repos.tickets.updateAssignee(ticketId, 'u-agt-2', TENANT);
+    await repos.tickets.updateAssignee(ticketId, { from: null, to: 'u-agt-2' }, TENANT);
     // 投稿者は別エージェント (AGENT) で、依頼者 + 担当者の両方に通知が飛ぶ想定
     mockSession = buildSession(AGENT, 'agent', TENANT);
     const { POST } = await import('@/app/api/tickets/[id]/comments/route');
@@ -454,7 +454,7 @@ describe('POST /api/tickets/[id]/comments', () => {
   it('does not notify the commenter themselves', async () => {
     const { ticketId } = await seed();
     // 担当者と投稿者が同一 (AGENT)
-    await repos.tickets.updateAssignee(ticketId, AGENT, TENANT);
+    await repos.tickets.updateAssignee(ticketId, { from: null, to: AGENT }, TENANT);
     mockSession = buildSession(AGENT, 'agent', TENANT);
     const { POST } = await import('@/app/api/tickets/[id]/comments/route');
     const res = await POST(buildRequest('自分のコメント', []), makeParams(ticketId));

--- a/tests/features/update-ticket.test.ts
+++ b/tests/features/update-ticket.test.ts
@@ -754,6 +754,40 @@ describe('updateTicketAssignee (provider-agnostic)', () => {
     const t = await repos.tickets.findById(ticketId, TENANT);
     expect(t?.assigneeId).toBeNull();
   });
+
+  // フォローアップ (2026-07-16): updateTicketStatus/updatePriority と同じ CAS (check-then-act)
+  // 保護を担当者変更にも追加した回帰テスト。読み取り後に別操作が担当者を変えていた場合、
+  // 古い担当者判定のまま上書きされず競合エラーになることを確認する
+  it('読み取り後に担当者が変わっていた場合は競合エラーになり上書きしない', async () => {
+    const { ticketId } = await seed();
+    // 実際の行は既に u-agt-2 (先行操作が割当済み)
+    await repos.tickets.updateAssignee(ticketId, { from: null, to: 'u-agt-2' }, TENANT);
+    // Map#get の最初の呼び出しだけ古いスナップショット (未割当) を返すようにする (TOCTOU の再現)。
+    // 2 回目以降 (updateAssignee 内の where 判定用の再読み込み) は実際の値 (u-agt-2) を返す
+    let callCount = 0;
+    const originalGet = store.tickets.get.bind(store.tickets);
+    vi.spyOn(store.tickets, 'get').mockImplementation((id: string) => {
+      callCount += 1;
+      const real = originalGet(id);
+      if (callCount === 1 && id === ticketId && real) {
+        return { ...real, assigneeId: null };
+      }
+      return real;
+    });
+    const { updateTicketAssignee } = await import('@/features/tickets/actions/update-ticket');
+
+    await expect(updateTicketAssignee(ticketId, 'u-agt-1')).rejects.toThrow(
+      /他の操作と競合したため/,
+    );
+
+    // 担当者は先行操作 (u-agt-2) のまま変化せず、履歴・通知も作られていない
+    // (先行の repos.tickets.updateAssignee 直呼びは Server Action を経ないため履歴を作らない)
+    vi.restoreAllMocks();
+    const t = await repos.tickets.findById(ticketId, TENANT);
+    expect(t?.assigneeId).toBe('u-agt-2');
+    expect([...store.histories.values()]).toHaveLength(0);
+    expect([...store.notifications.values()]).toHaveLength(0);
+  });
 });
 
 // フォローアップ (2026-07-14 #4): 監査で発見したギャップの解消。メール/LINE 取り込みチケットは
@@ -852,6 +886,41 @@ describe('updateTicketCategory (provider-agnostic)', () => {
       /エージェントまたは管理者/,
     );
   });
+
+  // フォローアップ (2026-07-16): updateTicketAssignee と同じ CAS 保護の回帰テスト。
+  // 読み取り後に別操作がカテゴリを変えていた場合、古いカテゴリ判定のまま上書きされず
+  // 競合エラーになることを確認する
+  it('読み取り後にカテゴリが変わっていた場合は競合エラーになり上書きしない', async () => {
+    const { ticketId } = await seed();
+    store.categories.set('cat-2', {
+      id: 'cat-2',
+      name: '請求',
+      createdAt: new Date(),
+      tenantId: TENANT,
+    });
+    // 実際の行は既に cat-2 (先行操作が変更済み。seed() の初期値は cat-1)
+    await repos.tickets.updateCategory(ticketId, { from: 'cat-1', to: 'cat-2' }, TENANT);
+    // Map#get の最初の呼び出しだけ古いスナップショット (cat-1) を返すようにする (TOCTOU の再現)
+    let callCount = 0;
+    const originalGet = store.tickets.get.bind(store.tickets);
+    vi.spyOn(store.tickets, 'get').mockImplementation((id: string) => {
+      callCount += 1;
+      const real = originalGet(id);
+      if (callCount === 1 && id === ticketId && real) {
+        return { ...real, categoryId: 'cat-1' };
+      }
+      return real;
+    });
+    const { updateTicketCategory } = await import('@/features/tickets/actions/update-ticket');
+
+    await expect(updateTicketCategory(ticketId, null)).rejects.toThrow(/他の操作と競合したため/);
+
+    // カテゴリは先行操作 (cat-2) のまま変化せず、履歴も作られていない
+    vi.restoreAllMocks();
+    const t = await repos.tickets.findById(ticketId, TENANT);
+    expect(t?.categoryId).toBe('cat-2');
+    expect([...store.histories.values()]).toHaveLength(0);
+  });
 });
 
 // フォローアップ (2026-07-14 #4): 同上。拠点は Lite/Pro 両モードで使える概念なので mode 強制は無い
@@ -926,6 +995,39 @@ describe('updateTicketLocation (provider-agnostic)', () => {
     await expect(updateTicketLocation(ticketId, location.id)).rejects.toThrow(
       /エージェントまたは管理者/,
     );
+  });
+
+  // フォローアップ (2026-07-16): updateTicketAssignee と同じ CAS 保護の回帰テスト。
+  // 読み取り後に別操作が拠点を変えていた場合、古い拠点判定のまま上書きされず
+  // 競合エラーになることを確認する
+  it('読み取り後に拠点が変わっていた場合は競合エラーになり上書きしない', async () => {
+    const { ticketId } = await seed();
+    const locationA = await repos.locations.create({ tenantId: TENANT, name: '渋谷本店' });
+    const locationB = await repos.locations.create({ tenantId: TENANT, name: '大阪支店' });
+    // 実際の行は既に locationA (先行操作が設定済み)
+    await repos.tickets.updateLocation(ticketId, { from: null, to: locationA.id }, TENANT);
+    // Map#get の最初の呼び出しだけ古いスナップショット (未設定) を返すようにする (TOCTOU の再現)
+    let callCount = 0;
+    const originalGet = store.tickets.get.bind(store.tickets);
+    vi.spyOn(store.tickets, 'get').mockImplementation((id: string) => {
+      callCount += 1;
+      const real = originalGet(id);
+      if (callCount === 1 && id === ticketId && real) {
+        return { ...real, locationId: null };
+      }
+      return real;
+    });
+    const { updateTicketLocation } = await import('@/features/tickets/actions/update-ticket');
+
+    await expect(updateTicketLocation(ticketId, locationB.id)).rejects.toThrow(
+      /他の操作と競合したため/,
+    );
+
+    // 拠点は先行操作 (locationA) のまま変化せず、履歴も作られていない
+    vi.restoreAllMocks();
+    const t = await repos.tickets.findById(ticketId, TENANT);
+    expect(t?.locationId).toBe(locationA.id);
+    expect([...store.histories.values()]).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Relates to `docs/smb-dx-pivot-plan.md`'s general reliability/quality bar (not a specific new Phase item — this is a concurrency-safety bug fix for existing Phase-agnostic ticket-mutation logic).

- `updateTicketStatus`/`updateTicketPriority`/`escalateTicket` all use an atomic, optimistic-concurrency update (`transition: {from, to}` in the `where` clause, returning `false` on 0-row conflict → `TICKET_CONFLICT_MESSAGE`), but `updateTicketAssignee`/`updateTicketCategory`/`updateTicketLocation` had no such protection — a straight unconditional update. Two concurrent assignee/category/location changes could race: the second write silently wins, and `recordHistory`'s `oldValue` (read before the write) can end up recording the wrong "from" value.
- `EntitySelect.tsx` (the shared client component behind all three fields) already implements "show the error in place, then `router.refresh()`" for conflicts — that path was effectively dead code since the server never actually detected a conflict.
- Changed the `TicketRepository` port's `updateAssignee`/`updateCategory`/`updateLocation` signatures to take `transition: {from, to}` and return `Promise<boolean>`, matching `updateStatus`'s established contract. Updated both the Prisma and in-memory adapters to add the expected-current-value `where` clause / equality check. Updated the three Server Actions to pass the ticket's just-read value as `from` and throw `TICKET_CONFLICT_MESSAGE` on `false`.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 1009/1009 pass (146 Prisma contract tests skipped, as expected without `RUN_PRISMA_CONTRACT=1` + a real DB)
  - Added a TOCTOU-reproduction unit test per Server Action (mocks the in-memory store's `get` to return a stale snapshot on the first read only), verifying the conflict is now detected, the field stays unchanged, and no spurious history/notification is recorded
  - Added matching CAS contract tests to `tests/data/ticket-repository.contract.ts` (mirrors the existing `updateStatus`/`markEscalated` contract tests), which run against both the memory adapter now and the Prisma adapter under `RUN_PRISMA_CONTRACT=1`
  - Updated existing call sites (`post-comment-route.test.ts`, `ticket-repository.contract.ts`) for the new `updateAssignee` signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012F1pfMzPVfppq7xrX22iNo

---
_Generated by [Claude Code](https://claude.ai/code/session_012F1pfMzPVfppq7xrX22iNo)_