### PR TITLE
feat(notifications): SLA期限接近リマインダー機能を追加 (issue-backlog #20)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,8 @@ BACKUP_RETENTION_DAYS="14"
 # .github/workflows/trial-reminders.yml が毎日 1 回、この値と同じ Secret を Bearer トークンとして
 # 叩く共有シークレット。未設定の間はこのエンドポイントは常に 500 を返し無効化される (fail-closed)。
 TRIAL_REMINDER_CRON_SECRET=""
+
+# SLA 期限接近リマインダー (issue-backlog #20 フォローアップ / POST /api/internal/sla-reminders)。
+# .github/workflows/sla-reminders.yml が毎時 1 回、この値と同じ Secret を Bearer トークンとして
+# 叩く共有シークレット。未設定の間はこのエンドポイントは常に 500 を返し無効化される (fail-closed)。
+SLA_REMINDER_CRON_SECRET=""

--- a/.github/workflows/sla-reminders.yml
+++ b/.github/workflows/sla-reminders.yml
@@ -1,0 +1,51 @@
+# issue-backlog #20 フォローアップ: SLA 期限接近リマインダーの定期実行。
+#
+# 仕組み:
+#   - 毎時 1 回 (cron) と手動実行 (workflow_dispatch) で、デプロイ済みアプリの
+#     POST /api/internal/sla-reminders を共有シークレット付きで叩く。
+#   - trial-reminders.yml と同じく、このリポジトリ自体はビルド・デプロイを行わず、
+#     常に稼働中のアプリ経由でのみ実行する設計。
+#   - SLA の警告帯 (§lib/sla.ts DEFAULT_WARNING_THRESHOLD_MS = 24 時間) はトライアル終了
+#     リマインダー (日単位) より粒度が細かいため、trial-reminders (daily) より高頻度の
+#     毎時実行にする。
+#   - Secret `SLA_REMINDER_CRON_SECRET` が未設定なら、ジョブは安全に no-op で終了する
+#     (fail-closed: 認証情報が無い状態で叩かない)。
+#
+# セキュリティ上の注意:
+#   - SLA_REMINDER_CRON_SECRET はエンドポイント側 (process.env) と同じ値を Secret に登録すること。
+#   - APP_BASE_URL は trial-reminders.yml と共有の公開情報 Variable (Secret ではない)。
+
+name: SLA Reminders
+
+on:
+  schedule:
+    # 毎時 0 分に実行する (トライアルリマインダーの日次実行と時間をずらして負荷分散)
+    - cron: '0 * * * *'
+  # 手動トリガも許可する (Actions 画面の Run workflow ボタン)
+  workflow_dispatch:
+
+# 既定の GITHUB_TOKEN は読み取りのみで十分 (このジョブはリポジトリに書き込まない)
+permissions:
+  contents: read
+
+jobs:
+  send-reminders:
+    name: Call sla-reminders endpoint
+    runs-on: ubuntu-latest
+    steps:
+      # Secret / Variable が両方設定されているときだけ実行する。
+      # 未設定なら no-op (このリポジトリを fork した環境でもジョブが赤くならないようにする)。
+      - name: Call endpoint
+        env:
+          SLA_REMINDER_CRON_SECRET: ${{ secrets.SLA_REMINDER_CRON_SECRET }}
+          APP_BASE_URL: ${{ vars.APP_BASE_URL }}
+        run: |
+          if [ -z "${SLA_REMINDER_CRON_SECRET}" ] || [ -z "${APP_BASE_URL}" ]; then
+            echo "SLA_REMINDER_CRON_SECRET または APP_BASE_URL が未設定のためスキップします (no-op)。" >&2
+            exit 0
+          fi
+          # レスポンスボディを表示しつつ、HTTP ステータスが 2xx でなければジョブを失敗させる
+          curl --fail-with-body -sS \
+            -X POST \
+            -H "Authorization: Bearer ${SLA_REMINDER_CRON_SECRET}" \
+            "${APP_BASE_URL%/}/api/internal/sla-reminders"

--- a/prisma/migrations/20260719000000_add_sla_due_soon_reminder/migration.sql
+++ b/prisma/migrations/20260719000000_add_sla_due_soon_reminder/migration.sql
@@ -1,0 +1,14 @@
+-- issue-backlog #20 フォローアップ: SLA 期限接近 (警告帯) の通知機能を追加する。
+-- POST /api/internal/sla-reminders (定期実行 cron) が、resolutionDueAt が警告帯に入った
+-- 未解決チケットの担当者へアプリ内通知を送るために使う。
+
+-- AlterEnum: 通知種別に SLA 期限接近を追加する
+-- PostgreSQL の ALTER TYPE ... ADD VALUE は DDL トランザクション外でのみ実行できるが、
+-- Prisma のマイグレーションエンジンがこの制約を検知して自動的にトランザクション外で実行するため、
+-- 20260707000000_add_notification_type_priority_changed と同様に特別な設定は不要。
+-- IF NOT EXISTS で冪等性を保つ。
+ALTER TYPE "NotificationType" ADD VALUE IF NOT EXISTS 'slaDueSoon';
+
+-- AlterTable: 「どの resolutionDueAt に対して通知済みか」を保持する冪等化フラグ。
+-- 既存行は未通知として扱うため NULL 許容・既定値なしで追加する。
+ALTER TABLE "Ticket" ADD COLUMN "slaReminderNotifiedForDueAt" TIMESTAMP(3);

--- a/prisma/migrations/20260719000000_add_sla_due_soon_reminder/migration.sql
+++ b/prisma/migrations/20260719000000_add_sla_due_soon_reminder/migration.sql
@@ -12,3 +12,7 @@ ALTER TYPE "NotificationType" ADD VALUE IF NOT EXISTS 'slaDueSoon';
 -- AlterTable: 「どの resolutionDueAt に対して通知済みか」を保持する冪等化フラグ。
 -- 既存行は未通知として扱うため NULL 許容・既定値なしで追加する。
 ALTER TABLE "Ticket" ADD COLUMN "slaReminderNotifiedForDueAt" TIMESTAMP(3);
+
+-- CreateIndex: listSlaDueSoonCandidates (全テナント横断で resolutionDueAt の範囲検索を行う) 用の索引。
+-- /code-review ultra 指摘対応: 他の Ticket クエリと異なり resolutionDueAt を絞り込む索引が無かった。
+CREATE INDEX "Ticket_resolutionDueAt_idx" ON "Ticket"("resolutionDueAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -477,6 +477,10 @@ model Ticket {
   @@index([tenantId]) // テナントスコープ検索用
   @@index([tenantId, status]) // テナント別ステータス絞り込み用
   @@index([tenantId, createdAt(sort: Desc)]) // テナント別新着順
+  // issue-backlog #20 フォローアップ: SLA 期限接近リマインダー (POST /api/internal/sla-reminders) の
+  // listSlaDueSoonCandidates は全テナント横断で resolutionDueAt の範囲検索を行うため専用索引を追加する
+  // (/code-review ultra 指摘対応: 他の Ticket クエリと異なり resolutionDueAt を絞り込む索引が無かった)
+  @@index([resolutionDueAt])
 }
 
 // ─────────────────────────────────────────────

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,6 +102,7 @@ enum NotificationType {
   statusChanged // ステータス変更通知
   priorityChanged // 優先度変更通知
   imported // CSV・メール一括取り込みによる複数チケット追加通知
+  slaDueSoon // issue-backlog #20 フォローアップ: SLA 解決期限が近い (警告帯) ことの通知
 }
 
 // テナント (組織) の動作モード。SMB 向けピボットの Lite/Pro 二層に対応
@@ -431,6 +432,12 @@ model Ticket {
   resolutionDueAt    DateTime? // 解決期限
   firstRespondedAt   DateTime? // 実際の初回応答日時
   resolvedAt         DateTime? // 解決日時
+  // issue-backlog #20 フォローアップ: SLA 期限接近リマインダー (POST /api/internal/sla-reminders) の
+  // 冪等化フラグ。「送信済みか」という真偽値ではなく「どの resolutionDueAt に対して送信済みか」を
+  // 保持することで、優先度変更等で resolutionDueAt が再計算されたときに他のコード (updatePriority 等)
+  // を一切変更せずとも自動的に再アーム状態になる (値が変われば一致しなくなるため)。
+  // src/lib/sla-reminder.ts の needsSlaDueSoonReminder が「resolutionDueAt と一致するか」で判定する
+  slaReminderNotifiedForDueAt DateTime?
 
   // Escalation (エスカレーション情報)
   escalatedAt      DateTime? // エスカレーション発生日時

--- a/src/app/api/internal/sla-reminders/route.ts
+++ b/src/app/api/internal/sla-reminders/route.ts
@@ -29,8 +29,8 @@ import {
 } from '@/lib/sla-reminder';
 // 未読件数の再配信 (SSE 経由で通知ベルへ即時反映)
 import { broadcastUnreadCount } from '@/features/notifications/notify';
-// 定数時間比較の共通ヘルパー (LINE Webhook 署名検証・trial-reminders と共有)
-import { constantTimeStringEqual } from '@/lib/timing-safe-compare';
+// 定数時間比較・Bearer トークン抽出の共通ヘルパー (LINE Webhook 署名検証・trial-reminders と共有)
+import { constantTimeStringEqual, extractBearerToken } from '@/lib/timing-safe-compare';
 // Route Handler 向け共通レート制限ラッパー (trial-reminders 等と共有)
 import { checkRouteRateLimit } from '@/lib/route-rate-limit';
 
@@ -39,14 +39,6 @@ import { checkRouteRateLimit } from '@/lib/route-rate-limit';
 const SLA_REMINDER_RATE_LIMIT = { limit: 5, windowMs: 60_000 } as const;
 const SLA_REMINDER_RATE_LIMIT_MESSAGE =
   'リクエストが多すぎます。しばらくしてから再試行してください';
-
-// Authorization ヘッダの "Bearer <token>" から token 部分だけを取り出す。
-// 形式が違えば null を返す (呼び出し側で認証失敗として扱う)
-function extractBearerToken(header: string | null): string | null {
-  if (!header) return null;
-  const match = header.match(/^Bearer (.+)$/);
-  return match ? match[1] : null;
-}
 
 // POST /api/internal/sla-reminders : SLA 解決期限が警告帯に入った未解決チケットの
 // 担当者へアプリ内通知を送る
@@ -57,6 +49,7 @@ export async function POST(request: Request): Promise<NextResponse> {
     SLA_REMINDER_RATE_LIMIT,
     SLA_REMINDER_RATE_LIMIT_MESSAGE,
   );
+  // 制限超過なら (429 レスポンスが返っているので) ここで処理を打ち切って返す
   if (rateLimitResponse) return rateLimitResponse;
 
   // 共有シークレットを環境変数から取得する。未設定なら fail-closed で即座に拒否する
@@ -112,8 +105,16 @@ export async function POST(request: Request): Promise<NextResponse> {
       });
       // 通知作成に成功した場合のみ、冪等化フラグ (この期限に対して通知済み) を永続化する。
       // 先に永続化すると、直後の broadcastUnreadCount 失敗時に「通知は作られたのに未読バッジが
-      // 更新されない」まま次回以降も再送されなくなる不整合が起きるため、通知作成の後に置く
+      // 更新されない」まま次回以降も再送されなくなる不整合が起きるため、通知作成の後に置く。
+      // 既知の制約 (trial-reminders と同じ設計): この永続化自体が例外を投げた場合 (DB 接続断等)、
+      // 通知は既に作成済みなのに冪等化フラグだけ書き込めず、次回実行時に同じ期限へ再度通知される
+      // (重複通知)。逆の順序 (先にフラグを立ててから通知を作る) にすれば重複は防げるが、
+      // 今度は通知作成自体が失敗したときに「フラグだけ立って一度も通知されない」まま
+      // (resolutionDueAt が変わらない限り) 永久に再試行されなくなる。後者の「静かに通知が
+      // 消える」方が「まれに重複する」より運用上気づきにくく害が大きいため、
+      // trial-reminders/route.ts (updateTrialReminderLastSent) と同じくこの順序を採用する
       await repos.tickets.markSlaReminderNotified(ticket.id, resolutionDueAt, ticket.tenantId);
+      // 通知作成・冪等化フラグ永続化のいずれも例外を投げなかった (=完了した) 件数として加算する
       remindersSent += 1;
       // 未読カウントを SSE で即時配信して通知ベルに反映させる (ベストエフォート)
       await broadcastUnreadCount(assigneeId, ticket.tenantId).catch((err) => {

--- a/src/app/api/internal/sla-reminders/route.ts
+++ b/src/app/api/internal/sla-reminders/route.ts
@@ -1,0 +1,131 @@
+// issue-backlog #20 フォローアップ: SLA 期限接近リマインダーの定期実行エンドポイント。
+//
+// src/app/api/internal/trial-reminders/route.ts と同じ「daily/hourly cron から叩く」設計。
+// GitHub Actions の cron は手動再実行 (workflow_dispatch)・遅延・欠落がありうる best-effort な
+// 定期実行であるため、「ちょうどそのタイミングだけ送る」設計ではなく
+// Ticket.slaReminderNotifiedForDueAt に「どの期限に対して通知済みか」を永続化することで
+// 何度・いつ叩かれても二重送信/取りこぼしが起きないようにしてある
+// (src/lib/sla-reminder.ts の needsSlaDueSoonReminder 参照)。
+// ユーザー操作ではなく定期実行ジョブから呼ばれる想定のため、認証はセッションではなく
+// 共有シークレットで行う (src/middleware.ts の INTERNAL_CRON_ROUTES でセッション認証ガードの
+// 対象外にしてある。trial-reminders と同じ扱い)。
+//
+// セキュリティ:
+// 1. Authorization: Bearer <SLA_REMINDER_CRON_SECRET> をタイミング攻撃対策の定数時間比較で
+//    検証する (trial-reminders/route.ts と共通ヘルパーを共有)。
+// 2. SLA_REMINDER_CRON_SECRET が環境変数に未設定の場合は、リクエストを一切処理せず
+//    500 で拒否する (§9 fail-closed。「シークレット未設定 = 誰でも叩ける」を防ぐ)。
+// 3. 固定キーのレート制限を認証より前に適用する (trial-reminders と同じ方針)。
+// 4. 1 件の通知作成失敗が他のチケットへの通知を止めないよう、チケット単位で try/catch する。
+
+import { NextResponse } from 'next/server';
+// データリポジトリ (Composition Root 経由。Prisma を直接 import しない)
+import { repos } from '@/data';
+// リマインダー要否判定・通知文言組み立ての純粋ヘルパー
+import {
+  needsSlaDueSoonReminder,
+  renderSlaDueSoonMessage,
+  SLA_DUE_SOON_QUERY_LIMIT,
+} from '@/lib/sla-reminder';
+// 未読件数の再配信 (SSE 経由で通知ベルへ即時反映)
+import { broadcastUnreadCount } from '@/features/notifications/notify';
+// 定数時間比較の共通ヘルパー (LINE Webhook 署名検証・trial-reminders と共有)
+import { constantTimeStringEqual } from '@/lib/timing-safe-compare';
+// Route Handler 向け共通レート制限ラッパー (trial-reminders 等と共有)
+import { checkRouteRateLimit } from '@/lib/route-rate-limit';
+
+// trial-reminders と同じ考え方: 正規の利用は 1 時間に 1 回程度の cron 実行のみのため、
+// 正規利用を妨げない範囲で厳しめの値にする
+const SLA_REMINDER_RATE_LIMIT = { limit: 5, windowMs: 60_000 } as const;
+const SLA_REMINDER_RATE_LIMIT_MESSAGE =
+  'リクエストが多すぎます。しばらくしてから再試行してください';
+
+// Authorization ヘッダの "Bearer <token>" から token 部分だけを取り出す。
+// 形式が違えば null を返す (呼び出し側で認証失敗として扱う)
+function extractBearerToken(header: string | null): string | null {
+  if (!header) return null;
+  const match = header.match(/^Bearer (.+)$/);
+  return match ? match[1] : null;
+}
+
+// POST /api/internal/sla-reminders : SLA 解決期限が警告帯に入った未解決チケットの
+// 担当者へアプリ内通知を送る
+export async function POST(request: Request): Promise<NextResponse> {
+  // 固定キーのレート制限を認証より前に適用する (シークレット比較・DB 走査より前に弾く)
+  const rateLimitResponse = checkRouteRateLimit(
+    'sla-reminders:unauthenticated',
+    SLA_REMINDER_RATE_LIMIT,
+    SLA_REMINDER_RATE_LIMIT_MESSAGE,
+  );
+  if (rateLimitResponse) return rateLimitResponse;
+
+  // 共有シークレットを環境変数から取得する。未設定なら fail-closed で即座に拒否する
+  const secret = process.env.SLA_REMINDER_CRON_SECRET?.trim();
+  if (!secret) {
+    console.error(
+      '[sla-reminders] SLA_REMINDER_CRON_SECRET が未設定のため、このエンドポイントは無効化されています',
+    );
+    return NextResponse.json({ error: 'このエンドポイントは設定されていません' }, { status: 500 });
+  }
+
+  // リクエストの Authorization ヘッダから Bearer トークンを取り出して検証する
+  const token = extractBearerToken(request.headers.get('authorization'));
+  if (!token || !constantTimeStringEqual(token, secret)) {
+    // 認証失敗の理由 (未設定/不一致) を区別せず同一の 401 を返す (総当たり耐性)
+    return NextResponse.json({ error: '認証に失敗しました' }, { status: 401 });
+  }
+
+  // 現在時刻を 1 度だけ取得し、以降の全判定で使い回す (呼び出し中に時刻が変わる不整合を防ぐ)
+  const now = new Date();
+
+  // SLA 警告帯に入った未解決チケットを全テナント横断で一括取得する (§8 上限付き)
+  const candidates = await repos.tickets.listSlaDueSoonCandidates(now, SLA_DUE_SOON_QUERY_LIMIT);
+  // 上限件数ちょうど返ってきた場合、上限を超えるチケットが黙って切り捨てられている可能性がある。
+  // §8「一覧取得は必ず上限を持たせる」の趣旨(サイレントな打ち切りを避ける)に沿ってログに残す
+  if (candidates.length === SLA_DUE_SOON_QUERY_LIMIT) {
+    console.error(
+      `[sla-reminders] 対象チケットが上限 (${SLA_DUE_SOON_QUERY_LIMIT} 件) に達しました。一部のチケットへのリマインダーが漏れている可能性があります`,
+    );
+  }
+
+  // 送信件数を集計する (レスポンスで運用者に結果を伝える)
+  let remindersSent = 0;
+
+  // チケットごとに独立して処理する。1 件の失敗が他のチケットへの通知を止めないよう
+  // ループ内で try/catch する
+  for (const ticket of candidates) {
+    // DB クエリは効率のための粗い事前絞り込みに徹しているため、ここで最終判定を行う
+    // (§6 一元管理: 一覧画面のバッジと同じ getSlaState ベースの定義を経由する)
+    if (!needsSlaDueSoonReminder(ticket)) continue;
+    // needsSlaDueSoonReminder が true を返した時点で resolutionDueAt / assigneeId は非 null
+    const resolutionDueAt = ticket.resolutionDueAt!;
+    const assigneeId = ticket.assigneeId!;
+
+    try {
+      // アプリ内通知を 1 件作成する (担当者宛。tenantId スコープ必須)
+      await repos.notifications.create({
+        userId: assigneeId,
+        type: 'slaDueSoon',
+        message: renderSlaDueSoonMessage(ticket.title),
+        ticketId: ticket.id,
+        tenantId: ticket.tenantId,
+      });
+      // 通知作成に成功した場合のみ、冪等化フラグ (この期限に対して通知済み) を永続化する。
+      // 先に永続化すると、直後の broadcastUnreadCount 失敗時に「通知は作られたのに未読バッジが
+      // 更新されない」まま次回以降も再送されなくなる不整合が起きるため、通知作成の後に置く
+      await repos.tickets.markSlaReminderNotified(ticket.id, resolutionDueAt, ticket.tenantId);
+      remindersSent += 1;
+      // 未読カウントを SSE で即時配信して通知ベルに反映させる (ベストエフォート)
+      await broadcastUnreadCount(assigneeId, ticket.tenantId).catch((err) => {
+        // SSE 配信失敗はバッジ更新が遅れるだけ。ログのみ残して続行する
+        console.warn(`[sla-reminders] チケット ${ticket.id}: 未読カウント配信に失敗しました`, err);
+      });
+    } catch (err) {
+      // 1 件分の失敗はログに残すだけで処理を継続する (内部詳細はログのみ、レスポンスには含めない)
+      console.error(`[sla-reminders] チケット ${ticket.id} への通知送信に失敗しました:`, err);
+    }
+  }
+
+  // 運用者向けに処理件数を返す (機微情報は含まない)
+  return NextResponse.json({ checked: candidates.length, remindersSent });
+}

--- a/src/app/api/internal/trial-reminders/route.ts
+++ b/src/app/api/internal/trial-reminders/route.ts
@@ -33,8 +33,8 @@ import {
 import { getEmailSender } from '@/lib/email';
 // アプリの公開ベース URL (メール内の設定画面リンク組み立てに使う)
 import { resolveAppBaseUrl } from '@/lib/app-url';
-// 定数時間比較の共通ヘルパー (LINE Webhook 署名検証と共有)
-import { constantTimeStringEqual } from '@/lib/timing-safe-compare';
+// 定数時間比較・Bearer トークン抽出の共通ヘルパー (LINE Webhook 署名検証・sla-reminders と共有)
+import { constantTimeStringEqual, extractBearerToken } from '@/lib/timing-safe-compare';
 // Route Handler 向け共通レート制限ラッパー (inbound-email/inbound-line/sso-acs と共有)
 import { checkRouteRateLimit } from '@/lib/route-rate-limit';
 
@@ -47,14 +47,6 @@ import { checkRouteRateLimit } from '@/lib/route-rate-limit';
 const TRIAL_REMINDER_RATE_LIMIT = { limit: 5, windowMs: 60_000 } as const;
 const TRIAL_REMINDER_RATE_LIMIT_MESSAGE =
   'リクエストが多すぎます。しばらくしてから再試行してください';
-
-// Authorization ヘッダの "Bearer <token>" から token 部分だけを取り出す。
-// 形式が違えば null を返す (呼び出し側で認証失敗として扱う)
-function extractBearerToken(header: string | null): string | null {
-  if (!header) return null;
-  const match = header.match(/^Bearer (.+)$/);
-  return match ? match[1] : null;
-}
 
 // POST /api/internal/trial-reminders : Free trial 終了間近のテナント管理者へリマインダーメールを送る
 export async function POST(request: Request): Promise<NextResponse> {

--- a/src/data/adapters/memory/ticket-repository.memory.ts
+++ b/src/data/adapters/memory/ticket-repository.memory.ts
@@ -15,11 +15,14 @@ import {
   type TicketDetail,
   type TicketListFilter,
   type TicketRepository,
+  type TicketSlaReminderCandidate,
   TICKET_DETAIL_COMMENTS_LIMIT,
   TICKET_DETAIL_HISTORY_LIMIT,
 } from '@/data/ports/ticket-repository';
 // メモリストアと ID 生成ヘルパーをインポート
 import { nextId, type Store } from './store';
+// SLA 期限接近リマインダーの「警告帯」窓の長さ (§6 一元管理: Prisma アダプタと同じ値を使う)
+import { DEFAULT_WARNING_THRESHOLD_MS } from '@/lib/sla';
 
 // ID からユーザー概要を作るヘルパー (見つからなければ null)
 function userSummary(store: Store, id: string | null): UserSummary | null {
@@ -289,6 +292,7 @@ export function makeTicketRepo(store: Store): TicketRepository {
         resolvedAt: input.resolvedAt ?? null,
         escalatedAt: null,
         escalationReason: null,
+        slaReminderNotifiedForDueAt: null, // 新規作成時点では未通知
         creatorId: input.creatorId,
         // フォローアップ (2026-07-13): CSV インポートで担当者名を解決した ID (未指定なら未アサイン)
         assigneeId: input.assigneeId ?? null,
@@ -388,6 +392,41 @@ export function makeTicketRepo(store: Store): TicketRepository {
       // 同じ規約に揃える。呼び出し側のスナップショット判定が古くても、ここで最終防衛する)
       if (t.firstRespondedAt) return;
       store.tickets.set(id, { ...t, firstRespondedAt: at, updatedAt: new Date() });
+    },
+
+    // issue-backlog #20 フォローアップ: SLA 期限接近リマインダーの対象候補を取得する
+    // (全テナント横断)。Prisma アダプタと同じ粗い事前絞り込み (未解決・担当者あり・警告帯の窓内)
+    // を行い、「本当に通知すべきか」の最終判定は呼び出し側 (needsSlaDueSoonReminder) に委ねる
+    async listSlaDueSoonCandidates(now, limit) {
+      const windowEnd = new Date(now.getTime() + DEFAULT_WARNING_THRESHOLD_MS);
+      const candidates: TicketSlaReminderCandidate[] = [];
+      for (const t of store.tickets.values()) {
+        if (t.resolvedAt != null) continue; // 未解決のみ (null/undefined 両対応)
+        if (t.status === 'Resolved' || t.status === 'Closed') continue; // 終息状態は除外
+        if (!t.assigneeId) continue; // 通知先が無いので対象外
+        if (!t.resolutionDueAt) continue; // 期限未設定は対象外
+        if (t.resolutionDueAt <= now) continue; // 既に超過
+        if (t.resolutionDueAt > windowEnd) continue; // まだ警告帯に入っていない
+        candidates.push({
+          id: t.id,
+          tenantId: t.tenantId,
+          title: t.title,
+          assigneeId: t.assigneeId,
+          resolutionDueAt: t.resolutionDueAt,
+          resolvedAt: t.resolvedAt,
+          slaReminderNotifiedForDueAt: t.slaReminderNotifiedForDueAt,
+        });
+        if (candidates.length >= limit) break; // §8 上限付き
+      }
+      // Prisma アダプタと同じく期限が近い順に揃える
+      return candidates.sort((a, b) => a.resolutionDueAt!.getTime() - b.resolutionDueAt!.getTime());
+    },
+
+    // issue-backlog #20 フォローアップ: SLA 期限接近リマインダーの冪等化フラグを更新する
+    async markSlaReminderNotified(id, dueAt, tenantId) {
+      const t = store.tickets.get(id);
+      if (!t || t.tenantId !== tenantId) return;
+      store.tickets.set(id, { ...t, slaReminderNotifiedForDueAt: dueAt });
     },
 
     // 品質メトリクスを算出して返す (tenantId スコープ。since 指定時はその日時以降作成分のみ)

--- a/src/data/adapters/memory/ticket-repository.memory.ts
+++ b/src/data/adapters/memory/ticket-repository.memory.ts
@@ -398,7 +398,12 @@ export function makeTicketRepo(store: Store): TicketRepository {
     // (全テナント横断)。Prisma アダプタと同じ粗い事前絞り込み (未解決・担当者あり・警告帯の窓内)
     // を行い、「本当に通知すべきか」の最終判定は呼び出し側 (needsSlaDueSoonReminder) に委ねる
     async listSlaDueSoonCandidates(now, limit) {
+      // 警告帯の終端時刻 (この時刻以前に期限が来るものだけが対象)
       const windowEnd = new Date(now.getTime() + DEFAULT_WARNING_THRESHOLD_MS);
+      // 条件に合う候補を全件集める配列 (limit で打ち切らず、まず全件集めてから並べ替える。
+      // /code-review ultra 指摘対応: Map の反復順 (挿入順) で limit 件に達した時点で打ち切ると、
+      // Prisma アダプタの「orderBy 期限昇順 → take limit」と異なり、期限が近い順とは限らない
+      // 挿入順の先頭 limit 件を返してしまい、本来最優先で通知すべきチケットが漏れうる)
       const candidates: TicketSlaReminderCandidate[] = [];
       for (const t of store.tickets.values()) {
         if (t.resolvedAt != null) continue; // 未解決のみ (null/undefined 両対応)
@@ -407,6 +412,7 @@ export function makeTicketRepo(store: Store): TicketRepository {
         if (!t.resolutionDueAt) continue; // 期限未設定は対象外
         if (t.resolutionDueAt <= now) continue; // 既に超過
         if (t.resolutionDueAt > windowEnd) continue; // まだ警告帯に入っていない
+        // 条件を満たしたチケットを候補配列に追加する (この時点では並び順を気にしない)
         candidates.push({
           id: t.id,
           tenantId: t.tenantId,
@@ -416,16 +422,20 @@ export function makeTicketRepo(store: Store): TicketRepository {
           resolvedAt: t.resolvedAt,
           slaReminderNotifiedForDueAt: t.slaReminderNotifiedForDueAt,
         });
-        if (candidates.length >= limit) break; // §8 上限付き
       }
-      // Prisma アダプタと同じく期限が近い順に揃える
-      return candidates.sort((a, b) => a.resolutionDueAt!.getTime() - b.resolutionDueAt!.getTime());
+      // Prisma アダプタと同じく期限が近い順に並べ替えてから、上限件数だけ返す (§8 上限付き)
+      return candidates
+        .sort((a, b) => a.resolutionDueAt!.getTime() - b.resolutionDueAt!.getTime())
+        .slice(0, limit);
     },
 
     // issue-backlog #20 フォローアップ: SLA 期限接近リマインダーの冪等化フラグを更新する
     async markSlaReminderNotified(id, dueAt, tenantId) {
+      // 対象チケットを取得する
       const t = store.tickets.get(id);
+      // 存在しない、または他テナントのチケットなら何もしない (tenantId スコープ)
       if (!t || t.tenantId !== tenantId) return;
+      // 冪等化フラグ (slaReminderNotifiedForDueAt) だけを新しい期限値で上書きして保存する
       store.tickets.set(id, { ...t, slaReminderNotifiedForDueAt: dueAt });
     },
 

--- a/src/data/adapters/prisma/mappers.ts
+++ b/src/data/adapters/prisma/mappers.ts
@@ -88,6 +88,7 @@ export function toTicket(row: TicketRow): Ticket {
     resolvedAt: row.resolvedAt,
     escalatedAt: row.escalatedAt,
     escalationReason: row.escalationReason,
+    slaReminderNotifiedForDueAt: row.slaReminderNotifiedForDueAt, // SLA 期限接近リマインダーの冪等化フラグ
     creatorId: row.creatorId,
     assigneeId: row.assigneeId,
     categoryId: row.categoryId,

--- a/src/data/adapters/prisma/ticket-repository.prisma.ts
+++ b/src/data/adapters/prisma/ticket-repository.prisma.ts
@@ -23,6 +23,8 @@ import {
 } from './mappers';
 // Prisma クライアント共通型
 import type { PrismaLike } from './types';
+// SLA 期限接近リマインダーの「警告帯」窓の長さ (§6 一元管理: sla.ts の getSlaState と同じ値を使う)
+import { DEFAULT_WARNING_THRESHOLD_MS } from '@/lib/sla';
 
 // ドメインのフィルター条件 + tenantId を Prisma の WhereInput に変換するヘルパー
 // tenantId は **必ず AND 条件として注入** し、テナント越境参照を遮断する
@@ -356,6 +358,43 @@ export function makeTicketRepo(db: PrismaLike): TicketRepository {
       await db.ticket.updateMany({
         where: { id, tenantId, firstRespondedAt: null },
         data: { firstRespondedAt: at },
+      });
+    },
+
+    // issue-backlog #20 フォローアップ: SLA 期限接近リマインダーの対象候補を取得する
+    // (全テナント横断。POST /api/internal/sla-reminders から呼ばれる)
+    async listSlaDueSoonCandidates(now, limit) {
+      const rows = await db.ticket.findMany({
+        where: {
+          resolvedAt: null, // 未解決のみ
+          status: { notIn: ['Resolved', 'Closed'] }, // 業務上の終息状態は除外 (overdue フィルタと同じ規約)
+          assigneeId: { not: null }, // 担当者未アサインは通知先が無いので対象外
+          resolutionDueAt: {
+            gt: now, // まだ超過していない (超過後は対象外。sla-reminder.ts のコメント参照)
+            lte: new Date(now.getTime() + DEFAULT_WARNING_THRESHOLD_MS), // 警告帯の窓内
+          },
+        },
+        select: {
+          id: true,
+          tenantId: true,
+          title: true,
+          assigneeId: true,
+          resolutionDueAt: true,
+          resolvedAt: true,
+          slaReminderNotifiedForDueAt: true,
+        },
+        take: limit, // §8 一覧取得は必ず上限を持たせる
+        orderBy: { resolutionDueAt: 'asc' }, // 期限が近い順 (ログ確認時の見やすさのため)
+      });
+      // Prisma 行 → 呼び出し側 (needsSlaDueSoonReminder) が期待する形にそのまま詰め替える
+      return rows;
+    },
+
+    // issue-backlog #20 フォローアップ: SLA 期限接近リマインダーの冪等化フラグを更新する
+    async markSlaReminderNotified(id, dueAt, tenantId) {
+      await db.ticket.updateMany({
+        where: { id, tenantId },
+        data: { slaReminderNotifiedForDueAt: dueAt },
       });
     },
 

--- a/src/data/ports/ticket-repository.ts
+++ b/src/data/ports/ticket-repository.ts
@@ -10,6 +10,9 @@ import type {
 } from '@/domain/types';
 // 添付ファイルのサマリ型 (詳細画面でサムネ表示する際に必要な最小情報)
 import type { AttachmentSummary } from '@/domain/attachment-summary';
+// SLA 期限接近リマインダーの判定に使う最小フィールド集合 (§6 一元管理: 判定ロジックと
+// 同じ形の型を再利用し、port 側で別の型を作って定義がずれるのを防ぐ)
+import type { SlaReminderCandidate } from '@/lib/sla-reminder';
 import type { Page, Sort, TextFilter } from './filters';
 
 // チケット一覧の絞り込み条件
@@ -151,6 +154,13 @@ export interface QualityMetrics {
   totalCount: number;
 }
 
+// listSlaDueSoonCandidates が返す行 (通知作成・冪等化更新に必要な最小フィールドのみ)
+export interface TicketSlaReminderCandidate extends SlaReminderCandidate {
+  id: string; // チケット ID
+  tenantId: string; // 所属テナント (通知作成の tenantId スコープに必須)
+  title: string; // 通知文言の組み立てに使う件名
+}
+
 // チケットリポジトリの契約 (port)
 // 全メソッドの ID 系引数は tenantId 必須化済。テナント越境参照/更新を Adapter 層で遮断する
 export interface TicketRepository {
@@ -267,4 +277,18 @@ export interface TicketRepository {
   // 初回応答日時を記録する (tenantId スコープ)。呼び出し側が「まだ未応答」を確認してから
   // 呼ぶ前提 (2 回目以降の呼び出しで上書きしないための判定は呼び出し側の責務)
   markFirstResponded(id: string, at: Date, tenantId: string): Promise<void>;
+
+  /**
+   * SLA 期限接近リマインダー (issue-backlog #20) の対象候補チケットを、全テナント横断で取得する
+   * (POST /api/internal/sla-reminders から呼ばれる cron 用。trial-reminders と同じく内部エンドポイント
+   * が全テナントを横断して処理する設計のため、他メソッドと異なり tenantId 引数を取らない)。
+   * DB 側では「未解決 かつ 担当者あり かつ resolutionDueAt が警告帯 (now 〜 now+DEFAULT_WARNING_THRESHOLD_MS)
+   * 内」まで絞り込んで返す (§8 一覧取得は必ず上限を持たせる)。「本当に通知すべきか」
+   * (既に同じ期限で通知済みでないか等) の最終判定は呼び出し側が src/lib/sla-reminder.ts の
+   * needsSlaDueSoonReminder に通して行う契約 (DB クエリは効率のための粗い事前絞り込みに徹する)
+   */
+  listSlaDueSoonCandidates(now: Date, limit: number): Promise<TicketSlaReminderCandidate[]>;
+  // SLA 期限接近リマインダーの冪等化フラグ (slaReminderNotifiedForDueAt) を更新する
+  // (tenantId スコープ)。dueAt には通知対象と判定した時点の resolutionDueAt をそのまま渡す
+  markSlaReminderNotified(id: string, dueAt: Date, tenantId: string): Promise<void>;
 }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -117,7 +117,8 @@ export type NotificationType =
   | 'commented' // コメント追加通知
   | 'statusChanged' // ステータス変更通知
   | 'priorityChanged' // 優先度変更通知
-  | 'imported'; // CSV・メール一括取り込みで複数チケットが追加された通知
+  | 'imported' // CSV・メール一括取り込みで複数チケットが追加された通知
+  | 'slaDueSoon'; // issue-backlog #20 フォローアップ: SLA 解決期限が近い (警告帯) ことの通知
 
 // テナントの動作モード (Lite=SMB 既定 / Pro=現行フル機能)
 export type TenantMode = 'lite' | 'pro';
@@ -241,6 +242,9 @@ export interface Ticket {
   resolvedAt: Date | null; // 解決した日時。未解決なら null
   escalatedAt: Date | null; // エスカレーションした日時。していなければ null
   escalationReason: string | null; // エスカレーション理由のテキスト
+  // issue-backlog #20 フォローアップ: SLA 期限接近リマインダーの冪等化フラグ。
+  // 「どの resolutionDueAt に対して通知済みか」を保持する (未通知/対象外なら null)
+  slaReminderNotifiedForDueAt: Date | null;
   creatorId: string; // 起票者ユーザー ID
   assigneeId: string | null; // 担当者ユーザー ID (未アサインなら null)
   categoryId: string | null; // カテゴリ ID (未分類なら null)

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -225,6 +225,7 @@ export const NOTIFICATION_TYPE_LABELS: Record<string, string> = {
   statusChanged: 'ステータス変更',
   priorityChanged: '優先度変更',
   imported: '一括取り込み', // CSV・メール一括インポートで複数チケットが追加されたことを通知する
+  slaDueSoon: 'SLA期限間近', // issue-backlog #20 フォローアップ: 解決期限が警告帯に入ったことの通知
 };
 
 // 変更履歴の oldValue / newValue を field 種別に応じて日本語表示に変換する関数

--- a/src/lib/sla-reminder.ts
+++ b/src/lib/sla-reminder.ts
@@ -1,0 +1,59 @@
+/**
+ * SLA due-soon reminder helpers (pure logic — no I/O).
+ *
+ * issue-backlog.md #20「通知機能（アサイン/期限/更新）」フォローアップ。
+ * 監査で発見したギャップ: SLA 期限が近いことは一覧・詳細画面のバッジ (src/lib/sla.ts の
+ * getSlaState が 'warning' を返す状態) でしか分からず、担当者が画面を開かない限り気づけない。
+ * 定期実行のリマインダー (アプリ内通知) が無いため、対応漏れのまま期限超過に至る事故を防ぐために追加する。
+ *
+ * すべて副作用のない純粋関数なのでユニットテスト (tests/sla-reminder.test.ts) で網羅できる。
+ * 実際の一覧取得・通知作成は呼び出し側 (POST /api/internal/sla-reminders) が担う。
+ */
+
+// SLA 状態判定 (ok/warning/overdue/none) は既存の一元管理された定義をそのまま再利用する
+// (§6 一元管理: 「期限間近」の閾値をここで再定義すると、一覧画面のバッジ表示と定義がずれる恐れがある)
+import { getSlaState } from '@/lib/sla';
+
+// このリマインダーの判定対象になる最小限のチケット情報
+export interface SlaReminderCandidate {
+  resolutionDueAt: Date | null; // 解決期限 (SLA)
+  resolvedAt: Date | null; // 解決日時 (未解決なら null)
+  assigneeId: string | null; // 担当者 (未アサインなら通知先が無いので対象外)
+  // 直近に通知済みの resolutionDueAt (未通知/対象外なら null)。resolutionDueAt と一致していれば
+  // 既に同じ期限に対して通知済みとみなす (優先度変更等で期限が再計算されれば自動的に再アームされる)
+  slaReminderNotifiedForDueAt: Date | null;
+}
+
+// 内部一覧取得の上限件数 (§8 一覧取得は必ず上限を持たせる)。SMB 向け SaaS の想定規模
+// (テナントあたり数十〜数百件の未解決チケット程度) では 1 回の cron 実行で十分に収まる件数
+export const SLA_DUE_SOON_QUERY_LIMIT = 500;
+
+// 指定チケットに SLA 期限接近リマインダーを送るべきかを判定する純粋関数。
+// 条件: (1) SLA 状態が 'warning' (getSlaState と同じ定義。期限間近かつ未解決)
+//       (2) 担当者が割り当て済み (通知先が決まっている)
+//       (3) 現在の resolutionDueAt に対してまだ通知していない
+export function needsSlaDueSoonReminder(ticket: SlaReminderCandidate): boolean {
+  // 期限未設定 (resolutionDueAt が null) なら getSlaState が 'none' を返すため自然に対象外になる
+  const state = getSlaState(ticket.resolutionDueAt, ticket.resolvedAt);
+  // 'warning' (期限間近) 以外 ('ok' / 'overdue' / 'none') は対象外。
+  // 'overdue' (既に超過) を含めないのは意図的な選択: 超過は既に一覧・詳細画面のバッジで
+  // 常時警告されており、このリマインダーは「まだ間に合ううちに気づいてもらう」ことが目的のため
+  if (state !== 'warning') return false;
+  // 担当者未アサインなら通知先が無いので対象外
+  if (!ticket.assigneeId) return false;
+  // resolutionDueAt は state が 'warning' の時点で null ではないことが保証されている
+  // (getSlaState は null なら 'none' を返す) が、TypeScript の型情報上はまだ Date | null なので
+  // ここで明示的にガードする
+  if (!ticket.resolutionDueAt) return false;
+  // 直近の通知が今と同じ resolutionDueAt に対してであれば、既に通知済みなので再送しない
+  if (ticket.slaReminderNotifiedForDueAt?.getTime() === ticket.resolutionDueAt.getTime()) {
+    return false;
+  }
+  // 上記のいずれにも該当しなければ通知が必要
+  return true;
+}
+
+// SLA 期限接近リマインダーの通知本文を組み立てる純粋関数 (副作用なし)
+export function renderSlaDueSoonMessage(title: string): string {
+  return `チケット「${title}」の解決期限が近づいています`;
+}

--- a/src/lib/sla.ts
+++ b/src/lib/sla.ts
@@ -48,7 +48,10 @@ export function calculateFirstResponseDueAt(priority: Priority, from: Date): Dat
 // 解決期限 (24〜168 時間の窓) 向けに調整された値。初回応答期限は窓が 4〜24 時間と
 // 短いため、この既定値をそのまま使うと起票直後から常に warning になってしまう
 // (回帰防止: getSlaState の呼び出し側は窓の長さに応じた閾値を明示的に渡すこと)
-const DEFAULT_WARNING_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+// issue-backlog #20 フォローアップ: SLA 期限接近リマインダー (src/lib/sla-reminder.ts) の
+// DB 側の絞り込みクエリでも同じ「警告帯」の窓を使うため export する (§6 一元管理: 画面バッジと
+// リマインダー通知の「期限間近」の定義を同じ 1 つの値に揃え、別々に定義してずれるのを防ぐ)
+export const DEFAULT_WARNING_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 
 // 期限日時と解決日時から現在の SLA 状態を判定する関数。
 // warningThresholdMs: 「期限間近」とみなす残り時間 (ミリ秒)。省略時は解決期限向けの

--- a/src/lib/timing-safe-compare.ts
+++ b/src/lib/timing-safe-compare.ts
@@ -18,3 +18,16 @@ export function constantTimeStringEqual(a: string, b: string): boolean {
   if (bufA.length !== bufB.length) return false;
   return timingSafeEqual(bufA, bufB);
 }
+
+// /code-review ultra 指摘対応: trial-reminders/route.ts と sla-reminders/route.ts の両方が
+// 「Authorization ヘッダの "Bearer <token>" から token 部分を取り出す」全く同じ実装を
+// 個別に持っていた (2 箇所目の重複、CLAUDE.md §6 DRY) ため、constantTimeStringEqual と同じく
+// ここに切り出す。共有シークレット認証を行う内部 cron エンドポイントはセットで使う想定
+//
+// Authorization ヘッダの "Bearer <token>" から token 部分だけを取り出す。
+// 形式が違えば null を返す (呼び出し側で認証失敗として扱う)
+export function extractBearerToken(header: string | null): string | null {
+  if (!header) return null;
+  const match = header.match(/^Bearer (.+)$/);
+  return match ? match[1] : null;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,7 +6,12 @@ import { isAgent } from '@/lib/role';
 // /code-review ultra 指摘対応: 「/api/internal/」配下丸ごとをプレフィックスで除外すると、
 // 「内部向け = 安全」という誤解を招きやすい名前のため、将来ここに認証を自前実装し忘れた
 // 別ルートが追加されてもセッション認証ガードの対象から外れないよう、個別ルートを明示列挙する
-const INTERNAL_CRON_ROUTES = ['/api/internal/trial-reminders'];
+const INTERNAL_CRON_ROUTES = [
+  '/api/internal/trial-reminders',
+  // issue-backlog #20 フォローアップ: SLA 期限接近リマインダー (POST /api/internal/sla-reminders)。
+  // trial-reminders と同じく共有シークレットで自前認可するため、明示的にここへ追加する
+  '/api/internal/sla-reminders',
+];
 
 // 認証ミドルウェア
 // - ログイン状態のチェック (未ログインは /login に飛ばす or API は 401 を返す)
@@ -32,11 +37,11 @@ export default auth((req) => {
   // ルート側で HMAC 署名検証 (stripe.webhooks.constructEvent) を行うため、
   // セッション認証ガードの対象外にする (Phase 4 課金)。
   const isApiWebhook = req.nextUrl.pathname.startsWith('/api/webhooks/');
-  // 内部 cron 専用エンドポイント (trial-reminders) はブラウザセッションを持たず、
+  // 内部 cron 専用エンドポイント (trial-reminders / sla-reminders) はブラウザセッションを持たず、
   // GitHub Actions 等の定期実行ジョブから共有シークレット (Authorization: Bearer) で
   // 叩かれる。ルート側で constantTimeStringEqual による検証を行うため、ここでは
   // isApiInbound / isApiWebhook と同じ理由でセッション認証ガードの対象外にする
-  // (§7.2.1 Free trial 終了リマインダー。対象ルートは INTERNAL_CRON_ROUTES で明示列挙)。
+  // (§7.2.1 Free trial 終了リマインダー・issue-backlog #20。対象ルートは INTERNAL_CRON_ROUTES で明示列挙)。
   const isApiInternal = INTERNAL_CRON_ROUTES.includes(req.nextUrl.pathname);
   const isApiRoute = req.nextUrl.pathname.startsWith('/api/');
 

--- a/tests/data/location-repository.memory.test.ts
+++ b/tests/data/location-repository.memory.test.ts
@@ -35,6 +35,7 @@ function seedTicket(id: string, tenantId: string, locationId: string | null) {
     resolvedAt: null,
     escalatedAt: null,
     escalationReason: null,
+    slaReminderNotifiedForDueAt: null,
     creatorId: 'creator-1',
     assigneeId: null,
     categoryId: null,

--- a/tests/features/delete-location.test.ts
+++ b/tests/features/delete-location.test.ts
@@ -140,6 +140,7 @@ describe('deleteLocation', () => {
       resolvedAt: null,
       escalatedAt: null,
       escalationReason: null,
+      slaReminderNotifiedForDueAt: null,
       creatorId: 'creator-1',
       assigneeId: null,
       categoryId: null,

--- a/tests/features/sla-reminders-route.test.ts
+++ b/tests/features/sla-reminders-route.test.ts
@@ -1,0 +1,256 @@
+// POST /api/internal/sla-reminders (issue-backlog #20 SLA 期限接近リマインダー) のテスト。
+// 共有シークレット認証 (未設定/欠落/不一致)・警告帯判定・冪等化・
+// 1件の失敗が他のチケットを止めないことをメモリアダプタで検証する。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// レート制限バケットをテスト間で初期化するヘルパー
+import { __resetRateLimits } from '@/lib/rate-limit';
+// 「上限までは429にならず、上限+1回目で429になる」の共通アサーションヘルパー
+import { expectRateLimitTripsAfter } from './sso-rate-limit-assertions';
+// メモリ実装の context (store/repos)
+import { createMemoryContext, type Store } from '@/data/adapters/memory';
+// リポジトリ束の型
+import type { Repos } from '@/data/ports/unit-of-work';
+
+const CRON_SECRET = 'test-sla-cron-secret-value';
+const HOUR_MS = 60 * 60 * 1000;
+
+// 各テストで差し替える可変な依存 (Route import 前に値を入れる)
+let store: Store;
+let repos: Repos;
+
+// @/data を差し替え (getter で beforeEach の上書きを反映)
+vi.mock('@/data', () => ({
+  get repos() {
+    return repos;
+  },
+}));
+
+// 未読カウントの SSE 再配信は本テストの関心事ではないため、呼び出しの記録だけ行うモックに置換する
+// (import-tickets.test.ts と同じ方式。sse-subscribers 経由の notificationBroadcaster は
+// @/data のモックに含まれておらず、実装をそのまま呼ぶとそこで例外になるため必須)
+const { broadcastCalls } = vi.hoisted(() => ({
+  broadcastCalls: [] as Array<{ userId: string; tenantId: string }>,
+}));
+vi.mock('@/features/notifications/notify', () => ({
+  broadcastUnreadCount: vi.fn(async (userId: string, tenantId: string) => {
+    broadcastCalls.push({ userId, tenantId });
+  }),
+}));
+
+// 動的 import: 上のモック設定が反映された後で対象を読み込む
+async function loadRoute() {
+  const mod = await import('@/app/api/internal/sla-reminders/route');
+  return mod.POST;
+}
+
+// 認証済みリクエストを組み立てるヘルパー (token 省略時は正しいシークレットを使う)
+function makeRequest(token?: string | null): Request {
+  const headers = new Headers();
+  if (token !== null) {
+    headers.set('authorization', `Bearer ${token ?? CRON_SECRET}`);
+  }
+  return new Request('http://localhost/api/internal/sla-reminders', {
+    method: 'POST',
+    headers,
+  });
+}
+
+// 指定条件のチケットを 1 件シードする (差分のみ overrides で上書き)
+function seedTicket(
+  id: string,
+  overrides: {
+    resolutionDueAt: Date | null;
+    resolvedAt?: Date | null;
+    assigneeId?: string | null;
+    status?: 'Open' | 'InProgress' | 'Resolved' | 'Closed';
+    slaReminderNotifiedForDueAt?: Date | null;
+    tenantId?: string;
+  },
+) {
+  const now = new Date();
+  store.tickets.set(id, {
+    id,
+    title: `チケット${id}`,
+    body: '本文',
+    status: overrides.status ?? 'Open',
+    priority: 'Medium',
+    createdAt: now,
+    updatedAt: now,
+    firstResponseDueAt: null,
+    resolutionDueAt: overrides.resolutionDueAt,
+    firstRespondedAt: null,
+    resolvedAt: overrides.resolvedAt ?? null,
+    escalatedAt: null,
+    escalationReason: null,
+    slaReminderNotifiedForDueAt: overrides.slaReminderNotifiedForDueAt ?? null,
+    creatorId: 'creator-1',
+    // `??` だと明示的な `null` (未アサインを表す意図) まで既定値 'agent-1' に丸めてしまうため、
+    // 「overrides に含まれているか」で「未指定 (既定値を使う)」と「明示的に null」を区別する
+    assigneeId: 'assigneeId' in overrides ? (overrides.assigneeId as string | null) : 'agent-1',
+    categoryId: null,
+    locationId: null,
+    tenantId: overrides.tenantId ?? 'tenant-1',
+  });
+}
+
+describe('POST /api/internal/sla-reminders', () => {
+  beforeEach(() => {
+    const ctx = createMemoryContext();
+    store = ctx.store;
+    repos = ctx.repos;
+    broadcastCalls.length = 0;
+    vi.stubEnv('SLA_REMINDER_CRON_SECRET', CRON_SECRET);
+    // このファイルは 1 テストあたり複数回 POST するため、レート制限バケットをリセットする
+    // (リセットしないと後続のテストが前のテストのカウントを引き継いで意図せず 429 になる)
+    __resetRateLimits();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  // fail-closed: シークレット未設定なら処理せず 500 を返す
+  it('シークレット未設定時は処理せず500を返す', async () => {
+    vi.stubEnv('SLA_REMINDER_CRON_SECRET', '');
+    seedTicket('t1', { resolutionDueAt: new Date(Date.now() + 12 * HOUR_MS) });
+    const POST = await loadRoute();
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(500);
+    expect(store.notifications.size).toBe(0);
+  });
+
+  // Authorization ヘッダが無ければ 401
+  it('Authorizationヘッダが無ければ401を返す', async () => {
+    const POST = await loadRoute();
+    const res = await POST(makeRequest(null));
+    expect(res.status).toBe(401);
+  });
+
+  // トークンが不一致なら 401
+  it('トークン不一致は401を返す', async () => {
+    const POST = await loadRoute();
+    const res = await POST(makeRequest('wrong-token'));
+    expect(res.status).toBe(401);
+  });
+
+  // 警告帯 (残り24時間以内・未超過) の未解決チケットには通知する
+  it('警告帯のチケットに通知を送る', async () => {
+    seedTicket('t1', { resolutionDueAt: new Date(Date.now() + 12 * HOUR_MS) });
+    const POST = await loadRoute();
+    const res = await POST(makeRequest());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.remindersSent).toBe(1);
+    const notifications = [...store.notifications.values()];
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].type).toBe('slaDueSoon');
+    expect(notifications[0].userId).toBe('agent-1');
+    expect(notifications[0].ticketId).toBe('t1');
+    expect(broadcastCalls).toEqual([{ userId: 'agent-1', tenantId: 'tenant-1' }]);
+  });
+
+  // まだ警告帯に入っていなければ送信しない
+  it('警告帯に入っていなければ送信しない', async () => {
+    seedTicket('t1', { resolutionDueAt: new Date(Date.now() + 48 * HOUR_MS) });
+    const POST = await loadRoute();
+    const res = await POST(makeRequest());
+    const body = await res.json();
+    expect(body.remindersSent).toBe(0);
+    expect(store.notifications.size).toBe(0);
+  });
+
+  // 既に期限超過なら送信しない (超過は一覧・詳細のバッジで既に警告済みのため対象外)
+  it('期限超過のチケットには送信しない', async () => {
+    seedTicket('t1', { resolutionDueAt: new Date(Date.now() - HOUR_MS) });
+    const POST = await loadRoute();
+    const res = await POST(makeRequest());
+    const body = await res.json();
+    expect(body.remindersSent).toBe(0);
+  });
+
+  // 担当者未アサインなら送信しない
+  it('担当者未アサインのチケットには送信しない', async () => {
+    seedTicket('t1', { resolutionDueAt: new Date(Date.now() + 12 * HOUR_MS), assigneeId: null });
+    const POST = await loadRoute();
+    const res = await POST(makeRequest());
+    const body = await res.json();
+    expect(body.remindersSent).toBe(0);
+  });
+
+  // 解決済みなら送信しない
+  it('解決済みのチケットには送信しない', async () => {
+    seedTicket('t1', {
+      resolutionDueAt: new Date(Date.now() + 12 * HOUR_MS),
+      resolvedAt: new Date(),
+      status: 'Resolved',
+    });
+    const POST = await loadRoute();
+    const res = await POST(makeRequest());
+    const body = await res.json();
+    expect(body.remindersSent).toBe(0);
+  });
+
+  // 既に同じ期限に対して通知済みなら再送しない (workflow_dispatch の手動再実行や
+  // 同一時間内の複数回実行での二重送信防止)
+  it('同じ期限に既に通知済みなら再送しない', async () => {
+    const dueAt = new Date(Date.now() + 12 * HOUR_MS);
+    seedTicket('t1', { resolutionDueAt: dueAt, slaReminderNotifiedForDueAt: dueAt });
+    const POST = await loadRoute();
+    const res = await POST(makeRequest());
+    const body = await res.json();
+    expect(body.remindersSent).toBe(0);
+    expect(store.notifications.size).toBe(0);
+  });
+
+  // 送信成功後は slaReminderNotifiedForDueAt が resolutionDueAt と同じ値で永続化されること
+  it('送信成功後に冪等化フラグを永続化する', async () => {
+    const dueAt = new Date(Date.now() + 12 * HOUR_MS);
+    seedTicket('t1', { resolutionDueAt: dueAt });
+    const POST = await loadRoute();
+    await POST(makeRequest());
+    expect(store.tickets.get('t1')?.slaReminderNotifiedForDueAt?.getTime()).toBe(dueAt.getTime());
+  });
+
+  // 優先度変更等で期限が前と変わっていれば、以前の通知済みフラグがあっても再送する (取りこぼし防止)
+  it('期限が変わっていれば再送する', async () => {
+    const oldDueAt = new Date(Date.now() + 48 * HOUR_MS);
+    const newDueAt = new Date(Date.now() + 12 * HOUR_MS);
+    seedTicket('t1', { resolutionDueAt: newDueAt, slaReminderNotifiedForDueAt: oldDueAt });
+    const POST = await loadRoute();
+    const res = await POST(makeRequest());
+    const body = await res.json();
+    expect(body.remindersSent).toBe(1);
+  });
+
+  // 1 件の通知作成失敗が他のチケットへの通知を止めない
+  it('1件の通知作成失敗が他のチケットの送信を妨げない', async () => {
+    seedTicket('t-fail', { resolutionDueAt: new Date(Date.now() + 12 * HOUR_MS) });
+    seedTicket('t-ok', { resolutionDueAt: new Date(Date.now() + 12 * HOUR_MS) });
+    // t-fail への通知作成だけ失敗させる
+    const originalCreate = repos.notifications.create.bind(repos.notifications);
+    repos.notifications.create = async (input) => {
+      if (input.ticketId === 't-fail') throw new Error('DB 接続エラー (テスト用)');
+      return originalCreate(input);
+    };
+    const POST = await loadRoute();
+    const res = await POST(makeRequest());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.remindersSent).toBe(1);
+    const notifications = [...store.notifications.values()];
+    expect(notifications.map((n) => n.ticketId)).toEqual(['t-ok']);
+    // 失敗したチケットは冪等化フラグを永続化しない (次回実行時に再試行できるようにする)
+    expect(store.tickets.get('t-fail')?.slaReminderNotifiedForDueAt).toBeNull();
+  });
+
+  // 監査で発見したギャップ対応: 共有シークレットのみで守られたこの経路にレート制限が無いと、
+  // シークレット漏洩時に無制限に叩けてしまう。固定キーのレート制限 (60秒5回) を検証する
+  describe('レート制限', () => {
+    // 上限 (5回/60秒) を超えると、認証結果 (トークン不一致) より前に429を返す
+    it('固定キーのレート制限を超えると429を返す', async () => {
+      const POST = await loadRoute();
+      await expectRateLimitTripsAfter(() => POST(makeRequest('wrong-token')), 5);
+    });
+  });
+});

--- a/tests/sla-reminder.test.ts
+++ b/tests/sla-reminder.test.ts
@@ -1,0 +1,94 @@
+// Vitest のテスト DSL
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// テスト対象 (純粋ヘルパー)
+import { needsSlaDueSoonReminder, renderSlaDueSoonMessage } from '@/lib/sla-reminder';
+
+// DEFAULT_WARNING_THRESHOLD_MS (24時間) を意識したテスト用の基準時刻とオフセット。
+// needsSlaDueSoonReminder は内部で getSlaState (src/lib/sla.ts) 経由で `new Date()` を
+// 参照するため、テスト側の基準時刻と実際の `new Date()` を一致させる必要がある。
+// vi.setSystemTime でシステム時刻ごと固定することでこれを保証する
+const NOW = new Date('2026-07-19T00:00:00Z');
+const HOUR_MS = 60 * 60 * 1000;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// needsSlaDueSoonReminder のテストで共通に使う「素直な候補」を組み立てるヘルパー。
+// 個々のテストは差分のみ上書きする
+function candidate(overrides: Partial<Parameters<typeof needsSlaDueSoonReminder>[0]> = {}) {
+  return {
+    resolutionDueAt: new Date(NOW.getTime() + 12 * HOUR_MS), // 残り12時間 (24時間窓の warning に該当)
+    resolvedAt: null,
+    assigneeId: 'agent-1',
+    slaReminderNotifiedForDueAt: null,
+    ...overrides,
+  };
+}
+
+describe('needsSlaDueSoonReminder', () => {
+  // 警告帯 (残り24時間以内・未超過) かつ担当者ありかつ未通知なら true
+  it('警告帯・担当者あり・未通知なら true を返す', () => {
+    expect(needsSlaDueSoonReminder(candidate())).toBe(true);
+  });
+
+  // まだ警告帯に入っていない (残り時間が長い) なら false ('ok' 状態)
+  it('警告帯に入っていなければ false を返す', () => {
+    const c = candidate({ resolutionDueAt: new Date(NOW.getTime() + 48 * HOUR_MS) });
+    expect(needsSlaDueSoonReminder(c)).toBe(false);
+  });
+
+  // 既に期限超過 ('overdue' 状態) なら false (超過は一覧・詳細のバッジで既に警告済みのため対象外)
+  it('期限超過は false を返す (バッジで既に警告済みのため対象外)', () => {
+    const c = candidate({ resolutionDueAt: new Date(NOW.getTime() - HOUR_MS) });
+    expect(needsSlaDueSoonReminder(c)).toBe(false);
+  });
+
+  // 期限未設定 ('none' 状態) なら false
+  it('期限未設定なら false を返す', () => {
+    const c = candidate({ resolutionDueAt: null });
+    expect(needsSlaDueSoonReminder(c)).toBe(false);
+  });
+
+  // 既に解決済み ('ok' 状態) なら false
+  it('解決済みなら false を返す', () => {
+    const c = candidate({ resolvedAt: new Date(NOW.getTime() - HOUR_MS) });
+    expect(needsSlaDueSoonReminder(c)).toBe(false);
+  });
+
+  // 担当者未アサインなら通知先が無いので false
+  it('担当者未アサインなら false を返す', () => {
+    const c = candidate({ assigneeId: null });
+    expect(needsSlaDueSoonReminder(c)).toBe(false);
+  });
+
+  // 同じ resolutionDueAt に対して既に通知済みなら再送しない (二重送信防止)
+  it('同じ期限に既に通知済みなら false を返す', () => {
+    const dueAt = new Date(NOW.getTime() + 12 * HOUR_MS);
+    const c = candidate({ resolutionDueAt: dueAt, slaReminderNotifiedForDueAt: dueAt });
+    expect(needsSlaDueSoonReminder(c)).toBe(false);
+  });
+
+  // 過去に別の (古い) 期限に対して通知済みでも、期限が変わっていれば再アームされ true を返す
+  // (優先度変更等で resolutionDueAt が再計算されたケースを想定。取りこぼし防止)
+  it('通知済みの期限と現在の期限が異なれば再アームされ true を返す', () => {
+    const oldDueAt = new Date(NOW.getTime() + 48 * HOUR_MS); // 以前は余裕があった期限
+    const newDueAt = new Date(NOW.getTime() + 12 * HOUR_MS); // 優先度変更等で前倒しされた期限
+    const c = candidate({ resolutionDueAt: newDueAt, slaReminderNotifiedForDueAt: oldDueAt });
+    expect(needsSlaDueSoonReminder(c)).toBe(true);
+  });
+});
+
+describe('renderSlaDueSoonMessage', () => {
+  // 件名を含む通知文言を組み立てること
+  it('チケット件名を含む通知文言を返す', () => {
+    const message = renderSlaDueSoonMessage('サーバーが応答しない');
+    expect(message).toContain('サーバーが応答しない');
+    expect(message).toContain('解決期限');
+  });
+});


### PR DESCRIPTION
## Summary

`docs/issue-backlog.md` #20「通知機能（アサイン/期限/更新）」のフォローアップ。既存の通知種別（担当割当/エスカレーション/コメント/状態変更/一括取り込み）は揃っていたが、**SLA解決期限が近いこと**は一覧・詳細画面のバッジ（`getSlaState` の `'warning'`）でしか分からず、担当者が画面を開かない限り気づけないギャップがあった。

- `POST /api/internal/sla-reminders`（毎時 cron）が、解決期限が警告帯（既定24時間以内・未超過）に入った未解決チケットの担当者へ**アプリ内通知**を送る
- 設計は既存の `POST /api/internal/trial-reminders` を踏襲: 共有シークレット認証（`SLA_REMINDER_CRON_SECRET`）＋固定キーのレート制限＋1件失敗が他を止めない try/catch
- `Ticket.slaReminderNotifiedForDueAt` に「どの期限に対して通知済みか」を保持する冪等化フラグを追加。真偽値ではなく期限の値そのものを保持することで、優先度変更等で期限が再計算されたときに **他のコードを一切変更せず自動的に再アーム**される
- 「期限間近」の判定は一覧画面のバッジと同じ `src/lib/sla.ts` の `getSlaState`／`DEFAULT_WARNING_THRESHOLD_MS` を再利用し、定義がずれないようにした（CLAUDE.md §6 一元管理）

## 変更対象ファイル

- `prisma/schema.prisma` / `prisma/migrations/20260719000000_add_sla_due_soon_reminder/` — `NotificationType.slaDueSoon` 追加・`Ticket.slaReminderNotifiedForDueAt` 追加
- `src/domain/types.ts` / `src/data/adapters/prisma/__schema-parity.ts`（既存の drift 検知で型エラーを検出→対応） — ドメイン型を同期
- `src/lib/sla-reminder.ts`（新規） — 判定・文言組み立ての純粋関数（`needsSlaDueSoonReminder` / `renderSlaDueSoonMessage`）
- `src/lib/sla.ts` — `DEFAULT_WARNING_THRESHOLD_MS` を export（一元管理のため）
- `src/data/ports/ticket-repository.ts` / `adapters/prisma` / `adapters/memory` — `listSlaDueSoonCandidates` / `markSlaReminderNotified` を追加
- `src/app/api/internal/sla-reminders/route.ts`（新規） — cron エンドポイント
- `src/middleware.ts` — `INTERNAL_CRON_ROUTES` に追加（セッション認証ガード対象外）
- `.github/workflows/sla-reminders.yml`（新規） — 毎時 cron
- `.env.example` — `SLA_REMINDER_CRON_SECRET` を追記
- `tests/sla-reminder.test.ts` / `tests/features/sla-reminders-route.test.ts`（新規） — 純粋ロジック・ルートの単体テスト

## 再利用した既存実装

- `src/app/api/internal/trial-reminders/route.ts` の cron エンドポイント設計（認証・レート制限・冪等化・try/catchの方針）をそのまま踏襲
- `src/lib/timing-safe-compare.ts` / `src/lib/route-rate-limit.ts` / `src/features/notifications/notify.ts::broadcastUnreadCount` を再利用（新規実装なし）
- `getSlaState`（`src/lib/sla.ts`）を再利用し、通知の閾値定義を新設しない

## 検証方法

- `npm run typecheck` — ✅ (ドメイン型 drift 検知ファイルも含めてパス)
- `npm run lint` — ✅
- `npx prettier --check` — ✅
- `npx vitest run` — ✅ 105 files / 1114 tests passed（21 files skip = `RUN_PRISMA_CONTRACT=1` 必須の契約テスト、DB未起動のため今回はローカルで未実行。CI のサービスコンテナで実行される）
- マイグレーション SQL は既存の同種マイグレーション（enum `ADD VALUE` + `ALTER TABLE ADD COLUMN` の組み合わせ、例: `20260713010000_add_quarantine_channel_and_line_fields`）と同じパターンを踏襲。ローカルに Docker デーモンが無く `prisma migrate dev` の実機検証はできなかったため、CI の Postgres サービスコンテナでの適用結果を要確認

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx prettier --check`
- [x] `npx vitest run`（契約テスト以外）
- [ ] CI（Postgres サービスコンテナ）でのマイグレーション適用・契約テストの確認

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01V5WaHUMQSQHHa99fV77u3o)_