### PR TITLE
fix(auth,dashboard): サインアップ完了のレート制限漏れと拠点フィルタの drill-down 消失を修正

### DIFF
--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -1439,6 +1439,51 @@ RATE_LIMIT`) を追加済みだったが、兄弟にあたる `requestMagicLink`
   `tests/features/notifications-stream-route.test.ts`（同時接続数の上限到達 429・接続を閉じれば
   再び空くこと）に、それぞれ回帰テストを追加した。
 
+#### 4.21 フォローアップ（2026-07-20）: セルフサーブサインアップ完了にエンドポイント全体のレート制限が無かった
+
+コードベース監査（既存フォローアップ群と同じ「済マーク済みの機能を実装から再点検する」観点）で
+発見したギャップの修正。§4.19 で招待受諾 (`acceptInvitation`) とマジックリンクコールバックの
+レート制限漏れを埋めたが、同じ「公開 (未認証) アクション + Serializable トランザクション」の
+構造を持つ `completeSignup`（セルフサーブサインアップ完了。`src/features/auth/actions/
+complete-signup.ts`）だけは対象から漏れていた。`requestSignup`・`acceptInvitation`・
+`requestMagicLink` はいずれも冒頭で `enforceRateLimit` を呼ぶが、`completeSignup` には
+一切無く、不正なサインアップ完了トークンを連打されると、Serializable トランザクション + bcrypt
+ハッシュ化（cost 12）という重い処理をレート制限無しに繰り返し実行できてしまい、DB 負荷増大の
+踏み台になり得た（§9 公開エンドポイント保護）。
+
+- `src/lib/signup.ts` に `SIGNUP_COMPLETE_GLOBAL_RATE_LIMIT`（1 分 30 件）を追加した。
+  値は `acceptInvitation` の `INVITE_ACCEPT_GLOBAL_RATE_LIMIT` と同じにした（テナント作成という
+  同種の重さの操作であり、防御水準を割る理由がないため）。
+- `completeSignup` の先頭で `enforceRateLimit('signup-complete:global', ...)` を呼ぶ
+  (`acceptInvitation` と同じ設計。固定キーでエンドポイント全体を頭打ちにする)。
+- 回帰テスト: `tests/features/complete-signup.test.ts` に、上限件数まで（無効な）トークンで
+  呼んでも「無効」エラーのままだが、上限+1 件目は別のトークンでも全体レート制限に引っかかる
+  ことを確認するテストを追加した（`accept-invitation.test.ts` の同名テストと同じ設計）。
+
+#### 4.22 フォローアップ（2026-07-20）: ダッシュボードの拠点フィルタが一覧への drill-down で失われていた
+
+コードベース監査で発見したギャップの修正。§4.1/§4.1.1 で Pro/Lite 両ダッシュボードに拠点
+(`locationId`) フィルタを追加し、集計値は正しく絞り込まれるようになっていたが、その集計値
+から「一覧を見る」ために遷移するリンク（ステータス別件数カード・担当者別ワークロード行・Lite
+の「自分の未対応」「期限切れ」タイル、いずれも `src/app/(app)/dashboard/page.tsx`）はどれも
+`locationId` を含めずに `/tickets` へリンクしていた。拠点を選んだ状態でダッシュボードの数値を
+見てからカード/タイルをクリックすると、遷移先の一覧では絞り込みが「全拠点」に戻ってしまい、
+直前に見ていた件数と一覧の表示件数が一致しない事故があった。Lite モードでは `TicketFilters`
+に拠点セレクトが無い（§3.1「Lite はフリーワード検索のみ」）ため、Lite の管理者は一覧側で
+拠点フィルタを掛け直す手段が無く、ダッシュボードの拠点フィルタが drill-down 後は完全に
+失われていた。
+
+- `src/features/tickets/dashboard-links.ts` に `buildTicketListHref(baseQuery, locationId)`
+  を新設し、「拠点以外の絞り込み条件 + 選択中の拠点」から `/tickets` への href を組み立てる
+  処理を 1 か所に集約した（Pro/Lite 両ブランチ・4 箇所の呼び出し元で書き写さないための共通化。
+  §6 DRY）。
+- ステータスカード・担当者別ワークロード行・Lite の 2 タイル、いずれも本ヘルパー経由の
+  href に置き換えた。一覧側 (`tickets/page.tsx`) は元々 `sp.locationId` をモードに関わらず
+  そのままフィルタへ渡しており、集計は常に `tenantId` でスコープされるため、他テナントの
+  `locationId` が紛れ込んでも危険はない（§9）。
+- 回帰テスト: `tests/features/dashboard-links.test.ts` に `buildTicketListHref` の
+  境界値（拠点未選択・選択中・`tab=` クエリでも同様に付け足されること）を追加した。
+
 ### スケジュール感
 
 ```

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -14,6 +14,9 @@ import { getCurrentTenantMode } from '@/lib/tenant';
 import { getTutorialVideoUrl } from '@/lib/tutorial-video';
 // タブ ('mine' / 'overdue') の絞り込み条件を一元管理する純粋関数 (一覧ページと共有)
 import { applyTabFilter } from '@/features/tickets/tab-filter';
