### PR TITLE
fix(settings,data): SSO/拠点更新のTOCTOUとUserRepository一覧の上限漏れを解消

### DIFF
--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -1484,6 +1484,52 @@ complete-signup.ts`）だけは対象から漏れていた。`requestSignup`・`
 - 回帰テスト: `tests/features/dashboard-links.test.ts` に `buildTicketListHref` の
   境界値（拠点未選択・選択中・`tab=` クエリでも同様に付け足されること）を追加した。
 
+#### 4.23 フォローアップ（2026-07-20 #2）: SSO 設定更新の TOCTOU・UserRepository 一覧の上限漏れ・拠点更新の TOCTOU
+
+コードベース監査（既存フォローアップ群と同じ「済マーク済みの機能を実装から再点検する」観点）で
+発見した 3 件のギャップの修正。
+
+- **`updateSsoConfig` に TOCTOU が残っていた**: §4.19/§4.20 で `updateNotificationChannels` /
+  `update-line-config.ts` に導入してきた CAS (compare-and-swap) パターンが、同じ「読み取り→
+  検証→無条件書き込み」構成を持つ `updateSsoConfig`（`src/features/settings/actions/
+  update-sso-config.ts`）には一度も適用されていなかった。SSO 設定フォームは LINE 連携設定と
+  異なり「空欄なら維持」という緩衝が無く、IdP EntityID/SSO URL/証明書の全項目を毎回
+  `defaultValue` で事前入力して丸ごと再送信する構成のため、他の管理者が IdP 証明書を
+  ローテーションした直後にこのリクエストが割り込むと、認証の信頼アンカーである証明書が
+  古い値のまま黙って上書きされてしまう（LINE 連携設定より実害の大きい変種）。
+  `SsoConfigRepository.upsert` に `expected`（読み取り時点の 4 フィールド値）を追加し、
+  指定時のみ原子的な条件付き更新（0 件なら競合として `null`）にした
+  （Prisma/メモリ両アダプタ対応）。`updateSsoConfig` は事前に `findByTenant` した
+  スナップショットを `expected` としてそのまま渡し、競合時は他の設定アクションと同じ
+  「他の管理者による変更と競合しました」を返す。
+- **`UserRepository` の一覧系メソッドに上限が無かった**: §4.11/§4.12/§4.19 で
+  「一覧取得は必ず上限を持たせる」（§8）を `FaqRepository` / `TicketRepository` の
+  コメント・履歴 / `LocationRepository` / `CategoryRepository` に適用してきたが、
+  `listAgents` / `listByTenant` / `listAgentIds` / `listAgentEmails` / `listAdminEmails`
+  だけは上限が無いまま残っていた。`USER_LIMIT.enterprise = Infinity`（`src/lib/
+  plan-guard.ts`）により Enterprise プランはスタッフ数上限が無いため、大規模テナントでは
+  理論上ではなく実際に無制限件数を返しうる（担当者プルダウン・CSV インポートの名前解決・
+  エスカレーション一斉メール・メール/LINE 取り込みの自動割当など、高頻度に呼ばれる経路が
+  対象）。拠点/カテゴリと異なりこのリポジトリには表示用ページング画面が無く、全呼び出し元が
+  「テナント内の対象者全員」を必要とするため、表示用/網羅用の二段構成ではなく単一の上限
+  `USER_LIST_LIMIT`（`src/data/ports/user-repository.ts`。網羅用途の規模である
+  `LOCATION_LIST_MATCHING_LIMIT` 等と同じ 10,000 に揃える）を追加し、Prisma アダプタは
+  `take`、メモリアダプタは `slice` で切り詰める。
+- **`updateLocation` にも同種の TOCTOU が残っていた**: 拠点編集フォームも SSO 設定と同じく
+  現在値を全項目事前入力して丸ごと再送信する構成のため、同じ穴が `LocationRepository.update`
+  にもあった。他の管理者の並行編集を上書きしうる実害は SSO ほど大きくない（表示名・補足説明の
+  巻き戻りのみ）が、同一クラスの欠陥の 2 件目として合わせて修正する。`update` に
+  `expected?: { name, description }` を追加し、指定時のみ CAS 経路（Prisma は
+  `updateMany` + 読み直し、メモリは値比較）にした。既存の「存在しない/他テナントの拠点」判定
+  (`findFirst` → 例外) は競合検知とは独立に維持し、CAS の 0 件更新だけを競合 (`null`) として
+  区別する。
+- 回帰テスト: `tests/features/update-sso-config.test.ts` / `tests/data/
+  sso-config-repository.{memory,contract.prisma}.test.ts`・`tests/data/user-repository.
+  memory.test.ts`（`USER_LIST_LIMIT` 超過時の切り詰め）・`tests/features/
+  update-location.test.ts` / `tests/data/location-repository.{memory,contract.prisma}
+  .test.ts` に、それぞれ CAS の競合再現（`findByTenant`/`findById` だけ古いスナップショットを
+  返すよう一時的にモックする、§4.13 以来の手法）と上限切り詰めの回帰テストを追加した。
+
 ### スケジュール感
 
 ```

--- a/src/data/adapters/memory/location-repository.memory.ts
+++ b/src/data/adapters/memory/location-repository.memory.ts
@@ -54,12 +54,21 @@ export function makeLocationRepo(store: Store): LocationRepository {
     },
 
     // 拠点名・補足説明を更新する
-    async update(id, tenantId, data) {
+    async update(id, tenantId, data, expected) {
       // 対象拠点を取得してテナントスコープを確認する
       const existing = store.locations.get(id);
       if (!existing || existing.tenantId !== tenantId) {
         // 他テナントの拠点や存在しない拠点への更新は Prisma と同様にエラー
         throw new Error(`Location ${id} not found in tenant ${tenantId}`);
+      }
+      // CAS: expected が渡されていれば、現在値がそれと一致するときだけ更新する
+      // (Prisma アダプタの updateMany 版 CAS と同じ契約。§9 fail-closed で後勝ち上書きを防ぐ)
+      if (
+        expected &&
+        (existing.name !== expected.name || existing.description !== expected.description)
+      ) {
+        // 読み取り後に他の管理者が編集していた (競合) ため null を返し、上書きしない
+        return null;
       }
       // 既存オブジェクトに差分を上書きする
       const updated: Location = {

--- a/src/data/adapters/memory/sso-config-repository.memory.ts
+++ b/src/data/adapters/memory/sso-config-repository.memory.ts
@@ -30,6 +30,18 @@ export function makeSsoConfigRepo(store: Store): SsoConfigRepository {
       if (existing) {
         // 既存設定を取り出して値を更新する
         const cfg = store.ssoConfigs.get(existing)!;
+        // CAS: expected が渡されていれば、現在値がそれと一致するときだけ更新する
+        // (Prisma アダプタの updateMany 版 CAS と同じ契約。§9 fail-closed で後勝ち上書きを防ぐ)
+        if (
+          input.expected &&
+          (cfg.enabled !== input.expected.enabled ||
+            cfg.idpEntityId !== input.expected.idpEntityId ||
+            cfg.idpSsoUrl !== input.expected.idpSsoUrl ||
+            cfg.idpX509Cert !== input.expected.idpX509Cert)
+        ) {
+          // 読み取り後に他の更新が割り込んでいた (競合) ため null を返し、上書きしない
+          return null;
+        }
         // 更新後の設定オブジェクトを組み立てる (createdAt は維持、updatedAt を更新)
         const updated = {
           ...cfg,

--- a/src/data/adapters/memory/user-repository.memory.ts
+++ b/src/data/adapters/memory/user-repository.memory.ts
@@ -1,5 +1,5 @@
-// ユーザーリポジトリの契約 (port) と、ドメイン型/ストア型をインポート
-import type { UserRepository } from '@/data/ports/user-repository';
+// ユーザーリポジトリの契約 (port)・一覧系メソッド共通の上限と、ドメイン型/ストア型をインポート
+import { USER_LIST_LIMIT, type UserRepository } from '@/data/ports/user-repository';
 import type { User, UserSummary } from '@/domain/types';
 import { nextId, type Store } from './store';
 
@@ -64,8 +64,8 @@ export function makeUserRepo(store: Store): UserRepository {
       }
       // 名前でロケール順に並び替え
       agents.sort((a, b) => a.name.localeCompare(b.name));
-      // 結果を返す
-      return agents;
+      // 監査で発見したギャップ対応: USER_LIST_LIMIT で上限を設ける (Prisma アダプタの take と同じ)
+      return agents.slice(0, USER_LIST_LIMIT);
     },
 
     // 当該テナント内の全ユーザー (ロール問わず) を名前順で一覧取得 (フォローアップ 2026-07-14:
@@ -80,8 +80,8 @@ export function makeUserRepo(store: Store): UserRepository {
       }
       // 名前でロケール順に並び替え
       out.sort((a, b) => a.name.localeCompare(b.name));
-      // 結果を返す
-      return out;
+      // 監査で発見したギャップ対応: USER_LIST_LIMIT で上限を設ける
+      return out.slice(0, USER_LIST_LIMIT);
     },
 
     // 当該テナント内の agent または admin の ID だけを一覧取得
@@ -93,8 +93,8 @@ export function makeUserRepo(store: Store): UserRepository {
         if (u.tenantId !== tenantId) continue; // 他テナントは除外
         if (u.role === 'agent' || u.role === 'admin') ids.push(u.id);
       }
-      // 結果を返す
-      return ids;
+      // 監査で発見したギャップ対応: USER_LIST_LIMIT で上限を設ける
+      return ids.slice(0, USER_LIST_LIMIT);
     },
 
     // 指定 ID 群に含まれる当該テナント内ユーザーの概要をまとめて返す
@@ -121,8 +121,8 @@ export function makeUserRepo(store: Store): UserRepository {
         if (u.tenantId !== tenantId) continue; // 他テナントは除外
         if (u.role === 'agent' || u.role === 'admin') out.push({ id: u.id, email: u.email });
       }
-      // 結果を返す
-      return out;
+      // 監査で発見したギャップ対応: USER_LIST_LIMIT で上限を設ける
+      return out.slice(0, USER_LIST_LIMIT);
     },
 
     // §7.2 Free trial 終了リマインダー等、課金関連の通知先として admin のみの id + email を取得
@@ -134,8 +134,8 @@ export function makeUserRepo(store: Store): UserRepository {
         if (u.tenantId !== tenantId) continue; // 他テナントは除外
         if (u.role === 'admin') out.push({ id: u.id, email: u.email });
       }
-      // 結果を返す
-      return out;
+      // 監査で発見したギャップ対応: USER_LIST_LIMIT で上限を設ける
+      return out.slice(0, USER_LIST_LIMIT);
     },
 
     // Phase 4 課金: テナント内のスタッフ (agent + admin) 数を返す (プランのシート上限チェック用)

--- a/src/data/adapters/prisma/location-repository.prisma.ts
+++ b/src/data/adapters/prisma/location-repository.prisma.ts
@@ -63,16 +63,37 @@ export function makeLocationRepo(db: PrismaLike): LocationRepository {
     },
 
     // 拠点名・補足説明を更新する (tenantId スコープで他テナントは not-found エラー)
-    async update(id, tenantId, data) {
+    async update(id, tenantId, data, expected) {
       // まず対象拠点がこのテナントに属するか findFirst で確認する。
       // db.location.update の where は PK (id) のみで解決されるため tenantId は AND にならない。
       // deleteMany は任意 WHERE をサポートするが update は @@unique 経由でしか複合条件を取れない。
       // 事前 findFirst でテナント所有を検証してから id のみで更新することでクロステナントを防ぐ。
       const existing = await db.location.findFirst({ where: { id, tenantId } });
-      // 見つからない場合は他テナントの行か存在しない行 — 更新を拒否する
+      // 見つからない場合は他テナントの行か存在しない行 — 更新を拒否する (CAS 競合とは別の扱い)
       if (!existing) {
         throw new Error(`Location not found: ${id}`);
       }
+
+      // 監査で発見したギャップ対応: expected が渡された場合は CAS (compare-and-swap) 経路。
+      // 「読み取り時点の値」を where に足した updateMany で、書き込み直前にも現在値が
+      // 一致することを保証する (LineConfigRepository.upsert と同じ方針)。存在確認は
+      // 直前の findFirst で済んでいるため、ここでの 0 件は「その間に他の管理者が編集した」
+      // 競合を意味する
+      if (expected) {
+        const result = await db.location.updateMany({
+          where: { id, tenantId, name: expected.name, description: expected.description },
+          data: { name: data.name, description: data.description },
+        });
+        // 0 件更新 = 直前の読み取り後に他の管理者が値を変えていた (競合)。null を返し、
+        // 後勝ちで上書きしないようにする (§9 fail-closed)
+        if (result.count === 0) return null;
+        // 更新できた行を読み直してドメイン型で返す (updateMany は更新後の行を返さないため)
+        const row = await db.location.findFirst({ where: { id, tenantId } });
+        if (!row) return null;
+        return toLocation(row);
+      }
+
+      // expected 未指定: 従来どおりの無条件更新 (競合検知が不要な呼び出し)。
       // テナント所有を確認後、PK だけで更新する (Prisma の update は PK 必須)
       const row = await db.location.update({
         where: { id },

--- a/src/data/adapters/prisma/sso-config-repository.prisma.ts
+++ b/src/data/adapters/prisma/sso-config-repository.prisma.ts
@@ -38,6 +38,41 @@ export function makeSsoConfigRepo(db: PrismaLike): SsoConfigRepository {
 
     // SSO 設定を作成または更新する (tenantId をキーに upsert)
     async upsert(input) {
+      // expected が渡された場合は CAS (compare-and-swap) 経路: 「読み取り時点の値」を
+      // where に足した updateMany で、書き込み直前にも現在値が一致することを保証する
+      // (LineConfigRepository.upsert と同じ方針)。expected は「既存設定がある」ことを
+      // 前提にした呼び出し (呼び出し側は既存行が無ければ expected を渡さない契約) のため、
+      // ここでは無条件に updateMany を使う
+      if (input.expected) {
+        const result = await db.tenantSsoConfig.updateMany({
+          where: {
+            tenantId: input.tenantId,
+            enabled: input.expected.enabled,
+            idpEntityId: input.expected.idpEntityId,
+            idpSsoUrl: input.expected.idpSsoUrl,
+            idpX509Cert: input.expected.idpX509Cert,
+          },
+          data: {
+            enabled: input.enabled,
+            idpEntityId: input.idpEntityId,
+            idpSsoUrl: input.idpSsoUrl,
+            idpX509Cert: input.idpX509Cert,
+          },
+        });
+        // 0 件更新 = 読み取り後に他の管理者が値を変えていた (競合)。呼び出し側へ null を返し、
+        // 後勝ちで上書きしないようにする (§9 fail-closed)
+        if (result.count === 0) return null;
+        // 更新できた行を読み直してドメイン型で返す (updateMany は更新後の行を返さないため)。
+        // findUniqueOrThrow だと、更新成功〜読み直しの間に別リクエストが同じ設定を削除する
+        // 極めて稀な競合で例外を投げてしまうため、findUnique + null チェックにして
+        // その競合ケースも「他の更新と競合した」という一貫した扱い (null 相当) に丸める
+        // (LineConfigRepository.upsert と同じ理由)
+        const row = await db.tenantSsoConfig.findUnique({ where: { tenantId: input.tenantId } });
+        if (!row) return null;
+        return toSsoConfig(row);
+      }
+
+      // expected 未指定: 従来どおりの無条件 upsert (新規作成、または競合検知が不要な呼び出し)。
       // tenantId が既存なら update、なければ create される
       const row = await db.tenantSsoConfig.upsert({
         where: { tenantId: input.tenantId },

--- a/src/data/adapters/prisma/user-repository.prisma.ts
+++ b/src/data/adapters/prisma/user-repository.prisma.ts
@@ -1,5 +1,5 @@
-// ユーザーリポジトリの契約 (port)、マッパー関数、Prisma 共通型をインポート
-import type { UserRepository } from '@/data/ports/user-repository';
+// ユーザーリポジトリの契約 (port)、一覧系メソッド共通の上限、マッパー関数、Prisma 共通型をインポート
+import { USER_LIST_LIMIT, type UserRepository } from '@/data/ports/user-repository';
 import { toUser, toUserSummary } from './mappers';
 import type { PrismaLike } from './types';
 
@@ -34,34 +34,40 @@ export function makeUserRepo(db: PrismaLike): UserRepository {
       return toUser(row);
     },
 
-    // 当該テナント内の agent または admin を名前順で取得 (担当者候補)
+    // 当該テナント内の agent または admin を名前順で取得 (担当者候補)。
+    // 監査で発見したギャップ対応: USER_LIST_LIMIT で上限を設ける (§8 一覧取得は上限必須)
     async listAgents(tenantId) {
       const rows = await db.user.findMany({
         where: { tenantId, role: { in: ['agent', 'admin'] } }, // テナント + ロールで絞る
         select: { id: true, name: true }, // 必要列のみ
         orderBy: { name: 'asc' }, // 名前昇順
+        take: USER_LIST_LIMIT, // 上限 (Enterprise はスタッフ数無制限のため全件走査を防ぐ)
       });
       // 各行を UserSummary に変換
       return rows.map(toUserSummary);
     },
 
     // 当該テナント内の全ユーザー (ロール問わず) を名前順で取得 (フォローアップ 2026-07-14:
-    // CSV インポートの「起票者」列名解決用。起票者は依頼者もなり得るため listAgents では絞り込めない)
+    // CSV インポートの「起票者」列名解決用。起票者は依頼者もなり得るため listAgents では絞り込めない)。
+    // 監査で発見したギャップ対応: USER_LIST_LIMIT で上限を設ける
     async listByTenant(tenantId) {
       const rows = await db.user.findMany({
         where: { tenantId }, // テナントのみで絞る (ロール不問)
         select: { id: true, name: true }, // 必要列のみ
         orderBy: { name: 'asc' }, // 名前昇順
+        take: USER_LIST_LIMIT, // 上限
       });
       // 各行を UserSummary に変換
       return rows.map(toUserSummary);
     },
 
-    // 当該テナント内の agent または admin の ID だけを取得 (通知一斉送信用)
+    // 当該テナント内の agent または admin の ID だけを取得 (通知一斉送信用)。
+    // 監査で発見したギャップ対応: USER_LIST_LIMIT で上限を設ける
     async listAgentIds(tenantId) {
       const rows = await db.user.findMany({
         where: { tenantId, role: { in: ['agent', 'admin'] } }, // テナント + ロールで絞る
         select: { id: true }, // id だけ
+        take: USER_LIST_LIMIT, // 上限
       });
       // id の配列に変換して返す
       return rows.map((r) => r.id);
@@ -79,21 +85,25 @@ export function makeUserRepo(db: PrismaLike): UserRepository {
       return rows.map(toUserSummary);
     },
 
-    // 当該テナント内の agent / admin の id + email を一括取得 (一斉メール送信用。N+1 回避)
+    // 当該テナント内の agent / admin の id + email を一括取得 (一斉メール送信用。N+1 回避)。
+    // 監査で発見したギャップ対応: USER_LIST_LIMIT で上限を設ける
     async listAgentEmails(tenantId) {
       const rows = await db.user.findMany({
         where: { tenantId, role: { in: ['agent', 'admin'] } }, // テナント + ロールで絞る
         select: { id: true, email: true }, // 必要列のみ
+        take: USER_LIST_LIMIT, // 上限
       });
       // { id, email } の配列をそのまま返す (追加の変換は不要)
       return rows;
     },
 
-    // §7.2 Free trial 終了リマインダー等、課金関連の通知先として admin のみの id + email を取得
+    // §7.2 Free trial 終了リマインダー等、課金関連の通知先として admin のみの id + email を取得。
+    // 監査で発見したギャップ対応: USER_LIST_LIMIT で上限を設ける
     async listAdminEmails(tenantId) {
       const rows = await db.user.findMany({
         where: { tenantId, role: 'admin' }, // テナント + admin のみで絞る (agent は含まない)
         select: { id: true, email: true }, // 必要列のみ
+        take: USER_LIST_LIMIT, // 上限
       });
       // { id, email } の配列をそのまま返す (追加の変換は不要)
       return rows;

--- a/src/data/ports/location-repository.ts
+++ b/src/data/ports/location-repository.ts
@@ -44,11 +44,17 @@ export interface LocationRepository {
     description?: string | null; // 補足説明 (任意)
   }): Promise<Location>;
   // 拠点名・補足説明を更新する (tenantId スコープで他テナントの ID は no-op)
+  // 監査で発見したギャップ対応 (2026-07-20): 拠点編集フォームは常に現在値を全項目
+  // defaultValue で事前入力して丸ごと再送信する構成のため (SSO/LINE 連携設定と同じ形)、
+  // 読み取り→無条件書き込みの間に他の管理者が並行更新すると check-then-act (TOCTOU) で
+  // 後勝ち上書きが起きる。expected を渡した場合のみ、書き込み直前の現在値がそれと一致する
+  // ときだけ更新する CAS になる (未指定なら従来どおり無条件更新)。
   update(
     id: string,
     tenantId: string,
     data: { name?: string; description?: string | null },
-  ): Promise<Location>;
+    expected?: { name: string; description: string | null },
+  ): Promise<Location | null>; // null は「見つからない」ではなく CAS 競合を意味する (not found は従来どおり例外)
   // 拠点を削除する。紐づくチケットの locationId は DB の ON DELETE SET NULL で null になる
   delete(id: string, tenantId: string): Promise<void>;
 }

--- a/src/data/ports/sso-config-repository.ts
+++ b/src/data/ports/sso-config-repository.ts
@@ -8,14 +8,29 @@ import type { TenantSsoConfig } from '@/domain/types';
 export interface SsoConfigRepository {
   // テナントの SSO 設定を取得する (未設定なら null)
   findByTenant(tenantId: string): Promise<TenantSsoConfig | null>;
-  // SSO 設定を作成または更新する (1 テナント 1 設定なので tenantId で upsert)
+  // SSO 設定を作成または更新する (1 テナント 1 設定なので tenantId で upsert)。
+  // フォローアップ (監査で発見したギャップ): 設定フォームは常に現在値を全項目 defaultValue で
+  // 事前入力して丸ごと再送信する構成のため (channelSecret 等を空欄=維持で扱う LINE 連携設定とは
+  // 異なり、この画面には「変更しない」フィールドという概念が無い)、読み取り→無条件書き込みの間に
+  // 他の管理者が並行更新すると check-then-act (TOCTOU) で後勝ち上書きが起きる。特に IdP 証明書の
+  // ローテーション直後に古いフォームが送信されると、認証の信頼アンカーが黙って古い証明書へ
+  // 巻き戻ってしまう (update-line-config.ts の LineConfigRepository.upsert と同じ穴)。
   upsert(input: {
     tenantId: string; // 所属テナント (セッション由来のみ許可。クロステナント設定防止)
     enabled: boolean; // SSO ログインを有効化するか
     idpEntityId: string; // IdP の EntityID (Issuer)
     idpSsoUrl: string; // IdP の SSO エンドポイント URL
     idpX509Cert: string; // IdP の署名検証用 X.509 証明書
-  }): Promise<TenantSsoConfig>;
+    // CAS: 読み取り時点の既存設定値。渡された場合、書き込み直前の現在値がこれと一致する
+    // ときだけ更新する。未指定 (新規作成、または呼び出し側が競合検知を必要としない場合) なら
+    // 従来どおり無条件 upsert する (LineConfigRepository.upsert と同じ契約)。
+    expected?: {
+      enabled: boolean;
+      idpEntityId: string;
+      idpSsoUrl: string;
+      idpX509Cert: string;
+    };
+  }): Promise<TenantSsoConfig | null>; // null は競合 (書き込み直前に他の更新が割り込んだ) を意味する
   // テナントの SSO 設定を削除する (tenantId スコープで他テナントは no-op)
   delete(tenantId: string): Promise<void>;
 }

--- a/src/data/ports/user-repository.ts
+++ b/src/data/ports/user-repository.ts
@@ -1,6 +1,18 @@
 // ドメイン層のユーザー型をインポート
 import type { Role, User, UserSummary } from '@/domain/types';
 
+// 監査で発見したギャップ対応 (2026-07-20): §4.11/§4.12/§4.19 で「一覧取得は必ず上限を持たせる」
+// (CLAUDE.md §8) を FaqRepository / TicketRepository の詳細一覧 / LocationRepository /
+// CategoryRepository に適用してきたが、UserRepository の一覧系メソッドだけは上限が無いまま
+// 残っていた。Enterprise プランはスタッフ数の上限が無い (`USER_LIMIT.enterprise = Infinity`、
+// src/lib/plan-guard.ts) ため、大規模な Enterprise テナントでは理論上ではなく実際に無制限の
+// 件数を返しうる。ロケーション/カテゴリと異なりこのリポジトリには「表示用のページング付き
+// 管理画面」が無く、呼び出し元はすべて「テナント内の対象ユーザー全員」を必要とする用途
+// (担当者プルダウン・CSV インポートの名前解決・通知の一斉送信・エスカレーション対象抽出) の
+// ため、表示用/網羅用の二段構成 (LOCATION_LIST_LIMIT/LOCATION_LIST_MATCHING_LIMIT) ではなく、
+// 単一の上限だけを設ける。値は網羅用途の上限 (LOCATION_LIST_MATCHING_LIMIT 等) と同じ規模に揃える
+export const USER_LIST_LIMIT = 10_000;
+
 // LINE ワンタイムコードによる紐付け試行の結果。
 // - linked: 連携成功 (userId は連携されたメンバー)。同一ユーザーの再送 (冪等) もここに含む。
 // - invalid: 一致するコードが無い / 失効済み (= そのテキストはコードではなかった)。

--- a/src/features/settings/actions/update-location.ts
+++ b/src/features/settings/actions/update-location.ts
@@ -60,9 +60,28 @@ export async function updateLocation(
     return { error: '拠点名は100文字以内で入力してください' };
   }
 
+  // 監査で発見したギャップ対応: この編集フォームは常に現在値を全項目 defaultValue で
+  // 事前入力して丸ごと再送信する構成のため、読み取り時点の値を expected として渡し、
+  // 書き込み直前にも現在値が変わっていないことを保証する CAS にする
+  // (update-line-config.ts / update-sso-config.ts と同じ設計)。
+  const existing = await repos.locations.findById(locationId, tenantId);
+
   try {
     // tenantId をスコープに含めて更新 (他テナントの拠点を変更できないよう保護)
-    await repos.locations.update(locationId, tenantId, { name, description });
+    const updated = await repos.locations.update(
+      locationId,
+      tenantId,
+      { name, description },
+      existing ? { name: existing.name, description: existing.description } : undefined,
+    );
+    if (!updated) {
+      // 競合時もフォームの表示を最新化できるよう再レンダリングしておく
+      // (update-line-config.ts と同じ「エラー時に最新状態を取り直す」方針)
+      revalidatePath('/settings');
+      return {
+        error: '他の管理者による変更と競合しました。最新の設定を確認してから再度お試しください。',
+      };
+    }
     // 設定ページのキャッシュを無効化して更新結果がすぐ反映されるようにする
     revalidatePath('/settings');
 

--- a/src/features/settings/actions/update-sso-config.ts
+++ b/src/features/settings/actions/update-sso-config.ts
@@ -113,15 +113,41 @@ export async function updateSsoConfig(
     };
   }
 
+  // 監査で発見したギャップ対応: このフォームは常に現在値を全項目 defaultValue で事前入力して
+  // 丸ごと再送信する構成のため、読み取り時点の値を expected として渡し、書き込み直前にも
+  // 現在値が変わっていないことを保証する CAS にする (update-line-config.ts と同じ設計)。
+  // これが無いと、他の管理者が IdP 証明書をローテーションした直後にこのリクエストが割り込むと、
+  // 古い証明書のまま上書きしてローテーションを黙って巻き戻してしまう。
+  const existing = await repos.ssoConfigs.findByTenant(tenantId);
+
   try {
     // SSO 設定を upsert する (tenantId スコープで他テナントに影響しない)
-    await repos.ssoConfigs.upsert({
+    const updated = await repos.ssoConfigs.upsert({
       tenantId,
       enabled,
       idpEntityId,
       idpSsoUrl,
       idpX509Cert: cert,
+      // 既存設定がある場合のみ expected を渡す (新規作成時は比較対象が無いため無条件で作成する)
+      ...(existing
+        ? {
+            expected: {
+              enabled: existing.enabled,
+              idpEntityId: existing.idpEntityId,
+              idpSsoUrl: existing.idpSsoUrl,
+              idpX509Cert: existing.idpX509Cert,
+            },
+          }
+        : {}),
     });
+    if (!updated) {
+      // 競合時もフォームの表示を最新化できるよう再レンダリングしておく
+      // (update-line-config.ts と同じ「エラー時に最新状態を取り直す」方針)
+      revalidatePath('/settings');
+      return {
+        error: '他の管理者による変更と競合しました。最新の設定を確認してから再度お試しください。',
+      };
+    }
     // 設定ページのキャッシュを無効化して結果をすぐ反映する
     revalidatePath('/settings');
 

--- a/tests/data/location-repository.contract.prisma.test.ts
+++ b/tests/data/location-repository.contract.prisma.test.ts
@@ -155,8 +155,29 @@ describe.runIf(SHOULD_RUN)('LocationRepository (prisma adapter)', () => {
       name: '新名称',
       description: '新説明',
     });
-    expect(updated.name).toBe('新名称');
-    expect(updated.description).toBe('新説明');
+    // expected 未指定の無条件更新なので null にはならない
+    expect(updated?.name).toBe('新名称');
+    expect(updated?.description).toBe('新説明');
+  });
+
+  // 監査で発見したギャップ対応: expected (CAS) 指定時は、書き込み直前の現在値と一致する
+  // ときだけ更新され、一致しなければ null (競合) を返して上書きしないことを実 DB で確認する
+  it('expectedが現在値と食い違う場合は更新されずnullを返す (実DB)', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const location = await repos.locations.create({
+      tenantId: TENANT_A,
+      name: '現在の名前',
+      description: '現在の説明',
+    });
+    const result = await repos.locations.update(
+      location.id,
+      TENANT_A,
+      { name: '新しい名前', description: '新しい説明' },
+      { name: '食い違う古い名前', description: '現在の説明' },
+    );
+    expect(result).toBeNull();
+    const found = await repos.locations.findById(location.id, TENANT_A);
+    expect(found?.name).toBe('現在の名前');
   });
 
   // 他テナントの拠点 ID を更新しようとするとエラーになる (fail-closed)。

--- a/tests/data/location-repository.memory.test.ts
+++ b/tests/data/location-repository.memory.test.ts
@@ -173,8 +173,50 @@ describe('LocationRepository.update (memory)', () => {
       name: '新名称',
       description: '新説明',
     });
-    expect(updated.name).toBe('新名称');
-    expect(updated.description).toBe('新説明');
+    // expected 未指定の無条件更新なので null にはならない
+    expect(updated?.name).toBe('新名称');
+    expect(updated?.description).toBe('新説明');
+  });
+
+  // 監査で発見したギャップ対応: expected (CAS) 省略時は従来どおり無条件更新、
+  // expected 指定時は読み取り時点の値と一致するときだけ更新することを検証する
+  // (LineConfigRepository.upsert の同名テストと同じ設計)
+  it('expectedが現在値と一致しない場合は更新せずnullを返す', async () => {
+    const location = await repos.locations.create({
+      tenantId: TENANT_A,
+      name: '現在の名前',
+      description: '現在の説明',
+    });
+    // 誤った (古い) expected を渡して更新を試みる
+    const result = await repos.locations.update(
+      location.id,
+      TENANT_A,
+      { name: '新しい名前', description: '新しい説明' },
+      { name: '食い違う古い名前', description: '現在の説明' },
+    );
+    // 競合とみなされ null を返す
+    expect(result).toBeNull();
+    // 実際の値は上書きされていない
+    const found = await repos.locations.findById(location.id, TENANT_A);
+    expect(found?.name).toBe('現在の名前');
+  });
+
+  // expected が現在値と一致すれば更新される
+  it('expectedが現在値と一致すれば更新できる', async () => {
+    const location = await repos.locations.create({
+      tenantId: TENANT_A,
+      name: '現在の名前',
+      description: '現在の説明',
+    });
+    const result = await repos.locations.update(
+      location.id,
+      TENANT_A,
+      { name: '新しい名前', description: '新しい説明' },
+      { name: '現在の名前', description: '現在の説明' },
+    );
+    expect(result?.name).toBe('新しい名前');
+    const found = await repos.locations.findById(location.id, TENANT_A);
+    expect(found?.name).toBe('新しい名前');
   });
 
   // 他テナントの拠点 ID を更新しようとするとエラーになる (fail-closed)

--- a/tests/data/sso-config-repository.contract.prisma.test.ts
+++ b/tests/data/sso-config-repository.contract.prisma.test.ts
@@ -61,7 +61,7 @@ describe.runIf(SHOULD_RUN)('SsoConfigRepository (prisma adapter)', () => {
   it('upsert で作成し findByTenant で取得できる', async () => {
     const repos = buildPrismaRepos(prisma);
     const created = await repos.ssoConfigs.upsert(input(TENANT_A));
-    expect(created.tenantId).toBe(TENANT_A);
+    expect(created?.tenantId).toBe(TENANT_A);
     const found = await repos.ssoConfigs.findByTenant(TENANT_A);
     expect(found?.idpEntityId).toBe(`https://idp.example.com/${TENANT_A}`);
   });
