### PR TITLE
fix(settings): Stripe Webhookの配信順序非保証によるプラン巻き戻りを解消

### DIFF
--- a/prisma/migrations/20260720000000_add_stripe_event_ordering/migration.sql
+++ b/prisma/migrations/20260720000000_add_stripe_event_ordering/migration.sql
@@ -1,0 +1,7 @@
+-- 監査で発見したギャップ (2026-07-20): Stripe Webhook はイベントの配信順序を保証しない
+-- (リトライ・ネットワーク遅延により、古いイベントが新しいイベントより後に届くことがある)。
+-- 直近に適用した Stripe イベントの発生時刻 (event.created) を保持し、次回以降の Webhook 処理で
+-- 「保存済みの時刻より古いイベントは適用しない」CAS (compare-and-swap) の比較対象にする。
+
+-- AlterTable: 既存行は未処理として扱うため NULL 許容・既定値なしで追加する
+ALTER TABLE "Tenant" ADD COLUMN "stripeEventProcessedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -214,6 +214,14 @@ model Tenant {
   // (src/lib/trial-reminder.ts の resolveTrialReminderMilestone が参照する)
   trialReminderLastSentDaysBefore Int? // 直近に送信済みのマイルストーン閾値 (未送信なら null)
 
+  // 監査で発見したギャップ (2026-07-20): Stripe Webhook はイベントの配信順序を保証しない
+  // (Stripe 公式ドキュメントに明記: リトライ・ネットワーク遅延により、古いイベントが新しい
+  // イベントより後に届くことがある)。素朴な上書き (updateStripeSubscription) だけだと、
+  // 例えば「解約」イベントの後に届いた古い「作成」イベントが最新の解約状態を巻き戻してしまう。
+  // 直近に適用した Stripe イベントの発生時刻 (event.created) を保持し、CAS の比較対象にする
+  // (未処理なら null。null または保存値以下の event.created のイベントのみ適用する)
+  stripeEventProcessedAt DateTime?
+
   createdAt DateTime @default(now()) // 作成日時
 
   // 配下のリソース (テナント削除で連鎖削除)

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -109,16 +109,20 @@ async function handleStripeEvent(event: Stripe.Event): Promise<void> {
   // unknown を経由することで型安全にキャストする (Stripe の各イベントオブジェクト型は
   // index signature を持たないため直接 Record にはキャストできない)
   const obj = event.data.object as unknown as Record<string, unknown>;
+  // フォローアップ (監査で発見したギャップ 2026-07-20): Stripe イベント自体の発生時刻
+  // (Unix 秒)。配信順序が保証されないため、適用可否の CAS 判定に使う (event.created は
+  // Stripe.Event が必ず持つフィールド)
+  const eventCreatedAt = new Date(event.created * 1000);
 
   // サブスクリプション作成・更新イベント: プランと状態を更新する
   if (type === STRIPE_EVENT_SUBSCRIPTION_CREATED || type === STRIPE_EVENT_SUBSCRIPTION_UPDATED) {
-    await handleSubscriptionUpsert(obj);
+    await handleSubscriptionUpsert(obj, eventCreatedAt);
     return;
   }
 
   // サブスクリプション削除イベント: free プランに降格し、Stripe 連携情報を保持する
   if (type === STRIPE_EVENT_SUBSCRIPTION_DELETED) {
-    await handleSubscriptionDeleted(obj);
+    await handleSubscriptionDeleted(obj, eventCreatedAt);
     return;
   }
 
@@ -136,6 +140,11 @@ async function handleStripeEvent(event: Stripe.Event): Promise<void> {
 // mode の読み取りは呼び出し元からではなく、トランザクション内で tx.tenants.findById により
 // 都度読み直す (呼び出し元の existingTenant はトランザクション開始前に取得したスナップショットで、
 // その後に届いた別の Stripe イベントや管理者操作で mode が変わっていても反映されない古い値になり得るため)。
+//
+// フォローアップ (監査で発見したギャップ 2026-07-20): Stripe は Webhook イベントの配信順序を
+// 保証しない (公式ドキュメント記載。リトライ・ネットワーク遅延で発生順とは異なる順序で届きうる)。
+// eventCreatedAt (今回のイベント自体の発生時刻) を updateStripeSubscription の CAS 判定に渡し、
+// 既により新しいイベントが適用済みなら今回の更新は無視する (古いイベントで新しい状態を巻き戻さない)。
 async function applyPlanChange(
   tenantId: string,
   stripeFields: {
@@ -144,16 +153,24 @@ async function applyPlanChange(
     stripeSubscriptionStatus: string;
     subscriptionPlan: SubscriptionPlan;
   },
+  eventCreatedAt: Date,
 ): Promise<void> {
-  const { shouldResetMode, planChanged } = await uow.run(async (tx) => {
+  const { applied, shouldResetMode, planChanged } = await uow.run(async (tx) => {
     // トランザクション内で最新のテナント状態を読み直す (呼び出し元のスナップショットに頼らない)
     const tenant = await tx.tenants.findById(tenantId);
     // 呼び出し元で存在確認済みだが、念のためここでも安全側 (何もしない) に倒す
-    if (!tenant) return { shouldResetMode: false, planChanged: false };
+    if (!tenant) return { applied: false, shouldResetMode: false, planChanged: false };
     // /code-review ultra 指摘対応 (2026-07-13): 監査ログに残すため、更新前のプランを保持しておく
     const previousPlan = tenant.subscriptionPlan;
-    // Stripe 連携情報とプランを反映する
-    await tx.tenants.updateStripeSubscription(tenantId, stripeFields);
+    // Stripe 連携情報とプランを反映する (CAS: 保存済みの直近処理イベントより古ければ 0 件更新で false)
+    const applied = await tx.tenants.updateStripeSubscription(
+      tenantId,
+      stripeFields,
+      eventCreatedAt,
+    );
+    // 古いイベントとして無視された場合、mode リセット・監査ログ記録も行わない
+    // (このイベントの subscriptionPlan は既に上書きされた古い情報のため判断材料にしない)
+    if (!applied) return { applied: false, shouldResetMode: false, planChanged: false };
     // 現在 Pro モードで運用中かつ、新プランが Pro モードを許可しないときだけモードを戻す
     const shouldReset = tenant.mode === 'pro' && !isProModeAllowed(stripeFields.subscriptionPlan);
     if (shouldReset) {
@@ -161,10 +178,21 @@ async function applyPlanChange(
       await tx.tenants.updateMode(tenantId, 'lite');
     }
     return {
+      applied: true,
       shouldResetMode: shouldReset,
       planChanged: previousPlan !== stripeFields.subscriptionPlan,
     };
   });
+
+  // 古いイベントとして無視された場合はログに残して終了する (Stripe には 200 を返し再送させない。
+  // 呼び出し元の POST ハンドラは常に 200 系で応答するため、ここで throw せず正常終了する)
+  if (!applied) {
+    console.warn(
+      `[stripe-webhook] テナント ${tenantId}: より新しい Stripe イベントが適用済みのため、` +
+        `このイベント (event.created=${eventCreatedAt.toISOString()}) は無視しました`,
+    );
+    return;
+  }
 
   // §4.3 フォローアップ (2026-07-10): モードが強制的に戻された場合は監査ログにも記録する。
   // §4.3 で tenant_mode_update アクションを追加した際は管理者による手動切替 (update-tenant-mode.ts)
@@ -203,6 +231,7 @@ async function applyPlanChange(
 // サブスクリプション作成・更新を処理する: テナントのプランと状態を最新に保つ
 async function handleSubscriptionUpsert(
   subscriptionObject: Record<string, unknown>,
+  eventCreatedAt: Date, // このイベント自体の発生時刻 (配信順序が保証されないための CAS 判定に使う)
 ): Promise<void> {
   // Stripe のサブスクリプションオブジェクトから必要なフィールドを取り出す
   const subscriptionId = subscriptionObject['id'] as string | undefined;
@@ -251,17 +280,22 @@ async function handleSubscriptionUpsert(
   const nextPlan = existingTenant.subscriptionPlan === 'enterprise' ? 'enterprise' : plan;
 
   // テナントのサブスク情報を更新する (ダウングレードなら Pro モードも同時に強制解除する)
-  await applyPlanChange(tenantId, {
-    stripeCustomerId: customerId,
-    stripeSubscriptionId: subscriptionId,
-    stripeSubscriptionStatus: status,
-    subscriptionPlan: nextPlan,
-  });
+  await applyPlanChange(
+    tenantId,
+    {
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: subscriptionId,
+      stripeSubscriptionStatus: status,
+      subscriptionPlan: nextPlan,
+    },
+    eventCreatedAt,
+  );
 }
 
 // サブスクリプション削除を処理する: free プランに降格してキャンセル状態を記録する
 async function handleSubscriptionDeleted(
   subscriptionObject: Record<string, unknown>,
+  eventCreatedAt: Date, // このイベント自体の発生時刻 (配信順序が保証されないための CAS 判定に使う)
 ): Promise<void> {
   // サブスクリプション ID と status を取得する
   const subscriptionId = subscriptionObject['id'] as string | undefined;
@@ -295,10 +329,14 @@ async function handleSubscriptionDeleted(
 
   // サブスクリプション削除後は (Enterprise を除き) free に降格し、canceled 状態を記録する
   // (free は Pro モード対象外なので Pro モードも同時に強制解除される)
-  await applyPlanChange(tenantId, {
-    stripeCustomerId: customerId,
-    stripeSubscriptionId: subscriptionId,
-    stripeSubscriptionStatus: 'canceled', // Stripe の deleted イベントは canceled 扱いにする
-    subscriptionPlan: nextPlan, // Enterprise 以外は free に降格
-  });
+  await applyPlanChange(
+    tenantId,
+    {
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: subscriptionId,
+      stripeSubscriptionStatus: 'canceled', // Stripe の deleted イベントは canceled 扱いにする
+      subscriptionPlan: nextPlan, // Enterprise 以外は free に降格
+    },
+    eventCreatedAt,
+  );
 }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -90,8 +90,12 @@ export async function POST(request: Request): Promise<NextResponse> {
   try {
     await handleStripeEvent(stripeEvent);
   } catch (err) {
-    // テナント更新失敗は 500 で返す (Stripe が再送するため冪等性が重要)
-    // 再送時に重複処理しても安全なように updateStripeSubscription は上書き更新
+    // テナント更新失敗は 500 で返す (Stripe が再送するため冪等性が重要)。
+    // フォローアップ (2026-07-20): updateStripeSubscription は eventCreatedAt による CAS
+    // (配信順序チェック) を行うようになったが、同一イベントの再送 (event.created が同じ) は
+    // 「保存済みの直近処理イベント時刻 <= 今回の event.created」の条件に一致するため
+    // 通常どおり (べき等に) 再適用される。再送時に安全なのは古いイベントを弾く仕組みと
+    // 両立している
     console.error('[stripe-webhook] イベント処理エラー:', err);
     return NextResponse.json({ error: 'イベント処理に失敗しました' }, { status: 500 });
   }
@@ -111,7 +115,14 @@ async function handleStripeEvent(event: Stripe.Event): Promise<void> {
   const obj = event.data.object as unknown as Record<string, unknown>;
   // フォローアップ (監査で発見したギャップ 2026-07-20): Stripe イベント自体の発生時刻
   // (Unix 秒)。配信順序が保証されないため、適用可否の CAS 判定に使う (event.created は
-  // Stripe.Event が必ず持つフィールド)
+  // Stripe.Event が必ず持つフィールドだが、§9 fail-closed に従い型を信用せず値を検証する)。
+  // 不正な値のまま Date 化すると Invalid Date (NaN) になり、CAS の比較が常に false 判定
+  // (どんな比較も NaN を含むと false) になって配信順序チェックがそのテナントだけ無効化されて
+  // しまう。ここで検出して処理を中断し、呼び出し元 (POST ハンドラ) の catch で 500 を返して
+  // Stripe に再送させる方が安全 (§9: 不明なら拒否)
+  if (!Number.isFinite(event.created)) {
+    throw new Error(`Stripe イベントの created が不正です: ${String(event.created)}`);
+  }
   const eventCreatedAt = new Date(event.created * 1000);
 
   // サブスクリプション作成・更新イベント: プランと状態を更新する

--- a/src/data/adapters/memory/tenant-repository.memory.ts
+++ b/src/data/adapters/memory/tenant-repository.memory.ts
@@ -126,11 +126,24 @@ export function makeTenantRepo(store: Store): TenantRepository {
       return true;
     },
 
-    // Phase 4 課金: Stripe の連携情報を一括更新する (Webhook 受信時に呼ぶ)
-    async updateStripeSubscription(id, data) {
-      // 対象テナントを Map から取得 (存在しなければエラー)
+    // Phase 4 課金: Stripe の連携情報を一括更新する (Webhook 受信時に呼ぶ)。
+    // フォローアップ (監査で発見したギャップ 2026-07-20): Prisma アダプタの updateMany 版 CAS と
+    // 同じ契約。eventCreatedAt が渡され、かつ保存済みの stripeEventProcessedAt がそれより新しい
+    // (=今回のイベントの方が古い) ときは更新せず false を返す (Stripe Webhook の配信順序非保証対策)
+    async updateStripeSubscription(id, data, eventCreatedAt) {
+      // 対象テナントを Map から取得 (存在しなければ updateMode/updateNotificationChannels と
+      // 同じく false を返す。Prisma の updateMany が 0 件更新になる場合と同じ扱いに揃える)
       const t = store.tenants.get(id);
-      if (!t) throw new Error('テナントが見つかりません');
+      if (!t) return false;
+      // 順序チェック: 保存済みの直近処理イベント時刻が、今回のイベントより新しければ古いイベントとして無視する
+      if (
+        eventCreatedAt &&
+        t.stripeEventProcessedAt &&
+        t.stripeEventProcessedAt.getTime() > eventCreatedAt.getTime()
+      ) {
+        // 更新せず false を返す (呼び出し側は「古いイベントとしてスキップされた」と解釈する)
+        return false;
+      }
       // 渡されたフィールドだけ差し替える (undefined はスキップ)
       const updated: Tenant = {
         ...t,
@@ -146,10 +159,12 @@ export function makeTenantRepo(store: Store): TenantRepository {
             ? data.stripeSubscriptionStatus
             : t.stripeSubscriptionStatus,
         subscriptionPlan: data.subscriptionPlan ?? t.subscriptionPlan,
+        // eventCreatedAt を渡された場合のみ、直近処理イベント時刻を更新する
+        stripeEventProcessedAt: eventCreatedAt ?? t.stripeEventProcessedAt,
       };
       store.tenants.set(id, updated);
-      // 防御的コピーを返す
-      return { ...updated };
+      // 更新できたことを返す
+      return true;
     },
 
     // §7.2 Free trial 終了リマインダー用: free プランかつトライアル進行中 (trialEndsAt > now)

--- a/src/data/adapters/prisma/tenant-repository.prisma.ts
+++ b/src/data/adapters/prisma/tenant-repository.prisma.ts
@@ -40,6 +40,9 @@ function toTenant(row: TenantRow): Tenant {
     teamsLastFailureMessage: row.teamsLastFailureMessage,
     chatworkLastFailureAt: row.chatworkLastFailureAt,
     chatworkLastFailureMessage: row.chatworkLastFailureMessage,
+    // フォローアップ (監査で発見したギャップ 2026-07-20): Stripe Webhook 配信順序 CAS 用の
+    // 直近処理イベント時刻 (未処理なら null)
+    stripeEventProcessedAt: row.stripeEventProcessedAt,
     createdAt: row.createdAt,
   };
 }

--- a/src/data/adapters/prisma/tenant-repository.prisma.ts
+++ b/src/data/adapters/prisma/tenant-repository.prisma.ts
@@ -143,11 +143,25 @@ export function makeTenantRepo(db: PrismaLike): TenantRepository {
       return result.count > 0;
     },
 
-    // Phase 4 課金: Stripe の連携情報 (Customer ID / Subscription ID / 状態 / プラン) を一括更新
-    async updateStripeSubscription(id, data) {
-      // undefined 以外のフィールドのみ更新する (Prisma は undefined を無視する)
-      const row = await db.tenant.update({
-        where: { id },
+    // Phase 4 課金: Stripe の連携情報 (Customer ID / Subscription ID / 状態 / プラン) を一括更新。
+    // フォローアップ (監査で発見したギャップ 2026-07-20): eventCreatedAt が渡された場合のみ、
+    // 「保存済みの stripeEventProcessedAt が null、またはそれ以下 (=今回のイベントの方が新しい
+    // か同時刻)」を where 条件に含めた原子的な updateMany (CAS) にする。Stripe Webhook の配信
+    // 順序は保証されないため、これが無いと古いイベントが後から届いて新しい状態を巻き戻しうる
+    async updateStripeSubscription(id, data, eventCreatedAt) {
+      // eventCreatedAt 省略時は主キーのみで絞り込む (順序チェックなし。従来どおりの無条件更新)
+      const where: Prisma.TenantWhereInput = eventCreatedAt
+        ? {
+            id,
+            OR: [
+              { stripeEventProcessedAt: null }, // まだ一度も Stripe イベントを適用していない
+              { stripeEventProcessedAt: { lte: eventCreatedAt } }, // 今回のイベントの方が新しいか同時刻
+            ],
+          }
+        : { id };
+      // 条件に一致する行だけを更新する (0 件・1 件のどちらもあり得る updateMany)
+      const result = await db.tenant.updateMany({
+        where,
         data: {
           // undefined なら Prisma が skip するため、明示的に条件分岐しない
           stripeCustomerId: data.stripeCustomerId,
@@ -155,10 +169,12 @@ export function makeTenantRepo(db: PrismaLike): TenantRepository {
           stripeSubscriptionStatus: data.stripeSubscriptionStatus,
           // subscriptionPlan は SubscriptionPlan 型として型チェックされた値のみ受け付ける
           subscriptionPlan: data.subscriptionPlan as SubscriptionPlan | undefined,
+          // eventCreatedAt を渡された場合のみ、直近処理イベント時刻を更新する
+          ...(eventCreatedAt ? { stripeEventProcessedAt: eventCreatedAt } : {}),
         },
       });
-      // 更新後の行をドメイン型に詰め替えて返す
-      return toTenant(row);
+      // 1 件以上更新できたか (0 件なら古いイベントとして無視された、または対象不在) を返す
+      return result.count > 0;
     },
 
     // §7.2 Free trial 終了リマインダー用: free プランかつトライアル進行中 (trialEndsAt > now)

--- a/src/data/ports/tenant-repository.ts
+++ b/src/data/ports/tenant-repository.ts
@@ -65,6 +65,14 @@ export interface TenantRepository {
   // Phase 4 課金: Stripe Billing の連携情報をまとめて更新する。
   // Stripe Webhook 受信時に呼び出し、Customer ID・Subscription ID・状態・プランを一括更新。
   // id はセッション/Webhook由来のテナント ID のみを渡すこと (クロステナント更新防止)。
+  //
+  // フォローアップ (監査で発見したギャップ 2026-07-20): Stripe は Webhook イベントの配信順序を
+  // 保証しない (公式ドキュメント記載。リトライ・ネットワーク遅延で古いイベントが新しいイベントより
+  // 後に届きうる)。eventCreatedAt (Stripe イベント自体の発生時刻 = event.created) を渡すと、
+  // 保存済みの直近処理イベント時刻より新しい (または未処理) ときだけ適用する CAS になる。
+  // updateMode/updateNotificationChannels と同じ「0 件更新なら false」の boolean 契約。
+  // eventCreatedAt を省略した場合は順序チェックをせず常に適用する (既存の契約テスト等、
+  // 順序保証が不要な呼び出し元との後方互換のため)
   updateStripeSubscription(
     id: string,
     data: {
@@ -73,7 +81,8 @@ export interface TenantRepository {
       stripeSubscriptionStatus?: string | null;
       subscriptionPlan?: SubscriptionPlan;
     },
-  ): Promise<Tenant>;
+    eventCreatedAt?: Date,
+  ): Promise<boolean>;
   // §7.2 Free trial 終了リマインダー用: 契約プランが free で、かつ trialEndsAt が now より
   // 未来 (=トライアル進行中) のテナントを limit 件までを上限に返す (§8 一覧取得は必ず上限を
   // 持たせる)。呼び出し側 (定期実行のリマインダー処理) が各テナントの残り日数からリマインド

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -164,6 +164,11 @@ export interface Tenant {
   // 既存フィクスチャ・呼び出しを壊さないよう任意 (optional) とし、アダプタは常に null か値で埋める
   // (User.lineUserId と同じパターン)
   trialReminderLastSentDaysBefore?: number | null;
+  // Stripe Webhook の配信順序保証がないことへの対策 (2026-07-20 フォローアップ)。直近に適用した
+  // イベントの発生時刻 (event.created)。未処理なら null。既存フィクスチャ・呼び出しを壊さない
+  // よう任意 (optional) とし、アダプタは常に null か値で埋める (trialReminderLastSentDaysBefore
+  // と同じパターン)
+  stripeEventProcessedAt?: Date | null;
   createdAt: Date; // 作成日時
 }
 

--- a/tests/data/tenant-repository.contract.prisma.test.ts
+++ b/tests/data/tenant-repository.contract.prisma.test.ts
@@ -133,12 +133,77 @@ describe.runIf(SHOULD_RUN)('TenantRepository (prisma adapter)', () => {
     const ok = await repos.tenants.updateNotificationChannels(
       tenant.id,
       { slackWebhookUrl: 'https://hooks.slack.com/services/STALE-WRITE' },
-      { slackWebhookUrl: null, teamsWebhookUrl: null, chatworkApiToken: null, chatworkRoomId: null },
+      {
+        slackWebhookUrl: null,
+        teamsWebhookUrl: null,
+        chatworkApiToken: null,
+        chatworkRoomId: null,
+      },
     );
     expect(ok).toBe(false);
     // 並行更新の値が上書きされずに残っている
     const reloaded = await repos.tenants.findById(tenant.id);
     expect(reloaded?.slackWebhookUrl).toBe('https://hooks.slack.com/services/CONCURRENT');
+  });
+
+  // フォローアップ (監査で発見したギャップ 2026-07-20): updateStripeSubscription に追加した
+  // eventCreatedAt による CAS (Stripe Webhook の配信順序非保証対策) が実 DB でも効くことの確認。
+  // 保存済みの stripeEventProcessedAt より古い event.created を渡すと更新されず false を返し、
+  // 実際に列も変わらないこと (=古いイベントで新しい状態を巻き戻さないこと) を検証する
+  it('updateStripeSubscriptionは保存済みより古いeventCreatedAtでは更新せずfalseを返す', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const tenant = await repos.tenants.create({ name: 'A組織' });
+    // 「10 分前のイベントまで適用済み」の状態を作る (先に新しいイベントを適用する)
+    const newEventCreatedAt = new Date('2026-07-20T12:00:00Z');
+    await repos.tenants.updateStripeSubscription(
+      tenant.id,
+      { subscriptionPlan: 'pro', stripeSubscriptionStatus: 'active' },
+      newEventCreatedAt,
+    );
+    // それより 1 時間古い event.created を持つイベントが後から届いたとして更新を試みる
+    const staleEventCreatedAt = new Date('2026-07-20T11:00:00Z');
+    const applied = await repos.tenants.updateStripeSubscription(
+      tenant.id,
+      { subscriptionPlan: 'free', stripeSubscriptionStatus: 'canceled' },
+      staleEventCreatedAt,
+    );
+    // CAS 不成立で false を返す
+    expect(applied).toBe(false);
+    // DB を再読込して実際に古いイベントの内容 (free/canceled) が反映されていないことを確認する
+    const reloaded = await repos.tenants.findById(tenant.id);
+    expect(reloaded?.subscriptionPlan).toBe('pro');
+    expect(reloaded?.stripeSubscriptionStatus).toBe('active');
+    // 適用済みイベント時刻も新しいイベントのままで巻き戻っていない
+    expect(reloaded?.stripeEventProcessedAt?.toISOString()).toBe(newEventCreatedAt.toISOString());
+  });
+
+  // 保存済みより新しい (または未処理=null の) eventCreatedAt では通常どおり適用され、
+  // stripeEventProcessedAt がそのイベントの発生時刻に更新される
+  it('updateStripeSubscriptionは保存済みより新しいeventCreatedAtでは適用されstripeEventProcessedAtが更新される', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const tenant = await repos.tenants.create({ name: 'A組織' });
+    // 未処理 (stripeEventProcessedAt = null) の状態から最初のイベントを適用する
+    const firstEventCreatedAt = new Date('2026-07-20T10:00:00Z');
+    const firstApplied = await repos.tenants.updateStripeSubscription(
+      tenant.id,
+      { subscriptionPlan: 'standard' },
+      firstEventCreatedAt,
+    );
+    expect(firstApplied).toBe(true);
+    // それより新しい 2 件目のイベントも通常どおり適用される
+    const secondEventCreatedAt = new Date('2026-07-20T10:05:00Z');
+    const secondApplied = await repos.tenants.updateStripeSubscription(
+      tenant.id,
+      { subscriptionPlan: 'pro' },
+      secondEventCreatedAt,
+    );
+    expect(secondApplied).toBe(true);
+    const reloaded = await repos.tenants.findById(tenant.id);
+    expect(reloaded?.subscriptionPlan).toBe('pro');
+    // 適用済みイベント時刻が最新の (2 件目の) イベント発生時刻に更新されている
+    expect(reloaded?.stripeEventProcessedAt?.toISOString()).toBe(
+      secondEventCreatedAt.toISOString(),
+    );
   });
 
   // recordOutboundChannelResult: 失敗記録は指定チャネルのカラムだけを更新する

--- a/tests/features/stripe-webhook-route.test.ts
+++ b/tests/features/stripe-webhook-route.test.ts
@@ -47,8 +47,13 @@ vi.mock('@/lib/stripe', () => ({
   stripeStatusToPlan: () => planForNextCall.current,
 }));
 
-// テナントをシードする (mode / plan を指定可能)
-function seedTenant(mode: 'lite' | 'pro', plan: 'free' | 'standard' | 'pro' | 'enterprise'): void {
+// テナントをシードする (mode / plan を指定可能)。stripeEventProcessedAt は配信順序 CAS の
+// テストで「既にこの時刻のイベントまで適用済み」を再現するために使う (省略時は未処理 = null)
+function seedTenant(
+  mode: 'lite' | 'pro',
+  plan: 'free' | 'standard' | 'pro' | 'enterprise',
+  stripeEventProcessedAt: Date | null = null,
+): void {
   const now = new Date();
   store.tenants.set(TENANT, {
     id: TENANT,
@@ -65,16 +70,20 @@ function seedTenant(mode: 'lite' | 'pro', plan: 'free' | 'standard' | 'pro' | 'e
     teamsWebhookUrl: null,
     chatworkApiToken: null,
     chatworkRoomId: null,
+    stripeEventProcessedAt,
     createdAt: now,
   });
 }
 
-// Stripe イベント JSON + 署名ヘッダ (値は何でもよい。constructEvent はモック済み) を組み立てる
+// Stripe イベント JSON + 署名ヘッダ (値は何でもよい。constructEvent はモック済み) を組み立てる。
+// created (イベント自体の発生時刻。Unix 秒) は実際の Stripe イベントに必ず含まれるフィールドの
+// ため、個別テストが明示指定しない限り「現在時刻」を既定値として補う (配信順序 CAS のテストは
+// eventBody 側で created を明示的に上書きする)
 function makeRequest(eventBody: Record<string, unknown>): Request {
   return new Request('http://localhost/api/webhooks/stripe', {
     method: 'POST',
     headers: { 'content-type': 'application/json', 'stripe-signature': 'sig' },
-    body: JSON.stringify(eventBody),
+    body: JSON.stringify({ created: Math.floor(Date.now() / 1000), ...eventBody }),
   });
 }
 
@@ -231,6 +240,75 @@ describe('POST /api/webhooks/stripe', () => {
     // フォローアップ (2026-07-13): プランも mode も変化していないので監査ログは記録されない
     // (無関係なイベントで監査ログを埋めない)
     expect(await repos.settingsAudit.findAllByTenant({ tenantId: TENANT })).toHaveLength(0);
+  });
+
+  // フォローアップ (監査で発見したギャップ 2026-07-20): Stripe は Webhook イベントの配信順序を
+  // 保証しない。既に新しいイベント (例: 解約 canceled) を適用済みのテナントに、ネットワーク遅延で
+  // 後から届いた古いイベント (例: それより前の active への更新) を適用すると、最新の解約状態を
+  // 巻き戻してしまう。古いイベントは無視され、現在の状態 (プラン・mode) が変わらないことを確認する
+  it('保存済みより古い event.created の更新イベントは無視され状態が巻き戻らない', async () => {
+    // 「直近 10 分前のイベントまで適用済み」のテナントを用意する (現在 free/lite = 解約済み相当)
+    const processedAt = new Date();
+    seedTenant('lite', 'free', processedAt);
+    // このイベントは 1 時間前 (=保存済みより古い) に発生した「pro へのアップグレード」イベントとして届く
+    const staleEventCreatedAt = Math.floor((processedAt.getTime() - 60 * 60 * 1000) / 1000);
+    planForNextCall.current = 'pro';
+    const { POST } = await import('@/app/api/webhooks/stripe/route');
+    const res = await POST(
+      makeRequest({
+        created: staleEventCreatedAt,
+        type: 'customer.subscription.updated',
+        data: {
+          object: {
+            id: 'sub_1',
+            customer: 'cus_1',
+            status: 'active',
+            items: { data: [{ price: { id: 'price_pro' } }] },
+            metadata: { tenantId: TENANT },
+          },
+        },
+      }),
+    );
+    // Stripe には 200 を返す (エラーではなく意図的な無視。再送させない)
+    expect(res.status).toBe(200);
+    const tenant = store.tenants.get(TENANT)!;
+    // 古いイベントは無視され、free/lite のまま (pro に巻き戻らない)
+    expect(tenant.subscriptionPlan).toBe('free');
+    expect(tenant.mode).toBe('lite');
+    // 無視されたイベントは「変更」ではないため監査ログにも残らない
+    expect(await repos.settingsAudit.findAllByTenant({ tenantId: TENANT })).toHaveLength(0);
+  });
+
+  // 保存済みより新しい event.created のイベントは通常どおり適用され、
+  // 適用後の stripeEventProcessedAt がそのイベントの発生時刻に更新される
+  it('保存済みより新しい event.created の更新イベントは通常どおり適用される', async () => {
+    // 「1 時間前のイベントまで適用済み」のテナントを用意する
+    const oldProcessedAt = new Date(Date.now() - 60 * 60 * 1000);
+    seedTenant('pro', 'pro', oldProcessedAt);
+    // このイベントは「今」発生した解約イベントとして届く (保存済みより新しい)
+    const newEventCreatedAtSec = Math.floor(Date.now() / 1000);
+    const { POST } = await import('@/app/api/webhooks/stripe/route');
+    const res = await POST(
+      makeRequest({
+        created: newEventCreatedAtSec,
+        type: 'customer.subscription.deleted',
+        data: {
+          object: {
+            id: 'sub_1',
+            customer: 'cus_1',
+            status: 'canceled',
+            metadata: { tenantId: TENANT },
+          },
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const tenant = store.tenants.get(TENANT)!;
+    // 新しいイベントなので通常どおり反映される
+    expect(tenant.subscriptionPlan).toBe('free');
+    expect(tenant.mode).toBe('lite');
+    // 適用済みイベント時刻が今回のイベントの発生時刻に更新されている
+    expect(tenant.stripeEventProcessedAt?.getTime()).toBe(newEventCreatedAtSec * 1000);
   });
 
   // 署名ヘッダが無いリクエストは 400 で拒否する (なりすまし対策)


### PR DESCRIPTION
## Summary

定期監査 (issue/PR無しの巡回レビュー) で発見したギャップの修正です。

- Stripe は Webhook イベントの配信順序を保証しません（[公式ドキュメント](https://stripe.com/docs/webhooks#ordering)にも明記: リトライやネットワーク遅延により、発生順とは異なる順序でイベントが届くことがあります）。
- `POST /api/webhooks/stripe` → `applyPlanChange` → `TenantRepository.updateStripeSubscription` は、これまで読み取り時点の状態を考慮しない素朴な上書きでした。
- そのため「解約 (`customer.subscription.deleted`)」など新しいイベントを適用した**後**に、ネットワーク遅延で遅れて届いた**古い**イベント（例: それ以前の `active` への更新）が処理されると、最新の課金状態を古い内容で巻き戻してしまう可能性がありました。Pro→Freeへのダウングレードが古いイベントで Pro に巻き戻る、といった実害につながります。

この PR では他の CAS (compare-and-swap) 実装 (`updateMode`, `updateNotificationChannels` 等) と同じパターンで、直近に適用した Stripe イベントの発生時刻 (`event.created`) を `Tenant.stripeEventProcessedAt` に保持し、それより古いイベントは無視するようにしました。

## 変更内容

- `prisma/schema.prisma` / 新規マイグレーション: `Tenant.stripeEventProcessedAt` (DateTime?, 既定 null) を追加。
- `src/domain/types.ts`: `Tenant.stripeEventProcessedAt` を任意フィールドとして追加 (既存フィクスチャを壊さないため)。
- `src/data/ports/tenant-repository.ts`: `updateStripeSubscription` に `eventCreatedAt?: Date` を追加し、戻り値を `Promise<Tenant>` → `Promise<boolean>` (CAS の成否) に変更。
- `src/data/adapters/prisma/tenant-repository.prisma.ts` / `memory/tenant-repository.memory.ts`: `eventCreatedAt` が渡された場合のみ「保存済みの `stripeEventProcessedAt` が null、またはそれ以下」を条件に含めた CAS 更新にする。
- `src/app/api/webhooks/stripe/route.ts`: `event.created` を末端まで受け渡し、CAS が不成立 (古いイベント) の場合は mode リセット・監査ログ記録を行わずログのみ残して正常終了 (Stripe には 200 を返し再送させない)。
- `tests/features/stripe-webhook-route.test.ts`: 古い event.created のイベントが無視され状態が巻き戻らないこと／新しい event.created のイベントは通常どおり適用され `stripeEventProcessedAt` が更新されることを検証するテストを追加。

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx vitest run` (105 files / 1117 tests passed, 21 files / 170 tests skipped = Prisma 契約テスト。RUN_PRISMA_CONTRACT 未設定のためローカルでは想定通りスキップ。CI の `prisma-contract` ジョブで実行される)
- [x] `npm run build` (Next.js ビルド成功)
- [x] `tests/features/stripe-webhook-route.test.ts` に追加した2件を含め全8件成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Df36TAmGz9wYA5cPxEd7Qg


---
_Generated by [Claude Code](https://claude.ai/code/session_01Df36TAmGz9wYA5cPxEd7Qg)_