### PR TITLE
fix(api): POST /api/tickets・comments にCSRF同一オリジン検証を追加

### DIFF
--- a/src/app/api/auth/magic-link/callback/route.ts
+++ b/src/app/api/auth/magic-link/callback/route.ts
@@ -43,6 +43,9 @@ import { escapeHtml } from '@/lib/html-escape';
 import { MAGIC_LINK_CALLBACK_RATE_LIMIT } from '@/lib/magic-link';
 // Route Handler 向け共通レート制限ラッパー (inbound-email/inbound-line/sso-acs と共有)
 import { checkRouteRateLimit } from '@/lib/route-rate-limit';
+// 同一オリジン検証ヘルパー (POST /api/tickets・POST /api/tickets/[id]/comments と共有。
+// /code-review ultra 指摘対応: 従来ここに個別実装されていたロジックを共通化した)
+import { isSameOriginRequest } from '@/lib/csrf';
 
 // GET ハンドラ: トークンを消費せず HTML 確認ページを返す。
 // メールゲートウェイのプリフェッチ対策として、実際の認証は POST でのみ行う。
@@ -169,47 +172,11 @@ export async function POST(request: Request) {
   // 制限超過なら 429 の NextResponse をそのまま返す (超過なしなら null が返り後続処理を続ける)
   if (limitResponse) return limitResponse;
 
-  // クロスオリジン CSRF 対策: 同一オリジンからのフォーム送信であることを検証する。
-  // 検証戦略:
-  //   1. Sec-Fetch-Site ヘッダ (Chrome 76+ / Firefox 90+): ブラウザが必ず付与し
-  //      JavaScript から偽造できない Fetch Metadata ヘッダ。'same-origin' のみ許可する。
-  //   2. Origin ヘッダ (Sec-Fetch-Site を送らない Safari 等): scheme+host+port を
-  //      正規化して比較する。ブラウザが送信する 'null' 文字列 (file:// 等) は拒否する。
-  //   3. どちらも存在しない場合: fail-closed で拒否する。
-
-  // Sec-Fetch-Site ヘッダは Chrome/Firefox が自動付与する Fetch Metadata ヘッダ
-  const secFetchSite = request.headers.get('sec-fetch-site');
-  // サーバー側の正規オリジン (scheme + host + port) を取り出す
-  const serverOrigin = new URL(request.url).origin;
-
-  if (secFetchSite !== null) {
-    // Sec-Fetch-Site が存在する場合 (Chrome/Firefox): 'same-origin' のみ許可する。
-    // 'cross-site' は別ドメインからの送信 (CSRF 攻撃)、
-    // 'same-site' は同一eTLD+1の別オリジン (許容しない)、
-    // 'none' はダイレクトナビゲーション (form POST には通常現れない) なので拒否する。
-    if (secFetchSite !== 'same-origin') {
-      // クロスオリジン送信 = CSRF の疑い → fail-closed でエラー扱い
-      redirect('/login?error=magic-link-invalid');
-    }
-  } else {
-    // Sec-Fetch-Site がない場合 (Safari 等): Origin ヘッダで同一オリジンを確認する。
-    const origin = request.headers.get('origin');
-    // 'null' 文字列はブラウザが file:// や data: URL 等から送信する特殊な Origin 値。
-    // 同一オリジンとは見なせないため除外する (null チェックとは別に文字列比較が必要)。
-    let requestOrigin: string | null = null;
-    if (origin && origin !== 'null') {
-      try {
-        // URL パースで scheme+host+port を正規化する (末尾スラッシュ等の揺れを吸収)
-        requestOrigin = new URL(origin).origin;
-      } catch {
-        // 不正な URL 文字列の場合は null 扱い → 後段で拒否する (fail-closed)
-        requestOrigin = null;
-      }
-    }
-    if (!requestOrigin || requestOrigin !== serverOrigin) {
-      // Origin 不一致または欠如は CSRF の疑いがあるためエラー扱い (fail-closed)
-      redirect('/login?error=magic-link-invalid');
-    }
+  // クロスオリジン CSRF 対策: 同一オリジンからのフォーム送信であることを検証する
+  // (POST /api/tickets・POST /api/tickets/[id]/comments と共有する判定ロジック)。
+  if (!isSameOriginRequest(request)) {
+    // クロスオリジン送信 = CSRF の疑い → fail-closed でエラー扱い
+    redirect('/login?error=magic-link-invalid');
   }
 
   // フォームの multipart/form-data または application/x-www-form-urlencoded からトークンを取り出す

--- a/src/app/api/tickets/[id]/comments/route.ts
+++ b/src/app/api/tickets/[id]/comments/route.ts
@@ -45,6 +45,10 @@ import {
 import { checkAttachmentQuota } from '@/lib/tenant-plan';
 // Phase 4: Slack/Teams/Chatwork 外部通知のベストエフォート送信共通ヘルパー
 import { notifyOutboundBestEffort } from '@/lib/outbound-notify';
+// 同一オリジン検証ヘルパー (§9 CSRF対策。magic-link/callback・POST /api/tickets と共有する
+// 判定ロジック。このルートも 1MB ボディ上限回避のため意図的に切り出した通常の Route Handler で、
+// Server Action の組み込み Origin 検証を受けないため、ここで明示的に検証する)
+import { isSameOriginRequest } from '@/lib/csrf';
 
 // /api/tickets/[id]/comments の動的セグメント
 type Params = { params: Promise<{ id: string }> };
@@ -75,6 +79,13 @@ export async function POST(req: Request, { params }: Params) {
   const tenantId = session.user.tenantId;
   const authorId = session.user.id;
   const authorIsAgent = isAgent(session.user.role);
+
+  // クロスオリジン CSRF 対策: 攻撃者サイトが被害者のブラウザに送らせたクロスサイト POST は
+  // セッション Cookie が自動付与されるため auth() だけでは弾けない。同一オリジンからの
+  // 送信であることを明示的に検証する (§9)
+  if (!isSameOriginRequest(req)) {
+    return NextResponse.json({ error: 'リクエストの送信元を確認できません' }, { status: 403 });
+  }
 
   // チケット ID を動的セグメントから取り出す
   const { id: ticketId } = await params;

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -40,6 +40,11 @@ import { isAgent } from '@/lib/role';
 import type { Ticket, Role } from '@/domain/types';
 // Route Handler 向け共通レート制限ラッパー (ticket-comment 等と同じ 429 契約)
 import { checkRouteRateLimit } from '@/lib/route-rate-limit';
+// 同一オリジン検証ヘルパー (§9 CSRF対策。magic-link/callback と共有する判定ロジック。
+// /code-review ultra 指摘対応 (2026-07-21): Server Action は Next.js の組み込み Origin
+// 検証で保護されるが、このルートは 1MB ボディ上限回避のため意図的に切り出した通常の
+// Route Handler でその保護を受けないため、ここで明示的に検証する)
+import { isSameOriginRequest } from '@/lib/csrf';
 
 // 監査で発見したギャップ: POST /api/tickets/[id]/comments (ticket-comment) や CSV インポート
 // (csv-import) 等、他の全てのチケット関連ミューテーションはレート制限済みだったが、
@@ -60,9 +65,7 @@ async function notifyAgentsOfWebTicket(
     // テナント内のエージェント/管理者一覧を取得する (メール/LINE 取り込みと同じヘルパー)
     const agents = await repos.users.listAgents(tenantId);
     // 通知対象: 起票者自身がエージェントなら本人以外、依頼者からの起票なら全エージェントへ通知する
-    const notifyTargets = isAgent(creatorRole)
-      ? agents.filter((a) => a.id !== creatorId)
-      : agents;
+    const notifyTargets = isAgent(creatorRole) ? agents.filter((a) => a.id !== creatorId) : agents;
     // 通知作成・SSE 配信はメール/LINE 取り込みと共有のヘルパーに委譲する
     await notifyAgentsOfNewTicket({
       tenantId,
@@ -109,6 +112,13 @@ export async function POST(req: Request) {
   const tenantId = session.user.tenantId;
   // 起票者 ID (添付メタの uploaderId にも使う)
   const userId = session.user.id;
+
+  // クロスオリジン CSRF 対策: 攻撃者サイトが被害者のブラウザに送らせたクロスサイト POST は
+  // セッション Cookie が自動付与されるため auth() だけでは弾けない。同一オリジンからの
+  // 送信であることを明示的に検証する (§9)
+  if (!isSameOriginRequest(req)) {
+    return NextResponse.json({ error: 'リクエストの送信元を確認できません' }, { status: 403 });
+  }
 
   // ユーザー単位でチケット作成頻度を制限する (ticket-comment と同じ 429 契約)
   const rateLimitResponse = checkRouteRateLimit(

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -65,7 +65,9 @@ async function notifyAgentsOfWebTicket(
     // テナント内のエージェント/管理者一覧を取得する (メール/LINE 取り込みと同じヘルパー)
     const agents = await repos.users.listAgents(tenantId);
     // 通知対象: 起票者自身がエージェントなら本人以外、依頼者からの起票なら全エージェントへ通知する
-    const notifyTargets = isAgent(creatorRole) ? agents.filter((a) => a.id !== creatorId) : agents;
+    const notifyTargets = isAgent(creatorRole)
+      ? agents.filter((a) => a.id !== creatorId)
+      : agents;
     // 通知作成・SSE 配信はメール/LINE 取り込みと共有のヘルパーに委譲する
     await notifyAgentsOfNewTicket({
       tenantId,

--- a/src/features/tickets/actions/update-ticket.ts
+++ b/src/features/tickets/actions/update-ticket.ts
@@ -26,8 +26,10 @@ import { getStatusLabel, PRIORITY_LABELS } from '@/lib/constants';
 // フォローアップ (2026-07-15): 優先度変更に追随して SLA 期限 (初回応答/解決) を再計算するための
 // 純粋関数。Web フォーム/CSV インポートの起票時と同じ計算式を共有する (§6 DRY)
 import { calculateFirstResponseDueAt, calculateResolutionDueAt } from '@/lib/sla';
-// 型のみインポート (優先度/ステータス/チケット詳細)
-import type { Priority, TicketStatus, TicketWithRefs } from '@/domain/types';
+// 型のみインポート (優先度/ステータス/チケット詳細/テナント mode)。
+// /code-review ultra 指摘対応: TenantMode だけ3箇所で `import('@/domain/types').TenantMode`
+// とインライン記法が個別に書かれ、他の型と参照経路が分かれていたため、ここに集約する (CLAUDE.md §6 DRY)
+import type { Priority, TicketStatus, TicketWithRefs, TenantMode } from '@/domain/types';
 // レート制限 (連打防止) の共通ヘルパー
 import { enforceRateLimit } from '@/lib/rate-limit';
 // Zod スキーマ (エスカレーション理由の検証用)
@@ -967,7 +969,7 @@ async function notifyRequesterOfStatusChange(args: {
   creatorId: string; // 起票者ユーザー ID (メールアドレス・LINE 連携状況の取得用)
   oldStatus: TicketStatus; // 変更前のステータス (ラベル変換用)
   newStatus: TicketStatus; // 変更後のステータス (ラベル変換用)
-  mode: import('@/domain/types').TenantMode; // テナント mode (ラベル変換で Lite/Pro を切替)
+  mode: TenantMode; // テナント mode (ラベル変換で Lite/Pro を切替)
   tenantId: string; // LINE 連携設定・プランの取得に使うテナントスコープ
 }): Promise<void> {
   const { ticketId, ticketTitle, creatorId, oldStatus, newStatus, mode, tenantId } = args;
@@ -1014,7 +1016,7 @@ async function sendStatusChangedEmailToRequester(args: {
   ticketTitle: string; // チケット件名 (メール本文用)
   oldStatus: TicketStatus; // 変更前のステータス (ラベル変換用)
   newStatus: TicketStatus; // 変更後のステータス (ラベル変換用)
-  mode: import('@/domain/types').TenantMode; // テナント mode (ラベル変換で Lite/Pro を切替)
+  mode: TenantMode; // テナント mode (ラベル変換で Lite/Pro を切替)
 }): Promise<void> {
   const { creator, ticketId, ticketTitle, oldStatus, newStatus, mode } = args;
   // メール未設定なら送りようがないのでスキップ
@@ -1053,7 +1055,7 @@ async function sendStatusChangedLineToRequester(args: {
   ticketTitle: string; // チケット件名 (LINE 本文用)
   oldStatus: TicketStatus; // 変更前のステータス (ラベル変換用)
   newStatus: TicketStatus; // 変更後のステータス (ラベル変換用)
-  mode: import('@/domain/types').TenantMode; // テナント mode (ラベル変換で Lite/Pro を切替)
+  mode: TenantMode; // テナント mode (ラベル変換で Lite/Pro を切替)
   tenantId: string; // LINE 連携設定・プランの取得に使うテナントスコープ
 }): Promise<void> {
   const { creator, ticketId, ticketTitle, oldStatus, newStatus, mode, tenantId } = args;

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -1,0 +1,42 @@
+// Route Handler (Next.js API ルート) 向けの同一オリジン検証ヘルパー。
+// /code-review ultra 指摘対応 (2026-07-21): Server Action は Next.js の組み込み Origin 検証で
+// クロスサイト POST から保護されるが、POST /api/tickets・POST /api/tickets/[id]/comments は
+// Server Action の既定 1MB ボディ上限を回避するため意図的に切り出した通常の Route Handler で、
+// この保護を受けない。CLAUDE.md §9「フォーム送信や書き込み系 API には CSRF トークン
+// （またはダブルサブミットクッキー）を必須とする」に反していたため、magic-link/callback/route.ts
+// に個別実装されていた同一オリジン判定ロジックをここへ共通化する
+// (CLAUDE.md §6「2〜3 箇所目で共通化する」の基準を満たす: magic-link + tickets + comments の3箇所)。
+
+// リクエストが同一オリジンからの送信かどうかを判定する。
+// 検証戦略 (優先順):
+//   1. Sec-Fetch-Site ヘッダ (Chrome 76+ / Firefox 90+): ブラウザが必ず付与し
+//      JavaScript から偽造できない Fetch Metadata ヘッダ。'same-origin' のみ許可する。
+//   2. Origin ヘッダ (Sec-Fetch-Site を送らない Safari 等): scheme+host+port を
+//      正規化して比較する。ブラウザが送信する 'null' 文字列 (file:// 等) は拒否する。
+//   3. どちらも存在しない場合: fail-closed で拒否する (§9 fail-safe)。
+export function isSameOriginRequest(request: Request): boolean {
+  // Sec-Fetch-Site ヘッダは Chrome/Firefox が自動付与する Fetch Metadata ヘッダ (偽装不可)
+  const secFetchSite = request.headers.get('sec-fetch-site');
+  // サーバー側の正規オリジン (scheme + host + port) を取り出す
+  const serverOrigin = new URL(request.url).origin;
+
+  if (secFetchSite !== null) {
+    // 'cross-site' は別ドメインからの送信 (CSRF 攻撃)、'same-site' は同一 eTLD+1 の
+    // 別オリジン (許容しない)、'none' はダイレクトナビゲーション (form POST には通常
+    // 現れない) なので、'same-origin' のみ許可する
+    return secFetchSite === 'same-origin';
+  }
+
+  // Sec-Fetch-Site がない場合 (Safari 等): Origin ヘッダで同一オリジンを確認する
+  const origin = request.headers.get('origin');
+  // 'null' 文字列はブラウザが file:// や data: URL 等から送信する特殊な Origin 値。
+  // 同一オリジンとは見なせないため拒否する
+  if (!origin || origin === 'null') return false;
+  try {
+    // URL パースで scheme+host+port を正規化してから比較する (末尾スラッシュ等の揺れを吸収)
+    return new URL(origin).origin === serverOrigin;
+  } catch {
+    // 不正な URL 文字列は fail-closed で拒否する
+    return false;
+  }
+}

--- a/tests/csrf.test.ts
+++ b/tests/csrf.test.ts
@@ -1,0 +1,64 @@
+// isSameOriginRequest (同一オリジン検証ヘルパー) の仕様確認テスト。
+// /code-review ultra 指摘対応: magic-link/callback に個別実装されていた CSRF 判定ロジックを
+// src/lib/csrf.ts に集約し、POST /api/tickets・POST /api/tickets/[id]/comments でも
+// 同じ判定を使うようにした。その集約先自体の単体テスト。
+
+import { describe, expect, it } from 'vitest';
+import { isSameOriginRequest } from '@/lib/csrf';
+
+// テスト用リクエストを組み立てるヘルパー (headers を個別に渡せるようにする)
+function makeRequest(headers: Record<string, string>): Request {
+  return new Request('https://helpdesk.example.com/api/tickets', {
+    method: 'POST',
+    headers,
+  });
+}
+
+describe('isSameOriginRequest', () => {
+  // Sec-Fetch-Site が 'same-origin' なら許可する
+  it('allows when Sec-Fetch-Site is same-origin', () => {
+    expect(isSameOriginRequest(makeRequest({ 'sec-fetch-site': 'same-origin' }))).toBe(true);
+  });
+
+  // Sec-Fetch-Site が 'cross-site' なら拒否する (別ドメインからの CSRF 攻撃)
+  it('rejects when Sec-Fetch-Site is cross-site', () => {
+    expect(isSameOriginRequest(makeRequest({ 'sec-fetch-site': 'cross-site' }))).toBe(false);
+  });
+
+  // Sec-Fetch-Site が 'same-site' (同一 eTLD+1 の別オリジン) も許容しない
+  it('rejects when Sec-Fetch-Site is same-site', () => {
+    expect(isSameOriginRequest(makeRequest({ 'sec-fetch-site': 'same-site' }))).toBe(false);
+  });
+
+  // Sec-Fetch-Site が 'none' (ダイレクトナビゲーション) も拒否する
+  it('rejects when Sec-Fetch-Site is none', () => {
+    expect(isSameOriginRequest(makeRequest({ 'sec-fetch-site': 'none' }))).toBe(false);
+  });
+
+  // Sec-Fetch-Site が無い場合 (Safari 等) は Origin ヘッダで判定する: 一致すれば許可
+  it('falls back to a matching Origin header when Sec-Fetch-Site is absent', () => {
+    expect(isSameOriginRequest(makeRequest({ origin: 'https://helpdesk.example.com' }))).toBe(true);
+  });
+
+  // Origin ヘッダがサーバーのオリジンと異なれば拒否する
+  it('rejects a mismatched Origin header', () => {
+    expect(isSameOriginRequest(makeRequest({ origin: 'https://attacker.example.com' }))).toBe(
+      false,
+    );
+  });
+
+  // ブラウザが file:// 等から送る特殊な 'null' 文字列は同一オリジンと見なさない
+  it('rejects the literal "null" Origin value', () => {
+    expect(isSameOriginRequest(makeRequest({ origin: 'null' }))).toBe(false);
+  });
+
+  // Origin ヘッダが不正な URL 文字列なら fail-closed で拒否する
+  it('rejects a malformed Origin header', () => {
+    expect(isSameOriginRequest(makeRequest({ origin: 'not-a-valid-url' }))).toBe(false);
+  });
+
+  // Sec-Fetch-Site も Origin も無ければ fail-closed で拒否する
+  it('rejects when neither Sec-Fetch-Site nor Origin is present', () => {
+    expect(isSameOriginRequest(makeRequest({}))).toBe(false);
+  });
+});

--- a/tests/features/attachments/create-ticket-with-files.test.ts
+++ b/tests/features/attachments/create-ticket-with-files.test.ts
@@ -97,14 +97,20 @@ function makeFile(name: string, type: string, body: string): File {
   return new File([data], name, { type });
 }
 
-// multipart/form-data リクエストを組み立てて Request 化する
+// multipart/form-data リクエストを組み立てて Request 化する。
+// sec-fetch-site: same-origin は isSameOriginRequest (CSRF 対策) を通過させるために付与する
+// (実ブラウザの同一オリジン fetch/フォーム送信を模擬)
 function buildMultipartRequest(fields: Record<string, string>, files: File[]): Request {
   // FormData を組み立てる
   const form = new FormData();
   for (const [k, v] of Object.entries(fields)) form.append(k, v);
   for (const f of files) form.append('files', f, f.name);
   // Request にして POST する (Node 環境では undici が multipart の境界を自動で組み立てる)
-  return new Request('http://localhost/api/tickets', { method: 'POST', body: form });
+  return new Request('http://localhost/api/tickets', {
+    method: 'POST',
+    body: form,
+    headers: { 'sec-fetch-site': 'same-origin' },
+  });
 }
 
 beforeEach(async () => {
@@ -135,7 +141,7 @@ describe('POST /api/tickets (multipart with attachments)', () => {
     // 大文字化した Content-Type で同じボディを再構築する
     const req = new Request('http://localhost/api/tickets', {
       method: 'POST',
-      headers: { 'content-type': upperType },
+      headers: { 'content-type': upperType, 'sec-fetch-site': 'same-origin' },
       body: bodyBuf,
     });
 
@@ -328,7 +334,7 @@ describe('POST /api/tickets (multipart with attachments)', () => {
     const buildJsonRequest = () =>
       new Request('http://localhost/api/tickets', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'sec-fetch-site': 'same-origin' },
         body: JSON.stringify({ title: 't', body: 'b', priority: 'Medium' }),
       });
     let last: Response | undefined;

--- a/tests/features/attachments/post-comment-route.test.ts
+++ b/tests/features/attachments/post-comment-route.test.ts
@@ -167,12 +167,18 @@ function makeFile(name: string, type: string, body: string): File {
   return new File([data], name, { type });
 }
 
-// multipart Request を組み立てるヘルパー (Content-Type は undici が自動付与する)
+// multipart Request を組み立てるヘルパー (Content-Type は undici が自動付与する)。
+// sec-fetch-site: same-origin は isSameOriginRequest (CSRF 対策) を通過させるために付与する
+// (実ブラウザの同一オリジン fetch/フォーム送信を模擬)
 function buildRequest(body: string, files: File[]): Request {
   const form = new FormData();
   form.set('body', body);
   for (const f of files) form.append('files', f, f.name);
-  return new Request('http://localhost/api/tickets/x/comments', { method: 'POST', body: form });
+  return new Request('http://localhost/api/tickets/x/comments', {
+    method: 'POST',
+    body: form,
+    headers: { 'sec-fetch-site': 'same-origin' },
+  });
 }
 
 // 動的セグメント params の Promise を作るヘルパー

--- a/tests/features/create-ticket-due-date-mode.test.ts
+++ b/tests/features/create-ticket-due-date-mode.test.ts
@@ -75,11 +75,13 @@ async function seedTenant(mode: 'lite' | 'pro') {
   });
 }
 
-// JSON ボディでチケット作成リクエストを組み立てる
+// JSON ボディでチケット作成リクエストを組み立てる。
+// sec-fetch-site: same-origin は isSameOriginRequest (CSRF 対策) を通過させるために付与する
+// (実ブラウザの同一オリジン fetch/フォーム送信を模擬)
 function buildJsonRequest(body: Record<string, unknown>): Request {
   return new Request('http://localhost/api/tickets', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'sec-fetch-site': 'same-origin' },
     body: JSON.stringify(body),
   });
 }

--- a/tests/features/create-ticket-outbound-notify.test.ts
+++ b/tests/features/create-ticket-outbound-notify.test.ts
@@ -104,11 +104,13 @@ async function seedTenant(slackWebhookUrl: string | null) {
   });
 }
 
-// JSON ボディでチケット作成リクエストを組み立てる
+// JSON ボディでチケット作成リクエストを組み立てる。
+// sec-fetch-site: same-origin は isSameOriginRequest (CSRF 対策) を通過させるために付与する
+// (実ブラウザの同一オリジン fetch/フォーム送信を模擬)
 function buildJsonRequest(body: Record<string, unknown>): Request {
   return new Request('http://localhost/api/tickets', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'sec-fetch-site': 'same-origin' },
     body: JSON.stringify(body),
   });
 }


### PR DESCRIPTION
## Summary

定期コードレビューで発見したセキュリティギャップの修正です。

- `POST /api/tickets` と `POST /api/tickets/[id]/comments` は、Server Action の既定 1MB ボディ上限を回避するため意図的に切り出した通常の Route Handler です。Server Action が受けている Next.js 組み込みの Origin 検証をこの2ルートは受けておらず、CLAUDE.md §9「フォーム送信や書き込み系 API には CSRF トークン（またはダブルサブミットクッキー）を必須とする」に反していました。
- セッション Cookie は `SameSite` 設定に依存する多層防御の1層にすぎず、単独では CSRF を防げません。
- `src/app/api/auth/magic-link/callback/route.ts` に既に実装されていた同一オリジン判定ロジック（Sec-Fetch-Site / Origin ヘッダのフォールバック判定）を `src/lib/csrf.ts` の `isSameOriginRequest()` に共通化し、3ルートで再利用しています（CLAUDE.md §6 DRY: 2〜3箇所目での共通化）。
- ついでに `update-ticket.ts` で `TenantMode` 型が3箇所で `import('@/domain/types').TenantMode` とインライン記法を個別に書いていた箇所を、ファイル冒頭の型 import に統一しました。

## Changes

- 新規: `src/lib/csrf.ts` — `isSameOriginRequest(request)`（Sec-Fetch-Site 優先、フォールバックで Origin ヘッダを正規化比較、いずれも無ければ fail-closed で拒否）
- `src/app/api/tickets/route.ts` — POST に同一オリジン検証を追加（不一致は403）
- `src/app/api/tickets/[id]/comments/route.ts` — 同上
- `src/app/api/auth/magic-link/callback/route.ts` — 個別実装していた判定ロジックを共通ヘルパーに置き換え（挙動は変更なし）
- `src/features/tickets/actions/update-ticket.ts` — `TenantMode` インライン import の重複解消
- 新規: `tests/csrf.test.ts` — `isSameOriginRequest` の単体テスト（9ケース）
- 既存テスト4ファイルのリクエスト構築ヘルパーに `sec-fetch-site: same-origin` ヘッダを追加（実ブラウザの同一オリジン送信を模擬するため）

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npx prettier --check` 通過（変更ファイルのみ）
- [x] `npm run test`: 108 test files passed / 1151 tests passed（DB依存の contract テストはスキップ、既存動作）
- [x] 新規 `tests/csrf.test.ts` 9ケース全て通過（same-origin許可、cross-site/same-site/none拒否、Originフォールバック、'null'値拒否、不正URL拒否、両ヘッダ欠如時のfail-closed）

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QsvxmSFkyLjr2qL1V3UX8r

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsvxmSFkyLjr2qL1V3UX8r)_