### PR TITLE
fix(settings): 認証チェックなしの issueInvitation を Server Action の公開面から外す

### DIFF
--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,7 +1,9 @@
 // 招待受諾フォーム (Client Component)
 import { AcceptInviteForm } from '@/features/auth/components/AcceptInviteForm';
-// トークンの有効性を読み取り専用で判定する (消費はしない)
-import { isInvitationAcceptable } from '@/features/auth/actions/accept-invitation';
+// トークンの有効性を読み取り専用で判定する (消費はしない)。
+// /code-review ultra 指摘対応 (2026-07-19): 'use server' モジュールから import すると
+// ヘルパーが公開エンドポイント化するため、Server Action ではない lib モジュールから読む
+import { isInvitationAcceptable } from '@/lib/invite-acceptance';
 // 共通ブランドマーク (シンボル + ワードマーク)
 import { Logo } from '@/components/brand/Logo';
 

--- a/src/app/signup/complete/page.tsx
+++ b/src/app/signup/complete/page.tsx
@@ -1,7 +1,9 @@
 // サインアップ完了フォーム (Client Component)
 import { CompleteSignupForm } from '@/features/auth/components/CompleteSignupForm';
-// トークンの有効性を読み取り専用で判定する (消費はしない)
-import { isSignupAcceptable } from '@/features/auth/actions/complete-signup';
+// トークンの有効性を読み取り専用で判定する (消費はしない)。
+// /code-review ultra 指摘対応 (2026-07-19): 'use server' モジュールから import すると
+// ヘルパーが公開エンドポイント化するため、Server Action ではない lib モジュールから読む
+import { isSignupAcceptable } from '@/lib/signup-acceptance';
 // 共通ブランドマーク (シンボル + ワードマーク)
 import { Logo } from '@/components/brand/Logo';
 

--- a/src/features/auth/actions/accept-invitation.ts
+++ b/src/features/auth/actions/accept-invitation.ts
@@ -17,8 +17,8 @@
 
 // bcrypt によるパスワードハッシュ化 (seed と同じ cost 12)
 import { hash } from 'bcryptjs';
-// データ層の Composition Root (リポジトリ束とトランザクション境界)
-import { repos, uow } from '@/data';
+// データ層の Composition Root (トランザクション境界。リポジトリはトランザクション内の tx 経由で使う)
+import { uow } from '@/data';
 // 招待トークンのハッシュ化 (生トークン → DB 保存値と同じ SHA-256 へ) と、受諾側の
 // エンドポイント全体レート制限値 (監査で発見したギャップ対応)
 import { hashInviteToken, INVITE_ACCEPT_GLOBAL_RATE_LIMIT } from '@/lib/invite';
@@ -172,21 +172,4 @@ export async function acceptInvitation(
 
   // トランザクションの結果 (作成に使ったメール) を返す
   return result;
-}
-
-// 受諾ページが「このトークンが今この瞬間に有効か」を表示判定するための読み取り専用ヘルパー。
-// 消費はしない (ページ表示で焼かないため)。期限切れ / 使用済み / 不在なら false を返す。
-export async function isInvitationAcceptable(
-  rawToken: string,
-): Promise<{ acceptable: boolean; needsEmail: boolean }> {
-  // 生トークンを DB 保存値と同じ SHA-256 ハッシュへ変換する
-  const tokenHash = await hashInviteToken(rawToken);
-  // tokenHash で招待を引く (読み取りのみ)
-  const invitation = await repos.invitations.findByTokenHash(tokenHash);
-  // 不在 / 使用済み / 失効はいずれも受諾不可
-  if (!invitation || invitation.consumedAt !== null || invitation.expiresAt < new Date()) {
-    return { acceptable: false, needsEmail: false };
-  }
-  // 招待にメールが無い場合は、受諾フォームでメール入力を求める必要がある
-  return { acceptable: true, needsEmail: invitation.email === null };
 }

--- a/src/features/auth/actions/complete-signup.ts
+++ b/src/features/auth/actions/complete-signup.ts
@@ -16,8 +16,8 @@
  *  - パスワードは bcrypt でハッシュ化して保存する (平文は保存しない / §9。provisionTenantWithAdmin 内)。
  */
 
-// データ層の Composition Root (リポジトリ束とトランザクション境界)
-import { repos, uow } from '@/data';
+// データ層の Composition Root (トランザクション境界。リポジトリはトランザクション内の tx 経由で使う)
+import { uow } from '@/data';
 // §7.2 Free trial の期間 (30 日) をミリ秒で表す定数
 import { FREE_TRIAL_DURATION_MS } from '@/lib/plan-guard';
 // Prisma の一意制約違反 (P2002) 判定の共通ヘルパー (accept-invitation.ts と共有 / §6 DRY)
