### PR TITLE
fix(email,notifications): 定数時間比較の自前実装解消とNotificationRepository一覧の上限漏れを解消

### DIFF
--- a/docs/smb-dx-pivot-plan.md
+++ b/docs/smb-dx-pivot-plan.md
@@ -1530,6 +1530,34 @@ complete-signup.ts`）だけは対象から漏れていた。`requestSignup`・`
   .test.ts` に、それぞれ CAS の競合再現（`findByTenant`/`findById` だけ古いスナップショットを
   返すよう一時的にモックする、§4.13 以来の手法）と上限切り詰めの回帰テストを追加した。
 
+#### 4.24 フォローアップ（2026-07-20 #3）: メール取り込みの定数時間比較が自前実装のまま・NotificationRepository.list が呼び出し側の limit を無条件に信頼していた
+
+コードベース監査で発見した 2 件のギャップの修正。ここまでの §4.21〜§4.23 で見つかった規模の
+ギャップと比べると影響は小さいが、同種の「兄弟には適用済みの対策が 1 箇所だけ漏れている」形の
+不整合であるため合わせて修正する。
+
+- **メール取り込み Webhook の共有シークレット比較が自前実装のままだった**:
+  `src/lib/timing-safe-compare.ts` の `constantTimeStringEqual` は、まさに LINE Webhook 署名
+  検証と内部 cron (trial-reminders/sla-reminders) の Bearer トークン検証で同じ「長さチェック→
+  `timingSafeEqual`」イディオムが複製されていたことを解消するために切り出された共通ヘルパーだが、
+  `POST /api/inbound/email`（`src/app/api/inbound/email/route.ts`）だけは `secretsMatch` という
+  同一ロジックの自前実装を使い続けていた。挙動そのものは今日時点で定数時間比較として正しく、
+  実害のある脆弱性ではないが、共通ヘルパーが解消しようとした「将来どちらか一方だけ書き換えられて
+  実装が乖離する」保守リスクをこの 1 箇所だけ再導入していた。`secretsMatch` を削除し
+  `constantTimeStringEqual` の呼び出しに置き換えた。
+- **`NotificationRepository.list` が呼び出し側の `limit` を無条件に信頼していた**:
+  `FaqRepository` / `LocationRepository` / `CategoryRepository` / `UserRepository`（§4.23）は
+  いずれもアダプタ自身が呼び出し側の `limit` をクランプし、クエリ自体が有界であることをアダプタが
+  保証する規約になっているが、`NotificationRepository.list` だけはこの規約から外れ、渡された
+  `limit` をそのまま `take`/`slice` に使っていた。現状の唯一の呼び出し元 (`/notifications` 画面)
+  は常に固定値 50 を渡すため実害は無いが、他の一覧系リポジトリと同じ「アダプタが自身の上限を
+  保証する」多層防御に揃えるため、`NOTIFICATION_LIST_MAX_LIMIT`（200。表示用途のため
+  `LOCATION_LIST_LIMIT` 等と同規模）を追加し、Prisma/メモリ両アダプタで `Math.min(limit, ...)`
+  によりクランプするようにした。
+- 回帰テスト: `tests/data/notification-repository.contract.ts`（memory/Prisma 両アダプタで共有する
+  契約テスト）に、`NOTIFICATION_LIST_MAX_LIMIT` を超える `limit` を指定してもクランプされることの
+  回帰テストを追加した。
+
 ### スケジュール感
 
 ```

--- a/src/app/api/inbound/email/route.ts
+++ b/src/app/api/inbound/email/route.ts
@@ -16,10 +16,12 @@
 
 // JSON レスポンスヘルパー
 import { NextResponse } from 'next/server';
-// 共有シークレットの定数時間比較に使う (Node ランタイム前提のルート)
-import { timingSafeEqual } from 'node:crypto';
 // ページキャッシュ無効化 (スレッド継続でコメント追記したチケット詳細を再描画させる)
 import { revalidatePath } from 'next/cache';
