### PR TITLE
fix(data): 通知作成時に親チケットのテナント整合を検証しfail-closedに統一

### DIFF
--- a/src/data/adapters/memory/notification-repository.memory.ts
+++ b/src/data/adapters/memory/notification-repository.memory.ts
@@ -11,6 +11,17 @@ export function makeNotificationRepo(store: Store): NotificationRepository {
   return {
     // 通知を 1 件作成してストアに登録
     async create(input) {
+      // 関連チケットが指定されている場合のみ、そのチケットが指定テナントに属することを検証する。
+      // Prisma 実装 (コメント Adapter の issue #123 と同じパターン) に合わせ、
+      // 他テナントのチケットに紐づく通知の作成を fail-closed で防ぐ。
+      if (input.ticketId) {
+        // ストアから親チケットを取得する (無ければ undefined)
+        const parent = store.tickets.get(input.ticketId);
+        // 親チケットが無い、または別テナントなら作成を拒否する
+        if (!parent || parent.tenantId !== input.tenantId) {
+          throw new Error('チケットが見つかりません');
+        }
+      }
       // 新しい通知行を組み立てる (read は false で開始)
       const notification: Notification = {
         id: nextId(store, 'ntf'), // 'ntf_...' 形式の一意 ID

--- a/src/data/adapters/prisma/notification-repository.prisma.ts
+++ b/src/data/adapters/prisma/notification-repository.prisma.ts
@@ -11,6 +11,21 @@ export function makeNotificationRepo(db: PrismaLike): NotificationRepository {
   return {
     // 通知を 1 件作成してドメイン型に変換して返す
     async create(input) {
+      // 関連チケットが指定されている場合のみ、そのチケットが指定テナントに属することを検証する。
+      // コメント Adapter (issue #123) と同じ fail-closed パターン: 呼び出し側が tenant スコープの
+      // 取得を忘れても、他テナントのチケットに紐づく通知は作れないよう Adapter 側で拒否する。
+      // (ticketId が無いチケット非関連の通知はこの検証をスキップする)
+      if (input.ticketId) {
+        // 親チケットをテナントスコープ付きで検索する
+        const parent = await db.ticket.findFirst({
+          where: { id: input.ticketId, tenantId: input.tenantId }, // チケット ID + テナントの AND 一致
+          select: { id: true }, // 存在確認だけなので id のみ取得
+        });
+        // 親チケットが無い (= 別テナント or 不在) なら作成を拒否する
+        if (!parent) {
+          throw new Error('チケットが見つかりません');
+        }
+      }
       const row = await db.notification.create({
         data: {
           userId: input.userId, // 受信者

--- a/src/data/ports/notification-repository.ts
+++ b/src/data/ports/notification-repository.ts
@@ -21,7 +21,11 @@ export interface NotificationListItem extends Notification {
 // markAllRead も tenantId 必須でクロステナント既読化を防ぐ
 // (userId を偽装されても他テナント由来の通知まで既読にできないようにする)。
 export interface NotificationRepository {
-  create(input: CreateNotificationInput): Promise<Notification>; // 通知を 1 件作成 (input.tenantId 必須)
+  // 通知を 1 件作成 (input.tenantId 必須)。
+  // input.ticketId が指定されている場合、そのチケットが input.tenantId に属さなければ
+  // fail-closed でエラーにする (コメント Adapter の issue #123 と同じ多層防御)。
+  // ticketId 無し (チケット非関連の通知) はこの検証をスキップする。
+  create(input: CreateNotificationInput): Promise<Notification>;
   countUnread(userId: string, tenantId: string): Promise<number>; // 未読件数を取得
   list(
     userId: string,

--- a/tests/data/cross-tenant-create.test.ts
+++ b/tests/data/cross-tenant-create.test.ts
@@ -1,6 +1,7 @@
 // クロステナント作成拒否の単体テスト (issue #123)。
-// コメント / 添付の create Adapter が「親チケットのテナント一致」を fail-closed で
+// コメント / 添付 / 通知の create Adapter が「親チケットのテナント一致」を fail-closed で
 // 検証することを確認する。呼び出し側の tenant チェック漏れに対する多層防御の最終段。
+// (通知は ticketId が任意のため、指定されたときだけ検証しチケット非関連の通知は素通しする)
 
 // Vitest の DSL とフック
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -115,6 +116,69 @@ describe('cross-tenant create guards (#123)', () => {
         ticketId: 'no-such-ticket',
         authorId: USER_A,
         body: '宛先なし',
+        tenantId: TENANT_A,
+      }),
+    ).rejects.toThrow(/チケットが見つかりません/);
+  });
+
+  // ticketId 無し (チケット非関連) の通知はテナント検証をスキップして作成できる
+  it('allows creating a notification without a ticketId', async () => {
+    // テナント A のシードを済ませる (チケットは使わない)
+    await seed();
+    // ticketId を指定せずに通知を作成 → 成功する
+    const notification = await repos.notifications.create({
+      userId: USER_A,
+      type: 'assigned',
+      message: 'チケット非関連の通知',
+      tenantId: TENANT_A,
+    });
+    // 関連チケットは null のまま保存されること
+    expect(notification.ticketId).toBeNull();
+  });
+
+  // 同テナントのチケットに紐づく通知は作成できる
+  it('allows creating a notification linked to a same-tenant ticket', async () => {
+    // テナント A のチケットを用意する
+    const ticketId = await seed();
+    // 同じテナント A 指定でチケット紐づき通知を作成 → 成功する
+    const notification = await repos.notifications.create({
+      userId: USER_A,
+      type: 'commented',
+      message: 'コメントが追加されました',
+      ticketId,
+      tenantId: TENANT_A,
+    });
+    // 作成された通知が対象チケットに紐づくこと
+    expect(notification.ticketId).toBe(ticketId);
+  });
+
+  // 別テナント指定のチケット紐づき通知は拒否される
+  it('rejects creating a notification linked to a ticket of another tenant', async () => {
+    // テナント A のチケットを用意する
+    const ticketId = await seed();
+    // テナント B を名乗ってテナント A のチケットに紐づく通知を作成 → 拒否される
+    await expect(
+      repos.notifications.create({
+        userId: USER_A,
+        type: 'commented',
+        message: '侵入',
+        ticketId,
+        tenantId: TENANT_B,
+      }),
+    ).rejects.toThrow(/チケットが見つかりません/);
+  });
+
+  // 存在しないチケット ID に紐づく通知作成も拒否される
+  it('rejects creating a notification linked to a non-existent ticket', async () => {
+    // テナント A を用意する (チケットは存在しない ID を指定)
+    await seed();
+    // 実在しないチケット ID に紐づく通知を作成 → 拒否される
+    await expect(
+      repos.notifications.create({
+        userId: USER_A,
+        type: 'commented',
+        message: '宛先なし',
+        ticketId: 'no-such-ticket',
         tenantId: TENANT_A,
       }),
     ).rejects.toThrow(/チケットが見つかりません/);

--- a/tests/data/notification-repository.contract.prisma.test.ts
+++ b/tests/data/notification-repository.contract.prisma.test.ts
@@ -89,8 +89,25 @@ describe.runIf(SHOULD_RUN)('prisma adapter', () => {
       return { tenantA: TENANT_A, tenantB: TENANT_B, userAId, userBId };
     };
 
+    // 指定テナント・指定起票者でチケットを 1 件作り、その ID を返すシード
+    // (create のクロステナント fail-closed 検証で使用)
+    const seedTicket: NotificationContractContext['seedTicket'] = async (tenantId, creatorId) => {
+      // 本番と同じチケットリポジトリ経由でテスト用チケットを 1 件作成する
+      const ticket = await repos.tickets.create({
+        title: '契約テスト用チケット', // 件名 (テスト用ダミー)
+        body: '本文', // 本文 (テスト用ダミー)
+        priority: 'Medium', // 優先度は既定の Medium
+        creatorId, // 起票者
+        categoryId: null, // カテゴリ未分類
+        locationId: null, // 拠点未指定
+        tenantId, // 所属テナント
+      });
+      // 後続のテストが参照するチケット ID を返す
+      return ticket.id;
+    };
+
     // 組み立てた repos とシード関数を契約コンテキストとして返す
-    return { repo: repos.notifications, seedTwoTenants };
+    return { repo: repos.notifications, seedTwoTenants, seedTicket };
   }
 
   // memory 版と同一の契約スイートを Prisma 実装に対して実行する

--- a/tests/data/notification-repository.contract.test.ts
+++ b/tests/data/notification-repository.contract.test.ts
@@ -73,8 +73,24 @@ function makeMemoryContext(): NotificationContractContext {
     return { tenantA: TENANT_A, tenantB: TENANT_B, userAId, userBId };
   };
 
+  // 指定テナント・指定起票者でチケットを 1 件作り、その ID を返すシード
+  // (create のクロステナント fail-closed 検証で使用)
+  const seedTicket: NotificationContractContext['seedTicket'] = async (tenantId, creatorId) => {
+    // チケットリポジトリ経由でテスト用チケットを 1 件作成する
+    const ticket = await repos.tickets.create({
+      title: '契約テスト用チケット', // 件名 (テスト用ダミー)
+      body: '本文', // 本文 (テスト用ダミー)
+      priority: 'Medium', // 優先度は既定の Medium
+      creatorId, // 起票者
+      categoryId: null, // カテゴリ未分類
+      tenantId, // 所属テナント
+    });
+    // 後続のテストが参照するチケット ID を返す
+    return ticket.id;
+  };
+
   // 検証対象の通知リポジトリとシード関数を文脈として返す
-  return { repo: repos.notifications, seedTwoTenants };
+  return { repo: repos.notifications, seedTwoTenants, seedTicket };
 }
 
 // メモリアダプタが NotificationRepository 契約を満たしているかを実行する

--- a/tests/data/notification-repository.contract.ts
+++ b/tests/data/notification-repository.contract.ts
@@ -27,6 +27,9 @@ export interface NotificationContractContext {
     userAId: string; // テナント A に属するユーザー ID
     userBId: string; // テナント B に属するユーザー ID
   }>;
+  // 指定テナント・指定起票者でチケットを 1 件作り、その ID を返すシード
+  // (create のクロステナント fail-closed 検証に使う。seedTwoTenants の後に呼ぶこと)
+  seedTicket: (tenantId: string, creatorId: string) => Promise<string>;
 }
 
 // アダプタごとに渡される文脈で同一テストを実行する関数
@@ -112,6 +115,61 @@ export function runNotificationRepositoryContract(
 
       // テナント B には userA の通知が存在しないので、A 側の通知は未読のまま残る
       expect(await ctx.repo.countUnread(userAId, tenantA)).toBe(1);
+    });
+
+    // 関連チケットが同一テナントに属する場合は、ticketId 付きの通知を作成できること (正常系)
+    it('create accepts a ticketId that belongs to the same tenant', async () => {
+      // テナント A / B と各ユーザーを用意する
+      const { tenantA, userAId } = await ctx.seedTwoTenants();
+      // テナント A にチケットを 1 件作成する
+      const ticketId = await ctx.seedTicket(tenantA, userAId);
+      // 同じテナント A のチケットに紐づく通知を作成する → 成功する
+      const created = await ctx.repo.create({
+        userId: userAId,
+        type: 'commented',
+        message: 'チケットにコメントが追加されました',
+        ticketId,
+        tenantId: tenantA,
+      });
+      // 作成された通知が対象チケットに紐づいていること
+      expect(created.ticketId).toBe(ticketId);
+    });
+
+    // 関連チケットが別テナントに属する場合、create が fail-closed で拒否すること
+    // (コメント Adapter の issue #123 と同じ多層防御をアダプタ側で強制する回帰テスト)
+    it('create rejects a ticketId that belongs to another tenant', async () => {
+      // テナント A / B と各ユーザーを用意する
+      const { tenantA, tenantB, userAId, userBId } = await ctx.seedTwoTenants();
+      // テナント A にチケットを 1 件作成する
+      const ticketId = await ctx.seedTicket(tenantA, userAId);
+      // 攻撃想定: テナント B を名乗ってテナント A のチケットに紐づく通知を作ろうとする → 拒否される
+      await expect(
+        ctx.repo.create({
+          userId: userBId,
+          type: 'commented',
+          message: '侵入',
+          ticketId,
+          tenantId: tenantB,
+        }),
+      ).rejects.toThrow(/チケットが見つかりません/);
+      // 拒否された結果、テナント B 側に通知行は 1 件も作られていないこと
+      expect(await ctx.repo.countUnread(userBId, tenantB)).toBe(0);
+    });
+
+    // 存在しないチケット ID を指定した create も fail-closed で拒否すること
+    it('create rejects a non-existent ticketId', async () => {
+      // テナント A / B と各ユーザーを用意する
+      const { tenantA, userAId } = await ctx.seedTwoTenants();
+      // 実在しないチケット ID に紐づく通知を作ろうとする → 拒否される
+      await expect(
+        ctx.repo.create({
+          userId: userAId,
+          type: 'commented',
+          message: '宛先なし',
+          ticketId: 'no-such-ticket',
+          tenantId: tenantA,
+        }),
+      ).rejects.toThrow(/チケットが見つかりません/);
     });
   });
 }


### PR DESCRIPTION
## 概要

コードベース横断のセキュリティ・アーキテクチャレビューで検出した、多層防御の非対称を解消します。

`notification-repository.prisma.ts` の `create()` は `input.tenantId` / `input.ticketId` をそのまま保存しており、コメントアダプタ（issue #123 で導入済みの親チケットテナント不一致 fail-closed チェック）と防御レベルが揃っていませんでした。現状の呼び出し側はすべてテナントスコープ済みのため実害はありませんが（読み取りも `(userId, tenantId)` で常にフィルタ）、Adapter 層の fail-closed 契約を通知にも統一します。

## 変更内容

- **Prisma アダプタ**: `create()` で `input.ticketId` 指定時のみ `ticket.findFirst({ where: { id, tenantId }, select: { id: true } })` で親チケットのテナント一致を検証し、不在・別テナントなら `throw new Error('チケットが見つかりません')`（コメントアダプタと同一文言・同一パターン）。`ticketId` 無し（チケット非関連の通知）は従来どおりスキップし、既存呼び出し側の契約は不変。
- **memory アダプタ**: 同一検証を追加（テスト用アダプタの挙動一致）。
- **port**: `create()` の fail-closed 契約をコメントで明文化（型シグネチャ不変）。
- **テスト**: 共有契約に 3 ケース追加（同テナント成功／別テナント拒否＋行未作成／不在チケット拒否）を memory・Prisma 両コンテキストで実施、`cross-tenant-create.test.ts` に通知 4 ケース追加。

## 検証

- `npm run db:generate` / `npm run lint` / `npm run typecheck`: すべてパス（Prisma 契約テストのコンパイル含む）
- `npm run test`: **1124 passed / 175 skipped**（skip は `RUN_PRISMA_CONTRACT` 系、DB 無し環境のため既定どおり）

## 対応 Phase

`docs/smb-dx-pivot-plan.md` Phase 0（マルチテナント基盤）のクロステナント分離強化に対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AkpKoQGjwwvSMJYvuYizv1

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkpKoQGjwwvSMJYvuYizv1)_