### PR TITLE
fix(security): テナントモード変更のTOCTOU・レート制限漏れ・一覧上限漏れを解消

### DIFF
--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -1332,6 +1332,55 @@ RATE_LIMIT`) を追加済みだったが、兄弟にあたる `requestMagicLink`
   memory/Prisma 契約テストに追加。`tests/features/request-magic-link.test.ts` に「進行中の
   SSO ハンドオフトークンは通常のマジックリンク発行で無効化されない」ことの統合テストを追加した。
 
+#### 4.19 フォローアップ（2026-07-18）: テナントモード変更の TOCTOU・招待受諾/マジックリンクコールバックのレート制限漏れ・拠点/カテゴリ一覧の上限漏れ
+
+コードベース監査（既存フォローアップ群と同じ「済マーク済みの機能を実装から再点検する」観点）で
+発見した 3 件のギャップの修正。
+
+- **`updateTenantMode` に Stripe Webhook 由来の自動ダウングレードとの TOCTOU が残っていた**:
+  §1.4/§1.5/§4.13 でチケット・FAQ 側の状態変更に導入した「期待する現在状態を where 条件に
+  含めた原子的な更新 (CAS)」が、`TenantRepository.updateMode` には一度も適用されていなかった。
+  `updateTenantMode`（`src/features/settings/actions/update-tenant-mode.ts`）は
+  `isProModeAllowed(plan)` の判定と `updateMode` の書き込みが別ステップのため、判定直後に
+  Stripe Webhook 由来の自動ダウングレード（`applyPlanChange` の `updateMode(id, 'lite')`、§4.4）
+  が割り込むと、古いプラン判定のまま Pro モードへ上書きしてしまう競合が起こり得た
+  （§9「認可はサーバー側で強制する」が意図する防御が TOCTOU の窓で崩れる）。
+  `src/lib/plan-guard.ts` に `PRO_MODE_ALLOWED_PLANS`（`isProModeAllowed` の単一の源）を追加し、
+  `TenantRepository.updateMode(id, mode, expectedPlanIn?)` の契約を、'pro' への切替時のみ
+  `expectedPlanIn` を where 条件に含めた原子的な更新（0 件なら `false`）にした（Prisma/メモリ
+  両アダプタ対応）。`updateTenantMode` は 0 件更新時に「プランが変更された可能性があるため
+  再読み込みしてください」という日本語エラーを throw する。
+- **招待受諾・マジックリンクコールバックにエンドポイント全体のレート制限が無かった**:
+  §4.16/§4.17 で「公開 (未認証) エンドポイントは固定キーのレート制限を持つ」方針を trial-reminders・
+  マジックリンク発行に適用したが、同じ公開エンドポイントである `acceptInvitation`
+  （`src/features/auth/actions/accept-invitation.ts`。シート上限の TOCTOU 防止のため
+  Serializable 分離レベルのトランザクションを毎回開く、通常よりコストの高い操作）と、
+  マジックリンクの「発行」ではなく「消費」を行う `POST /api/auth/magic-link/callback`
+  には一切無かった。トークン自体は高エントロピーで推測は現実的でないが、レート制限が無いと
+  不正なトークンでの連打により高コストな Serializable トランザクションや DB 参照を無制限に
+  発生させる DoS の的になる（§9 公開エンドポイント保護）。`INVITE_ACCEPT_GLOBAL_RATE_LIMIT`
+  （`src/lib/invite.ts`）と `MAGIC_LINK_CALLBACK_RATE_LIMIT`（`src/lib/magic-link.ts`）を追加し、
+  前者は `enforceRateLimit`（Server Action 向け）、後者は `checkRouteRateLimit`
+  （sso-acs 等と共有する Route Handler 向けラッパー）で、それぞれのハンドラの最初に適用した。
+- **拠点・カテゴリ一覧に上限が無かった**: §4.11/§4.12 で「一覧取得は必ず上限を持たせる」
+  （§8）を FAQ・チケット詳細のコメント/履歴に適用したが、`LocationRepository.listByTenant` と
+  `CategoryRepository.list` は依然として上限無しの `findMany` のままだった。拠点・カテゴリの
+  作成には既存のレート制限（§4.1 系フォローアップ）があるが、それは作成 "速度" しか抑えず
+  累計件数には上限が無い。`LOCATION_LIST_LIMIT`/`CATEGORY_LIST_LIMIT`（各 200 件。
+  `FAQ_LIST_LIMIT` と同じ規模感）を追加し、Prisma アダプタは `take`、メモリアダプタは
+  `slice` で上限化した。
+- 回帰テスト: `tests/data/tenant-repository.{memory,contract.prisma}.test.ts` に
+  `expectedPlanIn` の CAS 動作（許可リストに現在のプランが含まれない場合は `false`）を追加。
+  `tests/features/update-tenant-mode.test.ts` に、事前チェック後にプランがダウングレードされた
+  TOCTOU の再現テストを追加。`tests/features/accept-invitation.test.ts` に全体レート制限の
+  回帰テストを追加（マジックリンクコールバック側は、`next-auth` パッケージの実行時 import が
+  本リポジトリの Vitest 環境では `next/server` の解決に失敗し単体テスト不可能なため
+  — `POST /api/auth/magic-link/callback` に既存のテストファイルが 1 つも無かったのもこれが
+  理由 — 自動テストは追加せず、`checkRouteRateLimit` 自体の単体テスト
+  (`tests/route-rate-limit.test.ts`) と手動でのコードレビューで確認した）。
+  `tests/data/{location,category}-repository.{memory,contract.prisma}.test.ts` に上限件数の
+  回帰テストを追加した。
+
 ### スケジュール感
 
 ```

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -26,6 +26,10 @@ import { resolveTenantPlan } from '@/lib/tenant-plan';
 import { isEmailInboundAllowed } from '@/lib/plan-guard';
 // §7.1.2 フォローアップ: 「はじめかた」ステップをプランに応じて出し分ける純粋ヘルパー
 import { buildGettingStartedSteps } from '@/lib/getting-started-steps';
+// 監査で発見したギャップ対応: listByTenant は既定で表示用の上限 (LOCATION_LIST_LIMIT = 200) しか
+// 返さない。本ページの拠点フィルタは「テナントの全拠点」が前提のため、CSV インポートと同じ
+// 網羅的な上限を明示的に渡す (未指定のままだと 201 拠点目以降が選択肢から消える)
+import { LOCATION_LIST_MATCHING_LIMIT } from '@/data/ports/location-repository';
 
 // チュートリアルセクションを表示するかどうかの閾値 (テナント全体のチケット件数がこれ未満なら表示)
 // 初期サンプルチケット 2 件を含む。小規模なインポート (数件程度) までは表示し続けるため 10 に設定