+// 監査で発見したギャップ対応: 共有シークレットの定数時間比較は LINE Webhook / 内部 cron
+// エンドポイント (trial-reminders / sla-reminders) と同じ共通ヘルパーを使う (§6 DRY。
+// このルートだけ timingSafeEqual を直接使った自前実装が残っていた)
+import { constantTimeStringEqual } from '@/lib/timing-safe-compare';
 // データ層 (テナント / ユーザー / チケットのリポジトリ束 + トランザクション境界)
 import { repos, uow } from '@/data';
 // Webhook 再送に対する冪等起票の共通ヘルパー (LINE/メールで共有)。フォローアップ (2026-07-13):
@@ -103,17 +105,6 @@ class BodyTooLargeError extends Error {
     // (RateLimitError が this.name を設定しているのと同じ理由 - src/lib/rate-limit.ts:37 参照)
     this.name = 'BodyTooLargeError';
   }
-}
-
-// 2 つのシークレット文字列を定数時間で比較する (タイミング攻撃対策)。
-// 長さが違う場合は早期 false (情報量は長さのみで実用上問題なし)。
-function secretsMatch(provided: string, expected: string): boolean {
-  // バイト列化して長さ比較 (長さが違えば timingSafeEqual が例外を投げるため先に弾く)
-  const a = Buffer.from(provided);
-  const b = Buffer.from(expected);
-  if (a.length !== b.length) return false;
-  // 同じ長さなら定数時間比較する
-  return timingSafeEqual(a, b);
 }
 
 // リクエストから提示されたシークレットを取り出す。