+// 監査で発見したギャップ対応: /tickets への drill-down リンクに選択中の拠点フィルタを
+// 引き継ぐための共通ヘルパー (Pro/Lite 両ブランチで共有 / §6 DRY)
+import { buildTicketListHref } from '@/features/tickets/dashboard-links';
 // データ層が公開しているチケット一覧フィルタ型 (件数取得の引数)
 import type { TicketListFilter } from '@/data/ports/ticket-repository';
 // 拠点の型 (Phase 4 多拠点。§4.1 フォローアップで Lite ダッシュボードにも拠点フィルタを追加する)
@@ -192,10 +195,12 @@ export default async function DashboardPage({ searchParams }: Props) {
         {/* フォローアップ (2026-07-11 #3): statCards が 6→7 件になったため sm:4 / lg:7 列に調整 */}
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 lg:grid-cols-7">
           {statCards.map((card) => (
-            // カードクリックで該当ステータスのフィルタ済み一覧へ遷移
+            // カードクリックで該当ステータスのフィルタ済み一覧へ遷移。
+            // 監査で発見したギャップ対応: 選択中の拠点フィルタも引き継ぐ (でないと遷移先で
+            // 「全拠点」に戻り、カードで見た件数と一覧の表示件数が食い違う)
             <Link
               key={card.status}
-              href={`/tickets?status=${card.status}`}
+              href={buildTicketListHref(`status=${card.status}`, selectedLocationId)}
               className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-100 transition duration-200 hover:-translate-y-0.5 hover:shadow-md hover:ring-teal-200"
             >
               <p className="text-3xl font-bold text-slate-900">{card.count}</p>
@@ -266,8 +271,9 @@ export default async function DashboardPage({ searchParams }: Props) {
                         {row.count}
                       </td>
                       <td className="px-5 py-3.5 text-right">
+                        {/* 監査で発見したギャップ対応: 選択中の拠点フィルタも引き継ぐ */}
                         <Link
-                          href={`/tickets?${query}`}
+                          href={buildTicketListHref(query, selectedLocationId)}
                           className="text-xs text-teal-700 transition hover:text-teal-800 hover:underline"
                         >
                           一覧を見る
@@ -493,9 +499,10 @@ async function LiteDashboard({
 
       {/* 2 枚タイル (スマホでは縦 1 列、sm 以上で 2 列) */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        {/* 自分の未対応 (Open / InProgress)。落ち着いたティールで主要導線として強調 */}
+        {/* 自分の未対応 (Open / InProgress)。落ち着いたティールで主要導線として強調。
+            監査で発見したギャップ対応: 選択中の拠点フィルタも引き継ぐ */}
         <Link
-          href="/tickets?tab=mine"
+          href={buildTicketListHref('tab=mine', selectedLocationId)}
           className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 transition duration-200 hover:-translate-y-0.5 hover:shadow-md hover:ring-teal-200"
         >
           <p className="text-sm font-medium text-slate-500">自分の未対応</p>
@@ -503,9 +510,10 @@ async function LiteDashboard({
           <p className="mt-1 text-xs text-slate-400">未対応・対応中の問い合わせ</p>
         </Link>
 
-        {/* 期限切れ。件数 0 はニュートラル、1 件以上はロゼで注意喚起 */}
+        {/* 期限切れ。件数 0 はニュートラル、1 件以上はロゼで注意喚起。
+            監査で発見したギャップ対応: 選択中の拠点フィルタも引き継ぐ */}
         <Link
-          href="/tickets?tab=overdue"
+          href={buildTicketListHref('tab=overdue', selectedLocationId)}
           className={`rounded-2xl bg-white p-6 shadow-sm ring-1 transition duration-200 hover:-translate-y-0.5 hover:shadow-md ${
             overdueCount > 0
               ? 'ring-rose-200 hover:ring-rose-300'

--- a/src/features/auth/actions/complete-signup.ts
+++ b/src/features/auth/actions/complete-signup.ts
@@ -14,6 +14,9 @@
  *  - 消費 (単回使用ガード) とテナント + ユーザー作成を 1 トランザクションで行い、
  *    作成失敗時は消費もロールバックしてトークンを無駄に焼かない。
  *  - パスワードは bcrypt でハッシュ化して保存する (平文は保存しない / §9。provisionTenantWithAdmin 内)。
+ *  - 監査で発見したギャップ対応 (2026-07-20): 公開 (未認証) アクションかつ Serializable
+ *    トランザクションを伴うため、不正なトークンでの連打による DB 負荷増大を防ぐ固定キーの
+ *    全体レート制限を最初に適用する (accept-invitation.ts / requestMagicLink と同じ設計)。
  */
 
 // データ層の Composition Root (トランザクション境界。リポジトリはトランザクション内の tx 経由で使う)
@@ -22,8 +25,11 @@ import { uow } from '@/data';
 import { FREE_TRIAL_DURATION_MS } from '@/lib/plan-guard';
 // Prisma の一意制約違反 (P2002) 判定の共通ヘルパー (accept-invitation.ts と共有 / §6 DRY)
 import { isUniqueConstraintError } from '@/lib/prisma-errors';
-// サインアップトークンのハッシュ化 (生トークン → DB 保存値と同じ SHA-256 へ)
-import { hashSignupToken } from '@/lib/signup';
+// 連打防止のための共通レート制限ヘルパー (accept-invitation.ts / request-magic-link.ts と共有)
+import { enforceRateLimit } from '@/lib/rate-limit';
+// サインアップトークンのハッシュ化 (生トークン → DB 保存値と同じ SHA-256 へ) と、
+// このエンドポイント全体のレート制限値 (監査で発見したギャップ対応)
+import { hashSignupToken, SIGNUP_COMPLETE_GLOBAL_RATE_LIMIT } from '@/lib/signup';
 // テナント + 初代管理者作成の共通ロジック (create-tenant.ts と共有 / §6 DRY)
 import { provisionTenantWithAdmin } from '@/lib/tenant-provisioning';
 // フォローアップ (2026-07-14 #2): テナント作成 (admin 権限付与) を監査ログへ記録する共通ヘルパー
@@ -42,6 +48,11 @@ export async function completeSignup(
   rawToken: string,
   formData: FormData,
 ): Promise<CompleteSignupResult> {
+  // 監査で発見したギャップ対応: 公開 (未認証) アクションかつ Serializable トランザクションを
+  // 伴うため、不正なトークンでの連打による DB 負荷増大を防ぐ固定キーの全体レート制限を
+  // 最初に適用する (§9 公開エンドポイント保護。accept-invitation.ts と同じ設計)
+  enforceRateLimit('signup-complete:global', SIGNUP_COMPLETE_GLOBAL_RATE_LIMIT);
+
   // フォーム入力 (組織名・業種・氏名・パスワード) を Zod で検証する
   const parsed = completeSignupSchema.safeParse({
     tenantName: formData.get('tenantName'),

--- a/src/features/tickets/dashboard-links.ts
+++ b/src/features/tickets/dashboard-links.ts
@@ -1,0 +1,18 @@
+// ダッシュボード (/dashboard) から一覧 (/tickets) への drill-down リンクを組み立てる純粋関数。
+//
+// 監査で発見したギャップ対応 (2026-07-20): §4.1/§4.1.1 で Pro/Lite 両ダッシュボードに拠点
+// フィルタ (locationId) を追加したが、ステータス別件数カード・担当者別ワークロード行・Lite の
+// 2 枚タイルは、いずれも locationId を含めずに `/tickets` へリンクしていた。ダッシュボードで
+// 拠点を選んだ状態からカード/タイルをクリックすると、遷移先の一覧では絞り込みが「全拠点」に
+// 戻ってしまい、直前に見ていた件数と一覧の表示件数が一致しない (拠点フィルタが握り潰される)。
+// このヘルパーで「既存のクエリ文字列 + 選択中の拠点」を 1 か所に集約し、4 箇所の呼び出し元
+// (dashboard/page.tsx の Pro/Lite 両ブランチ) で書き写さないようにする (§6 DRY)。
+export function buildTicketListHref(
+  baseQuery: string, // 拠点以外の絞り込み条件を表すクエリ文字列 (例: 'status=Open', 'tab=mine')
+  locationId: string | undefined, // 選択中の拠点 ID (未選択 = 全拠点なら undefined)
+): string {
+  // 拠点が選択されていなければ、拠点以外の条件だけで一覧へ遷移する (今までと同じ挙動)
+  if (!locationId) return `/tickets?${baseQuery}`;
+  // 選択中の拠点を維持したまま一覧へ遷移する (一覧側の locationId 解釈は tickets/page.tsx が担う)
+  return `/tickets?${baseQuery}&locationId=${locationId}`;
+}

--- a/src/lib/signup.ts
+++ b/src/lib/signup.ts
@@ -29,6 +29,14 @@ export const SIGNUP_RATE_LIMIT_MAX = 5;
 // テナント/ユーザー単位ではなくエンドポイント全体で発行数を頭打ちにする (§9 公開エンドポイント保護)
 export const SIGNUP_REQUEST_GLOBAL_RATE_LIMIT = { limit: 20, windowMs: 60_000 } as const;
 
+// 監査で発見したギャップ対応 (2026-07-20): 上記は「発行 (requestSignup)」側のみを守っており、
+// 「完了 (completeSignup)」側には全体レート制限が一切なかった。completeSignup は公開
+// (未認証) アクションかつ Serializable トランザクションでテナント + 初代管理者を作成する
+// 重い処理のため、accept-invitation.ts の INVITE_ACCEPT_GLOBAL_RATE_LIMIT と同じ設計
+// (固定キーでエンドポイント全体を頭打ちにする) を適用する。値も同じ 1 分 30 件に揃える
+// (テナント作成という同種の重さの操作であり、防御水準を割る理由がないため)
+export const SIGNUP_COMPLETE_GLOBAL_RATE_LIMIT = { limit: 30, windowMs: 60_000 } as const;
+
 // 指定した baseUrl と生トークンから、サインアップ完了ページの URL を組み立てる
 // 例: buildSignupCompleteUrl('http://localhost:3000', 'xxx') -> 'http://localhost:3000/signup/complete?token=xxx'
 export function buildSignupCompleteUrl(baseUrl: string, rawToken: string): string {

--- a/tests/features/complete-signup.test.ts
+++ b/tests/features/complete-signup.test.ts
@@ -5,8 +5,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildMemoryRepos, createMemoryContext, type Store } from '@/data/adapters/memory';
 // リポジトリ束 / UnitOfWork の型
 import type { Repos, UnitOfWork } from '@/data/ports/unit-of-work';
-// サインアップトークンのハッシュ化 (DB 保存値と同じ SHA-256 を作るために使う)
-import { hashSignupToken } from '@/lib/signup';
+// サインアップトークンのハッシュ化 (DB 保存値と同じ SHA-256 を作るために使う) と、
+// 完了エンドポイントの全体レート制限値 (テストで上限件数を参照するために import する)
+import { hashSignupToken, SIGNUP_COMPLETE_GLOBAL_RATE_LIMIT } from '@/lib/signup';
+// テスト間でレート制限の状態を初期化するためのヘルパー (他テストの呼び出し回数を持ち越さない)
+import { __resetRateLimits } from '@/lib/rate-limit';
 
 // 各テスト前に書き換える依存。Action import 前に getter で参照させる
 let store: Store;
@@ -38,6 +41,8 @@ beforeEach(() => {
   store = ctx.store;
   repos = ctx.repos;
   uow = ctx.uow;
+  // 前のテストで消費したレート制限バケットを持ち越さない (下の全体レート制限テストと分離するため)
+  __resetRateLimits();
 });
 
 // サインアップトークンを 1 件作成して生トークンを返すヘルパー
@@ -225,6 +230,30 @@ describe('completeSignup', () => {
         makeForm({ tenantName: '', adminName: '名前', adminPassword: 'password123' }),
       ),
     ).rejects.toThrow(/組織名/);
+  });
+
+  // 監査で発見したギャップ対応 (2026-07-20): 公開 (未認証) アクションかつ Serializable
+  // トランザクションを伴うため、不正なトークンでの連打を固定キーの全体レート制限で頭打ちに
+  // すること。異なるトークンで呼んでもエンドポイント全体で共有の上限に引っかかることを確認する
+  // (accept-invitation.ts の同名テストと同じ設計)
+  it('全体レート制限を超えると異なるトークンでも拒否される', async () => {
+    const { completeSignup } = await loadActions();
+    // 上限ちょうどまでは異なる無効トークンで呼んでも「無効」エラー (レート制限には引っかからない)
+    for (let i = 0; i < SIGNUP_COMPLETE_GLOBAL_RATE_LIMIT.limit; i += 1) {
+      await expect(
+        completeSignup(
+          `bogus-token-${i}`,
+          makeForm({ tenantName: '組織X', adminName: 'x', adminPassword: 'password123' }),
+        ),
+      ).rejects.toThrow(/無効|使用/);
+    }
+    // 上限+1 件目は別のトークンでも全体レート制限に引っかかる
+    await expect(
+      completeSignup(
+        'bogus-token-overflow',
+        makeForm({ tenantName: '組織X', adminName: 'x', adminPassword: 'password123' }),
+      ),
+    ).rejects.toThrow(/頻度が高すぎます/);
   });
 });
 

--- a/tests/features/dashboard-links.test.ts
+++ b/tests/features/dashboard-links.test.ts
@@ -13,11 +13,15 @@ describe('buildTicketListHref', () => {
 
   // 拠点選択中なら、既存の条件を保ったまま locationId を末尾に付け足すこと
   it('拠点選択中なら既存の条件を維持したまま locationId を付け足す', () => {
-    expect(buildTicketListHref('status=Open', 'loc-1')).toBe('/tickets?status=Open&locationId=loc-1');
+    expect(buildTicketListHref('status=Open', 'loc-1')).toBe(
+      '/tickets?status=Open&locationId=loc-1',
+    );
   });
 
   // Lite ダッシュボードのタブ遷移 (tab=mine 等) でも同様に付け足せること
   it('tab クエリでも同様に locationId を付け足す', () => {
-    expect(buildTicketListHref('tab=overdue', 'loc-2')).toBe('/tickets?tab=overdue&locationId=loc-2');
+    expect(buildTicketListHref('tab=overdue', 'loc-2')).toBe(
+      '/tickets?tab=overdue&locationId=loc-2',
+    );
   });
 });

--- a/tests/features/dashboard-links.test.ts
+++ b/tests/features/dashboard-links.test.ts
@@ -1,0 +1,23 @@
+// Vitest のテスト DSL
+import { describe, expect, it } from 'vitest';
+// テスト対象の純粋関数
+import { buildTicketListHref } from '@/features/tickets/dashboard-links';
+
+// 監査で発見したギャップ対応 (2026-07-20): ダッシュボードの drill-down リンクが選択中の
+// 拠点フィルタを引き継ぐこと (§4.1/§4.1.1 で追加した拠点フィルタが一覧遷移で消えていた)
+describe('buildTicketListHref', () => {
+  // 拠点未選択 (undefined) なら、渡した条件だけで一覧へのパスを組み立てること
+  it('拠点が未選択なら locationId を含めない', () => {
+    expect(buildTicketListHref('status=Open', undefined)).toBe('/tickets?status=Open');
+  });
+
+  // 拠点選択中なら、既存の条件を保ったまま locationId を末尾に付け足すこと
+  it('拠点選択中なら既存の条件を維持したまま locationId を付け足す', () => {
+    expect(buildTicketListHref('status=Open', 'loc-1')).toBe('/tickets?status=Open&locationId=loc-1');
+  });
+
+  // Lite ダッシュボードのタブ遷移 (tab=mine 等) でも同様に付け足せること
+  it('tab クエリでも同様に locationId を付け足す', () => {
+    expect(buildTicketListHref('tab=overdue', 'loc-2')).toBe('/tickets?tab=overdue&locationId=loc-2');
+  });
+});


### PR DESCRIPTION
## 対応する Phase / 項目

`docs/smb-dx-pivot-plan.md` の全チェック項目は既に完了済みのため、既存の「フォローアップ」運用
（実装済み機能をコードベース監査で再点検し、見つかったギャップを埋める）に基づく修正です。
本 PR で計画書に **§4.21 / §4.22** として追記しています。

## Context

`docs/smb-dx-pivot-plan.md` の Phase 0〜4 は全項目 `[x]` 済みだったため、監査エージェントで
コードベース全体を再点検し、実装済み機能の一部が全箇所に一貫して適用されていないギャップを
2 件特定・修正しました。

## 変更内容

### 1. §4.21 — セルフサーブサインアップ完了にエンドポイント全体のレート制限が無かった

`completeSignup`（`src/features/auth/actions/complete-signup.ts`）は、公開（未認証）アクション
かつ Serializable トランザクションで新規テナント + 初代管理者を作成する重い処理にもかかわらず、
兄弟に当たる `requestSignup` / `acceptInvitation` / `requestMagicLink` がいずれも持つ
`enforceRateLimit` の呼び出しが無く、不正なトークンでの連打を防げませんでした。
`acceptInvitation` と同じ設計（`INVITE_ACCEPT_GLOBAL_RATE_LIMIT` 相当）で
`SIGNUP_COMPLETE_GLOBAL_RATE_LIMIT`（1 分 30 件）を `src/lib/signup.ts` に追加し、
`completeSignup` の先頭で適用しました。

### 2. §4.22 — ダッシュボードの拠点フィルタが一覧への drill-down で失われていた

Pro/Lite 両ダッシュボードには拠点 (`locationId`) フィルタが実装済みでしたが、集計から
「一覧を見る」ためのリンク（ステータス別カード・担当者別ワークロード行・Lite の 2 タイル、
いずれも `src/app/(app)/dashboard/page.tsx`）は `locationId` を引き継がずに `/tickets` へ
リンクしていました。拠点を選んだ状態で数値を見てからクリックすると、遷移先の一覧では
絞り込みが「全拠点」に戻ってしまい、直前に見ていた件数と一覧の表示件数が食い違う問題が
ありました（Lite モードは一覧側に拠点セレクトが無いため、選び直す手段もありませんでした）。
新設した `buildTicketListHref`（`src/features/tickets/dashboard-links.ts`）に共通化し、
4 箇所の呼び出し元すべてで選択中の拠点を引き継ぐようにしました。

## 再利用した既存実装

- レート制限: 既存の `enforceRateLimit` / `RateLimitOptions`（`src/lib/rate-limit.ts`）をそのまま利用。新しいレート制限機構は追加していません。
- 拠点フィルタ: 既存の `resolveSelectedLocationId` / `LocationFilterPills`（§4.1.1 で共通化済み）はそのまま利用し、drill-down リンクの組み立てだけを新規の純粋関数に切り出しました。

## 検証方法

- `npm run typecheck` — 通過
- `npm run lint` — 通過
- `npm run test` — 1121 tests 全通過（新規追加分含む）
  - `tests/features/complete-signup.test.ts`: 全体レート制限で異なるトークンでも頭打ちになることを確認する回帰テストを追加
  - `tests/features/dashboard-links.test.ts`: `buildTicketListHref` の境界値テストを新規追加

E2E (`npm run test:e2e`) は本 PR の変更が dev サーバー起動を要するため未実行です。ロジックは
既存の単体テストパターンに沿った回帰テストでカバーしています。


---
_Generated by [Claude Code](https://claude.ai/code/session_01UGQTTLx7yRTq4iSBdj2dLh)_