@@ -69,7 +73,9 @@ export default async function DashboardPage({ searchParams }: Props) {
     // §4.1 フォローアップ: 多店舗テナントは Pro ダッシュボードと同様に拠点で絞り込めるようにする
     // (Lite は既定モードであり、多拠点の SMB が最も多くこの画面を使うため Pro 限定のままでは
     // §4.1 で埋めたはずのギャップが Lite テナントに対しては残ってしまう)
-    const locations = await repos.locations.listByTenant(tenantId);
+    const locations = await repos.locations.listByTenant(tenantId, {
+      limit: LOCATION_LIST_MATCHING_LIMIT,
+    });
     // URL の locationId は当該テナントの拠点一覧に実在するものだけを有効とみなす (Pro 側と同じ検証)
     const selectedLocationId = resolveSelectedLocationId(sp.locationId, locations);
     // チュートリアルを表示する条件 (エージェントかつチケット件数が閾値未満)
@@ -96,8 +102,11 @@ export default async function DashboardPage({ searchParams }: Props) {
   }
 
   // 以降は Pro モードの従来ダッシュボード (情シス向けのフル集計)
-  // Phase 4 多拠点: テナントの拠点一覧を取得する (フィルタ UI の表示要否・選択肢に使う)
-  const locations = await repos.locations.listByTenant(tenantId);
+  // Phase 4 多拠点: テナントの拠点一覧を取得する (フィルタ UI の表示要否・選択肢に使う)。
+  // Lite 側と同じ理由で網羅的な上限を明示する
+  const locations = await repos.locations.listByTenant(tenantId, {
+    limit: LOCATION_LIST_MATCHING_LIMIT,
+  });
   // URL の locationId は当該テナントの拠点一覧に実在するものだけを有効とみなす
   const selectedLocationId = resolveSelectedLocationId(sp.locationId, locations);
 

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -41,6 +41,10 @@ import { buildSpUrls } from '@/lib/saml';
 import { resolveAppBaseUrl } from '@/lib/app-url';
 // メール取り込み用の転送先アドレスを組み立てるヘルパー (取り込みトークン + 配信ドメイン)
 import { buildInboundAddress } from '@/lib/inbound-email';
+// 監査で発見したギャップ対応: listByTenant は既定で表示用の上限 (LOCATION_LIST_LIMIT = 200) しか
+// 返さない。本ページは拠点の「管理」画面 (LocationsSection) であり全件が前提のため、CSV インポート
+// と同じ網羅的な上限を明示的に渡す (未指定のままだと 201 拠点目以降が管理画面から見えなくなる)
+import { LOCATION_LIST_MATCHING_LIMIT } from '@/data/ports/location-repository';
 
 // /settings : テナント設定ページ (現状は Lite/Pro モードの切替のみ。管理者専用)
 export default async function SettingsPage() {
@@ -64,8 +68,8 @@ export default async function SettingsPage() {
     // テナント情報 (slackWebhookUrl / プラン / Stripe 情報の現在値を取得)。共有キャッシュ経由
     // にすることで、同一リクエスト内の (app)/layout.tsx (mode/plan 解決) と Tenant SELECT を共有する
     getCachedTenant(session.user.tenantId),
-    // 拠点一覧 (LocationsSection の初期値として渡す)
-    repos.locations.listByTenant(session.user.tenantId),
+    // 拠点一覧 (LocationsSection の初期値として渡す)。管理画面のため網羅的な上限を明示する
+    repos.locations.listByTenant(session.user.tenantId, { limit: LOCATION_LIST_MATCHING_LIMIT }),
     // 現在のスタッフ人数 (agent/admin のみ)。Stripe ダウングレード後にプラン上限を
     // 超えていないかを BillingSection で警告表示するために使う
     repos.users.countByTenant(session.user.tenantId),

--- a/src/app/(app)/tickets/[id]/page.tsx
+++ b/src/app/(app)/tickets/[id]/page.tsx
@@ -47,6 +47,11 @@ import { getSlaState, SLA_LABELS, SLA_COLORS, FIRST_RESPONSE_HOURS_BY_PRIORITY }
 import { getAllowedTransitions, getCompletionStatuses } from '@/domain/ticket-status';
 // FAQ 候補登録フォーム
 import { FaqCandidateForm } from '@/features/faq/components/FaqCandidateForm';
+// 監査で発見したギャップ対応: list/listByTenant は既定で表示用の上限 (200 件) しか返さない。
+// 本ページのカテゴリ/拠点変更プルダウンは全件が選択肢の前提のため (現在値が 201 件目以降だと
+// 選択肢から欠落し編集不能になる)、CSV インポートと同じ網羅的な上限を明示的に渡す
+import { CATEGORY_LIST_MATCHING_LIMIT } from '@/data/ports/category-repository';
+import { LOCATION_LIST_MATCHING_LIMIT } from '@/data/ports/location-repository';
 
 // /tickets/[id] ページの props (動的セグメント id を受け取る)
 interface Props {
@@ -97,9 +102,13 @@ export default async function TicketDetailPage({ params }: Props) {
     getCurrentTenantMode(tenantId),
     // エージェント時のみカテゴリ候補一覧を取得 (Pro モード専用の概念だが、mode 判定前に
     // Promise.all で並列化するため取得自体は agents と同様に isAgent だけで判定する)
-    isAgent ? repos.categories.list(tenantId) : Promise.resolve([]),
+    isAgent
+      ? repos.categories.list(tenantId, { limit: CATEGORY_LIST_MATCHING_LIMIT })
+      : Promise.resolve([]),
     // エージェント時のみ拠点候補一覧を取得 (Lite/Pro 両方で使える概念)
-    isAgent ? repos.locations.listByTenant(tenantId) : Promise.resolve([]),
+    isAgent
+      ? repos.locations.listByTenant(tenantId, { limit: LOCATION_LIST_MATCHING_LIMIT })
+      : Promise.resolve([]),
   ]);
 
   // チケットが存在しなければ 404

--- a/src/app/(app)/tickets/import/page.tsx
+++ b/src/app/(app)/tickets/import/page.tsx
@@ -13,6 +13,10 @@ import { CsvImportForm } from '@/features/tickets/components/CsvImportForm';
 import Link from 'next/link';
 // 未ログイン / 権限不足時のリダイレクト
 import { redirect } from 'next/navigation';
+// 監査で発見したギャップ対応: list は既定で表示用の上限 (200 件) しか返さない。実際の
+// インポート処理 (import-tickets.ts) は網羅的な上限 (CATEGORY_LIST_MATCHING_LIMIT) で
+// カテゴリ名を解決するため、このプレビュー表示だけ 200 件で切れると実処理と一覧が食い違う
+import { CATEGORY_LIST_MATCHING_LIMIT } from '@/data/ports/category-repository';
 
 // チケット CSV インポートページ (Server Component)
 export default async function TicketImportPage() {
@@ -29,8 +33,9 @@ export default async function TicketImportPage() {
 
   // tenantId を使ってカテゴリ一覧を取得する (将来の列マッピング UI に備えた先行取得)
   const tenantId = session.user.tenantId;
-  // カテゴリをリポジトリ経由で取得する (tenantId スコープ)
-  const categories = await repos.categories.list(tenantId);
+  // カテゴリをリポジトリ経由で取得する (tenantId スコープ)。実際のインポート処理と
+  // 同じ網羅的な上限を使い、プレビューと実処理の一覧が食い違わないようにする
+  const categories = await repos.categories.list(tenantId, { limit: CATEGORY_LIST_MATCHING_LIMIT });
 
   return (
     <div className="space-y-6">

--- a/src/app/(app)/tickets/new/page.tsx
+++ b/src/app/(app)/tickets/new/page.tsx
@@ -6,6 +6,11 @@ import { repos } from '@/data';
 import { TicketForm } from '@/features/tickets/components/TicketForm';
 // 現在ログイン中のテナントの動作モード (lite | pro) を取得するヘルパー
 import { getCurrentTenantMode } from '@/lib/tenant';
+// 監査で発見したギャップ対応: list/listByTenant は既定で表示用の上限 (200 件) しか返さない。
+// 本フォームのプルダウンは全カテゴリ・全拠点が選択肢の前提のため、CSV インポートと同じ
+// 網羅的な上限を明示的に渡す (未指定のままだと 201 件目以降が選べなくなる)
+import { CATEGORY_LIST_MATCHING_LIMIT } from '@/data/ports/category-repository';
+import { LOCATION_LIST_MATCHING_LIMIT } from '@/data/ports/location-repository';
 
 // /tickets/new : 新規チケット作成ページ (Server Component)
 export default async function NewTicketPage() {
@@ -18,10 +23,10 @@ export default async function NewTicketPage() {
   const tenantId = session.user.tenantId;
   // カテゴリ一覧・テナント mode・拠点一覧を並列取得する
   const [categories, mode, locations] = await Promise.all([
-    repos.categories.list(tenantId),
+    repos.categories.list(tenantId, { limit: CATEGORY_LIST_MATCHING_LIMIT }),
     getCurrentTenantMode(tenantId),
     // Phase 4 多拠点: 拠点プルダウン用の一覧を取得する
-    repos.locations.listByTenant(tenantId),
+    repos.locations.listByTenant(tenantId, { limit: LOCATION_LIST_MATCHING_LIMIT }),
   ]);
 
   return (

--- a/src/app/(app)/tickets/page.tsx
+++ b/src/app/(app)/tickets/page.tsx
@@ -23,6 +23,11 @@ import { TicketTabs } from '@/features/tickets/components/TicketTabs';
 import { buildTicketListFilter } from '@/features/tickets/build-filter';
 // CSV エクスポートボタン (Client Component — Suspense でラップして使う)
 import { CsvExportButton } from '@/features/tickets/components/CsvExportButton';
+// 監査で発見したギャップ対応: list/listByTenant は既定で表示用の上限 (200 件) しか返さない。
+// 本ページの絞り込みプルダウンは全カテゴリ・全拠点が選択肢の前提のため、CSV インポートと同じ
+// 網羅的な上限を明示的に渡す (未指定のままだと 201 件目以降が選択肢から消える)
+import { CATEGORY_LIST_MATCHING_LIMIT } from '@/data/ports/category-repository';
+import { LOCATION_LIST_MATCHING_LIMIT } from '@/data/ports/location-repository';
 
 // 1 ページあたりの表示件数
 const PAGE_SIZE = 20;
@@ -103,13 +108,13 @@ export default async function TicketsPage({ searchParams }: Props) {
       tenantId,
     }),
     repos.tickets.count(filter, tenantId),
-    repos.categories.list(tenantId),
+    repos.categories.list(tenantId, { limit: CATEGORY_LIST_MATCHING_LIMIT }),
     // 担当者プルダウン用ユーザーは agent/admin のみ (依頼者には不要)
     isAgent ? repos.users.listAgents(tenantId) : Promise.resolve([]),
     // テナントの動作モード (lite | pro) を取得し、ステータス表記を Lite/Pro で切り替える
     getCurrentTenantMode(tenantId),
     // Phase 4 多拠点: 拠点一覧をフィルタプルダウン用に取得する
-    repos.locations.listByTenant(tenantId),
+    repos.locations.listByTenant(tenantId, { limit: LOCATION_LIST_MATCHING_LIMIT }),
   ]);
 
   // 総ページ数を計算

--- a/src/app/api/auth/magic-link/callback/route.ts
+++ b/src/app/api/auth/magic-link/callback/route.ts
@@ -166,6 +166,7 @@ export async function POST(request: Request) {
     MAGIC_LINK_CALLBACK_RATE_LIMIT,
     'しばらく時間をおいて再度お試しください',
   );
+  // 制限超過なら 429 の NextResponse をそのまま返す (超過なしなら null が返り後続処理を続ける)
   if (limitResponse) return limitResponse;
 
   // クロスオリジン CSRF 対策: 同一オリジンからのフォーム送信であることを検証する。

--- a/src/app/api/auth/magic-link/callback/route.ts
+++ b/src/app/api/auth/magic-link/callback/route.ts
@@ -39,6 +39,10 @@ import { CredentialsSignin } from 'next-auth';
 import { redirect } from 'next/navigation';
 // HTML に外部由来文字列を安全に差し込むためのエスケープ関数 (XSS 対策)
 import { escapeHtml } from '@/lib/html-escape';
+// トークン消費 (POST) 側の固定キーレート制限値 (監査で発見したギャップ対応)
+import { MAGIC_LINK_CALLBACK_RATE_LIMIT } from '@/lib/magic-link';
+// Route Handler 向け共通レート制限ラッパー (inbound-email/inbound-line/sso-acs と共有)
+import { checkRouteRateLimit } from '@/lib/route-rate-limit';
 
 // GET ハンドラ: トークンを消費せず HTML 確認ページを返す。
 // メールゲートウェイのプリフェッチ対策として、実際の認証は POST でのみ行う。
@@ -155,6 +159,15 @@ export async function GET(request: Request) {
 // POST ハンドラ: フォーム送信でトークンを受け取り実際に認証を行う。
 // ユーザーが明示的にボタンをクリックした場合のみ到達する。
 export async function POST(request: Request) {
+  // 固定キーの全体レート制限を最初に適用する (CSRF 検証やトークン消費 (DB 参照) より前に弾き、
+  // 不正なトークンでの連打による DB 負荷増大を防ぐ。sso-acs と同じ「最初に置く」方針)
+  const limitResponse = checkRouteRateLimit(
+    'magic-link-callback',
+    MAGIC_LINK_CALLBACK_RATE_LIMIT,
+    'しばらく時間をおいて再度お試しください',
+  );
+  if (limitResponse) return limitResponse;
+
   // クロスオリジン CSRF 対策: 同一オリジンからのフォーム送信であることを検証する。
   // 検証戦略:
   //   1. Sec-Fetch-Site ヘッダ (Chrome 76+ / Firefox 90+): ブラウザが必ず付与し

--- a/src/data/adapters/memory/category-repository.memory.ts
+++ b/src/data/adapters/memory/category-repository.memory.ts
@@ -1,17 +1,20 @@
-// カテゴリリポジトリの契約 (port)・一覧の上限件数定数と、テスト用メモリストア型をインポート
-import { CATEGORY_LIST_LIMIT, type CategoryRepository } from '@/data/ports/category-repository';
+// カテゴリリポジトリの契約 (port)・一覧の上限クランプ関数と、テスト用メモリストア型をインポート
+import {
+  resolveCategoryListLimit,
+  type CategoryRepository,
+} from '@/data/ports/category-repository';
 import { nextId, type Store } from './store';
 
 // メモリストアを使ったカテゴリリポジトリを生成するファクトリ関数
 export function makeCategoryRepo(store: Store): CategoryRepository {
   return {
-    // 当該テナントのカテゴリを名前昇順で取得
-    async list(tenantId) {
+    // 当該テナントのカテゴリを名前昇順で取得する (opts.limit 省略時は表示用の既定上限)
+    async list(tenantId, opts) {
       return [...store.categories.values()] // Map から配列化
         .filter((c) => c.tenantId === tenantId) // テナントで絞る
         .map((c) => ({ id: c.id, name: c.name })) // 返却用に id/name だけ抽出
         .sort((a, b) => a.name.localeCompare(b.name)) // 名前でロケール順に並び替え
-        .slice(0, CATEGORY_LIST_LIMIT); // §8 一覧取得は必ず上限を持たせる (Prisma アダプタの take と揃える)
+        .slice(0, resolveCategoryListLimit(opts?.limit)); // §8 一覧取得は必ず上限を持たせる (呼び出し元の指定値をさらにクランプ)
     },
     // ID 指定 + tenantId スコープで 1 件取得 (存在しないか他テナントなら null)
     async findById(id, tenantId) {

--- a/src/data/adapters/memory/category-repository.memory.ts
+++ b/src/data/adapters/memory/category-repository.memory.ts
@@ -1,5 +1,5 @@
-// カテゴリリポジトリの契約 (port) と、テスト用メモリストア型をインポート
-import type { CategoryRepository } from '@/data/ports/category-repository';
+// カテゴリリポジトリの契約 (port)・一覧の上限件数定数と、テスト用メモリストア型をインポート
+import { CATEGORY_LIST_LIMIT, type CategoryRepository } from '@/data/ports/category-repository';
 import { nextId, type Store } from './store';
 
 // メモリストアを使ったカテゴリリポジトリを生成するファクトリ関数
@@ -10,7 +10,8 @@ export function makeCategoryRepo(store: Store): CategoryRepository {
       return [...store.categories.values()] // Map から配列化
         .filter((c) => c.tenantId === tenantId) // テナントで絞る
         .map((c) => ({ id: c.id, name: c.name })) // 返却用に id/name だけ抽出
-        .sort((a, b) => a.name.localeCompare(b.name)); // 名前でロケール順に並び替え
+        .sort((a, b) => a.name.localeCompare(b.name)) // 名前でロケール順に並び替え
+        .slice(0, CATEGORY_LIST_LIMIT); // §8 一覧取得は必ず上限を持たせる (Prisma アダプタの take と揃える)
     },
     // ID 指定 + tenantId スコープで 1 件取得 (存在しないか他テナントなら null)
     async findById(id, tenantId) {

--- a/src/data/adapters/memory/location-repository.memory.ts
+++ b/src/data/adapters/memory/location-repository.memory.ts
@@ -1,5 +1,5 @@
-// Location リポジトリの契約 (port)
-import type { LocationRepository } from '@/data/ports/location-repository';
+// Location リポジトリの契約 (port) と一覧の上限件数定数
+import { LOCATION_LIST_LIMIT, type LocationRepository } from '@/data/ports/location-repository';
 // ドメイン型
 import type { Location } from '@/domain/types';
 // メモリストアと ID 生成ヘルパー
@@ -11,12 +11,11 @@ export function makeLocationRepo(store: Store): LocationRepository {
     // テナント内の全拠点を名前昇順で返す
     async listByTenant(tenantId) {
       // テナントスコープで絞り込み
-      const rows = [...store.locations.values()].filter(
-        (loc) => loc.tenantId === tenantId,
-      );
+      const rows = [...store.locations.values()].filter((loc) => loc.tenantId === tenantId);
       // 拠点名でアルファベット/日本語順に昇順ソート
       rows.sort((a, b) => a.name.localeCompare(b.name, 'ja'));
-      return rows;
+      // §8 一覧取得は必ず上限を持たせる (Prisma アダプタの take と揃える)
+      return rows.slice(0, LOCATION_LIST_LIMIT);
     },
 
     // ID + tenantId で 1 件取得

--- a/src/data/adapters/memory/location-repository.memory.ts
+++ b/src/data/adapters/memory/location-repository.memory.ts
@@ -1,5 +1,8 @@
-// Location リポジトリの契約 (port) と一覧の上限件数定数
-import { LOCATION_LIST_LIMIT, type LocationRepository } from '@/data/ports/location-repository';
+// Location リポジトリの契約 (port) と一覧の上限クランプ関数
+import {
+  resolveLocationListLimit,
+  type LocationRepository,
+} from '@/data/ports/location-repository';
 // ドメイン型
 import type { Location } from '@/domain/types';
 // メモリストアと ID 生成ヘルパー
@@ -8,14 +11,14 @@ import { nextId, type Store } from './store';
 // メモリ版 Location リポジトリを生成するファクトリ関数
 export function makeLocationRepo(store: Store): LocationRepository {
   return {
-    // テナント内の全拠点を名前昇順で返す
-    async listByTenant(tenantId) {
+    // テナント内の全拠点を名前昇順で返す (opts.limit 省略時は表示用の既定上限)
+    async listByTenant(tenantId, opts) {
       // テナントスコープで絞り込み
       const rows = [...store.locations.values()].filter((loc) => loc.tenantId === tenantId);
       // 拠点名でアルファベット/日本語順に昇順ソート
       rows.sort((a, b) => a.name.localeCompare(b.name, 'ja'));
-      // §8 一覧取得は必ず上限を持たせる (Prisma アダプタの take と揃える)
-      return rows.slice(0, LOCATION_LIST_LIMIT);
+      // §8 一覧取得は必ず上限を持たせる (Prisma アダプタの take と揃える。呼び出し元の指定値をさらにクランプ)
+      return rows.slice(0, resolveLocationListLimit(opts?.limit));
     },
 
     // ID + tenantId で 1 件取得

--- a/src/data/adapters/memory/tenant-repository.memory.ts
+++ b/src/data/adapters/memory/tenant-repository.memory.ts
@@ -57,16 +57,20 @@ export function makeTenantRepo(store: Store): TenantRepository {
       return { ...tenant };
     },
 
-    // テナントの動作モード (lite | pro) を更新し、更新後の Tenant を返す
-    async updateMode(id, mode) {
-      // 対象テナントを Map から取得 (存在しなければ Prisma の update と同様にエラー)
+    // テナントの動作モード (lite | pro) を更新する (Prisma アダプタの updateMany と同じ CAS 契約)。
+    // 'pro' への切替時のみ expectedPlanIn で現在の subscriptionPlan を検証する
+    async updateMode(id, mode, expectedPlanIn) {
+      // 対象テナントを Map から取得 (存在しなければ Prisma の updateMany と同様に false)
       const t = store.tenants.get(id);
-      if (!t) throw new Error('テナントが見つかりません');
+      if (!t) return false;
+      // 'pro' への切替かつ expectedPlanIn 指定時のみ、現在のプランが許可リストに含まれるか検証する
+      if (mode === 'pro' && expectedPlanIn && !expectedPlanIn.includes(t.subscriptionPlan)) {
+        // プランが許可リストに含まれない (競合、または元々不許可) — 更新せず false
+        return false;
+      }
       // mode だけ差し替えた新しいオブジェクトを作り Map に書き戻す
-      const updated = { ...t, mode };
-      store.tenants.set(id, updated);
-      // 防御的コピーを返す (呼び出し側で破壊されないように)
-      return { ...updated };
+      store.tenants.set(id, { ...t, mode });
+      return true;
     },
 
     // メール取り込み用の inboundToken を (再)発行する

--- a/src/data/adapters/memory/tenant-repository.memory.ts
+++ b/src/data/adapters/memory/tenant-repository.memory.ts
@@ -1,7 +1,7 @@
 // Tenant リポジトリの契約 (port)
 import type { TenantRepository } from '@/data/ports/tenant-repository';
-// ドメイン型
-import type { Tenant } from '@/domain/types';
+// ドメイン型・テナントモード型・課金プラン型
+import type { SubscriptionPlan, Tenant, TenantMode } from '@/domain/types';
 // メモリストア型と ID 生成関数
 import { nextId, type Store } from './store';
 
@@ -59,9 +59,16 @@ export function makeTenantRepo(store: Store): TenantRepository {
 
     // テナントの動作モード (lite | pro) を更新する (Prisma アダプタの updateMany と同じ CAS 契約)。
     // 'pro' への切替時のみ expectedPlanIn で現在の subscriptionPlan を検証する
-    async updateMode(id, mode, expectedPlanIn) {
+    // port のオーバーロードを単一の実装関数で満たすためパラメータ型を明示する
+    // (Prisma アダプタの updateMode と同じ理由)
+    async updateMode(
+      id: string,
+      mode: TenantMode,
+      expectedPlanIn?: SubscriptionPlan[],
+    ): Promise<boolean> {
       // 対象テナントを Map から取得 (存在しなければ Prisma の updateMany と同様に false)
       const t = store.tenants.get(id);
+      // 存在しないテナント ID は Prisma の updateMany (0 件更新) と同じく false を返す
       if (!t) return false;
       // 'pro' への切替かつ expectedPlanIn 指定時のみ、現在のプランが許可リストに含まれるか検証する
       if (mode === 'pro' && expectedPlanIn && !expectedPlanIn.includes(t.subscriptionPlan)) {
@@ -70,6 +77,7 @@ export function makeTenantRepo(store: Store): TenantRepository {
       }
       // mode だけ差し替えた新しいオブジェクトを作り Map に書き戻す
       store.tenants.set(id, { ...t, mode });
+      // 更新できたことを示す true を返す
       return true;
     },
 

--- a/src/data/adapters/prisma/category-repository.prisma.ts
+++ b/src/data/adapters/prisma/category-repository.prisma.ts
@@ -1,5 +1,5 @@
-// カテゴリリポジトリの契約 (port) と、Prisma クライアント共通型をインポート
-import type { CategoryRepository } from '@/data/ports/category-repository';
+// カテゴリリポジトリの契約 (port)・一覧の上限件数定数と、Prisma クライアント共通型をインポート
+import { CATEGORY_LIST_LIMIT, type CategoryRepository } from '@/data/ports/category-repository';
 import type { PrismaLike } from './types';
 
 // Prisma クライアントを使ったカテゴリリポジトリを生成する関数
@@ -12,6 +12,7 @@ export function makeCategoryRepo(db: PrismaLike): CategoryRepository {
         where: { tenantId }, // テナントスコープ (必須)
         orderBy: { name: 'asc' }, // 名前昇順
         select: { id: true, name: true }, // id と name だけ取得
+        take: CATEGORY_LIST_LIMIT, // §8 一覧取得は必ず上限を持たせる
       });
       // 結果をそのまま返す (port 契約と同じ形)
       return rows;

--- a/src/data/adapters/prisma/category-repository.prisma.ts
+++ b/src/data/adapters/prisma/category-repository.prisma.ts
@@ -1,18 +1,21 @@
-// カテゴリリポジトリの契約 (port)・一覧の上限件数定数と、Prisma クライアント共通型をインポート
-import { CATEGORY_LIST_LIMIT, type CategoryRepository } from '@/data/ports/category-repository';
+// カテゴリリポジトリの契約 (port)・一覧の上限クランプ関数と、Prisma クライアント共通型をインポート
+import {
+  resolveCategoryListLimit,
+  type CategoryRepository,
+} from '@/data/ports/category-repository';
 import type { PrismaLike } from './types';
 
 // Prisma クライアントを使ったカテゴリリポジトリを生成する関数
 export function makeCategoryRepo(db: PrismaLike): CategoryRepository {
   return {
-    // 当該テナントのカテゴリを名前昇順で取得
-    async list(tenantId) {
-      // Prisma の findMany で tenantId スコープのみ全件取得
+    // 当該テナントのカテゴリを名前昇順で取得する (opts.limit 省略時は表示用の既定上限)
+    async list(tenantId, opts) {
+      // Prisma の findMany で tenantId スコープのみを取得
       const rows = await db.category.findMany({
         where: { tenantId }, // テナントスコープ (必須)
         orderBy: { name: 'asc' }, // 名前昇順
         select: { id: true, name: true }, // id と name だけ取得
-        take: CATEGORY_LIST_LIMIT, // §8 一覧取得は必ず上限を持たせる
+        take: resolveCategoryListLimit(opts?.limit), // §8 一覧取得は必ず上限を持たせる (呼び出し元の指定値をさらにクランプ)
       });
       // 結果をそのまま返す (port 契約と同じ形)
       return rows;

--- a/src/data/adapters/prisma/location-repository.prisma.ts
+++ b/src/data/adapters/prisma/location-repository.prisma.ts
@@ -1,5 +1,5 @@
-// Location リポジトリの契約 (port)
-import type { LocationRepository } from '@/data/ports/location-repository';
+// Location リポジトリの契約 (port) と一覧の上限件数定数
+import { LOCATION_LIST_LIMIT, type LocationRepository } from '@/data/ports/location-repository';
 // ドメイン型
 import type { Location } from '@/domain/types';
 // Prisma の Location 行型
@@ -31,6 +31,7 @@ export function makeLocationRepo(db: PrismaLike): LocationRepository {
       const rows = await db.location.findMany({
         where: { tenantId },
         orderBy: { name: 'asc' },
+        take: LOCATION_LIST_LIMIT, // §8 一覧取得は必ず上限を持たせる
       });
       // 各行をドメイン型に変換して返す
       return rows.map(toLocation);

--- a/src/data/adapters/prisma/location-repository.prisma.ts
+++ b/src/data/adapters/prisma/location-repository.prisma.ts
@@ -1,5 +1,8 @@
-// Location リポジトリの契約 (port) と一覧の上限件数定数
-import { LOCATION_LIST_LIMIT, type LocationRepository } from '@/data/ports/location-repository';
+// Location リポジトリの契約 (port) と一覧の上限クランプ関数
+import {
+  resolveLocationListLimit,
+  type LocationRepository,
+} from '@/data/ports/location-repository';
 // ドメイン型
 import type { Location } from '@/domain/types';
 // Prisma の Location 行型
@@ -25,13 +28,13 @@ function toLocation(row: LocationRow): Location {
 // Prisma クライアントを使った Location リポジトリを生成するファクトリ関数
 export function makeLocationRepo(db: PrismaLike): LocationRepository {
   return {
-    // テナント内の全拠点を名前昇順で取得する
-    async listByTenant(tenantId) {
+    // テナント内の全拠点を名前昇順で取得する (opts.limit 省略時は表示用の既定上限)
+    async listByTenant(tenantId, opts) {
       // テナントスコープで絞り込み、拠点名で昇順ソートして取得する
       const rows = await db.location.findMany({
         where: { tenantId },
         orderBy: { name: 'asc' },
-        take: LOCATION_LIST_LIMIT, // §8 一覧取得は必ず上限を持たせる
+        take: resolveLocationListLimit(opts?.limit), // §8 一覧取得は必ず上限を持たせる (呼び出し元の指定値をさらにクランプ)
       });
       // 各行をドメイン型に変換して返す
       return rows.map(toLocation);

--- a/src/data/adapters/prisma/tenant-repository.prisma.ts
+++ b/src/data/adapters/prisma/tenant-repository.prisma.ts
@@ -82,12 +82,19 @@ export function makeTenantRepo(db: PrismaLike): TenantRepository {
       return toTenant(row);
     },
 
-    // テナントの動作モード (lite | pro) を更新し、更新後の行をドメイン型で返す
-    async updateMode(id, mode) {
-      // 主キー (tenantId) で対象テナントを特定し mode 列のみ更新する
-      const row = await db.tenant.update({ where: { id }, data: { mode } });
-      // 更新後の行をドメイン型に詰め替えて返す
-      return toTenant(row);
+    // テナントの動作モード (lite | pro) を更新する。
+    // 'pro' への切替時のみ expectedPlanIn を where 条件に含めた原子的な更新 (CAS) にする
+    // (Stripe Webhook 由来の自動ダウングレードとの TOCTOU 競合防止。ポートのコメント参照)。
+    // 'lite' への切替や expectedPlanIn 省略時は無条件更新。updateMany の対象は主キー (id) のみ
+    // (または + subscriptionPlan) のため、他テナントへ波及する余地はない
+    async updateMode(id, mode, expectedPlanIn) {
+      const where: Prisma.TenantWhereInput =
+        mode === 'pro' && expectedPlanIn
+          ? { id, subscriptionPlan: { in: expectedPlanIn } }
+          : { id };
+      const result = await db.tenant.updateMany({ where, data: { mode } });
+      // 1 件以上更新できたか (0 件ならプラン不一致による競合、または対象不在) を返す
+      return result.count > 0;
     },
 
     // メール取り込み用の inboundToken を (再)発行する。主キーで対象テナントを特定し列のみ更新する

--- a/src/data/adapters/prisma/tenant-repository.prisma.ts
+++ b/src/data/adapters/prisma/tenant-repository.prisma.ts
@@ -2,8 +2,8 @@
 import type { TenantRepository } from '@/data/ports/tenant-repository';
 // 課金プラン型 (Stripe 課金プランの型チェック)
 import type { SubscriptionPlan } from '@/domain/types';
-// ドメイン型
-import type { Tenant } from '@/domain/types';
+// ドメイン型・テナントモード型
+import type { Tenant, TenantMode } from '@/domain/types';
 // Prisma の Tenant 行型
 import type { Prisma } from '@/generated/prisma';
 // Prisma クライアント/トランザクション共通型
@@ -87,11 +87,21 @@ export function makeTenantRepo(db: PrismaLike): TenantRepository {
     // (Stripe Webhook 由来の自動ダウングレードとの TOCTOU 競合防止。ポートのコメント参照)。
     // 'lite' への切替や expectedPlanIn 省略時は無条件更新。updateMany の対象は主キー (id) のみ
     // (または + subscriptionPlan) のため、他テナントへ波及する余地はない
-    async updateMode(id, mode, expectedPlanIn) {
+    // port のオーバーロード (mode:'lite' は expectedPlanIn 無し / mode:'pro' は必須) を単一の
+    // 実装関数で満たすため、パラメータ型を明示する (未annotationだと最初のオーバーロードの
+    // シグネチャだけが contextual typing で採用され、'pro' 呼び出しが型エラーになるため)
+    async updateMode(
+      id: string,
+      mode: TenantMode,
+      expectedPlanIn?: SubscriptionPlan[],
+    ): Promise<boolean> {
+      // 'pro' への切替かつ expectedPlanIn 指定時のみ、現在のプランも where 条件に含める
+      // (それ以外は主キー (id) だけで絞り込む無条件更新)
       const where: Prisma.TenantWhereInput =
         mode === 'pro' && expectedPlanIn
           ? { id, subscriptionPlan: { in: expectedPlanIn } }
           : { id };
+      // 条件に一致する行だけを更新する (0 件・1 件のどちらもあり得る updateMany)
       const result = await db.tenant.updateMany({ where, data: { mode } });
       // 1 件以上更新できたか (0 件ならプラン不一致による競合、または対象不在) を返す
       return result.count > 0;

--- a/src/data/ports/category-repository.ts
+++ b/src/data/ports/category-repository.ts
@@ -4,15 +4,29 @@ export interface CategorySummary {
   name: string; // カテゴリ名
 }
 
-// テナント内のカテゴリ一覧の上限件数 (§8 一覧取得は必ず上限を持たせる)。
-// LOCATION_LIST_LIMIT / FAQ_LIST_LIMIT と同じ規模感に揃える
+// テナント内のカテゴリ一覧の既定上限件数 (§8 一覧取得は必ず上限を持たせる)。UI 表示向けの
+// 規模感で、LOCATION_LIST_LIMIT / FAQ_LIST_LIMIT と揃える
 export const CATEGORY_LIST_LIMIT = 200;
+
+// CSV インポート (import-tickets.ts) の「カテゴリ」列名前解決のように、テナントのカテゴリを
+// 漏れなく引く必要がある網羅的な用途向けの上限 (LOCATION_LIST_MATCHING_LIMIT と同じ理由・
+// 同じ規模感。監査で発見したギャップ対応の詳細は location-repository.ts のコメント参照)
+export const CATEGORY_LIST_MATCHING_LIMIT = 10_000;
+
+// 呼び出し側が指定した limit (未指定なら CATEGORY_LIST_LIMIT) を CATEGORY_LIST_MATCHING_LIMIT
+// 以下にクランプする (resolveFaqListLimit / resolveLocationListLimit と同じ方針)
+export function resolveCategoryListLimit(requested?: number): number {
+  if (requested === undefined) return CATEGORY_LIST_LIMIT;
+  return Math.min(requested, CATEGORY_LIST_MATCHING_LIMIT);
+}
 
 // カテゴリ取得用リポジトリの契約 (port)
 // 全メソッドが tenantId 必須化済み。テナント越境参照を Adapter 層で遮断する
 export interface CategoryRepository {
-  // 当該テナントのカテゴリ一覧を取得 (上限 CATEGORY_LIST_LIMIT 件)
-  list(tenantId: string): Promise<CategorySummary[]>;
+  // 当該テナントのカテゴリ一覧を取得する。opts.limit 省略時は CATEGORY_LIST_LIMIT (表示用)。
+  // CSV インポートの名前解決など網羅性が必要な用途は opts.limit に CATEGORY_LIST_MATCHING_LIMIT
+  // を渡す (Adapter 側でその値を上限にクランプする)
+  list(tenantId: string, opts?: { limit?: number }): Promise<CategorySummary[]>;
   // ID 指定で 1 件取得 (他テナントの ID なら null を返す)
   findById(id: string, tenantId: string): Promise<CategorySummary | null>;
   // カテゴリを 1 件新規作成して返す (Phase 3 業種テンプレ初期投入用)

--- a/src/data/ports/category-repository.ts
+++ b/src/data/ports/category-repository.ts
@@ -4,10 +4,14 @@ export interface CategorySummary {
   name: string; // カテゴリ名
 }
 
+// テナント内のカテゴリ一覧の上限件数 (§8 一覧取得は必ず上限を持たせる)。
+// LOCATION_LIST_LIMIT / FAQ_LIST_LIMIT と同じ規模感に揃える
+export const CATEGORY_LIST_LIMIT = 200;
+
 // カテゴリ取得用リポジトリの契約 (port)
 // 全メソッドが tenantId 必須化済み。テナント越境参照を Adapter 層で遮断する
 export interface CategoryRepository {
-  // 当該テナントのカテゴリ一覧を取得
+  // 当該テナントのカテゴリ一覧を取得 (上限 CATEGORY_LIST_LIMIT 件)
   list(tenantId: string): Promise<CategorySummary[]>;
   // ID 指定で 1 件取得 (他テナントの ID なら null を返す)
   findById(id: string, tenantId: string): Promise<CategorySummary | null>;

--- a/src/data/ports/category-repository.ts
+++ b/src/data/ports/category-repository.ts
@@ -1,3 +1,6 @@
+// 「表示用 / 一括処理用」2 段クランプの共通ロジック (location-repository.ts と重複させない)
+import { resolveListLimit } from '@/data/ports/list-limit';
+
 // カテゴリの一覧表示などに使う軽量なカテゴリ情報
 export interface CategorySummary {
   id: string; // カテゴリ ID
@@ -16,8 +19,7 @@ export const CATEGORY_LIST_MATCHING_LIMIT = 10_000;
 // 呼び出し側が指定した limit (未指定なら CATEGORY_LIST_LIMIT) を CATEGORY_LIST_MATCHING_LIMIT
 // 以下にクランプする (resolveFaqListLimit / resolveLocationListLimit と同じ方針)
 export function resolveCategoryListLimit(requested?: number): number {
-  if (requested === undefined) return CATEGORY_LIST_LIMIT;
-  return Math.min(requested, CATEGORY_LIST_MATCHING_LIMIT);
+  return resolveListLimit(requested, CATEGORY_LIST_LIMIT, CATEGORY_LIST_MATCHING_LIMIT);
 }
 
 // カテゴリ取得用リポジトリの契約 (port)

--- a/src/data/ports/list-limit.ts
+++ b/src/data/ports/list-limit.ts
@@ -1,0 +1,17 @@
+// 「表示用の既定上限」と「一括処理向けの網羅的な上限」の 2 段クランプを複数のリポジトリ
+// (拠点・カテゴリ) が同じロジックで必要としたため、重複 (CLAUDE.md §6「2〜3 箇所目で共通化する」)
+// を避けてここに集約する (audit-pagination.ts の resolveAuditLimit 集約と同じ方針)。
+
+// 呼び出し側が指定した limit を [1, maxLimit] の範囲にクランプして返す。
+// requested が未指定なら defaultLimit (表示用) を使う。指定時も maxLimit (一括処理向けの
+// 網羅的な上限) を超えさせない (DoS・リソース枯渇防止の多層防御クランプ)
+export function resolveListLimit(
+  requested: number | undefined,
+  defaultLimit: number,
+  maxLimit: number,
+): number {
+  // 未指定なら表示用の既定値を返す
+  if (requested === undefined) return defaultLimit;
+  // 指定値を網羅的な上限以下にクランプする
+  return Math.min(requested, maxLimit);
+}

--- a/src/data/ports/location-repository.ts
+++ b/src/data/ports/location-repository.ts
@@ -4,15 +4,36 @@
 // 拠点ドメイン型
 import type { Location } from '@/domain/types';
 
-// テナント内の拠点一覧の上限件数 (§8 一覧取得は必ず上限を持たせる)。FAQ_LIST_LIMIT / PAGE_LIMIT
-// と同じ規模感に揃える。拠点作成は §4.1 で 1 分あたりのレート制限を設けているが、それは作成
-// "速度" しか抑えず累計件数には上限が無かったため、一覧取得側にも上限を追加する
+// テナント内の拠点一覧の既定上限件数 (§8 一覧取得は必ず上限を持たせる)。UI 表示 (設定画面の
+// 拠点管理・ダッシュボードの拠点フィルタ・チケット詳細/一覧のプルダウン) 向けの規模感で、
+// FAQ_LIST_LIMIT / PAGE_LIMIT と揃える。拠点作成は §4.1 で 1 分あたりのレート制限を設けているが、
+// それは作成 "速度" しか抑えず累計件数には上限が無かったため、一覧取得側にも上限を追加する
 export const LOCATION_LIST_LIMIT = 200;
+
+// CSV インポート (import-tickets.ts) の「拠点」列名前解決のように、テナントの拠点を
+// 漏れなく引く必要がある網羅的な用途向けの上限。監査で発見したギャップ対応: 当初
+// LOCATION_LIST_LIMIT を listByTenant の唯一の上限にしたところ、CSV インポートの名前解決
+// (buildNameToIdMap) がこの一覧を丸ごと使って名前→ID のルックアップ表を作る設計だったため、
+// 201 件目以降の拠点が対応表から漏れ、実在する拠点名なのに「拠点が見つかりません」という
+// 誤った検証エラーになっていた。表示用の上限 (LOCATION_LIST_LIMIT) とは別に、一括処理向けの
+// 上限を分けて持つ (`GET /api/audit/export` が画面表示用の PAGE_LIMIT とは別に
+// MAX_AUDIT_EXPORT_ROWS を持つのと同じ「表示用と一括処理用で上限を分ける」考え方)
+export const LOCATION_LIST_MATCHING_LIMIT = 10_000;
+
+// 呼び出し側が指定した limit (未指定なら LOCATION_LIST_LIMIT) を LOCATION_LIST_MATCHING_LIMIT
+// 以下にクランプする (resolveFaqListLimit と同じ「アダプタ層での多層防御クランプ」方針。
+// 未指定時に低い表示用の既定値、指定時でも高い網羅用の上限を超えさせない)
+export function resolveLocationListLimit(requested?: number): number {
+  if (requested === undefined) return LOCATION_LIST_LIMIT;
+  return Math.min(requested, LOCATION_LIST_MATCHING_LIMIT);
+}
 
 // 拠点リポジトリの契約 (port)。テナントスコープで CRUD 操作を提供する
 export interface LocationRepository {
-  // テナント内の全拠点を名前昇順で取得する (上限 LOCATION_LIST_LIMIT 件)
-  listByTenant(tenantId: string): Promise<Location[]>;
+  // テナント内の全拠点を名前昇順で取得する。opts.limit 省略時は LOCATION_LIST_LIMIT (表示用)。
+  // CSV インポートの名前解決など網羅性が必要な用途は opts.limit に LOCATION_LIST_MATCHING_LIMIT
+  // を渡す (Adapter 側でその値を上限にクランプする)
+  listByTenant(tenantId: string, opts?: { limit?: number }): Promise<Location[]>;
   // ID + tenantId で 1 件取得 (他テナントの ID なら null を返す)
   findById(id: string, tenantId: string): Promise<Location | null>;
   // 新規拠点を作成する (name はテナント内一意)

--- a/src/data/ports/location-repository.ts
+++ b/src/data/ports/location-repository.ts
@@ -3,6 +3,8 @@
 
 // 拠点ドメイン型
 import type { Location } from '@/domain/types';
+// 「表示用 / 一括処理用」2 段クランプの共通ロジック (category-repository.ts と重複させない)
+import { resolveListLimit } from '@/data/ports/list-limit';
 
 // テナント内の拠点一覧の既定上限件数 (§8 一覧取得は必ず上限を持たせる)。UI 表示 (設定画面の
 // 拠点管理・ダッシュボードの拠点フィルタ・チケット詳細/一覧のプルダウン) 向けの規模感で、
@@ -24,8 +26,7 @@ export const LOCATION_LIST_MATCHING_LIMIT = 10_000;
 // 以下にクランプする (resolveFaqListLimit と同じ「アダプタ層での多層防御クランプ」方針。
 // 未指定時に低い表示用の既定値、指定時でも高い網羅用の上限を超えさせない)
 export function resolveLocationListLimit(requested?: number): number {
-  if (requested === undefined) return LOCATION_LIST_LIMIT;
-  return Math.min(requested, LOCATION_LIST_MATCHING_LIMIT);
+  return resolveListLimit(requested, LOCATION_LIST_LIMIT, LOCATION_LIST_MATCHING_LIMIT);
 }
 
 // 拠点リポジトリの契約 (port)。テナントスコープで CRUD 操作を提供する

--- a/src/data/ports/location-repository.ts
+++ b/src/data/ports/location-repository.ts
@@ -4,9 +4,14 @@
 // 拠点ドメイン型
 import type { Location } from '@/domain/types';
 
+// テナント内の拠点一覧の上限件数 (§8 一覧取得は必ず上限を持たせる)。FAQ_LIST_LIMIT / PAGE_LIMIT
+// と同じ規模感に揃える。拠点作成は §4.1 で 1 分あたりのレート制限を設けているが、それは作成
+// "速度" しか抑えず累計件数には上限が無かったため、一覧取得側にも上限を追加する
+export const LOCATION_LIST_LIMIT = 200;
+
 // 拠点リポジトリの契約 (port)。テナントスコープで CRUD 操作を提供する
 export interface LocationRepository {
-  // テナント内の全拠点を名前昇順で取得する
+  // テナント内の全拠点を名前昇順で取得する (上限 LOCATION_LIST_LIMIT 件)
   listByTenant(tenantId: string): Promise<Location[]>;
   // ID + tenantId で 1 件取得 (他テナントの ID なら null を返す)
   findById(id: string, tenantId: string): Promise<Location | null>;

--- a/src/data/ports/tenant-repository.ts
+++ b/src/data/ports/tenant-repository.ts
@@ -18,9 +18,16 @@ export interface TenantRepository {
     inboundToken?: string | null;
     trialEndsAt?: Date | null; // §7.2 Free trial の終了日時 (未指定なら null = トライアル無し)
   }): Promise<Tenant>;
-  // テナントの動作モード (lite | pro) を更新し、更新後の Tenant を返す
-  // id はセッション由来の tenantId のみを渡す契約 (リクエスト入力から注入しないこと = クロステナント防止)
-  updateMode(id: string, mode: TenantMode): Promise<Tenant>;
+  // テナントの動作モード (lite | pro) を更新する。
+  // id はセッション由来の tenantId のみを渡す契約 (リクエスト入力から注入しないこと = クロステナント防止)。
+  // 監査で発見したギャップ対応: 'pro' への切替時に expectedPlanIn を渡すと、その配列に現在の
+  // 契約プラン (subscriptionPlan) が含まれる場合のみ更新する原子的な更新 (CAS) になり、
+  // 0 件更新なら false を返す。これにより「プラン確認 (isProModeAllowed) → 書き込み」の間に
+  // Stripe Webhook 由来の自動ダウングレード (applyPlanChange の updateMode(id, 'lite')) が
+  // 割り込んでも、古いプラン判定のまま Pro モードへ上書きされることを防ぐ。
+  // 'lite' への切替は常にどのプランでも許可されるため expectedPlanIn は無視し、無条件更新で
+  // 常に true を返す (省略時も同様)。
+  updateMode(id: string, mode: TenantMode, expectedPlanIn?: SubscriptionPlan[]): Promise<boolean>;
   // メール取り込み用の inboundToken を (再)発行する。マイグレーション前から存在し未発行のままの
   // テナントへの初回発行、および漏洩・スパム混入時の再発行 (ローテーション) の両方に使う。
   // id はセッション由来の tenantId のみを渡す契約 (クロステナント防止)

--- a/src/data/ports/tenant-repository.ts
+++ b/src/data/ports/tenant-repository.ts
@@ -20,14 +20,18 @@ export interface TenantRepository {
   }): Promise<Tenant>;
   // テナントの動作モード (lite | pro) を更新する。
   // id はセッション由来の tenantId のみを渡す契約 (リクエスト入力から注入しないこと = クロステナント防止)。
-  // 監査で発見したギャップ対応: 'pro' への切替時に expectedPlanIn を渡すと、その配列に現在の
-  // 契約プラン (subscriptionPlan) が含まれる場合のみ更新する原子的な更新 (CAS) になり、
+  // 監査で発見したギャップ対応: 'pro' への切替時は expectedPlanIn を渡し、その配列に現在の
+  // 契約プラン (subscriptionPlan) が含まれる場合のみ更新する原子的な更新 (CAS) にする。
   // 0 件更新なら false を返す。これにより「プラン確認 (isProModeAllowed) → 書き込み」の間に
   // Stripe Webhook 由来の自動ダウングレード (applyPlanChange の updateMode(id, 'lite')) が
   // 割り込んでも、古いプラン判定のまま Pro モードへ上書きされることを防ぐ。
-  // 'lite' への切替は常にどのプランでも許可されるため expectedPlanIn は無視し、無条件更新で
-  // 常に true を返す (省略時も同様)。
-  updateMode(id: string, mode: TenantMode, expectedPlanIn?: SubscriptionPlan[]): Promise<boolean>;
+  // 'pro' への切替オーバーロードは expectedPlanIn を必須にしている (/code-review ultra 指摘対応:
+  // 省略可能な第 3 引数のままだと、将来 'pro' へ切り替える呼び出しが増えたときに渡し忘れても
+  // コンパイルが通り、この CAS 保護だけが黙って無効化された無条件更新に戻ってしまうため、
+  // オーバーロードで型レベルの強制にした)。'lite' への切替は常にどのプランでも許可されるため
+  // expectedPlanIn を取らない (常に無条件更新で true を返す)。
+  updateMode(id: string, mode: 'lite'): Promise<boolean>;
+  updateMode(id: string, mode: 'pro', expectedPlanIn: SubscriptionPlan[]): Promise<boolean>;
   // メール取り込み用の inboundToken を (再)発行する。マイグレーション前から存在し未発行のままの
   // テナントへの初回発行、および漏洩・スパム混入時の再発行 (ローテーション) の両方に使う。
   // id はセッション由来の tenantId のみを渡す契約 (クロステナント防止)

--- a/src/features/auth/actions/accept-invitation.ts
+++ b/src/features/auth/actions/accept-invitation.ts
@@ -19,10 +19,13 @@
 import { hash } from 'bcryptjs';
 // データ層の Composition Root (リポジトリ束とトランザクション境界)
 import { repos, uow } from '@/data';
-// 招待トークンのハッシュ化 (生トークン → DB 保存値と同じ SHA-256 へ)
-import { hashInviteToken } from '@/lib/invite';
+// 招待トークンのハッシュ化 (生トークン → DB 保存値と同じ SHA-256 へ) と、受諾側の
+// エンドポイント全体レート制限値 (監査で発見したギャップ対応)
+import { hashInviteToken, INVITE_ACCEPT_GLOBAL_RATE_LIMIT } from '@/lib/invite';
 // Prisma の一意制約違反 (P2002) 判定の共通ヘルパー (6 箇所に重複していた判定を一元化 / §6 DRY)
 import { isUniqueConstraintError } from '@/lib/prisma-errors';
+// 連打防止のための共通レート制限ヘルパー (request-magic-link.ts 等と共有)
+import { enforceRateLimit } from '@/lib/rate-limit';
 // 受諾フォームの入力検証スキーマと、ユーザー入力メールの検証・正規化スキーマ
 import { acceptInvitationSchema, emailSchema } from '@/lib/validations/invite';
 // Phase 4 課金: プランごとのスタッフシート空き状況チェック (create-invitation.ts と共有)。
@@ -41,6 +44,11 @@ export async function acceptInvitation(
   rawToken: string,
   formData: FormData,
 ): Promise<AcceptInvitationResult> {
+  // 監査で発見したギャップ対応: 公開 (未認証) アクションかつ Serializable トランザクションを
+  // 伴うため、不正なトークンでの連打による DB 負荷増大を防ぐ固定キーの全体レート制限を
+  // 最初に適用する (§9 公開エンドポイント保護。requestMagicLink/requestSignup と同じ設計)
+  enforceRateLimit('invitation-accept:global', INVITE_ACCEPT_GLOBAL_RATE_LIMIT);
+
   // フォーム入力 (氏名・パスワード) を Zod で検証する
   const parsed = acceptInvitationSchema.safeParse({
     name: formData.get('name'),

--- a/src/features/settings/actions/update-tenant-mode.ts
+++ b/src/features/settings/actions/update-tenant-mode.ts
@@ -13,7 +13,7 @@ import { assertAdminSession } from '@/lib/role';
 // テナントモード入力 (lite | pro) の Zod 検証スキーマ
 import { tenantModeSchema } from '@/lib/validations/tenant';
 // Pro モード機能のプランゲート (§6.1 料金プラン: Pro / Enterprise のみ利用可能)
-import { isProModeAllowed } from '@/lib/plan-guard';
+import { isProModeAllowed, PRO_MODE_ALLOWED_PLANS } from '@/lib/plan-guard';
 // テナントの現在プランを解決する共通ヘルパー (複数箇所での重複を避ける)
 import { resolveTenantPlan } from '@/lib/tenant-plan';
 // 設定変更監査ログへの記録を共通化するヘルパー
@@ -48,8 +48,23 @@ export async function updateTenantMode(formData: FormData): Promise<void> {
     }
   }
 
-  // テナントの mode 列を更新 (id はセッション由来の tenantId のみ)
-  await repos.tenants.updateMode(tenantId, parsed.data);
+  // テナントの mode 列を更新する (id はセッション由来の tenantId のみ)。
+  // 監査で発見したギャップ対応: 'pro' への切替は上の isProModeAllowed 判定だけでは、判定と
+  // この書き込みの間に Stripe Webhook 由来の自動ダウングレード (applyPlanChange) が割り込むと
+  // 古いプラン判定のまま上書きしてしまう TOCTOU が残る。expectedPlanIn を渡した原子的な更新
+  // (CAS) にすることで、書き込み時点でも現在のプランが許可リストに含まれることを DB レベルで
+  // 保証する。'lite' への切替は常に許可されるため expectedPlanIn は渡さない (無条件更新)。
+  const updated = await repos.tenants.updateMode(
+    tenantId,
+    parsed.data,
+    parsed.data === 'pro' ? [...PRO_MODE_ALLOWED_PLANS] : undefined,
+  );
+  if (!updated) {
+    // 0 件更新 = 判定後にプランが変わった (Stripe 由来のダウングレード等) ことによる競合
+    throw new Error(
+      'モードを変更できませんでした。プランが変更された可能性があるため、画面を再読み込みしてください。',
+    );
+  }
 
   // モード変更はラベル・遷移表・メニュー表示など広範囲に影響するため、
   // 設定画面と主要画面 (一覧 / ダッシュボード) のキャッシュを無効化して再描画させる

--- a/src/features/settings/actions/update-tenant-mode.ts
+++ b/src/features/settings/actions/update-tenant-mode.ts
@@ -39,26 +39,28 @@ export async function updateTenantMode(formData: FormData): Promise<void> {
     throw new Error(parsed.error.issues[0]?.message ?? 'モードの指定が正しくありません');
   }
 
-  // プランゲート: Pro モードへの切替は Pro / Enterprise プランのみ (Free / Standard では不可 §6.1)。
-  // UI 非表示に頼らずサーバー側で強制する。Lite への切替はどのプランでも常に許可する。
+  // テナントの mode 列を更新する (id はセッション由来の tenantId のみ)。ここで parsed.data を
+  // 'pro'/'lite' の literal に narrow してから updateMode を呼ぶことで、port 側のオーバーロード
+  // (mode:'pro' のときだけ expectedPlanIn を必須にする) を型レベルで正しく選択させる
+  // (/code-review ultra 指摘対応: expectedPlanIn が省略可能な単一シグネチャのままだと、渡し
+  // 忘れてもコンパイルが通ってしまい CAS 保護が黙って無効化されるため)。
+  let updated: boolean;
   if (parsed.data === 'pro') {
+    // プランゲート: Pro モードへの切替は Pro / Enterprise プランのみ (Free / Standard では不可
+    // §6.1)。UI 非表示に頼らずサーバー側で強制する。
     const plan = await resolveTenantPlan(tenantId);
     if (!isProModeAllowed(plan)) {
       throw new Error('Pro モードは Pro / Enterprise プランでご利用いただけます。');
     }
+    // 監査で発見したギャップ対応: 上の isProModeAllowed 判定だけでは、判定とこの書き込みの間に
+    // Stripe Webhook 由来の自動ダウングレード (applyPlanChange) が割り込むと古いプラン判定の
+    // まま上書きしてしまう TOCTOU が残る。expectedPlanIn を渡した原子的な更新 (CAS) にすることで、
+    // 書き込み時点でも現在のプランが許可リストに含まれることを DB レベルで保証する。
+    updated = await repos.tenants.updateMode(tenantId, 'pro', [...PRO_MODE_ALLOWED_PLANS]);
+  } else {
+    // 'lite' への切替はどのプランでも常に許可されるため無条件更新
+    updated = await repos.tenants.updateMode(tenantId, 'lite');
   }
-
-  // テナントの mode 列を更新する (id はセッション由来の tenantId のみ)。
-  // 監査で発見したギャップ対応: 'pro' への切替は上の isProModeAllowed 判定だけでは、判定と
-  // この書き込みの間に Stripe Webhook 由来の自動ダウングレード (applyPlanChange) が割り込むと
-  // 古いプラン判定のまま上書きしてしまう TOCTOU が残る。expectedPlanIn を渡した原子的な更新
-  // (CAS) にすることで、書き込み時点でも現在のプランが許可リストに含まれることを DB レベルで
-  // 保証する。'lite' への切替は常に許可されるため expectedPlanIn は渡さない (無条件更新)。
-  const updated = await repos.tenants.updateMode(
-    tenantId,
-    parsed.data,
-    parsed.data === 'pro' ? [...PRO_MODE_ALLOWED_PLANS] : undefined,
-  );
   if (!updated) {
     // 0 件更新 = 判定後にプランが変わった (Stripe 由来のダウングレード等) ことによる競合
     throw new Error(

--- a/src/features/tickets/actions/import-tickets.ts
+++ b/src/features/tickets/actions/import-tickets.ts
@@ -43,6 +43,10 @@ import { resolveStatusFromLabel, getStatusLabelsForMode } from '@/lib/constants'
 import { broadcastUnreadCountToMany } from '@/features/notifications/notify';
 // Phase 4 課金: 月間チケット上限チェック (Web フォーム・メール/LINE 取り込みと共有)
 import { getMonthlyTicketQuota } from '@/lib/tenant-plan';
+// 拠点・カテゴリの名前解決を網羅的に行うための上限値 (監査で発見したギャップ対応。
+// 既定の表示用上限 (LOCATION_LIST_LIMIT/CATEGORY_LIST_LIMIT) とは別の、CSV インポート専用の上限)
+import { LOCATION_LIST_MATCHING_LIMIT } from '@/data/ports/location-repository';
+import { CATEGORY_LIST_MATCHING_LIMIT } from '@/data/ports/category-repository';
 // Phase 4: Slack/Teams/Chatwork 外部通知ヘルパー (Web フォーム・メール・LINE 取り込みと共有)
 import { notifyOutboundBestEffort } from '@/lib/outbound-notify';
 // 優先度から初回応答期限を計算する SLA ヘルパー (Web フォーム・メール・LINE 取り込みと共有)
@@ -635,11 +639,19 @@ export async function importTickets(csvText: string): Promise<ImportTicketsResul
   // 限らず依頼者もなり得るため、agentsForAssignee (listAgents) ではなく listByTenant (全ロール) を
   // 別途取得する。同一テナント内で対象が重なっても listAgents とは目的の異なる独立した取得のため、
   // 拠点・カテゴリ・エージェント一覧と合わせて Promise.all で並列化する (§8 パフォーマンス)。
+  // 監査で発見したギャップ対応: listByTenant/list は既定で表示用の上限 (LOCATION_LIST_LIMIT /
+  // CATEGORY_LIST_LIMIT = 200件) にクランプされる (§8)。この名前解決は「テナントの拠点/カテゴリを
+  // 漏れなく引く」網羅性が必須のため、既定値のまま呼ぶと 201 件目以降の拠点/カテゴリが対応表から
+  // 抜け落ち、実在する名前を CSV で指定しても「見つかりません」という誤ったエラーになってしまう
+  // (表示用の上限とは別に、CSV インポートのような一括処理向けの上限 (LOCATION_LIST_MATCHING_LIMIT /
+  // CATEGORY_LIST_MATCHING_LIMIT) を明示的に渡す)
   const [locationsByName, categoriesByName, agentsForAssignee, usersForCreator] = await Promise.all(
     [
-      buildNameToIdMap(locationIndex !== -1, () => repos.locations.listByTenant(tenantId)),
+      buildNameToIdMap(locationIndex !== -1, () =>
+        repos.locations.listByTenant(tenantId, { limit: LOCATION_LIST_MATCHING_LIMIT }),
+      ),
       buildNameToIdMap(categoryIndex !== -1 && mode !== 'lite', () =>
-        repos.categories.list(tenantId),
+        repos.categories.list(tenantId, { limit: CATEGORY_LIST_MATCHING_LIMIT }),
       ),
       assigneeIndex !== -1 ? repos.users.listAgents(tenantId) : Promise.resolve(null),
       creatorIndex !== -1 ? repos.users.listByTenant(tenantId) : Promise.resolve(null),

--- a/src/lib/invite.ts
+++ b/src/lib/invite.ts
@@ -29,6 +29,16 @@ export const INVITE_RATE_LIMIT_MAX = 30;
 // (バッチが大きすぎて他の招待発行を長時間ブロックしないようにする意図)
 export const MAX_BULK_INVITE_ROWS = INVITE_RATE_LIMIT_MAX;
 
+// 監査で発見したギャップ対応: 招待「受諾」(accept-invitation.ts) は公開 (未認証) の
+// Server Action で、シート上限の TOCTOU 防止のため Serializable 分離レベルのトランザクションを
+// 毎回開く (通常の Read Committed より書き込み競合検知のオーバーヘッドが大きい)。上記の
+// INVITE_RATE_LIMIT_MAX は「招待の発行」側 (テナント単位) のみを制限しており、requestMagicLink /
+// requestSignup と同じ理由で「受諾」側にはエンドポイント全体の固定キー制限が無かった。
+// 招待トークンは高エントロピーで推測は現実的でないが、無制限に POST できると不正なトークンで
+// 高コストな Serializable トランザクションを繰り返し発生させる DoS の的になるため追加する
+// (§9 公開エンドポイント保護)
+export const INVITE_ACCEPT_GLOBAL_RATE_LIMIT = { limit: 30, windowMs: 60_000 } as const;
+
 // 指定した baseUrl と生トークンから、招待される人が踏む受諾ページの URL を組み立てる
 // 例: buildInviteUrl('http://localhost:3000', 'xxx') -> 'http://localhost:3000/invite/xxx'
 export function buildInviteUrl(baseUrl: string, rawToken: string): string {

--- a/src/lib/magic-link.ts
+++ b/src/lib/magic-link.ts
@@ -27,6 +27,15 @@ export const MAGIC_LINK_RATE_LIMIT_MAX = 5;
 // ユーザーに限られ、踏み台としての実害がやや小さいため
 export const MAGIC_LINK_REQUEST_GLOBAL_RATE_LIMIT = { limit: 30, windowMs: 60_000 } as const;
 
+// 監査で発見したギャップ対応: マジックリンクの「発行」(上記) にはエンドポイント全体の
+// レート制限があったが、発行されたトークンを消費する「コールバック」
+// (POST /api/auth/magic-link/callback) には一切無かった。トークンは高エントロピーで
+// 推測は現実的でないものの、この経路は毎回 DB 参照 (consumeValidToken) を伴うため、
+// レート制限が無いと不正なトークンでの POST を無制限に送りつけて DB 負荷を上げる
+// DoS の的になる (SSO ACS の SSO_UNAUTHENTICATED_RATE_LIMIT と同じ考え方の
+// 「テナント/ユーザーに紐づく前の固定キー制限」)。
+export const MAGIC_LINK_CALLBACK_RATE_LIMIT = { limit: 60, windowMs: 60_000 } as const;
+
 // 32 byte (256 bit) のランダム値を URL 安全な base64url 文字列にして返す
 // base64url なので URL に直接入れても percent-encode が要らない
 export function generateMagicLinkToken(): string {

--- a/src/lib/plan-guard.ts
+++ b/src/lib/plan-guard.ts
@@ -91,13 +91,19 @@ export function isLineIntegrationAllowed(plan: SubscriptionPlan): boolean {
   return plan === 'pro' || plan === 'enterprise';
 }
 
+// Pro モードへの切替を許可するプランの一覧 (単一の源)。isProModeAllowed だけでなく、
+// TenantRepository.updateMode の原子的な CAS (compare-and-swap) 更新の where 条件にも
+// そのまま渡す (監査で発見したギャップ対応: 管理者操作と Stripe Webhook 由来の自動
+// ダウングレードが競合する TOCTOU を防ぐため、プラン判定と書き込みを同じ配列で揃える)
+export const PRO_MODE_ALLOWED_PLANS: readonly SubscriptionPlan[] = ['pro', 'enterprise'];
+
 // Pro モード (7 ステータス・SLA・エスカレーション等) の利用可否
 // Standard と Pro の両方で Pro モードを許可する判断については、
 // 画面の mode フラグ (lite/pro) を管理者が個別に切り替える設計のため、
 // プラン上は Pro / Enterprise プランが既定で pro mode になる
 export function isProModeAllowed(plan: SubscriptionPlan): boolean {
   // Pro / Enterprise プランで Pro モードのフル機能を有効化できる
-  return plan === 'pro' || plan === 'enterprise';
+  return PRO_MODE_ALLOWED_PLANS.includes(plan);
 }
 
 // SSO (SAML) シングルサインオンの利用可否 (Enterprise のみ)。

--- a/tests/data/category-repository.contract.prisma.test.ts
+++ b/tests/data/category-repository.contract.prisma.test.ts
@@ -9,6 +9,7 @@
 import { describe, beforeAll, afterAll, beforeEach, expect, it } from 'vitest';
 import { PrismaClient } from '@/generated/prisma';
 import { buildPrismaRepos } from '@/data/adapters/prisma';
+import { CATEGORY_LIST_LIMIT } from '@/data/ports/category-repository';
 
 const TENANT_A = 'tenant-a';
 const TENANT_B = 'tenant-b';
@@ -79,5 +80,19 @@ describe.runIf(SHOULD_RUN)('CategoryRepository (prisma adapter)', () => {
     const category = await repos.categories.create({ name: 'A拠点用', tenantId: TENANT_A });
     const result = await repos.categories.findById(category.id, TENANT_B);
     expect(result).toBeNull();
+  });
+
+  // 監査で発見したギャップ対応: 上限件数を超えて作成しても CATEGORY_LIST_LIMIT 件までに
+  // 切り詰められること (§8 一覧取得は必ず上限を持たせる。実 DB の take が効くことの確認)
+  it('listは上限件数で切り詰める', async () => {
+    const repos = buildPrismaRepos(prisma);
+    for (let i = 0; i < CATEGORY_LIST_LIMIT + 3; i += 1) {
+      await repos.categories.create({
+        name: `カテゴリ${String(i).padStart(4, '0')}`,
+        tenantId: TENANT_A,
+      });
+    }
+    const result = await repos.categories.list(TENANT_A);
+    expect(result).toHaveLength(CATEGORY_LIST_LIMIT);
   });
 });

--- a/tests/data/category-repository.contract.prisma.test.ts
+++ b/tests/data/category-repository.contract.prisma.test.ts
@@ -9,7 +9,10 @@
 import { describe, beforeAll, afterAll, beforeEach, expect, it } from 'vitest';
 import { PrismaClient } from '@/generated/prisma';
 import { buildPrismaRepos } from '@/data/adapters/prisma';
-import { CATEGORY_LIST_LIMIT } from '@/data/ports/category-repository';
+import {
+  CATEGORY_LIST_LIMIT,
+  CATEGORY_LIST_MATCHING_LIMIT,
+} from '@/data/ports/category-repository';
 
 const TENANT_A = 'tenant-a';
 const TENANT_B = 'tenant-b';
@@ -94,5 +97,19 @@ describe.runIf(SHOULD_RUN)('CategoryRepository (prisma adapter)', () => {
     }
     const result = await repos.categories.list(TENANT_A);
     expect(result).toHaveLength(CATEGORY_LIST_LIMIT);
+  });
+
+  // 監査で発見したギャップ対応: opts.limit に CATEGORY_LIST_MATCHING_LIMIT を明示的に渡すと、
+  // 実 DB でも表示用の既定上限を超えて取得できること (CSV インポートの名前解決が依存する経路)
+  it('opts.limitを指定すると実DBでも既定上限を超えて取得できる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    for (let i = 0; i < CATEGORY_LIST_LIMIT + 3; i += 1) {
+      await repos.categories.create({
+        name: `カテゴリ${String(i).padStart(4, '0')}`,
+        tenantId: TENANT_A,
+      });
+    }
+    const result = await repos.categories.list(TENANT_A, { limit: CATEGORY_LIST_MATCHING_LIMIT });
+    expect(result).toHaveLength(CATEGORY_LIST_LIMIT + 3);
   });
 });

--- a/tests/data/category-repository.memory.test.ts
+++ b/tests/data/category-repository.memory.test.ts
@@ -5,7 +5,11 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createMemoryContext } from '@/data/adapters/memory';
-import { CATEGORY_LIST_LIMIT } from '@/data/ports/category-repository';
+import {
+  CATEGORY_LIST_LIMIT,
+  CATEGORY_LIST_MATCHING_LIMIT,
+  resolveCategoryListLimit,
+} from '@/data/ports/category-repository';
 import type { Repos } from '@/data/ports/unit-of-work';
 
 const TENANT_A = 'tenant-a';
@@ -73,5 +77,41 @@ describe('CategoryRepository (memory)', () => {
     }
     const result = await repos.categories.list(TENANT_A);
     expect(result).toHaveLength(CATEGORY_LIST_LIMIT);
+  });
+
+  // 監査で発見したギャップ対応: opts.limit に CATEGORY_LIST_MATCHING_LIMIT を明示的に渡すと、
+  // 表示用の既定上限 (CATEGORY_LIST_LIMIT) を超えて取得できること (CSV インポートの名前解決が
+  // これに依存する)
+  it('opts.limitを指定すると既定上限を超えて取得できる', async () => {
+    for (let i = 0; i < CATEGORY_LIST_LIMIT + 3; i += 1) {
+      await repos.categories.create({
+        name: `カテゴリ${String(i).padStart(4, '0')}`,
+        tenantId: TENANT_A,
+      });
+    }
+    const result = await repos.categories.list(TENANT_A, { limit: CATEGORY_LIST_MATCHING_LIMIT });
+    expect(result).toHaveLength(CATEGORY_LIST_LIMIT + 3);
+  });
+});
+
+// resolveCategoryListLimit (呼び出し元の指定値をクランプする純粋関数) の単体テスト。
+describe('resolveCategoryListLimit', () => {
+  // 未指定 (undefined) なら表示用の既定上限 (CATEGORY_LIST_LIMIT) を返す
+  it('未指定ならCATEGORY_LIST_LIMITを返す', () => {
+    expect(resolveCategoryListLimit(undefined)).toBe(CATEGORY_LIST_LIMIT);
+  });
+
+  // 指定値が CATEGORY_LIST_MATCHING_LIMIT 以下ならそのまま返す
+  it('CATEGORY_LIST_MATCHING_LIMIT以下ならそのまま返す', () => {
+    expect(resolveCategoryListLimit(CATEGORY_LIST_MATCHING_LIMIT)).toBe(
+      CATEGORY_LIST_MATCHING_LIMIT,
+    );
+  });
+
+  // 指定値が CATEGORY_LIST_MATCHING_LIMIT を超えるとクランプされる
+  it('CATEGORY_LIST_MATCHING_LIMITを超えるとクランプされる', () => {
+    expect(resolveCategoryListLimit(CATEGORY_LIST_MATCHING_LIMIT + 1000)).toBe(
+      CATEGORY_LIST_MATCHING_LIMIT,
+    );
   });
 });

--- a/tests/data/category-repository.memory.test.ts
+++ b/tests/data/category-repository.memory.test.ts
@@ -5,6 +5,7 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createMemoryContext } from '@/data/adapters/memory';
+import { CATEGORY_LIST_LIMIT } from '@/data/ports/category-repository';
 import type { Repos } from '@/data/ports/unit-of-work';
 
 const TENANT_A = 'tenant-a';
@@ -59,5 +60,18 @@ describe('CategoryRepository (memory)', () => {
   it('findByIdは存在しないIDにnullを返す', async () => {
     const result = await repos.categories.findById('no-such-category', TENANT_A);
     expect(result).toBeNull();
+  });
+
+  // 監査で発見したギャップ対応: 上限件数を超えて作成しても CATEGORY_LIST_LIMIT 件までに
+  // 切り詰められること (§8 一覧取得は必ず上限を持たせる)
+  it('listは上限件数で切り詰める', async () => {
+    for (let i = 0; i < CATEGORY_LIST_LIMIT + 3; i += 1) {
+      await repos.categories.create({
+        name: `カテゴリ${String(i).padStart(4, '0')}`,
+        tenantId: TENANT_A,
+      });
+    }
+    const result = await repos.categories.list(TENANT_A);
+    expect(result).toHaveLength(CATEGORY_LIST_LIMIT);
   });
 });

--- a/tests/data/location-repository.contract.prisma.test.ts
+++ b/tests/data/location-repository.contract.prisma.test.ts
@@ -13,7 +13,10 @@
 import { describe, beforeAll, afterAll, beforeEach, expect, it } from 'vitest';
 import { PrismaClient } from '@/generated/prisma';
 import { buildPrismaRepos } from '@/data/adapters/prisma';
-import { LOCATION_LIST_LIMIT } from '@/data/ports/location-repository';
+import {
+  LOCATION_LIST_LIMIT,
+  LOCATION_LIST_MATCHING_LIMIT,
+} from '@/data/ports/location-repository';
 
 const TENANT_A = 'default-tenant';
 const TENANT_B = 'tenant-b';
@@ -109,6 +112,23 @@ describe.runIf(SHOULD_RUN)('LocationRepository (prisma adapter)', () => {
     }
     const result = await repos.locations.listByTenant(TENANT_A);
     expect(result).toHaveLength(LOCATION_LIST_LIMIT);
+  });
+
+  // 監査で発見したギャップ対応: opts.limit に LOCATION_LIST_MATCHING_LIMIT を明示的に渡すと、
+  // 実 DB でも表示用の既定上限を超えて取得できること (CSV インポートの名前解決が依存する経路)
+  it('opts.limitを指定すると実DBでも既定上限を超えて取得できる', async () => {
+    const repos = buildPrismaRepos(prisma);
+    for (let i = 0; i < LOCATION_LIST_LIMIT + 3; i += 1) {
+      await repos.locations.create({
+        tenantId: TENANT_A,
+        name: `拠点${String(i).padStart(4, '0')}`,
+        description: null,
+      });
+    }
+    const result = await repos.locations.listByTenant(TENANT_A, {
+      limit: LOCATION_LIST_MATCHING_LIMIT,
+    });
+    expect(result).toHaveLength(LOCATION_LIST_LIMIT + 3);
   });
 
   // 他テナントの ID を渡すと null を返す (クロステナントアクセス防止)

--- a/tests/data/location-repository.contract.prisma.test.ts
+++ b/tests/data/location-repository.contract.prisma.test.ts
@@ -13,6 +13,7 @@
 import { describe, beforeAll, afterAll, beforeEach, expect, it } from 'vitest';
 import { PrismaClient } from '@/generated/prisma';
 import { buildPrismaRepos } from '@/data/adapters/prisma';
+import { LOCATION_LIST_LIMIT } from '@/data/ports/location-repository';
 
 const TENANT_A = 'default-tenant';
 const TENANT_B = 'tenant-b';
@@ -93,6 +94,21 @@ describe.runIf(SHOULD_RUN)('LocationRepository (prisma adapter)', () => {
     const result = await repos.locations.listByTenant(TENANT_A);
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe('A拠点');
+  });
+
+  // 監査で発見したギャップ対応: 上限件数を超えて作成しても LOCATION_LIST_LIMIT 件までに
+  // 切り詰められること (§8 一覧取得は必ず上限を持たせる。実 DB の take が効くことの確認)
+  it('listByTenantは上限件数で切り詰める', async () => {
+    const repos = buildPrismaRepos(prisma);
+    for (let i = 0; i < LOCATION_LIST_LIMIT + 3; i += 1) {
+      await repos.locations.create({
+        tenantId: TENANT_A,
+        name: `拠点${String(i).padStart(4, '0')}`,
+        description: null,
+      });
+    }
+    const result = await repos.locations.listByTenant(TENANT_A);
+    expect(result).toHaveLength(LOCATION_LIST_LIMIT);
   });
 
   // 他テナントの ID を渡すと null を返す (クロステナントアクセス防止)

--- a/tests/data/location-repository.memory.test.ts
+++ b/tests/data/location-repository.memory.test.ts
@@ -5,7 +5,11 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createMemoryContext, type Store } from '@/data/adapters/memory';
-import { LOCATION_LIST_LIMIT } from '@/data/ports/location-repository';
+import {
+  LOCATION_LIST_LIMIT,
+  LOCATION_LIST_MATCHING_LIMIT,
+  resolveLocationListLimit,
+} from '@/data/ports/location-repository';
 import type { Repos } from '@/data/ports/unit-of-work';
 
 const TENANT_A = 'tenant-a';
@@ -99,6 +103,47 @@ describe('LocationRepository.listByTenant (memory)', () => {
     }
     const result = await repos.locations.listByTenant(TENANT_A);
     expect(result).toHaveLength(LOCATION_LIST_LIMIT);
+  });
+
+  // 監査で発見したギャップ対応: opts.limit に LOCATION_LIST_MATCHING_LIMIT を明示的に渡すと、
+  // 表示用の既定上限 (LOCATION_LIST_LIMIT) を超えて取得できること (CSV インポートの名前解決が
+  // これに依存する)
+  it('opts.limitを指定すると既定上限を超えて取得できる', async () => {
+    for (let i = 0; i < LOCATION_LIST_LIMIT + 3; i += 1) {
+      await repos.locations.create({
+        tenantId: TENANT_A,
+        name: `拠点${String(i).padStart(4, '0')}`,
+        description: null,
+      });
+    }
+    const result = await repos.locations.listByTenant(TENANT_A, {
+      limit: LOCATION_LIST_MATCHING_LIMIT,
+    });
+    expect(result).toHaveLength(LOCATION_LIST_LIMIT + 3);
+  });
+});
+
+// resolveLocationListLimit (呼び出し元の指定値をクランプする純粋関数) の単体テスト。
+// アダプタ層の多層防御クランプが正しく機能することを、実データを介さず直接検証する
+// (resolveFaqListLimit と同じ「アダプタ経由ではなく関数自体を直接テストする」方針)
+describe('resolveLocationListLimit', () => {
+  // 未指定 (undefined) なら表示用の既定上限 (LOCATION_LIST_LIMIT) を返す
+  it('未指定ならLOCATION_LIST_LIMITを返す', () => {
+    expect(resolveLocationListLimit(undefined)).toBe(LOCATION_LIST_LIMIT);
+  });
+
+  // 指定値が LOCATION_LIST_MATCHING_LIMIT 以下ならそのまま返す
+  it('LOCATION_LIST_MATCHING_LIMIT以下ならそのまま返す', () => {
+    expect(resolveLocationListLimit(LOCATION_LIST_MATCHING_LIMIT)).toBe(
+      LOCATION_LIST_MATCHING_LIMIT,
+    );
+  });
+
+  // 指定値が LOCATION_LIST_MATCHING_LIMIT を超えるとクランプされる
+  it('LOCATION_LIST_MATCHING_LIMITを超えるとクランプされる', () => {
+    expect(resolveLocationListLimit(LOCATION_LIST_MATCHING_LIMIT + 1000)).toBe(
+      LOCATION_LIST_MATCHING_LIMIT,
+    );
   });
 });
 

--- a/tests/data/location-repository.memory.test.ts
+++ b/tests/data/location-repository.memory.test.ts
@@ -5,6 +5,7 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createMemoryContext, type Store } from '@/data/adapters/memory';
+import { LOCATION_LIST_LIMIT } from '@/data/ports/location-repository';
 import type { Repos } from '@/data/ports/unit-of-work';
 
 const TENANT_A = 'tenant-a';
@@ -84,6 +85,20 @@ describe('LocationRepository.listByTenant (memory)', () => {
     const result = await repos.locations.listByTenant(TENANT_A);
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe('A拠点');
+  });
+
+  // 監査で発見したギャップ対応: 上限件数を超えて作成しても LOCATION_LIST_LIMIT 件までに
+  // 切り詰められること (§8 一覧取得は必ず上限を持たせる)
+  it('上限件数で切り詰める', async () => {
+    for (let i = 0; i < LOCATION_LIST_LIMIT + 3; i += 1) {
+      await repos.locations.create({
+        tenantId: TENANT_A,
+        name: `拠点${String(i).padStart(4, '0')}`,
+        description: null,
+      });
+    }
+    const result = await repos.locations.listByTenant(TENANT_A);
+    expect(result).toHaveLength(LOCATION_LIST_LIMIT);
   });
 });
 

--- a/tests/data/tenant-repository.contract.prisma.test.ts
+++ b/tests/data/tenant-repository.contract.prisma.test.ts
@@ -58,7 +58,7 @@ describe.runIf(SHOULD_RUN)('TenantRepository (prisma adapter)', () => {
     const repos = buildPrismaRepos(prisma);
     const a = await repos.tenants.create({ name: 'A組織', mode: 'lite' });
     const b = await repos.tenants.create({ name: 'B組織', mode: 'lite' });
-    const updated = await repos.tenants.updateMode(a.id, 'pro');
+    const updated = await repos.tenants.updateMode(a.id, 'pro', ['free']);
     expect(updated).toBe(true);
     const reloadedA = await repos.tenants.findById(a.id);
     const reloadedB = await repos.tenants.findById(b.id);

--- a/tests/data/tenant-repository.contract.prisma.test.ts
+++ b/tests/data/tenant-repository.contract.prisma.test.ts
@@ -70,24 +70,35 @@ describe.runIf(SHOULD_RUN)('TenantRepository (prisma adapter)', () => {
   // 効くことの確認。現在の契約プランが許可リストに含まれない場合は更新せず false を返す
   // (Stripe Webhook 由来の自動ダウングレードと管理者操作の TOCTOU 競合防止)
   it('expectedPlanInに現在のプランが含まれない場合は更新せずfalseを返す', async () => {
+    // Prisma アダプタ経由のリポジトリ束を組み立てる
     const repos = buildPrismaRepos(prisma);
     // subscriptionPlan 省略時の既定は 'free' (Tenant.create の port 契約参照)
     const tenant = await repos.tenants.create({ name: 'A組織', mode: 'lite' });
+    // 現在のプラン ('free') が expectedPlanIn ('pro'/'enterprise') に含まれないため更新は不成立
     const updated = await repos.tenants.updateMode(tenant.id, 'pro', ['pro', 'enterprise']);
+    // CAS が不一致で false を返すことを確認する
     expect(updated).toBe(false);
+    // DB を再読込して実際にモードが変わっていないことを確認する
     const reloaded = await repos.tenants.findById(tenant.id);
+    // mode は元の 'lite' のまま
     expect(reloaded?.mode).toBe('lite');
   });
 
   // expectedPlanIn に現在のプランが含まれる場合は実 DB でも更新される
   it('expectedPlanInに現在のプランが含まれる場合は更新される', async () => {
+    // Prisma アダプタ経由のリポジトリ束を組み立てる
     const repos = buildPrismaRepos(prisma);
+    // subscriptionPlan 省略時の既定は 'free' のテナントを作成する
     const tenant = await repos.tenants.create({ name: 'A組織', mode: 'lite' });
     // Stripe 連携情報の更新経由で subscriptionPlan を 'pro' にする
     await repos.tenants.updateStripeSubscription(tenant.id, { subscriptionPlan: 'pro' });
+    // 現在のプラン ('pro') が expectedPlanIn に含まれるため CAS が成立し更新される
     const updated = await repos.tenants.updateMode(tenant.id, 'pro', ['pro', 'enterprise']);
+    // CAS が一致で true を返すことを確認する
     expect(updated).toBe(true);
+    // DB を再読込して実際に mode が変わったことを確認する
     const reloaded = await repos.tenants.findById(tenant.id);
+    // mode が 'pro' に更新されている
     expect(reloaded?.mode).toBe('pro');
   });
 

--- a/tests/data/tenant-repository.contract.prisma.test.ts
+++ b/tests/data/tenant-repository.contract.prisma.test.ts
@@ -58,11 +58,37 @@ describe.runIf(SHOULD_RUN)('TenantRepository (prisma adapter)', () => {
     const repos = buildPrismaRepos(prisma);
     const a = await repos.tenants.create({ name: 'A組織', mode: 'lite' });
     const b = await repos.tenants.create({ name: 'B組織', mode: 'lite' });
-    await repos.tenants.updateMode(a.id, 'pro');
+    const updated = await repos.tenants.updateMode(a.id, 'pro');
+    expect(updated).toBe(true);
     const reloadedA = await repos.tenants.findById(a.id);
     const reloadedB = await repos.tenants.findById(b.id);
     expect(reloadedA?.mode).toBe('pro');
     expect(reloadedB?.mode).toBe('lite');
+  });
+
+  // 監査で発見したギャップ対応: expectedPlanIn を渡した CAS (compare-and-swap) が実 DB でも
+  // 効くことの確認。現在の契約プランが許可リストに含まれない場合は更新せず false を返す
+  // (Stripe Webhook 由来の自動ダウングレードと管理者操作の TOCTOU 競合防止)
+  it('expectedPlanInに現在のプランが含まれない場合は更新せずfalseを返す', async () => {
+    const repos = buildPrismaRepos(prisma);
+    // subscriptionPlan 省略時の既定は 'free' (Tenant.create の port 契約参照)
+    const tenant = await repos.tenants.create({ name: 'A組織', mode: 'lite' });
+    const updated = await repos.tenants.updateMode(tenant.id, 'pro', ['pro', 'enterprise']);
+    expect(updated).toBe(false);
+    const reloaded = await repos.tenants.findById(tenant.id);
+    expect(reloaded?.mode).toBe('lite');
+  });
+
+  // expectedPlanIn に現在のプランが含まれる場合は実 DB でも更新される
+  it('expectedPlanInに現在のプランが含まれる場合は更新される', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const tenant = await repos.tenants.create({ name: 'A組織', mode: 'lite' });
+    // Stripe 連携情報の更新経由で subscriptionPlan を 'pro' にする
+    await repos.tenants.updateStripeSubscription(tenant.id, { subscriptionPlan: 'pro' });
+    const updated = await repos.tenants.updateMode(tenant.id, 'pro', ['pro', 'enterprise']);
+    expect(updated).toBe(true);
+    const reloaded = await repos.tenants.findById(tenant.id);
+    expect(reloaded?.mode).toBe('pro');
   });
 
   // updateNotificationChannels は渡したフィールドだけ更新し、undefined は現状維持する (部分更新契約)
@@ -136,7 +162,10 @@ describe.runIf(SHOULD_RUN)('TenantRepository (prisma adapter)', () => {
       name: 'trial-near',
       trialEndsAt: new Date('2026-07-05T00:00:00Z'),
     });
-    await repos.tenants.create({ name: 'trial-expired', trialEndsAt: new Date('2026-06-25T00:00:00Z') });
+    await repos.tenants.create({
+      name: 'trial-expired',
+      trialEndsAt: new Date('2026-06-25T00:00:00Z'),
+    });
     await repos.tenants.create({ name: 'no-trial' }); // trialEndsAt 未指定 (null)
 
     const result = await repos.tenants.listActiveTrials(now, 100);

--- a/tests/data/tenant-repository.memory.test.ts
+++ b/tests/data/tenant-repository.memory.test.ts
@@ -52,12 +52,12 @@ describe('TenantRepository.updateMode (memory)', () => {
     seed();
   });
 
-  // 正常系: 指定テナントの mode を lite → pro に切り替えられる
+  // 正常系: 指定テナントの mode を lite → pro に切り替えられる (expectedPlanIn 省略 = 無条件更新)
   it('対象テナントの mode を pro に更新できる', async () => {
     // テナント A を pro に切り替える
     const updated = await repos.tenants.updateMode(TENANT_A, 'pro');
-    // 戻り値の mode が pro になっている
-    expect(updated.mode).toBe('pro');
+    // 更新できたことを示す true が返る
+    expect(updated).toBe(true);
     // 再取得しても pro が永続化されている
     const reloaded = await repos.tenants.findById(TENANT_A);
     expect(reloaded?.mode).toBe('pro');
@@ -72,18 +72,41 @@ describe('TenantRepository.updateMode (memory)', () => {
     expect(tenantB?.mode).toBe('lite');
   });
 
-  // 異常系: 存在しないテナント ID はエラーになる (fail-closed)
-  it('存在しないテナント ID はエラーになる', async () => {
-    // 未登録の ID で更新しようとすると reject される
-    await expect(repos.tenants.updateMode('no-such-tenant', 'pro')).rejects.toThrow();
+  // 異常系: 存在しないテナント ID は false を返す (fail-closed。Prisma の updateMany と同じ 0 件挙動)
+  it('存在しないテナント ID はfalseを返す', async () => {
+    const updated = await repos.tenants.updateMode('no-such-tenant', 'pro');
+    expect(updated).toBe(false);
   });
 
   // 冪等: 同じ mode への更新でも成功し値が保たれる
   it('同じ mode への更新でも値が保たれる', async () => {
     // 既に lite のテナントを lite に更新する
     const updated = await repos.tenants.updateMode(TENANT_A, 'lite');
-    // mode は lite のまま
-    expect(updated.mode).toBe('lite');
+    expect(updated).toBe(true);
+    const reloaded = await repos.tenants.findById(TENANT_A);
+    expect(reloaded?.mode).toBe('lite');
+  });
+
+  // 監査で発見したギャップ対応: expectedPlanIn を渡した CAS (compare-and-swap) の検証。
+  // 現在の契約プランが許可リストに含まれない場合は更新せず false を返す
+  // (Stripe Webhook 由来の自動ダウングレードと管理者操作の TOCTOU 競合防止)
+  it('expectedPlanInに現在のプランが含まれない場合は更新せずfalseを返す', async () => {
+    // テナント A は 'free' プラン (seed 参照)。'pro'/'enterprise' のみ許可するリストを渡す
+    const updated = await repos.tenants.updateMode(TENANT_A, 'pro', ['pro', 'enterprise']);
+    expect(updated).toBe(false);
+    // 実際に mode は変更されていないこと
+    const reloaded = await repos.tenants.findById(TENANT_A);
+    expect(reloaded?.mode).toBe('lite');
+  });
+
+  // expectedPlanIn に現在のプランが含まれる場合は更新される
+  it('expectedPlanInに現在のプランが含まれる場合は更新される', async () => {
+    // テナント A のプランを 'pro' に書き換えてから CAS 付きで更新する
+    store.tenants.set(TENANT_A, { ...store.tenants.get(TENANT_A)!, subscriptionPlan: 'pro' });
+    const updated = await repos.tenants.updateMode(TENANT_A, 'pro', ['pro', 'enterprise']);
+    expect(updated).toBe(true);
+    const reloaded = await repos.tenants.findById(TENANT_A);
+    expect(reloaded?.mode).toBe('pro');
   });
 });
 

--- a/tests/data/tenant-repository.memory.test.ts
+++ b/tests/data/tenant-repository.memory.test.ts
@@ -52,10 +52,11 @@ describe('TenantRepository.updateMode (memory)', () => {
     seed();
   });
 
-  // 正常系: 指定テナントの mode を lite → pro に切り替えられる (expectedPlanIn 省略 = 無条件更新)
+  // 正常系: 指定テナントの mode を lite → pro に切り替えられる (expectedPlanIn に現在のプラン
+  // 'free' (seed 参照) を含めることで CAS を素通りさせる)
   it('対象テナントの mode を pro に更新できる', async () => {
-    // テナント A を pro に切り替える
-    const updated = await repos.tenants.updateMode(TENANT_A, 'pro');
+    // テナント A を pro に切り替える (expectedPlanIn に現在のプラン 'free' を含める)
+    const updated = await repos.tenants.updateMode(TENANT_A, 'pro', ['free']);
     // 更新できたことを示す true が返る
     expect(updated).toBe(true);
     // 再取得しても pro が永続化されている
@@ -66,7 +67,7 @@ describe('TenantRepository.updateMode (memory)', () => {
   // 分離: あるテナントの更新が他テナントに波及しない
   it('他テナントの mode には影響しない', async () => {
     // テナント A だけを pro に切り替える
-    await repos.tenants.updateMode(TENANT_A, 'pro');
+    await repos.tenants.updateMode(TENANT_A, 'pro', ['free']);
     // テナント B は元の lite のままであること
     const tenantB = await repos.tenants.findById(TENANT_B);
     expect(tenantB?.mode).toBe('lite');
@@ -74,7 +75,7 @@ describe('TenantRepository.updateMode (memory)', () => {
 
   // 異常系: 存在しないテナント ID は false を返す (fail-closed。Prisma の updateMany と同じ 0 件挙動)
   it('存在しないテナント ID はfalseを返す', async () => {
-    const updated = await repos.tenants.updateMode('no-such-tenant', 'pro');
+    const updated = await repos.tenants.updateMode('no-such-tenant', 'pro', ['free']);
     expect(updated).toBe(false);
   });
 

--- a/tests/features/accept-invitation.test.ts
+++ b/tests/features/accept-invitation.test.ts
@@ -5,8 +5,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildMemoryRepos, createMemoryContext, type Store } from '@/data/adapters/memory';
 // リポジトリ束 / UnitOfWork の型
 import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
-// 招待トークンのハッシュ化 (DB 保存値と同じ SHA-256 を作るために使う)
-import { hashInviteToken } from '@/lib/invite';
+// 招待トークンのハッシュ化 (DB 保存値と同じ SHA-256 を作るために使う) と全体レート制限値
+import { hashInviteToken, INVITE_ACCEPT_GLOBAL_RATE_LIMIT } from '@/lib/invite';
+// レート制限の履歴をテスト間でクリアする内部用関数
+import { __resetRateLimits } from '@/lib/rate-limit';
 
 // 各テスト前に書き換える依存。Action import 前に getter で参照させる
 let store: Store;
@@ -39,6 +41,9 @@ beforeEach(() => {
   store = ctx.store;
   repos = ctx.repos;
   uow = ctx.uow;
+  // レート制限の履歴をテスト間でクリアする (INVITE_ACCEPT_GLOBAL_RATE_LIMIT のテストが
+  // 他のテストの呼び出し回数を引き継いで誤って引っかからないようにする)
+  __resetRateLimits();
   // 現在時刻 (テナント作成日時に使う)
   const now = new Date();
   // テナント A / B を投入する (User の FK 先として必要)
@@ -312,5 +317,22 @@ describe('acceptInvitation', () => {
     expect((err as Error).message).toMatch(/既に登録/);
     // 生の Prisma エラー文言 (フィールド名等) が漏れていないこと
     expect((err as Error).message).not.toMatch(/email`|Unique constraint/);
+  });
+
+  // 監査で発見したギャップ対応: 公開 (未認証) アクションかつ Serializable トランザクションを
+  // 伴うため、不正なトークンでの連打を固定キーの全体レート制限で頭打ちにすること。
+  // 異なるトークン (テナント) で呼んでもエンドポイント全体で共有の上限に引っかかることを確認する
+  it('全体レート制限を超えると異なるトークンでも拒否される', async () => {
+    const acceptInvitation = await loadAction();
+    // 上限ちょうどまでは異なる無効トークンで呼んでも「無効」エラー (レート制限には引っかからない)
+    for (let i = 0; i < INVITE_ACCEPT_GLOBAL_RATE_LIMIT.limit; i += 1) {
+      await expect(
+        acceptInvitation(`bogus-token-${i}`, makeForm({ name: 'x', password: 'password123' })),
+      ).rejects.toThrow(/無効|使用/);
+    }
+    // 上限+1 件目は別のトークンでも全体レート制限に引っかかる
+    await expect(
+      acceptInvitation('bogus-token-overflow', makeForm({ name: 'x', password: 'password123' })),
+    ).rejects.toThrow(/頻度が高すぎます/);
   });
 });

--- a/tests/features/import-tickets.test.ts
+++ b/tests/features/import-tickets.test.ts
@@ -10,6 +10,10 @@ import { createMemoryContext, type Store } from '@/data/adapters/memory';
 import type { Repos } from '@/data/ports/unit-of-work';
 // レート制限をテスト間でクリアする内部用関数
 import { __resetRateLimits } from '@/lib/rate-limit';
+// 拠点一覧の表示用上限 (CSV インポートの名前解決がこの上限を超えても機能することの回帰テストで使う)
+import { LOCATION_LIST_LIMIT } from '@/data/ports/location-repository';
+// カテゴリ一覧の表示用上限 (同上)
+import { CATEGORY_LIST_LIMIT } from '@/data/ports/category-repository';
 
 // 外部通知 (Slack/Teams/Chatwork) テスト用の Slack Webhook URL (実際には送信されない)
 const SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/xxx';
@@ -340,6 +344,26 @@ describe('importTickets', () => {
       const ticket = [...store.tickets.values()][0];
       expect(ticket?.locationId).toBeNull();
     });
+
+    // 監査で発見したギャップ対応: listByTenant は表示用に LOCATION_LIST_LIMIT (200件) で
+    // 上限化されているが、CSV インポートの名前解決は網羅性が必要なため LOCATION_LIST_MATCHING_LIMIT
+    // を明示的に指定して取得する。201件目 (名前順で LOCATION_LIST_LIMIT を超える位置) の拠点も
+    // 正しく解決できることを確認する (この回帰が無ければ「拠点が見つかりません」エラーになる)
+    it('LOCATION_LIST_LIMIT を超える拠点数でも名前解決できる', async () => {
+      // 名前昇順で LOCATION_LIST_LIMIT+1 番目に来るよう、ゼロ埋め連番の拠点名を作る
+      for (let i = 0; i <= LOCATION_LIST_LIMIT; i += 1) {
+        await seedLocation(`拠点${String(i).padStart(4, '0')}`);
+      }
+      // 名前順で最後 (201番目、インデックス LOCATION_LIST_LIMIT) の拠点名を CSV で指定する
+      const targetName = `拠点${String(LOCATION_LIST_LIMIT).padStart(4, '0')}`;
+      const importTickets = await loadAction();
+      const csv = `件名,拠点\n複合機の紙詰まり,${targetName}`;
+      const result = await importTickets(csv);
+
+      // 表示用の上限を超えた位置の拠点名でも、見つからないエラーにはならず正しく起票される
+      expect(result.errors).toHaveLength(0);
+      expect(result.imported).toBe(1);
+    });
   });
 
   // フォローアップ (2026-07-11): 「カテゴリ」列の名前解決
@@ -409,6 +433,25 @@ describe('importTickets', () => {
       expect(result.errors).toHaveLength(0);
       const ticket = [...store.tickets.values()][0];
       expect(ticket?.categoryId).toBeNull();
+    });
+
+    // 監査で発見したギャップ対応: list は表示用に CATEGORY_LIST_LIMIT (200件) で上限化されて
+    // いるが、CSV インポートの名前解決は網羅性が必要なため CATEGORY_LIST_MATCHING_LIMIT を
+    // 明示的に指定して取得する。201件目のカテゴリも正しく解決できることを確認する
+    it('Pro テナントで CATEGORY_LIST_LIMIT を超えるカテゴリ数でも名前解決できる', async () => {
+      const tenant = store.tenants.get(TENANT)!;
+      store.tenants.set(TENANT, { ...tenant, mode: 'pro' });
+      // 名前昇順で CATEGORY_LIST_LIMIT+1 番目に来るよう、ゼロ埋め連番のカテゴリ名を作る
+      for (let i = 0; i <= CATEGORY_LIST_LIMIT; i += 1) {
+        await seedCategory(`カテゴリ${String(i).padStart(4, '0')}`);
+      }
+      const targetName = `カテゴリ${String(CATEGORY_LIST_LIMIT).padStart(4, '0')}`;
+      const importTickets = await loadAction();
+      const csv = `件名,カテゴリ\n複合機の紙詰まり,${targetName}`;
+      const result = await importTickets(csv);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.imported).toBe(1);
     });
 
     // 回帰テスト (/code-review ultra 指摘対応 2026-07-11): カテゴリは拠点と異なり Pro モード

--- a/tests/features/import-tickets.test.ts
+++ b/tests/features/import-tickets.test.ts
@@ -356,8 +356,11 @@ describe('importTickets', () => {
       }
       // 名前順で最後 (201番目、インデックス LOCATION_LIST_LIMIT) の拠点名を CSV で指定する
       const targetName = `拠点${String(LOCATION_LIST_LIMIT).padStart(4, '0')}`;
+      // テスト対象の importTickets アクションを読み込む
       const importTickets = await loadAction();
+      // 201番目の拠点名を指定した CSV データを組み立てる
       const csv = `件名,拠点\n複合機の紙詰まり,${targetName}`;
+      // インポートを実行する
       const result = await importTickets(csv);
 
       // 表示用の上限を超えた位置の拠点名でも、見つからないエラーにはならず正しく起票される
@@ -439,18 +442,26 @@ describe('importTickets', () => {
     // いるが、CSV インポートの名前解決は網羅性が必要なため CATEGORY_LIST_MATCHING_LIMIT を
     // 明示的に指定して取得する。201件目のカテゴリも正しく解決できることを確認する
     it('Pro テナントで CATEGORY_LIST_LIMIT を超えるカテゴリ数でも名前解決できる', async () => {
+      // 現在のテナントを取得する
       const tenant = store.tenants.get(TENANT)!;
+      // カテゴリ列が意味を持つ Pro モードへ切り替える
       store.tenants.set(TENANT, { ...tenant, mode: 'pro' });
       // 名前昇順で CATEGORY_LIST_LIMIT+1 番目に来るよう、ゼロ埋め連番のカテゴリ名を作る
       for (let i = 0; i <= CATEGORY_LIST_LIMIT; i += 1) {
         await seedCategory(`カテゴリ${String(i).padStart(4, '0')}`);
       }
+      // 名前順で最後 (201番目、インデックス CATEGORY_LIST_LIMIT) のカテゴリ名を CSV で指定する
       const targetName = `カテゴリ${String(CATEGORY_LIST_LIMIT).padStart(4, '0')}`;
+      // テスト対象の importTickets アクションを読み込む
       const importTickets = await loadAction();
+      // 201番目のカテゴリ名を指定した CSV データを組み立てる
       const csv = `件名,カテゴリ\n複合機の紙詰まり,${targetName}`;
+      // インポートを実行する
       const result = await importTickets(csv);
 
+      // 表示用の上限を超えた位置のカテゴリ名でも、見つからないエラーにはならない
       expect(result.errors).toHaveLength(0);
+      // 正しく起票される
       expect(result.imported).toBe(1);
     });
 

--- a/tests/features/update-tenant-mode.test.ts
+++ b/tests/features/update-tenant-mode.test.ts
@@ -128,4 +128,32 @@ describe('updateTenantMode', () => {
     await updateTenantMode(makeForm('pro'));
     expect(store.tenants.get(TENANT_ID)?.mode).toBe('pro');
   });
+
+  // 監査で発見したギャップ対応: プラン確認 (isProModeAllowed) と書き込みの間に Stripe Webhook
+  // 由来の自動ダウングレードが割り込んだ TOCTOU を再現する。resolveTenantPlan の読み取り時点では
+  // 'pro' だったが、書き込み時点では実際の subscriptionPlan が既に 'free' に変わっている
+  // (=Stripe の解約 Webhook が先に反映された) ケースで、CAS が競合を検知して安全に拒否すること
+  it('プラン確認後にプランがダウングレードされていた場合は競合エラーになる', async () => {
+    seedTenant('pro'); // 事前チェック用のスナップショット (resolveTenantPlan がこれを見る)
+    // モジュールキャッシュを破棄し、以降の import で新しい vi.doMock を確実に反映させる
+    // (このモジュールは既に他のテストで読み込み済みの可能性があるため)
+    vi.resetModules();
+    vi.doMock('@/lib/tenant-plan', () => ({
+      // 事前チェックは 'pro' を返す (=まだダウングレードを認識していない古い読み取り)
+      resolveTenantPlan: async () => 'pro',
+    }));
+    // 事前チェック後・書き込み前に実際の行が 'free' へダウングレードされた状況を再現する
+    store.tenants.set(TENANT_ID, {
+      ...store.tenants.get(TENANT_ID)!,
+      subscriptionPlan: 'free',
+    });
+    const { updateTenantMode } = await import('@/features/settings/actions/update-tenant-mode');
+    await expect(updateTenantMode(makeForm('pro'))).rejects.toThrow(
+      'モードを変更できませんでした。プランが変更された可能性があるため、画面を再読み込みしてください。',
+    );
+    // mode は 'lite' のまま (誤って 'pro' へ書き換わっていないこと)
+    expect(store.tenants.get(TENANT_ID)?.mode).toBe('lite');
+    // 以降のテストに影響しないようモックを解除する
+    vi.doUnmock('@/lib/tenant-plan');
+  });
 });


### PR DESCRIPTION
## Summary

`docs/smb-dx-pivot-plan.md` は Phase 0〜4 の全項目が `[x]` 済みだが、既存の慣習（済マーク済み機能をコードから再監査し、新たに見つかったギャップを `§4.x フォローアップ` として追記・修正する）に倣い、新規の監査で見つかった 3 件のギャップを修正した（本 PR は §4.19 として計画書に追記）。

- **`updateTenantMode` の TOCTOU**: §1.4/§1.5/§4.13 でチケット・FAQ の状態変更に導入した CAS (compare-and-swap) パターンが `TenantRepository.updateMode` には未適用だった。管理者による Pro モード切替（`isProModeAllowed` 判定 → 書き込み）と、Stripe Webhook 由来の自動ダウングレード（`applyPlanChange`）が競合すると、古いプラン判定のまま Pro モードへ上書きされ得た。`updateMode(id, mode, expectedPlanIn?)` を、'pro' への切替時のみ現在の `subscriptionPlan` を where 条件に含めた原子的な更新 (0 件なら `false`) に変更した。
- **公開エンドポイントのレート制限漏れ**: §4.16/§4.17 と同じ「公開 (未認証) エンドポイントは固定キーのレート制限を持つ」方針が、招待受諾 (`acceptInvitation`。シート上限防止のため Serializable トランザクションを毎回開く高コスト操作) とマジックリンクコールバック (`POST /api/auth/magic-link/callback`) には適用されていなかった。`INVITE_ACCEPT_GLOBAL_RATE_LIMIT` / `MAGIC_LINK_CALLBACK_RATE_LIMIT` を追加し、それぞれのハンドラの先頭に適用した。
- **拠点・カテゴリ一覧の上限漏れ**: §4.11/§4.12 の「一覧取得は必ず上限を持たせる」(§8) が `LocationRepository.listByTenant` / `CategoryRepository.list` には未適用だった。`LOCATION_LIST_LIMIT` / `CATEGORY_LIST_LIMIT` (各200件) を追加し、Prisma (`take`) / メモリ (`slice`) 両アダプタに適用した。

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (1042 passed / 167 skipped — Prisma契約テストはDB無しのため skip)
- [x] 変更した各リポジトリ・Server Action・ルートに対応する回帰テストを追加（メモリ/契約テスト双方。マジックリンクコールバックのみ、`next-auth` パッケージの実行時 import が本リポジトリの Vitest 環境で `next/server` 解決に失敗し単体テスト不可能なため自動テストを見送り、`checkRouteRateLimit` 自体のテストとコードレビューで確認）
- [ ] `npm run test:contract` (RUN_PRISMA_CONTRACT=1、専用DB要。ローカル未実施 — CI の `prisma-contract` ジョブで検証される)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASQQP7nQdmdsrZtgbgX6nZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASQQP7nQdmdsrZtgbgX6nZ)_