@@ -381,7 +372,7 @@ export async function POST(req: Request) {
 
   // 提示されたシークレットを取り出して定数時間比較する (ヘッダのみ受け付ける)
   const provided = readProvidedSecret(req);
-  if (!provided || !secretsMatch(provided, expectedSecret)) {
+  if (!provided || !constantTimeStringEqual(provided, expectedSecret)) {
     // 不一致は 401 (なりすまし POST を拒否)
     return NextResponse.json({ error: '認証に失敗しました' }, { status: 401 });
   }

--- a/src/data/adapters/memory/notification-repository.memory.ts
+++ b/src/data/adapters/memory/notification-repository.memory.ts
@@ -1,7 +1,8 @@
-// 通知リポジトリの契約 (port) とドメイン型、ストア関連をインポート
-import type {
-  NotificationListItem,
-  NotificationRepository,
+// 通知リポジトリの契約 (port)・上限クランプ定数とドメイン型、ストア関連をインポート
+import {
+  NOTIFICATION_LIST_MAX_LIMIT,
+  type NotificationListItem,
+  type NotificationRepository,
 } from '@/data/ports/notification-repository';
 import type { Notification } from '@/domain/types';
 import { nextId, type Store } from './store';
@@ -41,11 +42,13 @@ export function makeNotificationRepo(store: Store): NotificationRepository {
     },
 
     // 指定ユーザーの通知を新しい順に limit 件取得 (関連チケット付き、tenantId スコープ)
+    // 監査で発見したギャップ対応: 呼び出し側の limit をそのまま信頼せず、
+    // NOTIFICATION_LIST_MAX_LIMIT を超えないようクランプする (Prisma アダプタの take と揃える)
     async list(userId, { limit }, tenantId) {
       const rows = [...store.notifications.values()] // 全通知を配列化
         .filter((n) => n.tenantId === tenantId && n.userId === userId) // テナント + ユーザー
         .sort((a, b) => +b.createdAt - +a.createdAt) // 新しい順にソート
-        .slice(0, limit); // 先頭 limit 件に切る
+        .slice(0, Math.min(limit, NOTIFICATION_LIST_MAX_LIMIT)); // 先頭 limit 件 (クランプ済み) に切る
       // 各通知に関連チケットの要約を結合して返す
       return rows.map<NotificationListItem>((n) => {
         const ticket = n.ticketId ? (store.tickets.get(n.ticketId) ?? null) : null; // 関連チケット取得

--- a/src/data/adapters/prisma/notification-repository.prisma.ts
+++ b/src/data/adapters/prisma/notification-repository.prisma.ts
@@ -1,7 +1,8 @@
-// 通知リポジトリの契約 (port)、マッパー、Prisma 共通型をインポート
-import type {
-  NotificationListItem,
-  NotificationRepository,
+// 通知リポジトリの契約 (port)・上限クランプ定数、マッパー、Prisma 共通型をインポート
+import {
+  NOTIFICATION_LIST_MAX_LIMIT,
+  type NotificationListItem,
+  type NotificationRepository,
 } from '@/data/ports/notification-repository';
 import { toNotification } from './mappers';
 import type { PrismaLike } from './types';
@@ -29,12 +30,14 @@ export function makeNotificationRepo(db: PrismaLike): NotificationRepository {
       return db.notification.count({ where: { tenantId, userId, read: false } });
     },
 
-    // 指定ユーザーの通知を新しい順に limit 件取得 (関連チケット付き、tenantId スコープ)
+    // 指定ユーザーの通知を新しい順に limit 件取得 (関連チケット付き、tenantId スコープ)。
+    // 監査で発見したギャップ対応: 呼び出し側の limit をそのまま信頼せず、
+    // NOTIFICATION_LIST_MAX_LIMIT を超えないようクランプする (§8 一覧取得は必ず上限を持たせる)
     async list(userId, { limit }, tenantId) {
       const rows = await db.notification.findMany({
         where: { tenantId, userId }, // テナント + ユーザーで絞る
         orderBy: { createdAt: 'desc' }, // 新しい順
-        take: limit, // 件数上限
+        take: Math.min(limit, NOTIFICATION_LIST_MAX_LIMIT), // 件数上限 (呼び出し側の指定値をクランプ)
         include: { ticket: { select: { id: true, title: true } } }, // 関連チケットを JOIN
       });
       // NotificationListItem 形式に整形して返す

--- a/src/data/ports/notification-repository.ts
+++ b/src/data/ports/notification-repository.ts
@@ -1,6 +1,16 @@
 // ドメイン型 (通知本体/種別) をインポート
 import type { Notification, NotificationType } from '@/domain/types';
 
+// 監査で発見したギャップ対応 (2026-07-20): 他の一覧系リポジトリ (FaqRepository /
+// LocationRepository / CategoryRepository / UserRepository) はいずれもアダプタ自身が
+// 呼び出し側の limit をクランプするため、呼び出し元が誤って大きな値を渡してもクエリ自体は
+// 有界のままになる。NotificationRepository.list だけは limit を無条件に信頼しており
+// (現状は唯一の呼び出し元 `/notifications` が常に 50 を渡すため実害はないが)、
+// このリポジトリだけが「アダプタが自身の上限を保証する」という規約から外れていた。
+// 表示用の一覧 (件数無制限の一括処理用途は無い) なので、他の表示用上限
+// (LOCATION_LIST_LIMIT/CATEGORY_LIST_LIMIT = 200) と同じ規模のクランプ値を設ける
+export const NOTIFICATION_LIST_MAX_LIMIT = 200;
+
 // 通知を作成するときに渡す入力値
 export interface CreateNotificationInput {
   userId: string; // 受信者 ID
@@ -23,10 +33,6 @@ export interface NotificationListItem extends Notification {
 export interface NotificationRepository {
   create(input: CreateNotificationInput): Promise<Notification>; // 通知を 1 件作成 (input.tenantId 必須)
   countUnread(userId: string, tenantId: string): Promise<number>; // 未読件数を取得
-  list(
-    userId: string,
-    opts: { limit: number },
-    tenantId: string,
-  ): Promise<NotificationListItem[]>; // 一覧取得
+  list(userId: string, opts: { limit: number }, tenantId: string): Promise<NotificationListItem[]>; // 一覧取得
   markAllRead(userId: string, tenantId: string): Promise<void>; // 全通知を既読にする (ユーザー + テナントスコープ)
 }

--- a/tests/data/notification-repository.contract.ts
+++ b/tests/data/notification-repository.contract.ts
@@ -12,8 +12,11 @@
 
 // Vitest のテスト DSL (describe=グループ, it=ケース, beforeEach=前処理, expect=検証)
 import { describe, expect, it, beforeEach } from 'vitest';
-// 検証対象である通知リポジトリの契約 (port) 型
-import type { NotificationRepository } from '@/data/ports/notification-repository';
+// 検証対象である通知リポジトリの契約 (port) 型・上限クランプ定数
+import {
+  NOTIFICATION_LIST_MAX_LIMIT,
+  type NotificationRepository,
+} from '@/data/ports/notification-repository';
 
 // 契約テストが利用する文脈 (アダプタ別に差し替え可能)
 export interface NotificationContractContext {
@@ -112,6 +115,30 @@ export function runNotificationRepositoryContract(
 
       // テナント B には userA の通知が存在しないので、A 側の通知は未読のまま残る
       expect(await ctx.repo.countUnread(userAId, tenantA)).toBe(1);
+    });
+
+    // 監査で発見したギャップ対応: 呼び出し側が NOTIFICATION_LIST_MAX_LIMIT を超える limit を
+    // 渡しても、アダプタ自身が上限でクランプすること (§8 一覧取得は必ず上限を持たせる。
+    // 他の一覧系リポジトリと同じくアダプタが自身の上限を保証する規約に揃える)
+    it('list clamps the caller-provided limit to NOTIFICATION_LIST_MAX_LIMIT', async () => {
+      // テナント A とそのユーザーを用意する
+      const { tenantA, userAId } = await ctx.seedTwoTenants();
+      // 上限を超える件数の通知を作成する
+      for (let i = 0; i < NOTIFICATION_LIST_MAX_LIMIT + 3; i += 1) {
+        await ctx.repo.create({
+          userId: userAId,
+          type: 'assigned',
+          message: `通知${i}`,
+          tenantId: tenantA,
+        });
+      }
+      // 上限を大きく超える limit を指定しても、NOTIFICATION_LIST_MAX_LIMIT 件までに切り詰められる
+      const listed = await ctx.repo.list(
+        userAId,
+        { limit: NOTIFICATION_LIST_MAX_LIMIT + 1000 },
+        tenantA,
+      );
+      expect(listed).toHaveLength(NOTIFICATION_LIST_MAX_LIMIT);
     });
   });
 }


### PR DESCRIPTION
## 対応する Phase / 項目

`docs/smb-dx-pivot-plan.md` の全チェック項目は完了済みのため、既存の「フォローアップ」運用
（実装済み機能をコードベース監査で再点検し、見つかったギャップを埋める）に基づく修正です。
本 PR で計画書に **§4.24** として追記しています。

## Context

§4.21〜§4.23 までの規模と比べると影響は小さいですが、同種の「兄弟には適用済みの対策が
1 箇所だけ漏れている」形の不整合を 2 件見つけたため合わせて修正しました。

## 変更内容

### 1. メール取り込み Webhook の共有シークレット比較が自前実装のままだった

`src/lib/timing-safe-compare.ts` の `constantTimeStringEqual` は LINE Webhook 署名検証・
内部 cron の Bearer トークン検証で重複していた「長さチェック→`timingSafeEqual`」を集約した
共通ヘルパーですが、`POST /api/inbound/email` だけは `secretsMatch` という同一ロジックの
自前実装を使い続けていました。挙動自体は正しく実害のある脆弱性ではありませんが、共通ヘルパーが
解消しようとした保守リスク（将来どちらかだけ書き換えられて乖離する）を再導入していたため、
`constantTimeStringEqual` の呼び出しに置き換えました。

### 2. `NotificationRepository.list` が呼び出し側の `limit` を無条件に信頼していた

`FaqRepository` / `LocationRepository` / `CategoryRepository` / `UserRepository`（§4.23）は
アダプタ自身が `limit` をクランプする規約ですが、`NotificationRepository.list` だけはこの
規約から外れていました。現状唯一の呼び出し元は固定値 50 を渡すため実害はありませんが、
他のリポジトリと同じ多層防御に揃えるため `NOTIFICATION_LIST_MAX_LIMIT`（200）でクランプする
ようにしました。

## 再利用した既存実装

- 定数時間比較: 既存の `constantTimeStringEqual`（`src/lib/timing-safe-compare.ts`）をそのまま利用。
- 上限クランプ: 既存の `LOCATION_LIST_LIMIT` 等と同じ設計思想・規模を踏襲。

## 検証方法

- `npm run typecheck` — 通過
- `npm run lint` — 通過
- `npm run test` — 1135 tests 全通過（新規追加分含む）
  - `tests/data/notification-repository.contract.ts`（memory/Prisma 共有契約テスト）: `NOTIFICATION_LIST_MAX_LIMIT` 超過時のクランプ回帰テストを追加

E2E (`npm run test:e2e`) は dev サーバー起動を要するため未実行です。ロジックは既存の単体テストパターンに沿った回帰テストでカバーしています。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGQTTLx7yRTq4iSBdj2dLh)_