@@ -122,15 +122,4 @@ export async function completeSignup(
 
   // クライアントがログインに使うメールを返す
   return { email: provisioned.email };
-}
-
-// サインアップ完了ページが「このトークンが今この瞬間に有効か」を表示判定するための読み取り専用
-// ヘルパー。消費はしない (ページ表示で焼かないため)。期限切れ / 使用済み / 不在なら false を返す。
-export async function isSignupAcceptable(rawToken: string): Promise<boolean> {
-  // 生トークンを DB 保存値と同じ SHA-256 ハッシュへ変換する
-  const tokenHash = await hashSignupToken(rawToken);
-  // tokenHash でサインアップトークンを引く (読み取りのみ)
-  const signup = await repos.signupTokens.findByTokenHash(tokenHash);
-  // 不在 / 使用済み / 失効はいずれも受諾不可
-  return !!signup && signup.consumedAt === null && signup.expiresAt >= new Date();
 }

--- a/src/features/settings/actions/create-invitation.ts
+++ b/src/features/settings/actions/create-invitation.ts
@@ -22,107 +22,21 @@ import { repos } from '@/data';
 import { auth } from '@/lib/auth';
 // メール内リンクのベース URL を解決する共通ヘルパー
 import { resolveAppBaseUrl } from '@/lib/app-url';
-// 環境変数で切り替わる EmailSender 実装を取得するファクトリ
-import { getEmailSender } from '@/lib/email';
-// 招待固有のトークン生成・ハッシュ・URL/メール構築・各種定数
-import {
-  buildInviteUrl,
-  generateInviteToken,
-  hashInviteToken,
-  INVITE_RATE_LIMIT_MAX,
-  INVITE_RATE_LIMIT_WINDOW_MS,
-  INVITE_TTL_MS,
-  renderInviteEmail,
-} from '@/lib/invite';
+// 招待固有の定数 (レート制限)
+import { INVITE_RATE_LIMIT_MAX, INVITE_RATE_LIMIT_WINDOW_MS } from '@/lib/invite';
+// 招待発行の共有ロジック (認証・レート制限は本アクション側の責務)。
+// /security-review 指摘対応 (2026-07-19): issueInvitation は元々このファイルから export して
+// いたが、`'use server'` モジュールの export はすべて公開 Server Action エンドポイントとして
+// 登録されるため、認証チェックを持たない同関数が直接呼び出し可能になっていた。
+// Server Action ではない @/lib/invite-issue へ移設し、認証ゲート付きの本アクションと
+// createInvitationsBulk だけが import して使う構成に変更した。
+import { issueInvitation, type CreateInvitationResult } from '@/lib/invite-issue';
 // 管理者権限を強制する共通アサーション
 import { assertAdminSession } from '@/lib/role';
 // 招待発行フォームの入力検証スキーマ
 import { createInvitationSchema } from '@/lib/validations/invite';
-// Phase 4 課金: プランごとのスタッフシート空き状況チェック (accept-invitation.ts と共有)
-import { checkSeatAvailability } from '@/lib/tenant-plan';
 // フォローアップ (2026-07-11): 設定変更監査ログへの記録共通ヘルパー (§4.2/§4.3 と同じ方式)
 import { recordSettingsAudit } from '@/lib/settings-audit';
