### PR TITLE
fix(settings): LINE連携設定更新のTOCTOUを解消しCASで競合を検知する

### DIFF
--- a/src/data/adapters/memory/line-config-repository.memory.ts
+++ b/src/data/adapters/memory/line-config-repository.memory.ts
@@ -48,6 +48,17 @@ export function makeLineConfigRepo(store: Store): LineConfigRepository {
       if (existing) {
         // 既存設定を取り出して値を更新する
         const cfg = store.lineConfigs.get(existing)!;
+        // CAS: expected が渡されていれば、現在値がそれと一致するときだけ更新する
+        // (Prisma アダプタの updateMany 版 CAS と同じ契約。§9 fail-closed で後勝ち上書きを防ぐ)
+        if (
+          input.expected &&
+          (cfg.channelSecret !== input.expected.channelSecret ||
+            cfg.channelAccessToken !== input.expected.channelAccessToken ||
+            cfg.botUserId !== input.expected.botUserId)
+        ) {
+          // 読み取り後に他の更新が割り込んでいた (競合) ため null を返し、上書きしない
+          return null;
+        }
         // 更新後の設定オブジェクトを組み立てる (createdAt は維持、updatedAt を更新)
         const updated = {
           ...cfg,

--- a/src/data/adapters/prisma/line-config-repository.prisma.ts
+++ b/src/data/adapters/prisma/line-config-repository.prisma.ts
@@ -66,10 +66,14 @@ export function makeLineConfigRepo(db: PrismaLike): LineConfigRepository {
         // 0 件更新 = 読み取り後に他の管理者が値を変えていた (競合)。呼び出し側へ null を返し、
         // 後勝ちで上書きしないようにする (§9 fail-closed)
         if (result.count === 0) return null;
-        // 更新できた行を読み直してドメイン型で返す (updateMany は更新後の行を返さないため)
-        const row = await db.tenantLineConfig.findUniqueOrThrow({
-          where: { tenantId: input.tenantId },
-        });
+        // 更新できた行を読み直してドメイン型で返す (updateMany は更新後の行を返さないため)。
+        // findUniqueOrThrow だと、この直後 (更新成功〜読み直しの間) に別リクエストが同じ設定を
+        // 削除する極めて稀な競合で例外を投げてしまい、呼び出し側の catch が「保存に失敗しました」
+        // という誤解を招く汎用エラーにしてしまう (実際には更新自体は成功していた)。
+        // findUnique + null チェックにして、その競合ケースも「他の更新と競合した」という
+        // 一貫したメッセージ (null 相当) に丸める
+        const row = await db.tenantLineConfig.findUnique({ where: { tenantId: input.tenantId } });
+        if (!row) return null;
         return toLineConfig(row);
       }
 

--- a/src/data/adapters/prisma/line-config-repository.prisma.ts
+++ b/src/data/adapters/prisma/line-config-repository.prisma.ts
@@ -44,6 +44,36 @@ export function makeLineConfigRepo(db: PrismaLike): LineConfigRepository {
 
     // LINE 連携設定を作成または更新する (tenantId をキーに upsert)
     async upsert(input) {
+      // expected が渡された場合は CAS (compare-and-swap) 経路: 「読み取り時点の値」を
+      // where に足した updateMany で、書き込み直前にも現在値が一致することを保証する
+      // (update-notification-channels.ts の updateNotificationChannels と同じ方針)。
+      // expected は「既存設定がある」ことを前提にした呼び出し (呼び出し側は既存行が無ければ
+      // expected を渡さない契約) のため、ここでは無条件に updateMany を使う
+      if (input.expected) {
+        const result = await db.tenantLineConfig.updateMany({
+          where: {
+            tenantId: input.tenantId,
+            channelSecret: input.expected.channelSecret,
+            channelAccessToken: input.expected.channelAccessToken,
+            botUserId: input.expected.botUserId,
+          },
+          data: {
+            channelSecret: input.channelSecret,
+            channelAccessToken: input.channelAccessToken,
+            botUserId: input.botUserId,
+          },
+        });
+        // 0 件更新 = 読み取り後に他の管理者が値を変えていた (競合)。呼び出し側へ null を返し、
+        // 後勝ちで上書きしないようにする (§9 fail-closed)
+        if (result.count === 0) return null;
+        // 更新できた行を読み直してドメイン型で返す (updateMany は更新後の行を返さないため)
+        const row = await db.tenantLineConfig.findUniqueOrThrow({
+          where: { tenantId: input.tenantId },
+        });
+        return toLineConfig(row);
+      }
+
+      // expected 未指定: 従来どおりの無条件 upsert (新規作成、または競合検知が不要な呼び出し)。
       // tenantId が既存なら update、なければ create される。botUserId の @unique 制約に
       // 反する場合 (他テナントが同じチャネルを既に登録済み) は Prisma が P2002 を投げる
       // (呼び出し側の Server Action がユーザー向けメッセージへ変換する)

--- a/src/data/ports/line-config-repository.ts
+++ b/src/data/ports/line-config-repository.ts
@@ -12,13 +12,27 @@ export interface LineConfigRepository {
   // Webhook 受信時に「署名検証前の公開識別子からテナントを特定する」ために使う
   // (メール取り込みの inboundToken と同じ設計。botUserId 自体は秘密情報ではない)。
   findByBotUserId(botUserId: string): Promise<TenantLineConfig | null>;
-  // LINE 連携設定を作成または更新する (1 テナント 1 設定なので tenantId で upsert)
+  // LINE 連携設定を作成または更新する (1 テナント 1 設定なので tenantId で upsert)。
+  // フォローアップ (監査で発見したギャップ): update-line-config.ts は channelSecret /
+  // channelAccessToken が空欄送信されたとき「読み取り時点の既存値を引き継ぐ」処理を
+  // 挟むため、読み取り→無条件書き込みの間に他の管理者の並行更新が割り込むと check-then-act
+  // (TOCTOU) で後勝ち上書きが起きうる (update-notification-channels.ts の
+  // updateNotificationChannels で既に対応済みの同種の穴)。expected を渡した場合のみ、
+  // 書き込み直前にも現在値が一致することを DB レベルで保証する CAS になる。
   upsert(input: {
     tenantId: string; // 所属テナント (セッション由来のみ許可。クロステナント設定防止)
     channelSecret: string; // Webhook 署名検証用シークレット
     channelAccessToken: string; // Messaging API push 用の長期アクセストークン
     botUserId: string; // このチャネルの Bot User ID (destination 値)
-  }): Promise<TenantLineConfig>;
+    // CAS: 読み取り時点の既存設定値。渡された場合、書き込み直前の現在値がこれと一致する
+    // ときだけ更新する。未指定 (新規作成、または呼び出し側が競合検知を必要としない場合) なら
+    // 従来どおり無条件 upsert する。
+    expected?: {
+      channelSecret: string;
+      channelAccessToken: string;
+      botUserId: string;
+    };
+  }): Promise<TenantLineConfig | null>; // null は競合 (書き込み直前に他の更新が割り込んだ) を意味する
   // テナントの LINE 連携設定を削除する (tenantId スコープで他テナントは no-op)
   delete(tenantId: string): Promise<void>;
 }

--- a/src/features/settings/actions/update-line-config.ts
+++ b/src/features/settings/actions/update-line-config.ts
@@ -86,13 +86,36 @@ export async function updateLineConfig(
   }
 
   try {
-    // LINE 連携設定を upsert する (tenantId スコープで他テナントに影響しない)
-    await repos.lineConfigs.upsert({
+    // LINE 連携設定を upsert する (tenantId スコープで他テナントに影響しない)。
+    // フォローアップ (監査で発見したギャップ): channelSecret/channelAccessToken が空欄の
+    // ときは上で読み取った existing の値を引き継ぐ (書き込み専用フィールドの仕様)。
+    // 既存設定がある場合はその読み取り時点の値を expected として渡し、書き込み直前にも
+    // 現在値が変わっていないことを保証する CAS にする。これが無いと、他の管理者が
+    // シークレットをローテーションした直後にこのリクエストが割り込むと、古い値のまま
+    // 上書きしてローテーションを黙って巻き戻してしまう (update-notification-channels.ts の
+    // updateNotificationChannels と同じ TOCTOU)。新規作成時 (existing が null) は
+    // 比較対象の既存値が無いため expected を渡さず、従来どおり無条件で作成する。
+    const updated = await repos.lineConfigs.upsert({
       tenantId,
       channelSecret,
       channelAccessToken,
       botUserId,
+      ...(existing
+        ? {
+            expected: {
+              channelSecret: existing.channelSecret,
+              channelAccessToken: existing.channelAccessToken,
+              botUserId: existing.botUserId,
+            },
+          }
+        : {}),
     });
+    if (!updated) {
+      // 競合時もフォームの表示を最新化できるよう再レンダリングしておく
+      // (update-notification-channels.ts と同じ「エラー時に最新状態を取り直す」方針)
+      revalidatePath('/settings');
+      return { error: '他の管理者による変更と競合しました。最新の設定を確認してから再度お試しください。' };
+    }
     // 設定ページのキャッシュを無効化して結果をすぐ反映する
     revalidatePath('/settings');
 

--- a/tests/data/line-config-repository.contract.prisma.test.ts
+++ b/tests/data/line-config-repository.contract.prisma.test.ts
@@ -61,7 +61,8 @@ describe.runIf(SHOULD_RUN)('LineConfigRepository (prisma adapter)', () => {
     const repos = buildPrismaRepos(prisma);
     const botUserId = 'Ubbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
     const created = await repos.lineConfigs.upsert(input(TENANT_A, botUserId));
-    expect(created.tenantId).toBe(TENANT_A);
+    // expected を渡していない (無条件 upsert) 呼び出しなので null にはならない
+    expect(created?.tenantId).toBe(TENANT_A);
     const byTenant = await repos.lineConfigs.findByTenant(TENANT_A);
     expect(byTenant?.channelSecret).toBe(`secret-${TENANT_A}`);
     const byBotUserId = await repos.lineConfigs.findByBotUserId(botUserId);
@@ -77,9 +78,9 @@ describe.runIf(SHOULD_RUN)('LineConfigRepository (prisma adapter)', () => {
     const second = await repos.lineConfigs.upsert(
       input(TENANT_A, 'Ucccccccccccccccccccccccccccccccc'),
     );
-    // 同一レコードの更新なので ID は不変、値だけ変わる
-    expect(second.id).toBe(first.id);
-    expect(second.botUserId).toBe('Ucccccccccccccccccccccccccccccccc');
+    // 同一レコードの更新なので ID は不変、値だけ変わる (どちらも expected 未指定の無条件 upsert)
+    expect(second?.id).toBe(first?.id);
+    expect(second?.botUserId).toBe('Ucccccccccccccccccccccccccccccccc');
   });
 
   // 他テナントが既に使用している botUserId への upsert は一意制約違反でエラーになる

--- a/tests/data/line-config-repository.memory.test.ts
+++ b/tests/data/line-config-repository.memory.test.ts
@@ -47,9 +47,9 @@ describe('LineConfigRepository (memory)', () => {
   it('upsert で新規作成し findByTenant / findByBotUserId で取得できる', async () => {
     const botUserId = 'Ubbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
     const created = await repos.lineConfigs.upsert(sampleInput(TENANT_A, botUserId));
-    // 作成結果が入力どおりであること
-    expect(created.tenantId).toBe(TENANT_A);
-    expect(created.botUserId).toBe(botUserId);
+    // 作成結果が入力どおりであること (expected 未指定の無条件 upsert なので null にはならない)
+    expect(created?.tenantId).toBe(TENANT_A);
+    expect(created?.botUserId).toBe(botUserId);
     // tenantId からも botUserId からも同じ設定を取得できる
     const byTenant = await repos.lineConfigs.findByTenant(TENANT_A);
     expect(byTenant?.channelSecret).toBe(`secret-${TENANT_A}`);
@@ -68,10 +68,10 @@ describe('LineConfigRepository (memory)', () => {
       ...sampleInput(TENANT_A, botUserId2),
       channelSecret: 'new-secret',
     });
-    // ID は維持され (同一レコードの更新)、値だけ変わる
-    expect(second.id).toBe(first.id);
-    expect(second.botUserId).toBe(botUserId2);
-    expect(second.channelSecret).toBe('new-secret');
+    // ID は維持され (同一レコードの更新)、値だけ変わる (どちらも expected 未指定の無条件 upsert)
+    expect(second?.id).toBe(first?.id);
+    expect(second?.botUserId).toBe(botUserId2);
+    expect(second?.channelSecret).toBe('new-secret');
     // 旧 botUserId ではもう引けない
     expect(await repos.lineConfigs.findByBotUserId(botUserId1)).toBeNull();
   });

--- a/tests/features/update-line-config.test.ts
+++ b/tests/features/update-line-config.test.ts
@@ -199,4 +199,45 @@ describe('updateLineConfig', () => {
     expect(result.error).toEqual(expect.any(String));
     expect(result.success).toBeUndefined();
   });
+
+  // フォローアップ (監査で発見したギャップ): 読み取り (existing) →検証→無条件書き込みの
+  // check-then-act (TOCTOU) だった。空欄送信で「既存値を維持」する仕様のため、他の管理者が
+  // 並行してシークレットをローテーションした直後にこのリクエストが割り込むと、古い値のまま
+  // 上書きしてローテーションを黙って巻き戻してしまう。CAS 化により 0 件更新 (競合) を検知し、
+  // 後勝ちで上書きしないことを確認する (update-notification-channels.test.ts と同じ手法)
+  it('他の管理者による並行更新と競合すると保存されず、その値を上書きしない', async () => {
+    seedTenant('pro');
+    const { updateLineConfig } = await import('@/features/settings/actions/update-line-config');
+    // 1 回目: 通常どおり全項目を入力して作成 (これが「読み取り時点」の値になる)
+    await updateLineConfig(
+      {},
+      makeForm({
+        channelSecret: 'original-secret',
+        channelAccessToken: 'original-token',
+        botUserId: BOT_USER_ID_A,
+      }),
+    );
+    const stale = await repos.lineConfigs.findByTenant(TENANT_ID);
+    if (!stale) throw new Error('seed missing line config');
+    // 並行更新を模す: 先に別の管理者がシークレットをローテーションしたことにする
+    await repos.lineConfigs.upsert({
+      tenantId: TENANT_ID,
+      channelSecret: 'rotated-by-concurrent-admin',
+      channelAccessToken: 'rotated-by-concurrent-admin-token',
+      botUserId: BOT_USER_ID_A,
+    });
+    // findByTenant だけが古いスナップショット (ローテーション前) を返す状況を作る (TOCTOU の再現)
+    vi.spyOn(repos.lineConfigs, 'findByTenant').mockResolvedValueOnce(stale);
+    // このリクエストは botUserId だけ変更し、シークレット/トークンは空欄 (=既存値維持) のまま送信する
+    const result = await updateLineConfig({}, makeForm({ botUserId: BOT_USER_ID_B }));
+    expect(result.error).toBe(
+      '他の管理者による変更と競合しました。最新の設定を確認してから再度お試しください。',
+    );
+    expect(result.success).toBeUndefined();
+    // 並行更新 (ローテーション後) の値が上書きされずに残っている
+    const saved = await repos.lineConfigs.findByTenant(TENANT_ID);
+    expect(saved?.channelSecret).toBe('rotated-by-concurrent-admin');
+    expect(saved?.channelAccessToken).toBe('rotated-by-concurrent-admin-token');
+    expect(saved?.botUserId).toBe(BOT_USER_ID_A);
+  });
 });


### PR DESCRIPTION
## Summary

`docs/smb-dx-pivot-plan.md` §4 Phase 2.1「LINE 公式アカウント連携」フォローアップ。定期レビューで発見した未対応の TOCTOU（check-then-act 競合）。

`updateLineConfig`（`src/features/settings/actions/update-line-config.ts`）は channelSecret / channelAccessToken を書き込み専用フィールドとして扱い、空欄送信時は「読み取り時点 (`existing`) の既存値を引き継ぐ」処理を挟んでから `repos.lineConfigs.upsert(...)` で無条件保存する。この「読み取り→無条件書き込み」の間に別の管理者が並行更新すると、後から実行されたリクエストが古い `existing` の値で上書きしてしまう。特に「シークレットが漏洩したのでローテーションする」→（直後に別タブ/別管理者が botUserId だけ変更しようとして空欄送信）→ ローテーションが黙って古い値に巻き戻される、という実害のあるシナリオになりうる。

同種の TOCTOU は `update-notification-channels.ts` の `updateNotificationChannels` で既に CAS（expected 値を渡した `updateMany`、0 件更新なら競合として拒否）により対応済みだが（#230 系のフォローアップ）、同じ「空欄なら既存値を引き継ぐ」パターンを持つ `update-line-config.ts` には同じ対応が入っていなかった。今回、同一パターンを `LineConfigRepository.upsert` に適用した。

## 変更対象ファイル

- `src/data/ports/line-config-repository.ts` — `upsert` に任意の `expected`（読み取り時点の channelSecret/channelAccessToken/botUserId）引数を追加し、戻り値を `TenantLineConfig | null`（`null` = 競合）に変更
- `src/data/adapters/prisma/line-config-repository.prisma.ts` — `expected` 指定時は `updateMany` で現在値が一致する場合のみ更新する CAS 経路を追加（未指定時は従来どおり無条件 `upsert`）
- `src/data/adapters/memory/line-config-repository.memory.ts` — 同上のメモリ実装
- `src/features/settings/actions/update-line-config.ts` — 既存設定がある場合のみ読み取り時点の値を `expected` として渡し、競合時は `update-notification-channels.ts` と同じ日本語エラーメッセージを返す
- `tests/features/update-line-config.test.ts` — 並行更新競合の再現テストを追加（`update-notification-channels.test.ts` と同じ手法）
- `tests/data/line-config-repository.{memory,contract.prisma}.test.ts` — 戻り値型変更に伴う型修正（`expected` 未指定呼び出しなので実害なし）

## 再利用した既存実装

- `update-notification-channels.ts` / `TenantRepository.updateNotificationChannels`（`expected` を渡した `updateMany` による CAS）と全く同じパターンをそのまま踏襲。新しい抽象化は導入していない。
- 競合時のユーザー向けメッセージ文言も `update-notification-channels.ts` と統一。

## 検証方法

- `npm run typecheck` — ✅
- `npm run lint` — ✅
- `npx vitest run` — ✅ 105 files / 1115 tests passed（21 files skip = `RUN_PRISMA_CONTRACT=1` 必須の契約テスト。ローカルに Docker デーモンが無く未起動のため今回はスキップ。CI の Postgres サービスコンテナで実行される想定）
- Prisma アダプタの変更は `updateMany` + `findUniqueOrThrow` のみで、既に本番で稼働している `updateNotificationChannels` と同じクエリ形なのでスキーマ変更・マイグレーションは不要

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx vitest run`（契約テスト以外）
- [ ] CI（Postgres サービスコンテナ）での契約テスト確認

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxpYBYg2Vm1QkDpk7vAhf1)_