@@ -72,8 +72,28 @@ describe.runIf(SHOULD_RUN)('SsoConfigRepository (prisma adapter)', () => {
     const first = await repos.ssoConfigs.upsert(input(TENANT_A, true));
     const second = await repos.ssoConfigs.upsert(input(TENANT_A, false));
     // 同一レコードの更新なので ID は不変、値だけ変わる
-    expect(second.id).toBe(first.id);
-    expect(second.enabled).toBe(false);
+    expect(second?.id).toBe(first?.id);
+    expect(second?.enabled).toBe(false);
+  });
+
+  // 監査で発見したギャップ対応: expected (CAS) 指定時は、書き込み直前の現在値と一致する
+  // ときだけ更新され、一致しなければ null (競合) を返して上書きしないことを実 DB で確認する
+  it('expectedが現在値と食い違う場合は更新されずnullを返す (実DB)', async () => {
+    const repos = buildPrismaRepos(prisma);
+    const current = await repos.ssoConfigs.upsert(input(TENANT_A, true));
+    if (!current) throw new Error('seed missing sso config');
+    const result = await repos.ssoConfigs.upsert({
+      ...input(TENANT_A, false),
+      expected: {
+        enabled: false, // 実際の現在値 (true) と食い違う誤った期待値
+        idpEntityId: current.idpEntityId,
+        idpSsoUrl: current.idpSsoUrl,
+        idpX509Cert: current.idpX509Cert,
+      },
+    });
+    expect(result).toBeNull();
+    const found = await repos.ssoConfigs.findByTenant(TENANT_A);
+    expect(found?.enabled).toBe(true);
   });
 
   // クロステナント分離: A の設定は B から取得・削除できない

