### PR TITLE
test(layout): isItemActiveをsrc/lib/nav-active.tsへ切り出しユニットテストを追加

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -14,6 +14,8 @@ import type { Role, TenantMode } from '@/domain/types';
 import { FAQ_TERM_LABELS } from '@/lib/constants';
 // 共通ブランドマーク
 import { Logo } from '@/components/brand/Logo';
+// メニュー項目のアクティブ判定 (React/Next 非依存の純粋関数。単体テスト可能なため切り出し済み)
+import { isItemActive } from '@/lib/nav-active';
 // モバイルナビ Context (ハンバーガーで開閉するドロワー状態)
 import { useMobileNav } from './MobileNavProvider';
 
@@ -70,17 +72,8 @@ export function Sidebar({ role, mode }: Props) {
     // すべての制約を満たした項目だけ表示する
     return true;
   });
-  // メニュー項目がアクティブかどうかを判定 (完全一致 + 一部 prefix マッチ)
-  const isItemActive = (href: string) => {
-    // ルート "/" は完全一致のみ
-    if (href === '/') return pathname === '/';
-    // 完全一致なら即アクティブ
-    if (pathname === href) return true;
-    // nav item に完全一致するパスが存在する場合は prefix マッチを使わない
-    // （例: /tickets/new 閲覧時に /tickets を誤ってアクティブにしない）
-    const hasExactNavMatch = navItems.some((item) => item.href === pathname);
-    return !hasExactNavMatch && pathname.startsWith(`${href}/`);
-  };
+  // メニュー全項目の href 一覧 (デュアルハイライト防止の prefix マッチ判定に使う)
+  const navHrefs = navItems.map((item) => item.href);
 
   return (
     // ラッパー: モバイル時のバックドロップ + ドロワーを内包する
@@ -142,7 +135,7 @@ export function Sidebar({ role, mode }: Props) {
         <nav className={`flex-1 space-y-1 px-3 py-5 ${collapsed ? 'md:hidden' : ''}`}>
           {visibleItems.map((item) => {
             // この項目が現在のページかどうか
-            const isActive = isItemActive(item.href);
+            const isActive = isItemActive(pathname, item.href, navHrefs);
             // label が関数 (mode-aware) なら現在の mode で解決し、そうでなければそのまま使う
             const label = typeof item.label === 'function' ? item.label(mode) : item.label;
             return (

--- a/src/lib/nav-active.ts
+++ b/src/lib/nav-active.ts
@@ -1,0 +1,22 @@
+// サイドバーのメニュー項目が「現在表示中のページ」かどうかを判定する純粋関数。
+// Next.js (usePathname) にも React にも依存しないため、Vitest の node 環境でそのまま
+// ユニットテストできる (docs/pr-review-report.md §4 のフォローアップ「isItemActive のユニット
+// テスト追加」に対応。ロジック自体は src/components/layout/Sidebar.tsx に元々インライン定義
+// されていたものを、テスト容易性のためここへ切り出した。挙動は変更していない)。
+
+// 現在の URL パス (pathname) が、メニュー項目の href に対して「アクティブ」とみなせるかを判定する。
+// - href が "/" の場合は完全一致のみをアクティブとする (ルートを常時アクティブにしない)。
+// - それ以外は完全一致、または「他のどのメニュー項目とも完全一致しない」前提での prefix 一致を
+//   アクティブとする。navHrefs (メニュー全項目の href 一覧) を渡すのは、例えば /tickets/new を
+//   表示中に /tickets 側を誤って一緒にアクティブ表示しない (デュアルハイライト防止) ため。
+export function isItemActive(pathname: string, href: string, navHrefs: readonly string[]): boolean {
+  // ルート "/" は完全一致のみをアクティブとする
+  if (href === '/') return pathname === '/';
+  // 完全一致なら即アクティブ
+  if (pathname === href) return true;
+  // 現在のパスに完全一致するメニュー項目が別に存在する場合は、prefix マッチを使わない
+  // (例: /tickets/new 閲覧時に /tickets を誤ってアクティブにしない)
+  const hasExactNavMatch = navHrefs.some((navHref) => navHref === pathname);
+  // 完全一致する項目が無く、かつ "href/" で始まる場合のみ prefix マッチでアクティブとする
+  return !hasExactNavMatch && pathname.startsWith(`${href}/`);
+}

--- a/tests/nav-active.test.ts
+++ b/tests/nav-active.test.ts
@@ -1,0 +1,48 @@
+// Vitest のテスト DSL
+import { describe, expect, it } from 'vitest';
+
+// テスト対象: サイドバーのメニュー項目アクティブ判定 (純粋関数)
+import { isItemActive } from '../src/lib/nav-active';
+
+// docs/pr-review-report.md 推奨フォローアップ「isItemActive のユニットテスト追加」に対応
+describe('isItemActive', () => {
+  // ルート "/" は完全一致のときのみアクティブ
+  it('treats root "/" as active only on an exact match', () => {
+    expect(isItemActive('/', '/', ['/'])).toBe(true);
+    // ルート以外のパス配下でも "/" を誤ってアクティブにしない (prefix マッチを使わない特別扱い)
+    expect(isItemActive('/dashboard', '/', ['/', '/dashboard'])).toBe(false);
+  });
+
+  // 完全一致は常にアクティブ
+  it('is active on an exact pathname match', () => {
+    expect(isItemActive('/tickets', '/tickets', ['/tickets', '/tickets/new'])).toBe(true);
+  });
+
+  // 配下パスは prefix マッチでアクティブ (他に完全一致する項目が無い場合)
+  it('is active on a sub-path when no other nav item exactly matches', () => {
+    expect(isItemActive('/tickets/123', '/tickets', ['/dashboard', '/tickets'])).toBe(true);
+  });
+
+  // /tickets/new のように「配下パス自身が別のメニュー項目と完全一致する」場合は
+  // 親メニュー (/tickets) を誤ってアクティブにしない (デュアルハイライト防止)
+  it('does not prefix-match when another nav item exactly matches the current pathname', () => {
+    const navHrefs = ['/dashboard', '/tickets', '/tickets/new'];
+    // /tickets/new 自身は完全一致でアクティブ
+    expect(isItemActive('/tickets/new', '/tickets/new', navHrefs)).toBe(true);
+    // 親の /tickets は prefix マッチ対象だが、/tickets/new が完全一致項目として存在するため非アクティブ
+    expect(isItemActive('/tickets/new', '/tickets', navHrefs)).toBe(false);
+  });
+
+  // 無関係なパスは非アクティブ
+  it('is inactive for unrelated paths', () => {
+    expect(isItemActive('/faq', '/tickets', ['/faq', '/tickets'])).toBe(false);
+  });
+
+  // "/tickets-archive" のような紛らわしい別ページを "/tickets" の配下と誤認しない
+  // (startsWith(`${href}/`) がスラッシュ区切りを要求するため、文字列としての prefix だけでは一致しない)
+  it('does not match a sibling path that merely shares a string prefix', () => {
+    expect(isItemActive('/tickets-archive', '/tickets', ['/tickets', '/tickets-archive'])).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Context

`docs/pr-review-report.md` の推奨フォローアップ「1. テスト拡充: `isItemActive` 等のユーティリティ関数のユニットテスト追加」に対応する。

`src/components/layout/Sidebar.tsx` にインライン定義されていたメニューのアクティブ判定ロジック (`isItemActive`) は、Next.js の `usePathname` に依存するコンポーネント内クロージャとして定義されており、テストできない状態だった。本 PR ではロジックを React/Next 非依存の純粋関数として `src/lib/nav-active.ts` に切り出し、挙動を変更せずに単体テストを追加した。

## 変更内容

- `src/lib/nav-active.ts` (新規): `isItemActive(pathname, href, navHrefs)` — ルート `/` の完全一致限定・完全一致・prefix マッチ・デュアルハイライト防止 (`/tickets/new` 表示中に親の `/tickets` を誤アクティブにしない) を担う純粋関数。
- `src/components/layout/Sidebar.tsx`: インライン定義を削除し、上記関数を import して使用するよう変更 (`navItems` から `navHrefs` を導出して渡すのみで、レンダリング結果・挙動は変更なし)。
- `tests/nav-active.test.ts` (新規): ルート完全一致 / 完全一致 / prefix マッチ / デュアルハイライト防止 / 無関係パス / 文字列としてのみ似ているパス (`/tickets-archive`) の非マッチ、の6ケースをカバー。

## 検証

- `npm run typecheck`: エラーなし
- `npm run lint`: エラーなし
- `npx prettier --check` (変更ファイルのみ): 整形済み
- `npm run test`: 1123 passed | 172 skipped (新規6件を含め全件成功、既存テストの回帰なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gbzq6vfYjoBp5R9YY792jc)_