### PR TITLE
fix(settings): Chatwork ルーム ID に文字数上限を追加

### DIFF
--- a/src/features/settings/actions/update-notification-channels.ts
+++ b/src/features/settings/actions/update-notification-channels.ts
@@ -19,6 +19,8 @@ import { recordSettingsAudit } from '@/lib/settings-audit';
 
 // Chatwork API トークンの最大長 (常識的な上限。これを超える入力は不正として弾く)
 const CHATWORK_TOKEN_MAX_LENGTH = 200;
+// Chatwork ルーム ID の最大長 (常識的な上限。トークンと同じ方針で入力を弾く)
+const CHATWORK_ROOM_ID_MAX_LENGTH = 200;
 // Chatwork ルーム ID が数字のみで構成されるかを検証する正規表現 (パスインジェクション防止)
 const CHATWORK_ROOM_ID_PATTERN = /^\d+$/;
 
@@ -99,6 +101,10 @@ export async function updateNotificationChannels(
   // トークンが長すぎる入力は不正として弾く (ヘッダに載るため常識的な上限を設ける)
   if (hasToken && chatworkApiTokenRaw.length > CHATWORK_TOKEN_MAX_LENGTH) {
     return { error: 'Chatwork API トークンの形式が正しくありません' };
+  }
+  // ルーム ID が長すぎる入力は不正として弾く (トークンと同じ常識的な上限を設ける)
+  if (hasRoomId && chatworkRoomIdRaw.length > CHATWORK_ROOM_ID_MAX_LENGTH) {
+    return { error: 'Chatwork ルーム ID は数字で入力してください' };
   }
   // ルーム ID は数字のみ許可する (URL パスに埋め込むためインジェクションを防ぐ)
   if (hasRoomId && !CHATWORK_ROOM_ID_PATTERN.test(chatworkRoomIdRaw)) {

--- a/tests/features/update-notification-channels.test.ts
+++ b/tests/features/update-notification-channels.test.ts
@@ -159,6 +159,32 @@ describe('updateNotificationChannels', () => {
     expect(result.error).toBe('Chatwork ルーム ID は数字で入力してください');
   });
 
+  // Chatwork ルーム ID はちょうど上限(200文字)なら保存できる (境界値)
+  it('Chatworkルーム IDがちょうど200文字なら保存できる', async () => {
+    const { updateNotificationChannels } =
+      await import('@/features/settings/actions/update-notification-channels');
+    const roomId200 = '1'.repeat(200);
+    const result = await updateNotificationChannels(
+      {},
+      makeForm({ chatworkApiToken: 'tok123', chatworkRoomId: roomId200 }),
+    );
+    expect(result.success).toBe(true);
+    const saved = await repos.tenants.findById(TENANT_ID);
+    expect(saved?.chatworkRoomId).toBe(roomId200);
+  });
+
+  // Chatwork ルーム ID は上限(200文字)を1文字でも超えると拒否される (境界値)
+  it('Chatworkルーム IDが201文字だと拒否される', async () => {
+    const { updateNotificationChannels } =
+      await import('@/features/settings/actions/update-notification-channels');
+    const roomId201 = '1'.repeat(201);
+    const result = await updateNotificationChannels(
+      {},
+      makeForm({ chatworkApiToken: 'tok123', chatworkRoomId: roomId201 }),
+    );
+    expect(result.error).toBe('Chatwork ルーム ID は数字で入力してください');
+  });
+
   // 監査で発見したギャップ対応: Webhook URL を修正して保存すると、その場ですぐに
   // 直近の失敗記録 (「⚠️ 最終送信失敗」バッジ) がクリアされる (次の送信成功を待たない)
   it('チャネルの設定値を変更すると直近の失敗記録がクリアされる', async () => {


### PR DESCRIPTION
## Context

`docs/smb-dx-pivot-plan.md` §4 Phase 4「Slack / Chatwork / Microsoft Teams 通知 Adapter」の既存実装に対する定例コードレビュー対応です。

姉妹フィールドの `chatworkApiTokenRaw` は `CHATWORK_TOKEN_MAX_LENGTH`（200文字）で長さ上限を設けていますが、`chatworkRoomIdRaw` には対応する長さ上限がなく、`CHATWORK_ROOM_ID_PATTERN`（`/^\d+$/`、線形時間マッチでReDoS耐性あり）を通過しさえすれば任意長の数字文字列がそのまま DB へ保存できる状態でした。CLAUDE.md §9「入力は信用しない」の一貫性ギャップです。

## 変更内容

- `src/features/settings/actions/update-notification-channels.ts`: `CHATWORK_ROOM_ID_MAX_LENGTH`（200）を追加し、トークンと同じ方針で長さ上限チェックを追加

## 検証方法

- `npm run typecheck`: 成功
- `npm run lint`: 成功
- `npm run test`: 1052 passed / 169 skipped（既存の `tests/features/update-notification-channels.test.ts` を含め全て成功）

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0141a4TbBT9jmRFpBTxBuLjD

---
_Generated by [Claude Code](https://claude.ai/code/session_0141a4TbBT9jmRFpBTxBuLjD)_