--- a/tests/data/sso-config-repository.memory.test.ts
+++ b/tests/data/sso-config-repository.memory.test.ts
@@ -17,7 +17,10 @@ const TENANT_B = 'tenant-b';
 let repos: Repos;
 
 // SSO 設定の入力サンプルを作るヘルパー
-function sampleInput(tenantId: string, overrides: Partial<{ enabled: boolean; idpEntityId: string }> = {}) {
+function sampleInput(
+  tenantId: string,
+  overrides: Partial<{ enabled: boolean; idpEntityId: string }> = {},
+) {
   return {
     tenantId, // 所属テナント
     enabled: overrides.enabled ?? true, // 既定は有効
@@ -43,10 +46,10 @@ describe('SsoConfigRepository (memory)', () => {
   it('upsert で新規作成し findByTenant で取得できる', async () => {
     // 新規作成する
     const created = await repos.ssoConfigs.upsert(sampleInput(TENANT_A));
-    // 作成結果が入力どおりであること
-    expect(created.tenantId).toBe(TENANT_A);
-    expect(created.enabled).toBe(true);
-    expect(created.idpEntityId).toBe(`https://idp.example.com/${TENANT_A}`);
+    // 作成結果が入力どおりであること (expected 未指定の無条件 upsert なので null にはならない)
+    expect(created?.tenantId).toBe(TENANT_A);
+    expect(created?.enabled).toBe(true);
+    expect(created?.idpEntityId).toBe(`https://idp.example.com/${TENANT_A}`);
     // 取得しても同じ内容であること
     const found = await repos.ssoConfigs.findByTenant(TENANT_A);
     expect(found?.idpSsoUrl).toBe('https://idp.example.com/sso');
@@ -60,10 +63,10 @@ describe('SsoConfigRepository (memory)', () => {
     const second = await repos.ssoConfigs.upsert(
       sampleInput(TENANT_A, { enabled: false, idpEntityId: 'https://new-idp.example.com' }),
     );
-    // ID は維持され (同一レコードの更新)、値だけ変わる
-    expect(second.id).toBe(first.id);
-    expect(second.enabled).toBe(false);
-    expect(second.idpEntityId).toBe('https://new-idp.example.com');
+    // ID は維持され (同一レコードの更新)、値だけ変わる (どちらも expected 未指定の無条件 upsert)
+    expect(second?.id).toBe(first?.id);
+    expect(second?.enabled).toBe(false);
+    expect(second?.idpEntityId).toBe('https://new-idp.example.com');
     // 取得結果も更新後の値
     const found = await repos.ssoConfigs.findByTenant(TENANT_A);
     expect(found?.enabled).toBe(false);
@@ -76,6 +79,49 @@ describe('SsoConfigRepository (memory)', () => {
     await repos.ssoConfigs.delete(TENANT_A);
     // 削除後は null
     expect(await repos.ssoConfigs.findByTenant(TENANT_A)).toBeNull();
+  });
+
+  // 監査で発見したギャップ対応: expected (CAS) 省略時は従来どおり無条件更新、
+  // expected 指定時は読み取り時点の値と一致するときだけ更新することを検証する
+  // (LineConfigRepository.upsert の同名テストと同じ設計)
+  it('expectedが現在値と一致しない場合は更新せずnullを返す', async () => {
+    // 現在値を作成する
+    const current = await repos.ssoConfigs.upsert(sampleInput(TENANT_A, { enabled: true }));
+    // 誤った (古い) expected を渡して更新を試みる
+    const result = await repos.ssoConfigs.upsert({
+      ...sampleInput(TENANT_A, { enabled: false }),
+      expected: {
+        enabled: false, // 実際の現在値 (true) と食い違う誤った期待値
+        idpEntityId: current!.idpEntityId,
+        idpSsoUrl: current!.idpSsoUrl,
+        idpX509Cert: current!.idpX509Cert,
+      },
+    });
+    // 競合とみなされ null を返す
+    expect(result).toBeNull();
+    // 実際の値は上書きされていない
+    const found = await repos.ssoConfigs.findByTenant(TENANT_A);
+    expect(found?.enabled).toBe(true);
+  });
+
+  // expected が現在値と一致すれば更新される
+  it('expectedが現在値と一致すれば更新できる', async () => {
+    // 現在値を作成する
+    const current = await repos.ssoConfigs.upsert(sampleInput(TENANT_A, { enabled: true }));
+    // 正しい expected (現在値そのもの) を渡して更新する
+    const result = await repos.ssoConfigs.upsert({
+      ...sampleInput(TENANT_A, { enabled: false }),
+      expected: {
+        enabled: current!.enabled,
+        idpEntityId: current!.idpEntityId,
+        idpSsoUrl: current!.idpSsoUrl,
+        idpX509Cert: current!.idpX509Cert,
+      },
+    });
+    // 更新後の値が返る
+    expect(result?.enabled).toBe(false);
+    const found = await repos.ssoConfigs.findByTenant(TENANT_A);
+    expect(found?.enabled).toBe(false);
   });
 
   // クロステナント分離: テナント A の設定はテナント B から見えない

--- a/tests/data/user-repository.memory.test.ts
+++ b/tests/data/user-repository.memory.test.ts
@@ -9,6 +9,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createMemoryContext, type Store } from '@/data/adapters/memory';
 import type { Repos } from '@/data/ports/unit-of-work';
+import { USER_LIST_LIMIT } from '@/data/ports/user-repository';
 import { putUser } from './user-fixtures';
 
 const TENANT = 'default-tenant';
@@ -82,6 +83,22 @@ describe('UserRepository (memory)', () => {
 
     const agents = await repos.users.listAgents(TENANT);
     expect(agents.map((a) => a.id)).toEqual(['u-agent-a', 'u-agent-b']);
+  });
+
+  // 監査で発見したギャップ対応 (2026-07-20): listAgents/listByTenant/listAgentIds/
+  // listAgentEmails/listAdminEmails のいずれも上限が無かった (Enterprise はスタッフ数
+  // 無制限のため理論上ではなく実際に無制限件数を返しうる)。USER_LIST_LIMIT 件を超えて
+  // 作成しても USER_LIST_LIMIT 件までに切り詰められることを、代表として listAgents で確認する
+  // (Prisma アダプタの take と同じ挙動)
+  it('listAgentsはUSER_LIST_LIMIT件を超えて作成してもUSER_LIST_LIMIT件までに切り詰める', async () => {
+    for (let i = 0; i < USER_LIST_LIMIT + 3; i += 1) {
+      putUser(store, `u-agent-${i}`, TENANT, {
+        role: 'agent',
+        name: `agent${String(i).padStart(6, '0')}`,
+      });
+    }
+    const agents = await repos.users.listAgents(TENANT);
+    expect(agents).toHaveLength(USER_LIST_LIMIT);
   });
 
   // listByTenant: ロール問わず全ユーザーを名前順で返す (フォローアップ 2026-07-14:

--- a/tests/features/update-location.test.ts
+++ b/tests/features/update-location.test.ts
@@ -131,6 +131,35 @@ describe('updateLocation', () => {
     expect(result.error).toBe('拠点名は必須です');
   });
 
+  // フォローアップ (監査で発見したギャップ): この編集フォームは常に現在値を全項目
+  // defaultValue で事前入力して丸ごと再送信する構成のため、読み取り (existing) →検証→
+  // 無条件書き込みの check-then-act (TOCTOU) だった。他の管理者が並行して拠点名を
+  // 変更した直後にこのリクエストが割り込むと、古い値のまま上書きして変更を黙って
+  // 巻き戻してしまう。CAS 化により 0 件更新 (競合) を検知し、後勝ちで上書きしないことを
+  // 確認する (update-line-config.test.ts と同じ手法)
+  it('他の管理者による並行更新と競合すると保存されず、その値を上書きしない', async () => {
+    const location = await repos.locations.create({
+      tenantId: TENANT_ID,
+      name: '元の名前',
+      description: '元の説明',
+    });
+    const stale = await repos.locations.findById(location.id, TENANT_ID);
+    if (!stale) throw new Error('seed missing location');
+    // 並行更新を模す: 先に別の管理者が名前を変更したことにする
+    await repos.locations.update(location.id, TENANT_ID, { name: '並行更新後の名前' });
+    // findById だけが古いスナップショット (変更前) を返す状況を作る (TOCTOU の再現)
+    vi.spyOn(repos.locations, 'findById').mockResolvedValueOnce(stale);
+    const { updateLocation } = await import('@/features/settings/actions/update-location');
+    const result = await updateLocation(location.id, makeForm('このリクエストの新名称'));
+    expect(result.error).toBe(
+      '他の管理者による変更と競合しました。最新の設定を確認してから再度お試しください。',
+    );
+    expect(result.success).toBeUndefined();
+    // 並行更新後の値が上書きされずに残っている
+    const saved = await repos.locations.findById(location.id, TENANT_ID);
+    expect(saved?.name).toBe('並行更新後の名前');
+  });
+
   // レート制限: 60秒あたり10回を超える連打は拒否される
   it('60秒あたり10回を超える連打は拒否される', async () => {
     const location = await repos.locations.create({

--- a/tests/features/update-sso-config.test.ts
+++ b/tests/features/update-sso-config.test.ts
@@ -167,6 +167,41 @@ describe('updateSsoConfig', () => {
     expect(await repos.ssoConfigs.findByTenant(TENANT_ID)).toBeNull();
   });
 
+  // フォローアップ (監査で発見したギャップ): このフォームは常に現在値を全項目 defaultValue で
+  // 事前入力して丸ごと再送信する構成のため、読み取り (existing) →検証→無条件書き込みの
+  // check-then-act (TOCTOU) だった。他の管理者が IdP 証明書をローテーションした直後にこの
+  // リクエストが割り込むと、古い証明書のまま上書きしてローテーションを黙って巻き戻して
+  // しまう。CAS 化により 0 件更新 (競合) を検知し、後勝ちで上書きしないことを確認する
+  // (update-line-config.test.ts と同じ手法)
+  it('他の管理者による並行更新と競合すると保存されず、その値を上書きしない', async () => {
+    seedTenant('enterprise');
+    const { updateSsoConfig } = await import('@/features/settings/actions/update-sso-config');
+    // 1 回目: 通常どおり全項目を入力して作成 (これが「読み取り時点」の値になる)
+    await updateSsoConfig({}, makeForm({ enabled: true }));
+    const stale = await repos.ssoConfigs.findByTenant(TENANT_ID);
+    if (!stale) throw new Error('seed missing sso config');
+    // 並行更新を模す: 先に別の管理者が証明書をローテーションしたことにする
+    await repos.ssoConfigs.upsert({
+      tenantId: TENANT_ID,
+      enabled: true,
+      idpEntityId: stale.idpEntityId,
+      idpSsoUrl: stale.idpSsoUrl,
+      idpX509Cert: 'rotated-by-concurrent-admin-cert',
+    });
+    // findByTenant だけが古いスナップショット (ローテーション前) を返す状況を作る (TOCTOU の再現)
+    vi.spyOn(repos.ssoConfigs, 'findByTenant').mockResolvedValueOnce(stale);
+    // このリクエストは enabled だけ変更し、証明書等はフォームの defaultValue (古い値) のまま送信する
+    const result = await updateSsoConfig({}, makeForm({ enabled: false }));
+    expect(result.error).toBe(
+      '他の管理者による変更と競合しました。最新の設定を確認してから再度お試しください。',
+    );
+    expect(result.success).toBeUndefined();
+    // 並行更新 (ローテーション後) の値が上書きされずに残っている
+    const saved = await repos.ssoConfigs.findByTenant(TENANT_ID);
+    expect(saved?.idpX509Cert).toBe('rotated-by-concurrent-admin-cert');
+    expect(saved?.enabled).toBe(true);
+  });
+
   // レート制限: 60秒あたり10回を超える連打は拒否される (delete-sso-config.ts と共有)
   it('60秒あたり10回を超える連打は拒否される', async () => {
     seedTenant('enterprise');


### PR DESCRIPTION
## 対応する Phase / 項目

`docs/smb-dx-pivot-plan.md` の全チェック項目は既に完了済みのため、既存の「フォローアップ」運用
（実装済み機能をコードベース監査で再点検し、見つかったギャップを埋める）に基づく修正です。
本 PR で計画書に **§4.23** として追記しています。

## Context

コードベース監査で、実装済み機能の一部が全箇所に一貫して適用されていないギャップを 3 件
特定・修正しました。

## 変更内容

### 1. `updateSsoConfig` の TOCTOU (check-then-act) を解消

`§4.19`/`§4.20` で `updateNotificationChannels` / `update-line-config.ts` に導入した CAS
(compare-and-swap) パターンが、同じ「読み取り→検証→無条件書き込み」構成を持つ
`updateSsoConfig`（`src/features/settings/actions/update-sso-config.ts`）には未適用でした。
SSO 設定フォームは全項目を毎回 `defaultValue` で事前入力して丸ごと再送信する構成のため、
他の管理者が IdP 証明書をローテーションした直後にこのリクエストが割り込むと、認証の信頼
アンカーである証明書が古い値のまま黙って上書きされる恐れがありました。
`SsoConfigRepository.upsert` に `expected`（読み取り時点の値）を追加し、CAS 化しました。

### 2. `UserRepository` の一覧系メソッドに上限が無かった

`listAgents` / `listByTenant` / `listAgentIds` / `listAgentEmails` / `listAdminEmails` に
上限が無く、`USER_LIMIT.enterprise = Infinity`（`src/lib/plan-guard.ts`）により Enterprise
プランでは実際に無制限件数を返しうる状態でした。担当者プルダウン・CSV インポートの名前解決・
エスカレーション一斉メールなど高頻度に呼ばれる経路が対象です。単一の上限 `USER_LIST_LIMIT`
(10,000) を追加し、Prisma/メモリ両アダプタで切り詰めるようにしました。

### 3. `updateLocation` にも同種の TOCTOU

拠点編集フォームも同じ「全項目事前入力→丸ごと再送信」構成のため、同じ CAS パターンを
`LocationRepository.update` に追加しました。

## 再利用した既存実装

- CAS: 既存の `LineConfigRepository.upsert` / `updateNotificationChannels` の `expected`
  パターンをそのまま踏襲。新しい仕組みは追加していません。
- 上限: 既存の `LOCATION_LIST_LIMIT` 系と同じ規模・設計思想を踏襲。

## 検証方法

- `npm run typecheck` — 通過
- `npm run lint` — 通過
- `npm run test` — 1134 tests 全通過（新規追加分含む）
  - `tests/features/update-sso-config.test.ts` / `tests/data/sso-config-repository.{memory,contract.prisma}.test.ts`: CAS 競合の回帰テスト
  - `tests/data/user-repository.memory.test.ts`: `USER_LIST_LIMIT` 超過時の切り詰めテスト
  - `tests/features/update-location.test.ts` / `tests/data/location-repository.{memory,contract.prisma}.test.ts`: CAS 競合の回帰テスト

E2E (`npm run test:e2e`) は dev サーバー起動を要するため未実行です。ロジックは既存の単体テストパターンに沿った回帰テストでカバーしています。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGQTTLx7yRTq4iSBdj2dLh)_