-// 権限型 (issueInvitation の引数に使う)
-import type { Role } from '@/domain/types';
-
-// createInvitation の戻り値型 (発行した招待リンクの URL を返す)
-export interface CreateInvitationResult {
-  url: string; // 受諾ページの URL (admin がコピーして共有する / メールにも入る)
-}
-
-// 招待リンクを 1 件発行する内部ヘルパー。
-// §7.1 フォローアップ (2026-07-10): 一括招待 (create-invitations-bulk.ts) も同じ
-// 「シート上限確認 → トークン発行 → DB 保存 → (メール指定時) 案内メール送信」を必要とするため、
-// createInvitation から切り出して両者で共有する (§6 DRY: 2 箇所目の複製が生じる前に共通化)。
-// レート制限チェック・期限切れ招待の掃除・baseUrl 解決はバッチ全体で 1 回で済む処理のため、
-// 呼び出し側 (1 件発行 / 一括発行) の責務のまま残す。
-export async function issueInvitation(input: {
-  tenantId: string; // 参加先テナント (呼び出し側がセッション由来の値のみを渡すこと)
-  invitedById: string; // 招待を発行した管理者の ID
-  role: Role; // 付与する権限 (requester | agent)
-  email?: string; // 案内メール宛先 (未指定なら発行のみ)
-  baseUrl: string; // 受諾ページ URL のベース (呼び出し側で resolveAppBaseUrl() 済みの値)
-  // /code-review ultra 指摘対応 (2026-07-10): 一括招待 (create-invitations-bulk.ts) は
-  // バッチ全体で 1 回だけシート枠を見積もってから呼び出すため、ここでの再チェックは
-  // 常に同じ currentUserCount (招待発行だけではユーザー数は増えない) を読み直すだけの
-  // 無駄な SELECT になる。true のときはこの関数内のシートチェックをスキップする
-  skipSeatCheck?: boolean;
-}): Promise<CreateInvitationResult> {
-  const { tenantId, invitedById, role, email, baseUrl, skipSeatCheck } = input;
-
-  // Phase 4 課金: このロールがシートを消費する場合のみ上限を確認する (requester はシート対象外)
-  if (role === 'agent' && !skipSeatCheck) {
-    // テナントのプランを取得してスタッフシートの空き状況を確認する (受諾時と共通のロジック)
-    const seat = await checkSeatAvailability(repos, tenantId);
-    // 上限に達している場合は招待発行そのものを拒否する
-    if (!seat.available) {
-      throw new Error(
-        `このプランのメンバー上限 (${seat.limit} 名) に達しています。プランをアップグレードしてください。`,
-      );
-    }
-  }
-
-  // 256-bit のランダムトークンを生成し、SHA-256 ハッシュを DB に保存する (生は URL のみ)
-  const rawToken = generateInviteToken();
-  const tokenHash = await hashInviteToken(rawToken);
-  // 失効時刻 (現在時刻 + TTL)
-  const expiresAt = new Date(Date.now() + INVITE_TTL_MS);
-  // DB に招待行を作成 (tenantId / invitedById はセッション由来のみ)
-  const created = await repos.invitations.create({
-    tokenHash,
-    tenantId,
-    role,
-    expiresAt,
-    email: email ?? null,
-    invitedById,
-  });
-
-  // 受諾ページの URL を組み立てる (呼び出し側で解決済みの baseUrl を使う)
-  const url = buildInviteUrl(baseUrl, rawToken);
-
-  // email を指定した場合のみ案内メールを送る。送信失敗してもリンクは返す (admin が手渡し可能)
-  if (email) {
-    try {
-      // 参加先の組織名を取得して件名/本文に使う
-      const tenant = await repos.tenants.findById(tenantId);
-      // 件名 + 本文 (Text / HTML) を構築
-      const { subject, text, html } = renderInviteEmail({
-        url,
-        tenantName: tenant?.name ?? 'HelpDesk Hub',
-        expiresInDays: Math.floor(INVITE_TTL_MS / (24 * 60 * 60 * 1000)),
-      });
-      // EmailSender 経由で送信
-      await getEmailSender().send({ to: email, subject, text, html });
-    } catch (err) {
-      // 送信失敗はログに残すが、招待自体は有効なので URL は返す。
-      // 行を消すとリンクが無効になるため、ここでは created を削除しない
-      console.error('[invite] email delivery failed (link still issued):', created.id, err);
-    }
-  }
-
-  // 発行した招待リンクの URL を返す (画面でコピー表示する)
-  return { url };
-}
 
 // 招待リンクを 1 件発行するサーバーアクション。フォーム (FormData) から呼ぶ
 export async function createInvitation(formData: FormData): Promise<CreateInvitationResult> {

--- a/src/features/settings/actions/create-invitations-bulk.ts
+++ b/src/features/settings/actions/create-invitations-bulk.ts
@@ -22,8 +22,10 @@ import { auth } from '@/lib/auth';
 import { resolveAppBaseUrl } from '@/lib/app-url';
 // 管理者権限を強制する共通アサーション
 import { assertAdminSession } from '@/lib/role';
-// 招待発行の共有ロジック (createInvitation と同じヘルパーを再利用する)
-import { issueInvitation } from './create-invitation';
+// 招待発行の共有ロジック (createInvitation と同じヘルパーを再利用する)。
+// /security-review 指摘対応 (2026-07-19): 認証チェックを持たないヘルパーを 'use server'
+// モジュールから export すると公開エンドポイント化するため、@/lib/invite-issue へ移設した
+import { issueInvitation } from '@/lib/invite-issue';
 // 招待固有の定数 (レート制限) と、複数行テキストからメールアドレス候補を抽出する純粋関数
 import {
   INVITE_RATE_LIMIT_MAX,

--- a/src/lib/invite-acceptance.ts
+++ b/src/lib/invite-acceptance.ts
@@ -1,0 +1,33 @@
+/**
+ * 招待トークンの受諾可否を読み取り専用で判定するヘルパー (サーバー専用・Server Action ではない)。
+ *
+ * /code-review ultra 指摘対応 (2026-07-19): isInvitationAcceptable は元々 `'use server'`
+ * モジュール (features/auth/actions/accept-invitation.ts) から export されていたが、Next.js は
+ * `'use server'` ファイルの export をすべて「公開 Server Action エンドポイント」として登録する。
+ * 本関数の利用元は Server Component (app/invite/[token]/page.tsx) のみで、エンドポイント化する
+ * 必要が一切ないのに、レート制限のない匿名呼び出し可能なトークン有効性オラクル (DB 参照付き)
+ * を公開してしまっていた。invite-issue.ts と同じ方針で Server Action ではない本モジュールへ
+ * 移設し、公開面から除外する。
+ */
+
+// データ層の Composition Root (Prisma 直叩きを避けるための入口)
+import { repos } from '@/data';
+// 招待トークンのハッシュ化 (生トークン → DB 保存値と同じ SHA-256 へ)
+import { hashInviteToken } from '@/lib/invite';
+
+// 受諾ページが「このトークンが今この瞬間に有効か」を表示判定するための読み取り専用ヘルパー。
+// 消費はしない (ページ表示で焼かないため)。期限切れ / 使用済み / 不在なら false を返す。
+export async function isInvitationAcceptable(
+  rawToken: string,
+): Promise<{ acceptable: boolean; needsEmail: boolean }> {
+  // 生トークンを DB 保存値と同じ SHA-256 ハッシュへ変換する
+  const tokenHash = await hashInviteToken(rawToken);
+  // tokenHash で招待を引く (読み取りのみ)
+  const invitation = await repos.invitations.findByTokenHash(tokenHash);
+  // 不在 / 使用済み / 失効はいずれも受諾不可
+  if (!invitation || invitation.consumedAt !== null || invitation.expiresAt < new Date()) {
+    return { acceptable: false, needsEmail: false };
+  }
+  // 招待にメールが無い場合は、受諾フォームでメール入力を求める必要がある
+  return { acceptable: true, needsEmail: invitation.email === null };
+}

--- a/src/lib/invite-issue.ts
+++ b/src/lib/invite-issue.ts
@@ -1,0 +1,112 @@
+/**
+ * 招待リンク発行の共有ロジック (サーバー専用・Server Action ではない)。
+ *
+ * /security-review 指摘対応 (2026-07-19): このヘルパーは元々 `'use server'` モジュール
+ * (features/settings/actions/create-invitation.ts) から export されていたが、Next.js は
+ * `'use server'` ファイルの export をすべて「公開 Server Action エンドポイント」として登録する。
+ * issueInvitation は tenantId / invitedById / role を引数から受け取る設計 (認証・レート制限・
+ * 監査ログは呼び出し側の責務) のため、エンドポイント化すると認証なしでクロステナントの
+ * agent 招待を発行できてしまう。認証ゲート付きの呼び出し元 (createInvitation /
+ * createInvitationsBulk) だけが import できるよう、Server Action ではない本モジュールへ移設した。
+ *
+ * セキュリティ契約 (呼び出し側の責務):
+ *  - assertAdminSession 等で認証・権限を確認してから呼ぶこと。
+ *  - tenantId / invitedById にはセッション由来の値のみを渡すこと (リクエスト入力を渡さない)。
+ *  - レート制限・期限切れ掃除・監査ログ記録は呼び出し側で行うこと。
+ */
+
+// データ層の Composition Root (Prisma 直叩きを避けるための入口)
+import { repos } from '@/data';
+// 環境変数で切り替わる EmailSender 実装を取得するファクトリ
+import { getEmailSender } from '@/lib/email';
+// 招待固有のトークン生成・ハッシュ・URL/メール構築・TTL 定数
+import {
+  buildInviteUrl,
+  generateInviteToken,
+  hashInviteToken,
+  INVITE_TTL_MS,
+  renderInviteEmail,
+} from '@/lib/invite';
+// Phase 4 課金: プランごとのスタッフシート空き状況チェック (accept-invitation.ts と共有)
+import { checkSeatAvailability } from '@/lib/tenant-plan';
+// 権限型 (issueInvitation の引数に使う)
+import type { Role } from '@/domain/types';
+
+// 招待リンク発行の戻り値型 (発行した招待リンクの URL を返す)
+export interface CreateInvitationResult {
+  url: string; // 受諾ページの URL (admin がコピーして共有する / メールにも入る)
+}
+
+// 招待リンクを 1 件発行する内部ヘルパー。
+// §7.1 フォローアップ (2026-07-10): 一括招待 (create-invitations-bulk.ts) も同じ
+// 「シート上限確認 → トークン発行 → DB 保存 → (メール指定時) 案内メール送信」を必要とするため、
+// createInvitation から切り出して両者で共有する (§6 DRY: 2 箇所目の複製が生じる前に共通化)。
+// レート制限チェック・期限切れ招待の掃除・baseUrl 解決はバッチ全体で 1 回で済む処理のため、
+// 呼び出し側 (1 件発行 / 一括発行) の責務のまま残す。
+export async function issueInvitation(input: {
+  tenantId: string; // 参加先テナント (呼び出し側がセッション由来の値のみを渡すこと)
+  invitedById: string; // 招待を発行した管理者の ID
+  role: Role; // 付与する権限 (requester | agent)
+  email?: string; // 案内メール宛先 (未指定なら発行のみ)
+  baseUrl: string; // 受諾ページ URL のベース (呼び出し側で resolveAppBaseUrl() 済みの値)
+  // /code-review ultra 指摘対応 (2026-07-10): 一括招待 (create-invitations-bulk.ts) は
+  // バッチ全体で 1 回だけシート枠を見積もってから呼び出すため、ここでの再チェックは
+  // 常に同じ currentUserCount (招待発行だけではユーザー数は増えない) を読み直すだけの
+  // 無駄な SELECT になる。true のときはこの関数内のシートチェックをスキップする
+  skipSeatCheck?: boolean;
+}): Promise<CreateInvitationResult> {
+  const { tenantId, invitedById, role, email, baseUrl, skipSeatCheck } = input;
+
+  // Phase 4 課金: このロールがシートを消費する場合のみ上限を確認する (requester はシート対象外)
+  if (role === 'agent' && !skipSeatCheck) {
+    // テナントのプランを取得してスタッフシートの空き状況を確認する (受諾時と共通のロジック)
+    const seat = await checkSeatAvailability(repos, tenantId);
+    // 上限に達している場合は招待発行そのものを拒否する
+    if (!seat.available) {
+      throw new Error(
+        `このプランのメンバー上限 (${seat.limit} 名) に達しています。プランをアップグレードしてください。`,
+      );
+    }
+  }
+
+  // 256-bit のランダムトークンを生成し、SHA-256 ハッシュを DB に保存する (生は URL のみ)
+  const rawToken = generateInviteToken();
+  const tokenHash = await hashInviteToken(rawToken);
+  // 失効時刻 (現在時刻 + TTL)
+  const expiresAt = new Date(Date.now() + INVITE_TTL_MS);
+  // DB に招待行を作成 (tenantId / invitedById はセッション由来のみ)
+  const created = await repos.invitations.create({
+    tokenHash,
+    tenantId,
+    role,
+    expiresAt,
+    email: email ?? null,
+    invitedById,
+  });
+
+  // 受諾ページの URL を組み立てる (呼び出し側で解決済みの baseUrl を使う)
+  const url = buildInviteUrl(baseUrl, rawToken);
+
+  // email を指定した場合のみ案内メールを送る。送信失敗してもリンクは返す (admin が手渡し可能)
+  if (email) {
+    try {
+      // 参加先の組織名を取得して件名/本文に使う
+      const tenant = await repos.tenants.findById(tenantId);
+      // 件名 + 本文 (Text / HTML) を構築
+      const { subject, text, html } = renderInviteEmail({
+        url,
+        tenantName: tenant?.name ?? 'HelpDesk Hub',
+        expiresInDays: Math.floor(INVITE_TTL_MS / (24 * 60 * 60 * 1000)),
+      });
+      // EmailSender 経由で送信
+      await getEmailSender().send({ to: email, subject, text, html });
+    } catch (err) {
+      // 送信失敗はログに残すが、招待自体は有効なので URL は返す。
+      // 行を消すとリンクが無効になるため、ここでは created を削除しない
+      console.error('[invite] email delivery failed (link still issued):', created.id, err);
+    }
+  }
+
+  // 発行した招待リンクの URL を返す (画面でコピー表示する)
+  return { url };
+}

--- a/src/lib/signup-acceptance.ts
+++ b/src/lib/signup-acceptance.ts
@@ -1,0 +1,30 @@
+/**
+ * サインアップトークンの受諾可否を読み取り専用で判定するヘルパー (サーバー専用・Server Action ではない)。
+ *
+ * /code-review ultra 指摘対応 (2026-07-19): isSignupAcceptable は元々 `'use server'`
+ * モジュール (features/auth/actions/complete-signup.ts) から export されていたが、Next.js は
+ * `'use server'` ファイルの export をすべて「公開 Server Action エンドポイント」として登録する。
+ * 本関数の利用元は Server Component (app/signup/complete/page.tsx) のみで、エンドポイント化する
+ * 必要が一切ないのに、レート制限のない匿名呼び出し可能なトークン有効性オラクル (DB 参照付き)
+ * を公開してしまっていた。invite-acceptance.ts と同じ方針で Server Action ではない本モジュールへ
+ * 移設し、公開面から除外する。
+ *
+ * 注: repos (Prisma) に依存するため、クライアント安全な純粋ヘルパー集 (@/lib/signup) には
+ * 置かず専用モジュールとする。
+ */
+
+// データ層の Composition Root (Prisma 直叩きを避けるための入口)
+import { repos } from '@/data';
+// サインアップトークンのハッシュ化 (生トークン → DB 保存値と同じ SHA-256 へ)
+import { hashSignupToken } from '@/lib/signup';
+
+// サインアップ完了ページが「このトークンが今この瞬間に有効か」を表示判定するための読み取り専用
+// ヘルパー。消費はしない (ページ表示で焼かないため)。期限切れ / 使用済み / 不在なら false を返す。
+export async function isSignupAcceptable(rawToken: string): Promise<boolean> {
+  // 生トークンを DB 保存値と同じ SHA-256 ハッシュへ変換する
+  const tokenHash = await hashSignupToken(rawToken);
+  // tokenHash でサインアップトークンを引く (読み取りのみ)
+  const signup = await repos.signupTokens.findByTokenHash(tokenHash);
+  // 不在 / 使用済み / 失効はいずれも受諾不可
+  return !!signup && signup.consumedAt === null && signup.expiresAt >= new Date();
+}

--- a/tests/features/action-export-surface.test.ts
+++ b/tests/features/action-export-surface.test.ts
@@ -69,21 +69,32 @@ function listActionFiles(): string[] {
 
 // ファイル本文から「実行時に存在する export」の名前一覧を静的に抽出する。
 // 型のみの export (export type / export interface) は実行時に消えるため対象外。
-// export const / export function (非 async) / 再 export (export { ... }) / export default は
-// 「アクション以外の公開」としてそのまま検出し、テスト側で失敗させる。
+// それ以外の export 行は fail-closed で扱う: 意図された形 (export async function) だけを
+// 名前として抽出し、未知の形 (export * / class / enum / const / 再 export / default 等) は
+// すべて禁止マーカーとして記録し、許可リスト照合で必ず失敗させる
+// (/code-review ultra 指摘対応 2026-07-19: 既知形の列挙だけだと export * 等が無音で通るため)。
 function extractRuntimeExports(source: string): string[] {
-  // 検出した実行時 export 名を貯める配列
+  // 検出した実行時 export 名 (または禁止形マーカー) を貯める配列
   const names: string[] = [];
-  // 行頭の export 宣言を走査する (このリポジトリの整形規則では export は行頭に置かれる)
-  const exportPattern =
-    /^export\s+(?:async\s+function\s+(\w+)|function\s+(\w+)|const\s+(\w+)|let\s+(\w+)|var\s+(\w+)|default\b|\{)/gm;
-  // マッチごとに名前 (または禁止形の目印) を記録する
-  for (const m of source.matchAll(exportPattern)) {
-    // async function 以外の実行時 export はエンドポイントとして意図されないため、
-    // マーカー付きで記録して許可リスト照合で必ず失敗させる
-    const name = m[1] ?? (m[2] ? `[sync-function] ${m[2]}` : undefined) ?? m[3] ?? m[4] ?? m[5];
-    // export default / export { ... } は名前が取れないため形そのものを記録する
-    names.push(name ?? `[forbidden-form] ${m[0].trim()}`);
+  // 行頭の export で始まる行をすべて走査する (このリポジトリの整形規則では export は行頭に置かれる)
+  for (const m of source.matchAll(/^export\s.*$/gm)) {
+    // export 行の全文 (末尾空白は落とす)
+    const line = m[0].trimEnd();
+    // 型のみの export は実行時に消えるためスキップする
+    if (/^export\s+(type|interface|declare)\b/.test(line)) {
+      continue;
+    }
+    // 意図された唯一の形: 行頭の export async function 宣言 (generator の * は含まない)
+    const action = /^export\s+async\s+function\s+(\w+)\s*\(/.exec(line);
+    // async function なら関数名を記録する
+    if (action) {
+      names.push(action[1]);
+      continue;
+    }
+    // それ以外の実行時 export (export * / class / enum / const / let / var / default /
+    // export { ... } / async function* 等) はエンドポイントとして意図されないため、
+    // 行そのものを禁止マーカーとして記録し、許可リストと一致せず必ず失敗させる
+    names.push(`[forbidden-form] ${line}`);
   }
   // 抽出結果を返す
   return names;

--- a/tests/features/action-export-surface.test.ts
+++ b/tests/features/action-export-surface.test.ts
@@ -1,0 +1,114 @@
+// 'use server' アクションモジュールの公開面 (export) をリポジトリ全体で固定する回帰テスト。
+//
+// /security-review・/code-review ultra 指摘対応 (2026-07-19): Next.js は 'use server'
+// ファイルの export をすべて「公開 Server Action エンドポイント」として登録する。過去に
+// 認証チェックを持たない共有ヘルパー (issueInvitation) や読み取り専用ヘルパー
+// (isInvitationAcceptable / isSignupAcceptable) が export されて意図しない公開エンドポイントに
+// なっていたため、単一モジュールのスナップショットではなく src/features/**/actions/*.ts 全体を
+// 静的に走査し、「意図した Server Action だけが export されている」ことを許可リストで検証する。
+// 新しいアクションを追加したら、この許可リストに意図を持って追記すること。
+
+// Node 標準のファイル走査・読み取り (テストは vitest の node 環境で動く)
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// 走査対象のルート (src/features 配下の actions ディレクトリのみが対象)
+const FEATURES_ROOT = path.resolve(__dirname, '../../src/features');
+
+// モジュールごとの「意図した公開 Server Action」の許可リスト (キーは src/features からの相対パス)。
+// ここに無い runtime export が現れたらテストが落ちる = 公開エンドポイントの無断追加を検知する。
+const ACTION_EXPORT_ALLOWLIST: Record<string, string[]> = {
+  'auth/actions/accept-invitation.ts': ['acceptInvitation'],
+  'auth/actions/complete-signup.ts': ['completeSignup'],
+  'auth/actions/logout.ts': ['logout'],
+  'auth/actions/request-magic-link.ts': ['requestMagicLink'],
+  'auth/actions/request-signup.ts': ['requestSignup'],
+  'faq/actions/faq-actions.ts': ['createFaqCandidate', 'updateFaqStatus', 'updateFaqContent'],
+  'notifications/actions/notification-actions.ts': ['markAllRead'],
+  'settings/actions/create-checkout-session.ts': ['createCheckoutSession'],
+  'settings/actions/create-invitation.ts': ['createInvitation'],
+  'settings/actions/create-invitations-bulk.ts': ['createInvitationsBulk'],
+  'settings/actions/create-location.ts': ['createLocation'],
+  'settings/actions/create-portal-session.ts': ['createPortalSession'],
+  'settings/actions/create-tenant.ts': ['createTenant'],
+  'settings/actions/delete-line-config.ts': ['deleteLineConfig'],
+  'settings/actions/delete-location.ts': ['deleteLocation'],
+  'settings/actions/delete-sso-config.ts': ['deleteSsoConfig'],
+  'settings/actions/link-line-account.ts': [
+    'generateLineLinkCode_action',
+    'unlinkLineAccount_action',
+  ],
+  'settings/actions/regenerate-inbound-token.ts': ['regenerateInboundToken'],
+  'settings/actions/update-line-config.ts': ['updateLineConfig'],
+  'settings/actions/update-location.ts': ['updateLocation'],
+  'settings/actions/update-notification-channels.ts': ['updateNotificationChannels'],
+  'settings/actions/update-sso-config.ts': ['updateSsoConfig'],
+  'settings/actions/update-tenant-mode.ts': ['updateTenantMode'],
+  'tickets/actions/import-tickets.ts': ['importTickets'],
+  'tickets/actions/update-ticket.ts': [
+    'updateTicketStatus',
+    'updateTicketPriority',
+    'updateTicketAssignee',
+    'updateTicketCategory',
+    'updateTicketLocation',
+    'escalateTicket',
+  ],
+};
+
+// src/features 配下から actions ディレクトリ直下の .ts ファイルを再帰的に列挙する
+function listActionFiles(): string[] {
+  // recursive readdir で全ファイルの相対パスを取得する
+  const entries = readdirSync(FEATURES_ROOT, { recursive: true }) as string[];
+  // パス区切りを POSIX 形式へ正規化し、actions ディレクトリ直下の .ts のみに絞る
+  return entries
+    .map((p) => p.split(path.sep).join('/'))
+    .filter((p) => /(^|\/)actions\/[^/]+\.ts$/.test(p))
+    .sort();
+}
+
+// ファイル本文から「実行時に存在する export」の名前一覧を静的に抽出する。
+// 型のみの export (export type / export interface) は実行時に消えるため対象外。
+// export const / export function (非 async) / 再 export (export { ... }) / export default は
+// 「アクション以外の公開」としてそのまま検出し、テスト側で失敗させる。
+function extractRuntimeExports(source: string): string[] {
+  // 検出した実行時 export 名を貯める配列
+  const names: string[] = [];
+  // 行頭の export 宣言を走査する (このリポジトリの整形規則では export は行頭に置かれる)
+  const exportPattern =
+    /^export\s+(?:async\s+function\s+(\w+)|function\s+(\w+)|const\s+(\w+)|let\s+(\w+)|var\s+(\w+)|default\b|\{)/gm;
+  // マッチごとに名前 (または禁止形の目印) を記録する
+  for (const m of source.matchAll(exportPattern)) {
+    // async function 以外の実行時 export はエンドポイントとして意図されないため、
+    // マーカー付きで記録して許可リスト照合で必ず失敗させる
+    const name = m[1] ?? (m[2] ? `[sync-function] ${m[2]}` : undefined) ?? m[3] ?? m[4] ?? m[5];
+    // export default / export { ... } は名前が取れないため形そのものを記録する
+    names.push(name ?? `[forbidden-form] ${m[0].trim()}`);
+  }
+  // 抽出結果を返す
+  return names;
+}
+
+describe('Server Action モジュールの公開面 (export surface)', () => {
+  // 走査対象を一度だけ列挙する
+  const files = listActionFiles();
+
+  it('actions ディレクトリのモジュールがすべて許可リストに登録されている', () => {
+    // 実ファイル一覧と許可リストのキー一覧が一致すること (新規アクション追加時は許可リストも更新する)
+    expect(files).toEqual(Object.keys(ACTION_EXPORT_ALLOWLIST).sort());
+  });
+
+  // モジュールごとに「先頭 'use server' + 許可された async 関数のみ export」を検証する
+  it.each(files)('%s は許可された Server Action だけを export する', (relPath) => {
+    // 対象ファイルの本文を読み込む
+    const source = readFileSync(path.join(FEATURES_ROOT, relPath), 'utf8');
+    // 'use server' ディレクティブがファイル先頭にあること (アクションモジュールの前提)
+    expect(source.startsWith("'use server';")).toBe(true);
+    // 実行時 export の一覧を抽出し、許可リストと完全一致することを確認する。
+    // 許可リスト外の export (認証なしヘルパー・定数・再 export 等) が増えると
+    // 公開 Server Action エンドポイントが無断で増えるため、ここで検知して失敗させる
+    expect(extractRuntimeExports(source).sort()).toEqual(
+      [...(ACTION_EXPORT_ALLOWLIST[relPath] ?? [])].sort(),
+    );
+  });
+});

--- a/tests/features/complete-signup.test.ts
+++ b/tests/features/complete-signup.test.ts
@@ -24,9 +24,12 @@ vi.mock('@/data', () => ({
 }));
 
 // 動的 import: 上のモック設定が反映された後で対象を読み込む
+// (/code-review ultra 指摘対応 2026-07-19: isSignupAcceptable は公開エンドポイント化を防ぐため
+//  'use server' モジュールから @/lib/signup-acceptance へ移設)
 async function loadActions() {
   const mod = await import('@/features/auth/actions/complete-signup');
-  return { completeSignup: mod.completeSignup, isSignupAcceptable: mod.isSignupAcceptable };
+  const acceptance = await import('@/lib/signup-acceptance');
+  return { completeSignup: mod.completeSignup, isSignupAcceptable: acceptance.isSignupAcceptable };
 }
 
 // テストごとにクリーンな状態にする (テナントのシードは不要。complete-signup 自体がテナントを作る)

--- a/tests/features/create-invitation.test.ts
+++ b/tests/features/create-invitation.test.ts
@@ -172,4 +172,15 @@ describe('createInvitation', () => {
     const result = await createInvitation(makeForm('requester'));
     expect(result.url).toContain('/invite/');
   });
+
+  // /security-review 指摘対応 (2026-07-19): 'use server' モジュールの export はすべて公開
+  // Server Action エンドポイントになるため、認証チェックを持たない issueInvitation を
+  // このモジュールから export してはならない (認証なしでクロステナント招待が発行できてしまう)。
+  // 公開面を「認証ゲート付きアクションのみ」に固定する回帰テスト。
+  it('アクションモジュールは認証ゲート付きの createInvitation だけを export する', async () => {
+    // アクションモジュールの実行時 export 一覧を取得する (型 export は実行時には存在しない)
+    const mod = await import('@/features/settings/actions/create-invitation');
+    // issueInvitation が再び export されたら公開エンドポイント化するため失敗させる
+    expect(Object.keys(mod)).toEqual(['createInvitation']);
+  });
 });

--- a/tests/features/create-invitations-bulk.test.ts
+++ b/tests/features/create-invitations-bulk.test.ts
@@ -297,7 +297,8 @@ describe('createInvitationsBulk', () => {
       auth: async () => ({ user: { id: ADMIN_ID, role: 'admin', tenantId: TENANT_ID } }),
     }));
     // issueInvitation を差し替え、特定の 1 行だけ Prisma 風の生エラーを投げさせる
-    vi.doMock('@/features/settings/actions/create-invitation', () => ({
+    // (/security-review 指摘対応 2026-07-19: issueInvitation は @/lib/invite-issue へ移設)
+    vi.doMock('@/lib/invite-issue', () => ({
       issueInvitation: async (input: { email?: string }) => {
         if (input.email === 'boom@example.com') {
           // Prisma の一意制約違反エラーを模した生メッセージ (DB スキーマ情報を含む想定)


### PR DESCRIPTION
## 概要

定期コードレビューで検出したセキュリティ欠陥の修正です（docs/smb-dx-pivot-plan.md §5.6「クロステナント招待の防止」/ 共通規約 §9「認可はサーバー側で強制」に対応）。

## 問題

Next.js は **`'use server'` ファイルの export をすべて公開 Server Action エンドポイントとして登録**します。これにより、認証チェックを持たないヘルパーが意図せず直接呼び出し可能になっていました。

### 1. `issueInvitation`（重大）

共有ヘルパー `issueInvitation` は認証・レート制限・監査ログを「呼び出し側の責務」とする設計で `tenantId` / `invitedById` / `role` を引数から受け取るため、エンドポイント直接呼び出しで:

- `assertAdminSession` による管理者ゲートをバイパス
- 任意の `tenantId` を指定したクロステナントの **agent 権限**招待リンクの発行(`acceptInvitation` 経由で被害テナントへのフルアクセス獲得)
- 招待レート制限・`invitation_issue` 監査ログの回避

が可能でした。

### 2. `isInvitationAcceptable` / `isSignupAcceptable`(同一欠陥クラス・レビューで追加検出)

Server Component 専用の読み取りヘルパーなのに `'use server'` モジュールから export されており、レート制限のない匿名呼び出し可能なトークン有効性オラクル(DB 参照付き)として公開エンドポイント化していました。

## 修正内容

- `issueInvitation`(+ 型 `CreateInvitationResult`)を Server Action ではない `src/lib/invite-issue.ts` へ移設。ロジック無変更。
- `isInvitationAcceptable` → `src/lib/invite-acceptance.ts`、`isSignupAcceptable` → `src/lib/signup-acceptance.ts` へ移設し、ページの import を追随。
- ヘルパー移設で未使用になった `repos` import を削除(§6 デッドコード禁止)。
- **再発防止**: 単一モジュールのスナップショットではなく、`src/features/**/actions/*.ts` 全体を静的走査して「許可リストに載った Server Action だけが runtime export されている」ことを検証するガードテスト `tests/features/action-export-surface.test.ts` を追加。新しいアクション追加時は許可リストへの明示的な追記が必要になります。
- 既存テストの `vi.doMock` / import パスを移設先に追随。

## レビュー対応記録

- `/code-review ultra` 相当のレビューで「同一欠陥クラスの残存(上記 2)」「回帰テストの対象が 1 モジュールのみ」の指摘 → 本 PR の 2 コミット目で対応済み。
- `server-only` パッケージ導入の提案 → 新規依存の追加になるため見送り(import グラフは検証済みで、公開面ガードテストが再発を検知します)。

## 検証

- `npm run typecheck` / `npm run lint` ✅
- `npm run test` ✅(103 files / 1081 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Psyth7JUTHktLcCrs5Eke